### PR TITLE
fix(ci): fix publish-go heredoc/pipe conflict

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Reject local replace directives
         run: |
-          go mod edit -json | python3 - <<'PY'
+          go mod edit -json | python3 -c '
           import json, re, sys
           mod = json.load(sys.stdin)
           for entry in mod.get("Replace") or []:
@@ -31,7 +31,7 @@ jobs:
                   or path.startswith("/") or re.match(r"^[A-Za-z]:[\\\\/]", path)):
                   print(f"::error::go.mod contains a local replace directive ({path}) — remove it before releasing")
                   sys.exit(1)
-          PY
+          '
 
       - run: go vet ./...
       - run: go build ./...
@@ -62,7 +62,7 @@ jobs:
 
       - name: Reject local replace directives
         run: |
-          go mod edit -json | python3 - <<'PY'
+          go mod edit -json | python3 -c '
           import json, re, sys
           mod = json.load(sys.stdin)
           for entry in mod.get("Replace") or []:
@@ -71,7 +71,7 @@ jobs:
                   or path.startswith("/") or re.match(r"^[A-Za-z]:[\\\\/]", path)):
                   print(f"::error::go.mod contains a local replace directive ({path}) — remove it before releasing")
                   sys.exit(1)
-          PY
+          '
 
       - run: go vet ./...
       - run: go build ./...


### PR DESCRIPTION
## Summary
- The publish-go workflow used `go mod edit -json | python3 - <<'PY'` which has a pipe and heredoc competing for python's stdin
- The heredoc wins, so `json.load(sys.stdin)` gets empty input and crashes with `JSONDecodeError`
- Fix: use `python3 -c '...'` to pass the script as a CLI argument, leaving stdin free for the pipe

This has been broken since the workflow was created — affects both sdk-go and mcp-proxy publish jobs.

## Test plan
- [x] Merge, delete + recreate the `mcp-proxy/v0.1.1` release to trigger the workflow