### PR TITLE
Use per-installation random salt for Argon2id key derivation

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -147,13 +147,16 @@ func serve() {
 	engine := policy.NewEngine(rules)
 
 	// Encryption.
-	salt, err := auditDB.EncryptionSalt()
-	if err != nil {
-		log.Fatalf("mcp-proxy: init encryption salt: %v", err)
-	}
-	encryptor, err := audit.NewEncryptor(os.Getenv("BEACON_ENCRYPTION_KEY"), salt)
-	if err != nil {
-		log.Fatalf("mcp-proxy: init encryption: %v", err)
+	var encryptor *audit.Encryptor
+	if key := os.Getenv("BEACON_ENCRYPTION_KEY"); key != "" {
+		salt, err := auditDB.EncryptionSalt()
+		if err != nil {
+			log.Fatalf("mcp-proxy: init encryption salt: %v", err)
+		}
+		encryptor, err = audit.NewEncryptor(key, salt)
+		if err != nil {
+			log.Fatalf("mcp-proxy: init encryption: %v", err)
+		}
 	}
 
 	// Intent tracker.

--- a/mcp-proxy/internal/audit/encrypt.go
+++ b/mcp-proxy/internal/audit/encrypt.go
@@ -29,6 +29,9 @@ func NewEncryptor(passphrase string, salt []byte) (*Encryptor, error) {
 	if passphrase == "" {
 		return nil, nil
 	}
+	if len(salt) != 16 {
+		return nil, fmt.Errorf("invalid salt length: got %d, want 16", len(salt))
+	}
 	key := argon2.IDKey([]byte(passphrase), salt, 1, 64*1024, 4, 32)
 
 	block, err := aes.NewCipher(key)

--- a/mcp-proxy/internal/audit/encrypt_test.go
+++ b/mcp-proxy/internal/audit/encrypt_test.go
@@ -126,3 +126,18 @@ func TestNilEncryptorPassthrough(t *testing.T) {
 		t.Errorf("expected passthrough, got %q", got)
 	}
 }
+
+func TestNewEncryptorRejectsInvalidSalt(t *testing.T) {
+	_, err := NewEncryptor("passphrase", nil)
+	if err == nil {
+		t.Error("expected error for nil salt")
+	}
+	_, err = NewEncryptor("passphrase", []byte("short"))
+	if err == nil {
+		t.Error("expected error for short salt")
+	}
+	_, err = NewEncryptor("passphrase", []byte("this-is-too-long-for-a-salt"))
+	if err == nil {
+		t.Error("expected error for long salt")
+	}
+}

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -220,23 +220,34 @@ func (s *Store) LinkToolCallToIntent(intentID, toolCallID int64, seqOrder int) e
 }
 
 // EncryptionSalt returns the per-installation encryption salt, generating and
-// persisting a random 16-byte salt on first use.
+// persisting a random 16-byte salt on first use. Concurrent callers are safe:
+// INSERT OR IGNORE + re-SELECT ensures all callers converge on the same salt.
 func (s *Store) EncryptionSalt() ([]byte, error) {
 	var encoded string
 	err := s.db.QueryRow("SELECT value FROM metadata WHERE key = 'encryption_salt'").Scan(&encoded)
-	if err == nil {
-		return hex.DecodeString(encoded)
-	}
-	if err != sql.ErrNoRows {
+	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("query encryption salt: %w", err)
 	}
-	salt := make([]byte, 16)
-	if _, err := rand.Read(salt); err != nil {
-		return nil, fmt.Errorf("generate encryption salt: %w", err)
+	if err == sql.ErrNoRows {
+		salt := make([]byte, 16)
+		if _, err := rand.Read(salt); err != nil {
+			return nil, fmt.Errorf("generate encryption salt: %w", err)
+		}
+		encoded = hex.EncodeToString(salt)
+		if _, err := s.db.Exec("INSERT OR IGNORE INTO metadata (key, value) VALUES ('encryption_salt', ?)", encoded); err != nil {
+			return nil, fmt.Errorf("persist encryption salt: %w", err)
+		}
+		// Re-read to handle the race: another caller may have inserted first.
+		if err := s.db.QueryRow("SELECT value FROM metadata WHERE key = 'encryption_salt'").Scan(&encoded); err != nil {
+			return nil, fmt.Errorf("query persisted encryption salt: %w", err)
+		}
 	}
-	encoded = hex.EncodeToString(salt)
-	if _, err := s.db.Exec("INSERT INTO metadata (key, value) VALUES ('encryption_salt', ?)", encoded); err != nil {
-		return nil, fmt.Errorf("persist encryption salt: %w", err)
+	salt, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode encryption salt: %w", err)
+	}
+	if len(salt) != 16 {
+		return nil, fmt.Errorf("invalid encryption salt length: got %d, want 16", len(salt))
 	}
 	return salt, nil
 }

--- a/mcp-proxy/internal/audit/store_test.go
+++ b/mcp-proxy/internal/audit/store_test.go
@@ -1,6 +1,8 @@
 package audit
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 	"time"
 )
@@ -97,5 +99,63 @@ func TestInsertToolCallAllFields(t *testing.T) {
 	}
 	if approvedBy == nil || *approvedBy != "http" {
 		t.Errorf("expected approved_by = 'http', got %v", approvedBy)
+	}
+}
+
+func TestEncryptionSalt(t *testing.T) {
+	store, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// First call generates a 16-byte salt.
+	salt1, err := store.EncryptionSalt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(salt1) != 16 {
+		t.Fatalf("expected 16-byte salt, got %d", len(salt1))
+	}
+
+	// Second call returns the same salt.
+	salt2, err := store.EncryptionSalt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(salt1, salt2) {
+		t.Errorf("expected same salt on second call, got %x vs %x", salt1, salt2)
+	}
+
+	// Salt is persisted in the metadata table.
+	var encoded string
+	err = store.db.QueryRow("SELECT value FROM metadata WHERE key = 'encryption_salt'").Scan(&encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(salt1, persisted) {
+		t.Errorf("persisted salt doesn't match: %x vs %x", salt1, persisted)
+	}
+}
+
+func TestEncryptionSaltRejectsCorrupted(t *testing.T) {
+	store, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Insert a corrupted salt (wrong length).
+	if _, err := store.db.Exec("INSERT INTO metadata (key, value) VALUES ('encryption_salt', 'abcd')"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.EncryptionSalt()
+	if err == nil {
+		t.Error("expected error for corrupted salt")
 	}
 }


### PR DESCRIPTION
## Summary

- Generate a random 16-byte salt per installation, persisted in a new `metadata` table in the audit SQLite database
- Each installation derives a unique AES-256-GCM key even when using the same passphrase, preventing cross-installation precomputation attacks
- `NewEncryptor` now takes an explicit salt parameter; `Store.EncryptionSalt()` handles get-or-create
- Removes `crypto/sha256` dependency from the encryption module

Note: this changes the derived key, so existing encrypted audit data will need re-encryption.

Closes #54