### PR TITLE
Rename Attest Protocol to Agent Receipts

### DIFF
--- a/sdk/go/receipt/signing.go
+++ b/sdk/go/receipt/signing.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// The Attest Protocol spec uses base64url (u) rather than the W3C Data
+// The Agent Receipts spec uses base64url (u) rather than the W3C Data
 // Integrity default base58btc (z).
 const multibaseBase64URL = "u"
 

--- a/sdk/py/CLAUDE.md
+++ b/sdk/py/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Python SDK for the [Attest Protocol](https://github.com/agent-receipts/spec) — cryptographically signed, hash-chained Agent Receipts for AI agent audit trails.
+Python SDK for [Agent Receipts](https://github.com/agent-receipts/ar) — cryptographically signed, hash-chained audit trails for AI agents.
 
 ## Commands
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -35,7 +35,7 @@ AI agents that read files, run commands, and browse the web are powerful — but
 
 ### Beyond local storage
 
-Today, this SDK stores receipts locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/agent-receipts/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging between agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
+Today, this SDK stores receipts locally in SQLite — fully under your control. The [Agent Receipts protocol](https://github.com/agent-receipts/ar/tree/main/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging between agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
 
 ## Install
 

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -83,7 +83,7 @@ pip install agent-receipts
 ### 2. Create and sign a receipt
 
 ```python
-from attest_protocol import (
+from agent_receipts import (
     create_receipt,
     generate_key_pair,
     sign_receipt,
@@ -115,7 +115,7 @@ receipt_hash = hash_receipt(receipt)
 ### 3. Verify a chain
 
 ```python
-from attest_protocol import verify_chain
+from agent_receipts import verify_chain
 
 receipts = [receipt]  # or load from storage
 result = verify_chain(receipts, keys.public_key)


### PR DESCRIPTION
## Summary
- Fix Python quick-start imports: `from attest_protocol import` → `from agent_receipts import` (matches the actual published package name on PyPI)
- Update remaining "Attest Protocol" branding references in TS SDK README, Go SDK comment, and Python SDK CLAUDE.md

## Not changed
- `attest.sh/v1` JSON-LD context URI (protocol constant)
- `ojongerius/attest` repo links (separate project)
- Archived repos (deprecated, left as-is)

## Test plan
- [x] Verify site builds with `pnpm build` in `site/`
- [x] Confirm Go SDK compiles with `go build ./...` in `sdk/go/`