### PR TITLE
Add MCP Proxy documentation

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -71,6 +71,14 @@ export default defineConfig({
           ],
         },
         {
+          label: "MCP Proxy",
+          items: [
+            { label: "Overview", slug: "mcp-proxy/overview" },
+            { label: "Installation", slug: "mcp-proxy/installation" },
+            { label: "Configuration", slug: "mcp-proxy/configuration" },
+          ],
+        },
+        {
           label: "OpenClaw",
           items: [
             { label: "Overview", slug: "openclaw/overview" },

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -1,0 +1,136 @@
+---
+title: Configuration
+description: CLI flags, policy rules, redaction, and encryption options for the MCP Proxy.
+---
+
+## CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--db` | `audit.db` | SQLite audit database path |
+| `--receipt-db` | `receipts.db` | SQLite receipt store path |
+| `--key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
+| `--taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
+| `--rules` | (built-in defaults) | Policy rules YAML file |
+| `--name` | (inferred from command) | Server name for the audit trail |
+| `--issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
+| `--principal` | `did:user:unknown` | Principal DID for receipts |
+| `--chain` | (auto UUID) | Chain ID for receipt chaining |
+| `--http` | `127.0.0.1:8080` | HTTP address for the approval endpoint |
+
+## Policy rules
+
+Rules are defined in YAML and control what happens when a tool call matches:
+
+```yaml
+rules:
+  - name: block_destructive_ops
+    description: Block delete operations on sensitive tools
+    enabled: true
+    tool_pattern: "delete_*"
+    server_pattern: "*postgres*"
+    operation_types: [delete]
+    min_risk_score: 70
+    action: block
+
+  - name: pause_high_risk
+    description: Require approval for high-risk operations
+    enabled: true
+    min_risk_score: 50
+    action: pause
+```
+
+### Rule fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Unique rule identifier |
+| `description` | no | Human-readable description |
+| `enabled` | yes | Whether the rule is active |
+| `tool_pattern` | no | Glob pattern matching tool name (case-insensitive) |
+| `server_pattern` | no | Glob pattern matching server name |
+| `operation_types` | no | Filter by operation type: `read`, `write`, `delete`, `execute` |
+| `min_risk_score` | no | Minimum risk score (0-100) to match |
+| `action` | yes | One of `pass`, `flag`, `pause`, `block` |
+
+### Actions
+
+| Action | Behavior |
+|--------|----------|
+| `pass` | Log only, forward normally |
+| `flag` | Log with highlight, forward normally |
+| `pause` | Hold for HTTP approval (60-second timeout, auto-denied on timeout) |
+| `block` | Reject immediately with error |
+
+When multiple rules match, the most restrictive action wins (block > pause > flag > pass).
+
+## Risk scoring
+
+Risk scores range from 0 to 100, computed from:
+
+| Factor | Score | Condition |
+|--------|-------|-----------|
+| Operation type | 0--40 | read=0, write=20, execute=30, delete=40 |
+| Sensitive keywords | +30 | Tool name contains: auth, credential, password, token, secret, key |
+| SQL without WHERE | +30 | Arguments contain UPDATE/DELETE/TRUNCATE without WHERE |
+| Config modification | +20 | Tool name contains: config, setting |
+| External messaging | +15 | Tool name starts with: send\_, post\_ |
+| Unknown operation | +10 | Fallback if classification fails |
+
+## Operation classification
+
+Tool names are classified by prefix (case-insensitive):
+
+| Type | Prefixes |
+|------|----------|
+| delete | delete\_, remove\_, drop\_, destroy\_, purge\_ |
+| execute | run\_, exec\_, invoke\_, call\_, trigger\_ |
+| write | create\_, update\_, set\_, add\_, put\_, edit\_, modify\_, write\_ |
+| read | get\_, read\_, list\_, search\_, describe\_, show\_ |
+| unknown | (fallback) |
+
+For more precise classification, provide a `--taxonomy` JSON file mapping tool names to action types from the Agent Receipts taxonomy.
+
+## Approval workflow
+
+When a tool call is paused by a policy rule:
+
+1. The proxy logs an approval ID and waits up to 60 seconds
+2. An approval token is printed to stderr on startup
+3. Approve or deny via HTTP:
+
+```bash
+# Approve
+curl -X POST http://localhost:8080/api/tool-calls/{id}/approve \
+  -H "Authorization: Bearer $APPROVAL_TOKEN"
+
+# Deny
+curl -X POST http://localhost:8080/api/tool-calls/{id}/deny \
+  -H "Authorization: Bearer $APPROVAL_TOKEN"
+```
+
+If no response within 60 seconds, the call is automatically denied.
+
+## Data redaction
+
+The proxy redacts sensitive data before storage using two passes:
+
+**JSON-aware redaction** replaces values of sensitive keys including: `password`, `token`, `api_key`, `secret`, `authorization`, `private_key`, `access_token`, `jwt`, `database_url`, `ssh_key`, `connection_string`, and others (42 keys total).
+
+**Pattern-based redaction** matches known secret formats:
+- GitHub PATs and OAuth tokens (`ghp_*`, `gho_*`)
+- OpenAI/Anthropic API keys (`sk-*`)
+- AWS access keys (`AKIA*`)
+- Bearer tokens
+- Slack tokens (`xox*`)
+- PEM private key blocks
+
+## Encryption at rest
+
+Set the `BEACON_ENCRYPTION_KEY` environment variable to enable AES-256-GCM encryption of all stored audit data:
+
+```bash
+BEACON_ENCRYPTION_KEY="my-passphrase" mcp-proxy node server.js
+```
+
+Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored with an `enc:` prefix and transparently decrypted on retrieval.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -1,0 +1,44 @@
+---
+title: Installation
+description: Install and run the MCP Proxy.
+---
+
+## Install
+
+```bash
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+```
+
+## Requirements
+
+- Go 1.22+
+
+No CGO or external C libraries required -- the proxy uses pure Go SQLite.
+
+## Basic usage
+
+Wrap any MCP server by passing its command as arguments:
+
+```bash
+mcp-proxy node /path/to/mcp-server.js
+```
+
+The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. By default it generates an ephemeral Ed25519 key pair for signing receipts.
+
+## Persistent signing key
+
+Generate a key pair and use it across sessions:
+
+```bash
+# Generate a key pair (any Ed25519 PEM tool works)
+openssl genpkey -algorithm Ed25519 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+
+# Run with persistent key
+mcp-proxy --key private.pem node /path/to/mcp-server.js
+```
+
+## Next steps
+
+- [Configuration](/mcp-proxy/configuration/) for CLI flags, policy rules, redaction, and encryption
+- [CLI Commands](/reference/cli-commands/) for querying and verifying the audit trail

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -1,0 +1,77 @@
+---
+title: MCP Proxy
+description: Transparent audit proxy for MCP servers with receipt signing, policy enforcement, and risk scoring.
+---
+
+The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, etc.) and any MCP server. It intercepts every tool call and provides cryptographic audit trails, risk scoring, and policy enforcement -- without modifying the server or client.
+
+**Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
+
+## Features
+
+- **Risk scoring** -- scores every tool call 0-100 based on operation type, sensitive keywords, and patterns
+- **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
+- **Policy enforcement** -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
+- **Approval workflows** -- HTTP endpoints for async approval of paused operations
+- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, hash-chained per session
+- **Intent tracking** -- groups related tool calls by temporal proximity
+- **Data redaction** -- JSON-aware and pattern-based redaction of secrets before storage
+- **Encryption at rest** -- optional AES-256-GCM encryption of audit data
+- **Audit CLI** -- list, inspect, verify, export, and query receipts from the command line
+
+## How it works
+
+```
+MCP Client (Claude)
+    |
+    v
+ mcp-proxy (stdin/stdout)
+    |  - classify operation
+    |  - score risk
+    |  - evaluate policy rules
+    |  - redact sensitive data
+    |  - sign receipt
+    |  - log to SQLite
+    v
+ MCP Server (any)
+```
+
+The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call generates a signed Agent Receipt that is hash-chained into a tamper-evident audit log.
+
+## Quick start
+
+```bash
+# Install
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+
+# Wrap any MCP server
+mcp-proxy node /path/to/mcp-server.js
+
+# With configuration
+mcp-proxy \
+  --name github \
+  --key private.pem \
+  --rules rules.yaml \
+  --taxonomy taxonomy.json \
+  node /path/to/github-mcp-server.js
+```
+
+## Claude Desktop integration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "mcp-proxy",
+      "args": [
+        "--name", "github",
+        "node", "/path/to/github-mcp-server.js"
+      ]
+    }
+  }
+}
+```
+
+See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -1,13 +1,82 @@
 ---
 title: CLI Commands
-description: Command reference for the Agent Receipts ecosystem.
+description: Command reference for the MCP Proxy audit CLI.
 ---
 
-:::note
-Coming soon. CLI reference documentation will be added as tooling matures.
-:::
+The MCP Proxy includes subcommands for querying and verifying the audit trail.
 
-In the meantime, see the individual SDK repositories for usage examples:
+## `mcp-proxy list`
 
-- [TypeScript SDK](https://github.com/agent-receipts/sdk-ts)
-- [Python SDK](https://github.com/agent-receipts/sdk-py)
+List receipts from the audit store.
+
+```bash
+mcp-proxy list                            # all receipts
+mcp-proxy list --risk high                # filter by risk level
+mcp-proxy list --action read_file         # filter by action type
+mcp-proxy list --chain <chain-id>         # filter by chain
+mcp-proxy list --limit 100               # limit results
+mcp-proxy list --json                     # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `--risk` | Filter by risk level: `low`, `medium`, `high`, `critical` |
+| `--action` | Filter by action type |
+| `--chain` | Filter by chain ID |
+| `--limit` | Maximum number of receipts to return |
+| `--json` | Output as JSON |
+| `--db` | Receipt store path (default: `receipts.db`) |
+
+## `mcp-proxy inspect`
+
+Show details for a single receipt.
+
+```bash
+mcp-proxy inspect <receipt-id>
+mcp-proxy inspect --key public.pem <receipt-id>   # verify signature
+```
+
+| Flag | Description |
+|------|-------------|
+| `--key` | Public key PEM file to verify the receipt signature |
+| `--db` | Receipt store path (default: `receipts.db`) |
+
+## `mcp-proxy verify`
+
+Verify the integrity of a receipt chain -- checks signatures, hash linkage, and sequence numbers.
+
+```bash
+mcp-proxy verify --key public.pem <chain-id>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--key` | Public key PEM file (required) |
+| `--db` | Receipt store path (default: `receipts.db`) |
+
+## `mcp-proxy export`
+
+Export a receipt chain as JSON.
+
+```bash
+mcp-proxy export <chain-id>
+mcp-proxy export <chain-id> > chain.json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--db` | Receipt store path (default: `receipts.db`) |
+
+## `mcp-proxy stats`
+
+Show aggregate statistics about the audit store.
+
+```bash
+mcp-proxy stats
+mcp-proxy stats --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+| `--db` | Receipt store path (default: `receipts.db`) |

--- a/site/src/content/docs/reference/configuration.mdx
+++ b/site/src/content/docs/reference/configuration.mdx
@@ -3,11 +3,28 @@ title: Configuration
 description: Configuration options for Agent Receipts SDKs and tooling.
 ---
 
-:::note
-Coming soon. Configuration documentation will be added as tooling matures.
-:::
+## MCP Proxy
 
-In the meantime, see the individual SDK repositories for configuration options:
+The MCP Proxy is the primary configurable component. See the dedicated [MCP Proxy Configuration](/mcp-proxy/configuration/) page for:
 
-- [TypeScript SDK](https://github.com/agent-receipts/sdk-ts)
-- [Python SDK](https://github.com/agent-receipts/sdk-py)
+- CLI flags (database paths, signing keys, DIDs)
+- Policy rules (YAML format, actions, matching)
+- Risk scoring and operation classification
+- Approval workflows
+- Data redaction and encryption at rest
+
+## Taxonomy mappings
+
+All SDKs and the MCP Proxy accept a taxonomy mappings file that maps tool names to action types:
+
+```json
+{
+  "mappings": [
+    { "tool_name": "read_file", "action_type": "filesystem.file.read" },
+    { "tool_name": "write_file", "action_type": "filesystem.file.modify" },
+    { "tool_name": "exec_command", "action_type": "system.command.execute" }
+  ]
+}
+```
+
+See the [Action Taxonomy](/specification/action-taxonomy/) specification for the full list of built-in action types.


### PR DESCRIPTION
## Summary
- Adds MCP Proxy docs: overview, installation, and configuration (policy rules, risk scoring, approval workflows, redaction, encryption)
- Replaces "coming soon" CLI Commands page with full `mcp-proxy` subcommand reference (list, inspect, verify, export, stats)
- Replaces "coming soon" Configuration page with taxonomy mappings docs and links to proxy config
- Adds MCP Proxy section to sidebar

## Test plan
- [x] Verify site builds (`pnpm --dir site build`)
- [x] Check all new pages render: `/mcp-proxy/overview/`, `/mcp-proxy/installation/`, `/mcp-proxy/configuration/`
- [x] Verify updated reference pages: `/reference/cli-commands/`, `/reference/configuration/`
- [x] Confirm sidebar shows MCP Proxy section