### PR TITLE
chore: add release script for all modules

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,6 +23,9 @@ EOF
 
 fail() { echo "error: $1" >&2; exit 1; }
 
+# cd to repo root so the script works from any directory
+cd "$(git rev-parse --show-toplevel)"
+
 # Preflight: ensure common tools are available
 command -v git >/dev/null 2>&1 || fail "git is not installed"
 command -v gh >/dev/null 2>&1 || fail "gh CLI is not installed — see https://cli.github.com"
@@ -47,6 +50,13 @@ REMOTE=$(git rev-parse origin/main)
 
 # Ensure working tree is clean
 [[ -z "$(git status --porcelain)" ]] || fail "working tree is not clean — commit or stash changes first"
+
+# Go modules don't support build metadata in tags
+case "$MODULE" in
+  sdk-go|mcp-proxy)
+    [[ "$VERSION" != *+* ]] || fail "Go module versions cannot contain build metadata (+...)"
+    ;;
+esac
 
 case "$MODULE" in
   sdk-go)


### PR DESCRIPTION
## Summary
- Add `scripts/release.sh` to standardize the release process across all modules
- Validates: on main, clean tree, semver format, tag doesn't exist
- Module-specific checks:
  - **sdk-go / mcp-proxy**: `go vet`, `go test`
  - **mcp-proxy**: rejects if `replace` directive is present in go.mod
  - **sdk-ts**: validates package.json version matches, runs typecheck + test + build
  - **sdk-py**: validates pyproject.toml version matches, runs pytest
- Creates GitHub Release with the correct tag format per module
- Prompts for confirmation before creating the release

## Usage
```bash
./scripts/release.sh sdk-go 0.2.0
./scripts/release.sh sdk-ts 0.3.0
./scripts/release.sh mcp-proxy 0.1.0
```

## Test plan
- [ ] Run `./scripts/release.sh` with no args — should show usage
- [ ] Run on a non-main branch — should fail
- [ ] Run with dirty working tree — should fail
- [ ] Run with existing tag — should fail
- [ ] Run `./scripts/release.sh sdk-go 0.1.0` — should fail (tag exists)