### PR TITLE
docs: add pkg.go.dev link and vendor dashboard screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | **Project site & docs** | [agentreceipts.ai](https://agentreceipts.ai) |
 | **API reference** | [Go](https://agentreceipts.ai/sdk-go/api-reference/) · [TypeScript](https://agentreceipts.ai/sdk-ts/api-reference/) · [Python](https://agentreceipts.ai/sdk-py/api-reference/) |
 | **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) |
+| **Go** | [agent-receipts/ar/sdk/go](https://pkg.go.dev/github.com/agent-receipts/ar/sdk/go) |
 | **npm** | [@agnt-rcpt/sdk-ts](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts) |
 | **PyPI** | [agent-receipts](https://pypi.org/project/agent-receipts/) |
 | **Dashboard** | [agent-receipts/dashboard](https://github.com/agent-receipts/dashboard) |


### PR DESCRIPTION
## Summary
- Add a **Go** (pkg.go.dev) row to the README quick-links table, now that `sdk/go/v0.1.0` is published
- Vendor the dashboard screenshot into `site/public/images/` instead of hotlinking from `raw.githubusercontent.com` (addresses review feedback from PR #67)

## Test plan
- [x] Verify Go link renders in README quick-links table
- [x] Verify screenshot loads on the docs site dashboard overview page