### PR TITLE
Add Copilot review instructions and PR template hint

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "**"
+---
+
+# General review guidelines
+
+This is the Agent Receipts monorepo — cryptographically signed audit trails for AI agent actions.
+
+## Security
+
+- Flag any real private keys, secrets, or credentials in the diff.
+- Ed25519 is the only supported signing algorithm. Flag any introduction of alternative or weaker schemes.
+- Parameters in receipts must be hashed (SHA-256), never stored in plaintext. Flag any plaintext parameter storage.
+- Flag any changes to `.github/workflows/` — these require explicit maintainer review.
+
+## Cross-SDK consistency
+
+- Receipt output must be byte-identical across Go, TypeScript, and Python SDKs.
+- Changes to receipt creation, signing, hashing, or canonical JSON in any SDK should be flagged if there are no corresponding cross-language test updates.
+
+## Code quality
+
+- Flag unused code, dead imports, and breadcrumb comments ("moved to X", "removed").
+- Prefer first-principles fixes over bandaids.
+- Flag any `TODO` or `FIXME` comments that don't reference an issue number.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo:
+  - "sdk/go/**"
+  - "mcp-proxy/**"
+---
+
+# Go review guidelines
+
+- Pure Go SQLite via modernc.org/sqlite — flag any CGO dependencies.
+- Errors must be wrapped with context (`fmt.Errorf("operation: %w", err)`). Flag bare error returns.
+- Tests sit alongside source files as `*_test.go`. Flag test files in separate directories.
+- Run `go vet ./...` before committing.
+- The mcp-proxy depends on sdk/go via a `replace` directive — changes to sdk/go should trigger mcp-proxy test verification.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "sdk/py/**"
+---
+
+# Python SDK review guidelines
+
+- Prefer `from __future__ import annotations` in new or heavily-typed modules.
+- Pydantic v2 for receipt models, frozen dataclasses for simple types.
+- Use `TYPE_CHECKING` guards for type-only imports.
+- Ruff for lint and format (line-length 88). Flag lines exceeding this.
+- Tests mirror `src/` structure under `tests/`. Flag tests placed elsewhere.
+- Output must be byte-identical to the TypeScript SDK.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "sdk/ts/**"
+---
+
+# TypeScript SDK review guidelines
+
+- ESM-only: relative imports must use `.js` extensions. Flag relative imports missing the `.js` extension (package imports and `node:` built-ins are fine).
+- Strict TypeScript: no `any`, no type assertions unless unavoidable. Flag `as` casts and `any` types.
+- Use `import type` for type-only imports (`verbatimModuleSyntax` is enabled).
+- Zero runtime dependencies — only `node:crypto` and `node:sqlite`. Flag any new dependency additions.
+- No default exports. Flag `export default`.
+- Colocated tests: `foo.ts` → `foo.test.ts` in the same directory.
+- Biome for formatting (tab indentation, double quotes).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,6 @@ Motivation — what problem does this solve?
 - [ ] Cross-language tests pass (if receipt format, signing, or hashing changed)
 - [ ] AGENTS.md updated (if project structure changed)
 - [ ] Spec changes have been reviewed by a maintainer (if applicable)
+
+> [!TIP]
+> Request a Copilot review for automated checks against project conventions.


### PR DESCRIPTION
## Summary
- Adds path-scoped Copilot review instructions (`.github/instructions/`):
  - `general.instructions.md` — security, cross-SDK consistency, code quality (applies to all files)
  - `go.instructions.md` — Go conventions (applies to `sdk/go/**` and `mcp-proxy/**`)
  - `typescript.instructions.md` — TS SDK conventions (applies to `sdk/ts/**`)
  - `python.instructions.md` — Python SDK conventions (applies to `sdk/py/**`)
- Updates PR template with a tip to request Copilot review