### PR TITLE
Add reference file pointers to AGENTS.md files

### DIFF
--- a/mcp-proxy/AGENTS.md
+++ b/mcp-proxy/AGENTS.md
@@ -47,6 +47,12 @@ MCP Client → stdin/stdout → mcp-proxy → stdin/stdout → MCP Server
 - Pure Go SQLite via modernc.org/sqlite — no CGO
 - Tests sit alongside source files as `*_test.go`
 
+## Reference files
+
+- `internal/policy/engine.go` — policy evaluation: structured input/output, validation on init, composable matching logic
+- `internal/audit/classifier.go` — operation classification and risk scoring with priority ordering
+- `internal/audit/redact.go` — two-pass redaction pattern: JSON-aware key matching + regex-based secret detection
+
 ## Testing
 
 - Run `go test ./...` to execute all tests

--- a/sdk/go/AGENTS.md
+++ b/sdk/go/AGENTS.md
@@ -26,6 +26,11 @@ store/      # SQLite receipt persistence, query, stats, chain verification
 - Tests sit alongside source files as `*_test.go`
 - Pure Go SQLite via modernc.org/sqlite — no CGO
 
+## Reference files
+
+- `receipt/create.go` — pattern for receipt creation: clean input struct, single-purpose function
+- `receipt/signing.go` — Ed25519 signing and verification with proper error wrapping and spec-compliant encoding
+
 ## Testing
 
 - Run `go test ./...` to execute all tests

--- a/sdk/py/AGENTS.md
+++ b/sdk/py/AGENTS.md
@@ -43,6 +43,12 @@ tests/                 # Mirrors src structure, uses conftest.py fixtures
 - camelCase aliases exported at package level for TypeScript SDK users
 - Output must be byte-identical to the TypeScript SDK (`tests/test_cross_language.py` verifies this)
 
+## Reference files
+
+- `src/agent_receipts/receipt/signing.py` — Ed25519 signing with proper type guards, RFC 8785 canonicalization, and cross-SDK compatibility
+- `src/agent_receipts/receipt/hash.py` — RFC 8785 canonical JSON + SHA-256 hashing with detailed spec-compliance comments
+- `tests/test_cross_language.py` — cross-language test vectors: how to verify byte-identical output across SDKs
+
 ## Testing
 
 - Tests mirror `src/` structure under `tests/`

--- a/sdk/ts/AGENTS.md
+++ b/sdk/ts/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Zero runtime dependencies (Node.js built-ins only).
+
+## Commands
+
+```sh
+pnpm install        # install deps
+pnpm build          # compile (tsc → dist/)
+pnpm test           # vitest
+pnpm typecheck      # tsc --noEmit
+pnpm lint           # biome check
+pnpm lint:fix       # biome check --write
+```
+
+## Project structure
+
+```
+src/
+  receipt/
+    types.ts       # W3C Verifiable Credential types and interfaces
+    create.ts      # Receipt creation with auto-generated IDs
+    signing.ts     # Ed25519 signing and verification
+    hash.ts        # RFC 8785 canonicalization + SHA-256
+    chain.ts       # Hash chain verification
+  store/
+    store.ts       # SQLite persistence (node:sqlite)
+    verify.ts      # Chain verification against stored receipts
+  taxonomy/
+    actions.ts     # Action type definitions (15 built-in types)
+    classify.ts    # Tool call classification
+    config.ts      # Taxonomy config loading
+  test-utils/      # Shared test helpers
+  index.ts         # Public API exports
+```
+
+## Conventions
+
+- **ESM-only** (`"type": "module"`, imports use `.js` extensions)
+- **Strict TypeScript** — `strict: true`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`
+- **Zero runtime dependencies** — only `node:crypto` and `node:sqlite`
+- **Colocated tests** — `foo.ts` → `foo.test.ts` in the same directory
+- **Biome** for linting and formatting (tab indentation, double quotes)
+- **Explicit type imports** — use `import type` for type-only imports
+- **No default exports** — use named exports throughout
+- Output must be byte-identical to the Go and Python SDKs
+
+## Reference files
+
+- `src/receipt/create.ts` — receipt creation pattern: typed input, single-purpose function, JSDoc documentation
+- `src/receipt/hash.ts` — RFC 8785 canonicalization with comprehensive edge case handling
+- `src/receipt/hash.test.ts` — test structure: helper factories, edge case coverage, clear describe/it blocks
+
+## Testing
+
+- Vitest with colocated `.test.ts` files
+- Helper factories in `src/test-utils/` for receipt and stream test data
+- Receipt output must be byte-identical across SDKs — cross-language tests in `../../cross-sdk-tests/` verify this


### PR DESCRIPTION
## Summary
- Adds a **Reference files** section to `sdk/go/AGENTS.md`, `sdk/py/AGENTS.md`, and `mcp-proxy/AGENTS.md`
- Points agents and contributors to gold-standard files as patterns to follow
- Each pointer includes a brief description of why the file is exemplary

Closes #19