### PR TITLE
chore: add Conventional Commits enforcement via convco

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,14 @@ test: add or update tests
 ci: change CI/CD configuration
 ```
 
-The `commit-msg` hook enforces this via [convco](https://convco.github.io/). Install it with:
+The `commit-msg` hook enforces this via [convco](https://convco.github.io/check/). Install it with:
 
 ```bash
-brew install convco
+brew install convco          # macOS
+cargo install convco         # Linux / Windows / any platform with Rust
 ```
+
+See the [convco installation docs](https://convco.github.io/check/installation/) for all options.
 
 ## Working with AI agents
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -72,4 +72,4 @@ pre-push:
 commit-msg:
   commands:
     conventional-commit:
-      run: convco check --from-stdin < {1}
+      run: command -v convco >/dev/null 2>&1 || { echo "convco not found — install via 'brew install convco' or see https://convco.github.io/check/"; exit 1; } && convco check --from-stdin < "{1}"


### PR DESCRIPTION
## Summary

- Adds `commit-msg` hook to `lefthook.yml` enforcing Conventional Commits via convco
- Documents commit message convention in CONTRIBUTING.md
- Applies across all monorepo components (SDKs, mcp-proxy, spec)

Companion PRs: agent-receipts/openclaw and agent-receipts/dashboard

## Test plan

- [x] `lefthook install` picks up the new commit-msg hook
- [x] Valid messages pass: `echo "feat: test" | convco check --from-stdin`
- [x] Invalid messages fail: `echo "bad message" | convco check --from-stdin`