### PR TITLE
Use @agnt-rcpt npm scope for TS SDK

### DIFF
--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@agent-receipts/sdk-ts",
+	"name": "@agnt-rcpt/sdk-ts",
 	"version": "0.2.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",


### PR DESCRIPTION
The @agent-receipts npm org isn't available. Using the existing @agnt-rcpt scope instead.