### PR TITLE
Add Claude Code hooks for deterministic guardrails

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Lint files after Claude edits them.
+# Runs the appropriate linter based on file path and extension.
+# Exit 0: linting passed (or not applicable). Exit 2: linting failed.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "lint-on-edit: jq is not installed; skipping lint hook" >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+# Determine which component was edited and run the appropriate linter
+case "$FILE_PATH" in
+  */sdk/go/* | */mcp-proxy/*)
+    if [[ "$FILE_PATH" == *.go ]]; then
+      COMPONENT_DIR=$(echo "$FILE_PATH" | sed -E 's|(.*/(sdk/go|mcp-proxy))(/.*)?|\1|')
+      cd "$COMPONENT_DIR"
+      BAD=$(gofmt -l "$FILE_PATH")
+      if [ -n "$BAD" ]; then
+        gofmt -d "$FILE_PATH" >&2
+        echo "gofmt: $FILE_PATH needs formatting" >&2
+        exit 2
+      fi
+    fi
+    ;;
+  */sdk/ts/*)
+    if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.js ]]; then
+      cd "$PROJECT_DIR/sdk/ts"
+      pnpm exec biome check "$FILE_PATH" >&2 || { echo "biome: $FILE_PATH has issues" >&2; exit 2; }
+    fi
+    ;;
+  */sdk/py/*)
+    if [[ "$FILE_PATH" == *.py ]]; then
+      cd "$PROJECT_DIR/sdk/py"
+      uv run ruff check "$FILE_PATH" >&2 || { echo "ruff: $FILE_PATH has issues" >&2; exit 2; }
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run tests before git push.
+# Detects which components have committed changes relative to the upstream
+# branch and runs their tests.
+# Exit 0: tests passed. Exit 2: tests failed.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+FAILED=0
+
+get_changed_files() {
+  cd "$PROJECT_DIR"
+  if git rev-parse --verify '@{upstream}' >/dev/null 2>&1; then
+    git diff --name-only '@{upstream}'..HEAD
+    return
+  fi
+
+  local default_branch_ref merge_base
+  default_branch_ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$default_branch_ref" ]; then
+    merge_base=$(git merge-base "$default_branch_ref" HEAD 2>/dev/null || true)
+    if [ -n "$merge_base" ]; then
+      git diff --name-only "$merge_base"..HEAD
+      return
+    fi
+  fi
+
+  # No comparison base — run all test suites to be safe
+  printf '%s\n' "sdk/go/" "sdk/ts/" "sdk/py/" "mcp-proxy/"
+}
+
+CHANGED_FILES=$(get_changed_files)
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+run_if_changed() {
+  local pattern="$1"
+  local dir="$2"
+  shift 2
+
+  if echo "$CHANGED_FILES" | grep -q "$pattern"; then
+    echo "Running tests: $dir" >&2
+    (cd "$PROJECT_DIR/$dir" && "$@") >&2 || FAILED=1
+  fi
+}
+
+run_if_changed "^sdk/go/" "sdk/go" go test ./...
+run_if_changed "^sdk/ts/" "sdk/ts" pnpm test
+run_if_changed "^sdk/py/" "sdk/py" uv run pytest
+run_if_changed "^mcp-proxy/" "mcp-proxy" go test ./...
+
+# mcp-proxy also depends on sdk/go
+if echo "$CHANGED_FILES" | grep -q "^sdk/go/" && ! echo "$CHANGED_FILES" | grep -q "^mcp-proxy/"; then
+  echo "Running tests: mcp-proxy (sdk/go dependency changed)" >&2
+  (cd "$PROJECT_DIR/mcp-proxy" && go test ./...) >&2 || FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "Tests failed — fix before pushing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-on-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git push*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/test-before-push.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with two hooks:
  - **PostToolUse** (Write|Edit): runs language-appropriate linter after every file edit (gofmt, biome, ruff)
  - **PreToolUse** (Bash `git push`): runs tests for changed components before push, including cross-dependency checks (sdk/go → mcp-proxy)
- Hook scripts in `.claude/hooks/` — lint-on-edit.sh and test-before-push.sh
- Unlike AGENTS.md rules which are advisory, hooks always execute deterministically

Closes #23