### PR TITLE
Add shellcheck to pre-commit, Claude Code lint hook, and CI

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -45,6 +45,13 @@ case "$FILE_PATH" in
       uv run ruff check "$FILE_PATH" >&2 || { echo "ruff: $FILE_PATH has issues" >&2; exit 2; }
     fi
     ;;
+  *.sh)
+    if command -v shellcheck >/dev/null 2>&1; then
+      shellcheck "$FILE_PATH" >&2 || { echo "shellcheck: $FILE_PATH has issues" >&2; exit 2; }
+    else
+      echo "lint-on-edit: shellcheck not installed; skipping lint for $FILE_PATH" >&2
+    fi
+    ;;
 esac
 
 exit 0

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+name: "CI: shellcheck"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.sh"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.sh"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck on all shell scripts
+        run: find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*' -print0 | xargs -0 --no-run-if-empty shellcheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,6 +40,10 @@ pre-commit:
       glob: "*.{py,toml}"
       run: uv run ruff format --check .
 
+    - name: shellcheck
+      glob: "*.sh"
+      run: command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo "shellcheck not installed — skipping"
+
 pre-push:
   parallel: true
   jobs:


### PR DESCRIPTION
## Summary
- Adds `shellcheck` job to Lefthook pre-commit (graceful skip if not installed)
- Adds `*.sh` case to Claude Code lint-on-edit hook (graceful skip if not installed)
- Adds `.github/workflows/shellcheck.yml` — path-filtered CI check that hard-fails on shellcheck violations
- Three layers: Lefthook (local), Claude Code hook (agent edits), CI (enforced)

Verified: all `.claude/hooks/*.sh` scripts pass `shellcheck` as-is.