### PR TITLE
Rename repo paths from agent-receipts/agent-receipts to agent-receipts/ar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Cryptographically signed audit trails for AI agent actions**
 
-[![Go Tests](https://github.com/agent-receipts/agent-receipts/actions/workflows/go.yml/badge.svg)](https://github.com/agent-receipts/agent-receipts/actions/workflows/go.yml)
-[![TS Tests](https://github.com/agent-receipts/agent-receipts/actions/workflows/ts.yml/badge.svg)](https://github.com/agent-receipts/agent-receipts/actions/workflows/ts.yml)
-[![Python Tests](https://github.com/agent-receipts/agent-receipts/actions/workflows/py.yml/badge.svg)](https://github.com/agent-receipts/agent-receipts/actions/workflows/py.yml)
+[![Go Tests](https://github.com/agent-receipts/ar/actions/workflows/go.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/go.yml)
+[![TS Tests](https://github.com/agent-receipts/ar/actions/workflows/ts.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/ts.yml)
+[![Python Tests](https://github.com/agent-receipts/ar/actions/workflows/py.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/py.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 </div>
@@ -46,11 +46,11 @@ Agent Receipts is an open protocol and set of SDKs for producing cryptographical
 ### Go
 
 ```bash
-go get github.com/agent-receipts/agent-receipts/sdk/go
+go get github.com/agent-receipts/ar/sdk/go
 ```
 
 ```go
-import receipt "github.com/agent-receipts/agent-receipts/sdk/go/receipt"
+import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
 
 r, _ := receipt.New(receipt.WithAction("tool_call", payload))
 signed, _ := r.Sign(privateKey)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 If you discover a security vulnerability in Agent Receipts, please report it through
-[GitHub Security Advisories](https://github.com/agent-receipts/agent-receipts/security/advisories/new).
+[GitHub Security Advisories](https://github.com/agent-receipts/ar/security/advisories/new).
 
 Do **not** open a public issue for security vulnerabilities.
 

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
-	"github.com/agent-receipts/agent-receipts/sdk/go/store"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
 )
 
 func openReceiptStore(path string) *store.Store {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -14,12 +14,12 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/agent-receipts/agent-receipts/mcp-proxy/internal/audit"
-	"github.com/agent-receipts/agent-receipts/mcp-proxy/internal/policy"
-	"github.com/agent-receipts/agent-receipts/mcp-proxy/internal/proxy"
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
-	receiptStore "github.com/agent-receipts/agent-receipts/sdk/go/store"
-	"github.com/agent-receipts/agent-receipts/sdk/go/taxonomy"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	receiptStore "github.com/agent-receipts/ar/sdk/go/store"
+	"github.com/agent-receipts/ar/sdk/go/taxonomy"
 	"github.com/google/uuid"
 )
 

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -1,9 +1,9 @@
-module github.com/agent-receipts/agent-receipts/mcp-proxy
+module github.com/agent-receipts/ar/mcp-proxy
 
 go 1.26.1
 
 require (
-	github.com/agent-receipts/agent-receipts/sdk/go v0.1.0
+	github.com/agent-receipts/ar/sdk/go v0.1.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.49.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -21,4 +21,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/agent-receipts/agent-receipts/sdk/go => ../sdk/go
+replace github.com/agent-receipts/ar/sdk/go => ../sdk/go

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/agent-receipts/agent-receipts/sdk/go
+module github.com/agent-receipts/ar/sdk/go
 
 go 1.26.1
 

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 
 	_ "modernc.org/sqlite"
 )

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 func setupStore(t *testing.T) *Store {

--- a/sdk/go/taxonomy/taxonomy.go
+++ b/sdk/go/taxonomy/taxonomy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 // ActionTypeEntry describes a known action type.

--- a/sdk/go/taxonomy/taxonomy_test.go
+++ b/sdk/go/taxonomy/taxonomy_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/agent-receipts/agent-receipts/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 func TestClassifyToolCallWithMapping(t *testing.T) {

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/agent-receipts/agent-receipts"
-Repository = "https://github.com/agent-receipts/agent-receipts"
-Issues = "https://github.com/agent-receipts/agent-receipts/issues"
+Homepage = "https://github.com/agent-receipts/ar"
+Repository = "https://github.com/agent-receipts/ar"
+Issues = "https://github.com/agent-receipts/ar/issues"
 Spec = "https://github.com/agent-receipts/spec"
 
 [project.optional-dependencies]

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -6,7 +6,7 @@
 	"author": "Otto Jongerius",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/agent-receipts/agent-receipts.git",
+		"url": "git+https://github.com/agent-receipts/ar.git",
 		"directory": "sdk/ts"
 	},
 	"type": "module",


### PR DESCRIPTION
## Summary
Updates all Go module paths, import statements, package URLs, badge links, and security advisory URLs to reflect the repo rename from `agent-receipts/agent-receipts` to `agent-receipts/ar`.

## Test plan
- [x] `go test ./...` passes in sdk/go and mcp-proxy
- [x] No remaining references to old path