### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/mcp-proxy.yml
+++ b/.github/workflows/mcp-proxy.yml
@@ -12,6 +12,9 @@ on:
       - "mcp-proxy/**"
       - "sdk/go/**"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "sdk/go/**"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "**/*.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: { contents: read }` to the `sdk-go`, `mcp-proxy`, and `shellcheck` CI workflows
- Restricts GITHUB_TOKEN to read-only content access, resolving CodeQL alerts about missing workflow permissions

Closes #55