### PR TITLE
Fix npm package name references across documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Monorepo for the Agent Receipts protocol — cryptographically signed audit trai
 ```
 spec/          # Protocol specification and JSON schemas
 sdk/go/        # Go SDK (receipt, store, taxonomy)
-sdk/ts/        # TypeScript SDK (@agent-receipts/sdk-ts)
+sdk/ts/        # TypeScript SDK (@agnt-rcpt/sdk-ts)
 sdk/py/        # Python SDK (agent-receipts)
 mcp-proxy/     # MCP STDIO proxy with audit, policy, and receipts (Go)
 site/          # Documentation site (Astro)

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ signed, _ := r.Sign(privateKey)
 ### TypeScript
 
 ```bash
-npm install @agent-receipts/sdk-ts
+npm install @agnt-rcpt/sdk-ts
 ```
 
 ```typescript
-import { Receipt } from "@agent-receipts/sdk-ts";
+import { Receipt } from "@agnt-rcpt/sdk-ts";
 
 const receipt = await Receipt.create({ action: "tool_call", payload });
 const signed = await receipt.sign(privateKey);

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -198,7 +198,7 @@ from agent_receipts import (
 
 ## Cross-language compatibility
 
-This SDK produces **byte-identical** output to [`@agent-receipts/sdk-ts`](https://github.com/agent-receipts/sdk-ts):
+This SDK produces **byte-identical** output to [`@agnt-rcpt/sdk-ts`](https://github.com/agent-receipts/sdk-ts):
 
 - RFC 8785 canonical JSON matches exactly
 - SHA-256 hashes are identical
@@ -241,7 +241,7 @@ uv run pyright             # type check
 | Repository | Description |
 |:---|:---|
 | [agent-receipts/spec](https://github.com/agent-receipts/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
-| [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agent-receipts/sdk-ts)) |
+| [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
 | **agent-receipts/sdk-py** (this package) | Python SDK |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
 

--- a/site/README.md
+++ b/site/README.md
@@ -52,7 +52,7 @@ Sidebar order is controlled by `astro.config.mjs`, not by file naming.
 | Repository | Description |
 |:---|:---|
 | [agent-receipts/spec](https://github.com/agent-receipts/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
-| [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agent-receipts/sdk-ts)) |
+| [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
 | [agent-receipts/sdk-py](https://github.com/agent-receipts/sdk-py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
 | **agent-receipts/site** (this repo) | Documentation site |

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -10,7 +10,7 @@ This guide walks you through creating, signing, and verifying an Agent Receipt u
 ### 1. Install
 
 ```bash
-npm install @agent-receipts/sdk-ts
+npm install @agnt-rcpt/sdk-ts
 ```
 
 ### 2. Create and sign a receipt
@@ -21,7 +21,7 @@ import {
   generateKeyPair,
   signReceipt,
   hashReceipt,
-} from "@agent-receipts/sdk-ts";
+} from "@agnt-rcpt/sdk-ts";
 
 const keys = generateKeyPair();
 
@@ -51,7 +51,7 @@ console.log(hash);        // sha256:<hex>
 ### 3. Store and query
 
 ```typescript
-import { openStore } from "@agent-receipts/sdk-ts";
+import { openStore } from "@agnt-rcpt/sdk-ts";
 
 const store = openStore("receipts.db");
 store.insert(receipt, hash);
@@ -65,7 +65,7 @@ store.close();
 ### 4. Verify a chain
 
 ```typescript
-import { verifyChain } from "@agent-receipts/sdk-ts";
+import { verifyChain } from "@agnt-rcpt/sdk-ts";
 
 const result = verifyChain(chain, keys.publicKey);
 console.log(result.valid);   // true

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -13,7 +13,7 @@ import {
   generateKeyPair,
   hashReceipt,
   verifyChain,
-} from "@agent-receipts/sdk-ts";
+} from "@agnt-rcpt/sdk-ts";
 ```
 
 ### Functions
@@ -265,7 +265,7 @@ const VERSION: "0.1.0"
 ## Store
 
 ```typescript
-import { ReceiptStore, openStore, verifyStoredChain } from "@agent-receipts/sdk-ts";
+import { ReceiptStore, openStore, verifyStoredChain } from "@agnt-rcpt/sdk-ts";
 ```
 
 SQLite-backed receipt persistence and querying.
@@ -341,7 +341,7 @@ import {
   resolveActionType,
   loadTaxonomyConfig,
   ALL_ACTIONS,
-} from "@agent-receipts/sdk-ts";
+} from "@agnt-rcpt/sdk-ts";
 ```
 
 Action type registry and tool call classification.

--- a/site/src/content/docs/sdk-ts/installation.mdx
+++ b/site/src/content/docs/sdk-ts/installation.mdx
@@ -6,13 +6,13 @@ description: Install and configure the TypeScript SDK.
 ## Install
 
 ```bash
-npm install @agent-receipts/sdk-ts
+npm install @agnt-rcpt/sdk-ts
 ```
 
 Or with pnpm:
 
 ```bash
-pnpm add @agent-receipts/sdk-ts
+pnpm add @agnt-rcpt/sdk-ts
 ```
 
 ## Requirements

--- a/site/src/content/docs/sdk-ts/overview.mdx
+++ b/site/src/content/docs/sdk-ts/overview.mdx
@@ -3,7 +3,7 @@ title: TypeScript SDK
 description: TypeScript SDK for creating, signing, and verifying Agent Receipts.
 ---
 
-The TypeScript SDK (`@agent-receipts/sdk-ts`) provides tools for creating, signing, and verifying Agent Receipts in Node.js and browser environments.
+The TypeScript SDK (`@agnt-rcpt/sdk-ts`) provides tools for creating, signing, and verifying Agent Receipts in Node.js and browser environments.
 
 **Repository:** [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts)
 
@@ -18,7 +18,7 @@ The TypeScript SDK (`@agent-receipts/sdk-ts`) provides tools for creating, signi
 ## Quick example
 
 ```typescript
-import { createReceipt, signReceipt, generateKeyPair } from "@agent-receipts/sdk-ts";
+import { createReceipt, signReceipt, generateKeyPair } from "@agnt-rcpt/sdk-ts";
 
 const keys = generateKeyPair();
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -131,7 +131,7 @@ The canonical definitions live in [`spec/taxonomy/action-types.json`](spec/taxon
 
 | Repository | Language | Description |
 |:---|:---|:---|
-| [@agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript | SDK — receipt creation, signing, hashing, storage, taxonomy ([npm](https://www.npmjs.com/package/@agent-receipts/sdk-ts)) |
+| [@agnt-rcpt/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript | SDK — receipt creation, signing, hashing, storage, taxonomy ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | TypeScript | MCP proxy + CLI — reference implementation |
 | [agent-receipts/sdk-py](https://github.com/agent-receipts/sdk-py) | Python | SDK — receipt creation, signing, hashing, chain verification ([PyPI](https://pypi.org/project/agent-receipts/)) |
 


### PR DESCRIPTION
## Summary

- Replaced all occurrences of the incorrect npm package name `@agent-receipts/sdk-ts` with the correct `@agnt-rcpt/sdk-ts`
- Affected files: README.md, AGENTS.md, spec/README.md, site docs (overview, installation, api-reference, quick-start), site/README.md, and sdk/py/README.md
- Excludes sdk/ts/README.md (fixed separately) and sdk/ts/package-lock.json (will be regenerated)

## Test plan

- [x] Verify no remaining references to `@agent-receipts/sdk-ts` outside the two excluded files
- [x] Confirm documentation renders correctly on the site