### PR TITLE
chore: bump sdk/go to v0.2.0 in mcp-proxy

### DIFF
--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/mcp-proxy
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.1.0
+	github.com/agent-receipts/ar/sdk/go v0.2.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.1.0 h1:7VHCMXASLc7Rd3eGXfq2bEmdKiTv7yJ2Lxpazqnmjdw=
-github.com/agent-receipts/ar/sdk/go v0.1.0/go.mod h1:FBU6hYSzi/aZMU+pcwdixy4OdvbtJ4qzUHfMw6l5Wn0=
+github.com/agent-receipts/ar/sdk/go v0.2.0 h1:A6sWLq7TCJg1/GXSd+MSfJQeuTQ9wdBLrDJQu0XiLRA=
+github.com/agent-receipts/ar/sdk/go v0.2.0/go.mod h1:RrF1FArgaVJ64rO/eDe8sH5p76zUKl3GGrHw6taccbg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Update mcp-proxy to use the newly released sdk/go v0.2.0.