### PR TITLE
chore: SHA-pin all GitHub Actions for supply chain security

### DIFF
--- a/.github/workflows/cross-sdk-tests.yml
+++ b/.github/workflows/cross-sdk-tests.yml
@@ -24,9 +24,9 @@ jobs:
       run:
         working-directory: cross-sdk-tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.22"
 

--- a/.github/workflows/mcp-proxy.yml
+++ b/.github/workflows/mcp-proxy.yml
@@ -22,9 +22,9 @@ jobs:
       run:
         working-directory: mcp-proxy
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.22"
 

--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -15,8 +15,8 @@ jobs:
       run:
         working-directory: sdk/go
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: sdk/go/go.mod
 
@@ -55,8 +55,8 @@ jobs:
       run:
         working-directory: mcp-proxy
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: mcp-proxy/go.mod
 

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.13"
 
       - run: uv build
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: sdk/py/dist/

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -24,9 +24,9 @@ jobs:
       run:
         working-directory: sdk/go
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.22"
 

--- a/.github/workflows/sdk-py.yml
+++ b/.github/workflows/sdk-py.yml
@@ -25,9 +25,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sdk-ts.yml
+++ b/.github/workflows/sdk-ts.yml
@@ -21,15 +21,15 @@ jobs:
         working-directory: sdk/ts
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
 
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run shellcheck on all shell scripts
         run: find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*' -print0 | xargs -0 --no-run-if-empty shellcheck

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           cache: pnpm
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: site/dist
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: spec
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate JSON syntax
         run: |


### PR DESCRIPTION
## Summary

- SHA-pin every third-party and first-party GitHub Action across all 11 workflow files
- Human-readable version tags preserved as inline `# v6` comments for maintainability
- Prevents tag-based supply chain attacks (a compromised or force-pushed tag silently changing CI/CD code)

### Pinned actions

| Action | SHA | Tag |
|---|---|---|
| `actions/checkout` | `de0fac2e...` | v6 |
| `actions/setup-node` | `53b83947...` | v6 |
| `actions/setup-go` | `4a360112...` | v6 |
| `actions/upload-pages-artifact` | `7b1f4a76...` | v4 |
| `actions/deploy-pages` | `cd2ce8fc...` | v5 |
| `pnpm/action-setup` | `fc06bc12...` | v5 |
| `astral-sh/setup-uv` | `37802adc...` | v7 |
| `pypa/gh-action-pypi-publish` | `cef22109...` | release/v1 |

### Background

Even official GitHub Actions are not immune to supply chain attacks — the [tj-actions/changed-files incident (Mar 2025)](https://github.com/advisories/GHSA-mcph-m25j-8mfq) demonstrated that mutable tags can be hijacked. SHA-pinning ensures immutability: the exact code reviewed today is the code that runs tomorrow.

## Test plan

- [ ] Verify all workflows pass on this branch (no functional change, only ref format)
- [ ] Spot-check a few SHAs match the expected tags via `gh api repos/OWNER/REPO/git/ref/tags/TAG`