### PR TITLE
chore: upgrade Node.js from 22 to 24

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: site/pnpm-lock.yaml
 


### PR DESCRIPTION
Upgrades Node.js from 22 to 24 (current LTS) in site workflow.