### PR TITLE
ci: add Go module publish workflow

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Reject local replace directives
         run: |
-          go mod edit -json | python3 -c '
+          go mod edit -json | python3 - <<'PY'
           import json, re, sys
           mod = json.load(sys.stdin)
           for entry in mod.get("Replace") or []:
@@ -31,7 +31,7 @@ jobs:
                   or path.startswith("/") or re.match(r"^[A-Za-z]:[\\\\/]", path)):
                   print(f"::error::go.mod contains a local replace directive ({path}) — remove it before releasing")
                   sys.exit(1)
-          '
+          PY
 
       - run: go vet ./...
       - run: go build ./...
@@ -62,7 +62,7 @@ jobs:
 
       - name: Reject local replace directives
         run: |
-          go mod edit -json | python3 -c '
+          go mod edit -json | python3 - <<'PY'
           import json, re, sys
           mod = json.load(sys.stdin)
           for entry in mod.get("Replace") or []:
@@ -71,7 +71,7 @@ jobs:
                   or path.startswith("/") or re.match(r"^[A-Za-z]:[\\\\/]", path)):
                   print(f"::error::go.mod contains a local replace directive ({path}) — remove it before releasing")
                   sys.exit(1)
-          '
+          PY
 
       - run: go vet ./...
       - run: go build ./...


### PR DESCRIPTION
## Summary
- Add `publish-go.yml` workflow triggered by GitHub Releases
- Builds, tests, and requests pkg.go.dev indexing for `sdk/go` and `mcp-proxy` modules
- Uses matrix strategy with per-leg tag guards, matching the existing `publish-py.yml` / `publish-ts.yml` pattern
- Tags use Go's native subdirectory format: `sdk/go/v0.1.0`, `mcp-proxy/v0.1.0`
- Rejects releases if go.mod contains local replace directives
- Proxy indexing retries 3 times with warnings on failure

## Release process
```bash
gh release create sdk/go/v0.1.0 --title "sdk/go v0.1.0" --generate-notes
gh release create mcp-proxy/v0.1.0 --title "mcp-proxy v0.1.0" --generate-notes
```

Note: `mcp-proxy` releases require removing the `replace` directive in `mcp-proxy/go.mod` and pointing to a published `sdk/go` version first.

## Test plan
- [x] Publish a release with tag `sdk/go/v0.0.1-test` to confirm workflow triggers
- [x] Verify the replace directive check fails for mcp-proxy (which currently has one)
- [x] Verify pkg.go.dev indexing after a real release