### PR TITLE
chore: bump versions for v0.3.0 release

### DIFF
--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -2,10 +2,8 @@ module github.com/agent-receipts/ar/mcp-proxy
 
 go 1.26.1
 
-replace github.com/agent-receipts/ar/sdk/go => ../sdk/go
-
 require (
-	github.com/agent-receipts/ar/sdk/go v0.2.0
+	github.com/agent-receipts/ar/sdk/go v0.3.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.2.0 h1:A6sWLq7TCJg1/GXSd+MSfJQeuTQ9wdBLrDJQu0XiLRA=
-github.com/agent-receipts/ar/sdk/go v0.2.0/go.mod h1:RrF1FArgaVJ64rO/eDe8sH5p76zUKl3GGrHw6taccbg=
+github.com/agent-receipts/ar/sdk/go v0.3.0 h1:pKrOeVWL53fmbU8XgmkTNggsCrfyua5jCcoIjVwydrA=
+github.com/agent-receipts/ar/sdk/go v0.3.0/go.mod h1:RrF1FArgaVJ64rO/eDe8sH5p76zUKl3GGrHw6taccbg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.2.3"
+version = "0.3.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## Summary
- Bump sdk/ts `package.json` version: 0.2.2 → 0.3.0
- Bump sdk/py `pyproject.toml` version: 0.2.3 → 0.3.0
- Remove `replace` directive from mcp-proxy `go.mod`, update sdk/go dependency to v0.3.0

## Release order
1. **Tag `sdk/go/v0.3.0`** on main first (before merging this PR)
2. **Merge this PR**
3. Run `scripts/release.sh` for: `sdk-ts 0.3.0`, `sdk-py 0.3.0`, `mcp-proxy 0.2.0`