### PR TITLE
docs: fix CLI flag syntax in mcp-proxy docs

### DIFF
--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -7,16 +7,16 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--db` | `audit.db` | SQLite audit database path |
-| `--receipt-db` | `receipts.db` | SQLite receipt store path |
-| `--key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
-| `--taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
-| `--rules` | (built-in defaults) | Policy rules YAML file |
-| `--name` | (inferred from command) | Server name for the audit trail |
-| `--issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
-| `--principal` | `did:user:unknown` | Principal DID for receipts |
-| `--chain` | (auto UUID) | Chain ID for receipt chaining |
-| `--http` | `127.0.0.1:8080` | HTTP address for the approval endpoint |
+| `-db` | `audit.db` | SQLite audit database path |
+| `-receipt-db` | `receipts.db` | SQLite receipt store path |
+| `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
+| `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
+| `-rules` | (built-in defaults) | Policy rules YAML file |
+| `-name` | (inferred from command) | Server name for the audit trail |
+| `-issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
+| `-principal` | `did:user:unknown` | Principal DID for receipts |
+| `-chain` | (auto UUID) | Chain ID for receipt chaining |
+| `-http` | `127.0.0.1:8080` | HTTP address for the approval endpoint |
 
 ## Policy rules
 
@@ -89,7 +89,7 @@ Tool names are classified by prefix (case-insensitive):
 | read | get\_, read\_, list\_, search\_, describe\_, show\_ |
 | unknown | (fallback) |
 
-For more precise classification, provide a `--taxonomy` JSON file mapping tool names to action types from the Agent Receipts taxonomy.
+For more precise classification, provide a `-taxonomy` JSON file mapping tool names to action types from the Agent Receipts taxonomy.
 
 ## Approval workflow
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -11,21 +11,21 @@ List receipts from the audit store.
 
 ```bash
 mcp-proxy list                            # all receipts
-mcp-proxy list --risk high                # filter by risk level
-mcp-proxy list --action read_file         # filter by action type
-mcp-proxy list --chain <chain-id>         # filter by chain
-mcp-proxy list --limit 100               # limit results
-mcp-proxy list --json                     # JSON output
+mcp-proxy list -risk high                 # filter by risk level
+mcp-proxy list -action read_file          # filter by action type
+mcp-proxy list -chain <chain-id>          # filter by chain
+mcp-proxy list -limit 100                 # limit results
+mcp-proxy list -json                      # JSON output
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--risk` | Filter by risk level: `low`, `medium`, `high`, `critical` |
-| `--action` | Filter by action type |
-| `--chain` | Filter by chain ID |
-| `--limit` | Maximum number of receipts to return |
-| `--json` | Output as JSON |
-| `--db` | Receipt store path (default: `receipts.db`) |
+| `-risk` | Filter by risk level: `low`, `medium`, `high`, `critical` |
+| `-action` | Filter by action type |
+| `-chain` | Filter by chain ID |
+| `-limit` | Maximum number of receipts to return |
+| `-json` | Output as JSON |
+| `-receipt-db` | Receipt store path (default: `receipts.db`) |
 
 ## `mcp-proxy inspect`
 
@@ -33,26 +33,26 @@ Show details for a single receipt.
 
 ```bash
 mcp-proxy inspect <receipt-id>
-mcp-proxy inspect --key public.pem <receipt-id>   # verify signature
+mcp-proxy inspect -key public.pem <receipt-id>   # verify signature
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--key` | Public key PEM file to verify the receipt signature |
-| `--db` | Receipt store path (default: `receipts.db`) |
+| `-key` | Public key PEM file to verify the receipt signature |
+| `-receipt-db` | Receipt store path (default: `receipts.db`) |
 
 ## `mcp-proxy verify`
 
 Verify the integrity of a receipt chain -- checks signatures, hash linkage, and sequence numbers.
 
 ```bash
-mcp-proxy verify --key public.pem <chain-id>
+mcp-proxy verify -key public.pem <chain-id>
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--key` | Public key PEM file (required) |
-| `--db` | Receipt store path (default: `receipts.db`) |
+| `-key` | Public key PEM file (required) |
+| `-receipt-db` | Receipt store path (default: `receipts.db`) |
 
 ## `mcp-proxy export`
 
@@ -65,7 +65,7 @@ mcp-proxy export <chain-id> > chain.json
 
 | Flag | Description |
 |------|-------------|
-| `--db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `receipts.db`) |
 
 ## `mcp-proxy stats`
 
@@ -73,10 +73,10 @@ Show aggregate statistics about the audit store.
 
 ```bash
 mcp-proxy stats
-mcp-proxy stats --json
+mcp-proxy stats -json
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Output as JSON |
-| `--db` | Receipt store path (default: `receipts.db`) |
+| `-json` | Output as JSON |
+| `-receipt-db` | Receipt store path (default: `receipts.db`) |


### PR DESCRIPTION
## Summary
- Changes double-dash flags (`--flag`) to single-dash (`-flag`) to match Go's `flag` package convention
- Fixes `--db` → `-receipt-db` in all subcommand docs (list, inspect, verify, export, stats) — the actual flag in `cli.go` is `receipt-db`, not `db`
- Updates both `configuration.mdx` and `cli-commands.mdx`

Also filed #106 for the same issue in the dashboard installation docs.

## Test plan
- [x] Grepped both files — no remaining `--` flag references
- [x] Verified all flag names match Go source in `main.go` and `cli.go`

Closes #101