### PR TITLE
docs: add dashboard to README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ signed = receipt.sign(private_key)
 | [`mcp-proxy/`](mcp-proxy/) | MCP proxy with receipt signing, policy engine, intent tracking |
 | [`cross-sdk-tests/`](cross-sdk-tests/) | Cross-language verification tests |
 
-## Integrations
+## Tooling
 
 | Project | Description |
 |---------|-------------|
+| [dashboard](https://github.com/agent-receipts/dashboard) | Local web UI for browsing and verifying receipt databases |
 | [openclaw](https://github.com/agent-receipts/openclaw) | Agent Receipts plugin for OpenClaw |
 
 ## Contributing

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -79,6 +79,13 @@ export default defineConfig({
           ],
         },
         {
+          label: "Dashboard",
+          items: [
+            { label: "Overview", slug: "dashboard/overview" },
+            { label: "Installation", slug: "dashboard/installation" },
+          ],
+        },
+        {
           label: "OpenClaw",
           items: [
             { label: "Overview", slug: "openclaw/overview" },

--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -1,0 +1,45 @@
+---
+title: Installation
+description: Install and run the Agent Receipts Dashboard.
+---
+
+## Install with Go
+
+```sh
+go install github.com/agent-receipts/dashboard/cmd/dashboard@latest
+```
+
+## Build from source
+
+```sh
+git clone https://github.com/agent-receipts/dashboard.git
+cd dashboard
+make build
+```
+
+## Usage
+
+Point the dashboard at a receipt database:
+
+```sh
+dashboard --db ./receipts.db
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--db` | *(required)* | Path to a receipt SQLite database |
+| `--port` | `8080` | Port to serve on |
+
+### Example
+
+```sh
+# View receipts from the MCP proxy
+dashboard --db ~/.config/ar/receipts.db
+
+# Use a custom port
+dashboard --db ./receipts.db --port 9090
+```

--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -1,0 +1,28 @@
+---
+title: Dashboard
+description: Local web UI for browsing and verifying Agent Receipt databases.
+---
+
+:::caution
+The dashboard is an early prototype. Expect rough edges and breaking changes.
+:::
+
+The Agent Receipts Dashboard is a lightweight, read-only web UI for browsing receipt databases produced by any Agent Receipts SDK or the MCP proxy. It ships as a single Go binary with no external runtime dependencies.
+
+**Repository:** [agent-receipts/dashboard](https://github.com/agent-receipts/dashboard)
+
+## Features
+
+- Browse receipts stored in any Agent Receipts SQLite database
+- Filter by action type, risk level, status, time range, and chain ID
+- Chain verification — validates hash linkage and sequence ordering
+- Receipt detail view with raw JSON
+- Dark theme with risk-level color coding
+
+## How it works
+
+The dashboard opens your SQLite receipt database in **read-only** mode and serves a web UI at localhost. It never modifies your data.
+
+All three SDKs and the MCP proxy use an identical SQLite schema for receipt storage. The dashboard reads from any of them.
+
+See [Installation](/dashboard/installation/) to get started.


### PR DESCRIPTION
## Summary

- Rename "Integrations" to "Tooling" in README and add the [dashboard](https://github.com/agent-receipts/dashboard) as a project entry
- Add Dashboard section to the docs site sidebar with overview and installation pages
- Overview page includes an "early prototype" caution banner

## Test plan

- [x] Verify docs site builds (`cd site && pnpm build`)
- [x] Check dashboard sidebar section renders correctly
- [x] Confirm README links resolve