### PR TITLE
Fix TS publish workflow

### DIFF
--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -23,17 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - run: npm install -g npm@latest
-
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: sdk/ts/pnpm-lock.yaml
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/sdk-ts.yml
+++ b/.github/workflows/sdk-ts.yml
@@ -25,13 +25,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: sdk/ts/pnpm-lock.yaml
 


### PR DESCRIPTION
Remove `npm install -g npm@latest` which fails on Node 22 with MODULE_NOT_FOUND. Not needed — pnpm handles everything.