### PR TITLE
Rename attest-config- temp dir prefix to ar-config-

### DIFF
--- a/sdk/ts/src/taxonomy/config.test.ts
+++ b/sdk/ts/src/taxonomy/config.test.ts
@@ -9,7 +9,7 @@ describe("loadTaxonomyConfig", () => {
 	let tempDir: string;
 
 	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "attest-config-"));
+		tempDir = mkdtempSync(join(tmpdir(), "ar-config-"));
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary
- Rename `attest-config-` temp directory prefix in `sdk/ts/src/taxonomy/config.test.ts` to `ar-config-`

Follow-up to #10 — catches one remaining "attest" prefix in a test temp dir.

## Test plan
- [ ] `pnpm test` in `sdk/ts/`