### PR TITLE
chore: prepare mcp-proxy for first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | **Project site & docs** | [agentreceipts.ai](https://agentreceipts.ai) |
 | **API reference** | [Go](https://agentreceipts.ai/sdk-go/api-reference/) · [TypeScript](https://agentreceipts.ai/sdk-ts/api-reference/) · [Python](https://agentreceipts.ai/sdk-py/api-reference/) |
 | **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) |
-| **Go** | [agent-receipts/ar/sdk/go](https://pkg.go.dev/github.com/agent-receipts/ar/sdk/go) |
+| **Go** | [sdk/go](https://pkg.go.dev/github.com/agent-receipts/ar/sdk/go) · [mcp-proxy](https://pkg.go.dev/github.com/agent-receipts/ar/mcp-proxy) |
 | **npm** | [@agnt-rcpt/sdk-ts](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts) |
 | **PyPI** | [agent-receipts](https://pypi.org/project/agent-receipts/) |
 | **Dashboard** | [agent-receipts/dashboard](https://github.com/agent-receipts/dashboard) |

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -20,5 +20,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/agent-receipts/ar/sdk/go => ../sdk/go

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,3 +1,5 @@
+github.com/agent-receipts/ar/sdk/go v0.1.0 h1:7VHCMXASLc7Rd3eGXfq2bEmdKiTv7yJ2Lxpazqnmjdw=
+github.com/agent-receipts/ar/sdk/go v0.1.0/go.mod h1:FBU6hYSzi/aZMU+pcwdixy4OdvbtJ4qzUHfMw6l5Wn0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary
- Remove the local `replace` directive from `mcp-proxy/go.mod` — it now depends on the published `sdk/go v0.1.0`
- Add mcp-proxy pkg.go.dev link to the Go row in the README quick-links table

## Follow-up
After merge, create the first mcp-proxy release:
```bash
./scripts/release.sh mcp-proxy 0.1.0
```

## Test plan
- [x] mcp-proxy builds and tests pass without the replace directive
- [x] Verify mcp-proxy correctly resolves sdk/go v0.1.0 from the module proxy