### PR TITLE
Bump @agnt-rcpt/sdk-ts to 0.2.1

### DIFF
--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
0.2.0 was already published from the old repo. Bumping to 0.2.1 for the first monorepo publish.