### PR TITLE
docs: add doc.go for pkg.go.dev documentation

### DIFF
--- a/sdk/go/receipt/doc.go
+++ b/sdk/go/receipt/doc.go
@@ -1,0 +1,7 @@
+/*
+Package receipt provides tools to create, sign, and verify Agent Receipts.
+
+It implements the core protocol for cryptographically signed audit trails of AI agent actions.
+It supports Ed25519 signatures, W3C Verifiable Credentials-like structures, and hash-chaining.
+*/
+package receipt

--- a/sdk/go/store/doc.go
+++ b/sdk/go/store/doc.go
@@ -1,0 +1,6 @@
+/*
+Package store provides persistence for Agent Receipts.
+
+It currently supports SQLite-backed receipt storage, querying, and verification of receipt chains.
+*/
+package store

--- a/sdk/go/taxonomy/doc.go
+++ b/sdk/go/taxonomy/doc.go
@@ -1,0 +1,6 @@
+/*
+Package taxonomy provides a classification system for AI agent actions.
+
+It maps tool calls to standard action types and risk levels, enabling fine-grained policy enforcement.
+*/
+package taxonomy


### PR DESCRIPTION
Added doc.go files to the Go SDK packages (`receipt`, `store`, `taxonomy`) to improve documentation on pkg.go.dev. Fixes #73.