### PR TITLE
chore: add Dependabot config for all package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /sdk/ts
+    schedule:
+      interval: weekly
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /sdk/go
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /mcp-proxy
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /cross-sdk-tests
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /sdk/py
+    schedule:
+      interval: weekly
+    groups:
+      pip:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering all package directories
- Enables auto-PR creation for security and version updates (this was missing — alert #7 hung because Dependabot had no config to generate PRs)
- Covers: `sdk/ts` (npm), `sdk/go` (gomod), `sdk/py` (pip), `mcp-proxy` (gomod), `cross-sdk-tests` (gomod), `site` (npm), GitHub Actions
- Groups updates per ecosystem to reduce PR noise
- Weekly schedule for all ecosystems