### PR TITLE
Add links table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 </div>
 
+| | |
+|---|---|
+| **Project site & docs** | [agentreceipts.ai](https://agentreceipts.ai) |
+| **API reference** | [Go](https://agentreceipts.ai/sdk-go/api-reference/) · [TypeScript](https://agentreceipts.ai/sdk-ts/api-reference/) · [Python](https://agentreceipts.ai/sdk-py/api-reference/) |
+| **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) |
+| **npm** | [@agnt-rcpt/sdk-ts](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts) |
+| **PyPI** | [agent-receipts](https://pypi.org/project/agent-receipts/) |
+
 ---
 
 ## What is this?


### PR DESCRIPTION
## Summary
- Adds a quick-reference links table to the top of README.md (after badges, before "What is this?")
- Includes: project site & docs, per-SDK API references, blog post, npm, and PyPI links
- Package names verified from sdk/ts/package.json and sdk/py/pyproject.toml

## Test plan
- [x] Verify table renders correctly on GitHub
- [x] Confirm all links resolve