### PR TITLE
ci: fix publish-go workflow Go version

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version-file: sdk/go/go.mod
+          go-version: "1.26"
 
       - name: Reject local replace directives
         run: |
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version-file: mcp-proxy/go.mod
+          go-version: "1.26"
 
       - name: Reject local replace directives
         run: |


### PR DESCRIPTION
## Summary
- Replaces `go-version-file` with explicit `go-version: "1.26"` in the publish-go workflow
- The `setup-go` action couldn't parse `go.mod` requiring Go 1.26.1, causing the mcp-proxy v0.1.1 publish to fail

## Test plan
- [x] Merge, then re-run the mcp-proxy/v0.1.1 release publish workflow