### PR TITLE
chore: update uv.lock

### DIFF
--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Lockfile updated during sdk-py v0.3.0 release.