### PR TITLE
Replace ASCII architecture diagram with Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Cryptographically signed audit trails for AI agent actions**
 
-[![Go Tests](https://github.com/agent-receipts/ar/actions/workflows/go.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/go.yml)
-[![TS Tests](https://github.com/agent-receipts/ar/actions/workflows/ts.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/ts.yml)
-[![Python Tests](https://github.com/agent-receipts/ar/actions/workflows/py.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/py.yml)
+[![Go Tests](https://github.com/agent-receipts/ar/actions/workflows/sdk-go.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/sdk-go.yml)
+[![TS Tests](https://github.com/agent-receipts/ar/actions/workflows/sdk-ts.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/sdk-ts.yml)
+[![Python Tests](https://github.com/agent-receipts/ar/actions/workflows/sdk-py.yml/badge.svg)](https://github.com/agent-receipts/ar/actions/workflows/sdk-py.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
Swaps the ASCII box diagram for a Mermaid graph that GitHub renders natively.