### PR TITLE
docs: fix single-dash flags in mcp-proxy examples

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -32,6 +32,7 @@ jobs:
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           package_json_file: site/package.json
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -39,14 +40,6 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: site/pnpm-lock.yaml
-
-      - name: Debug pnpm
-        run: |
-          pnpm --version
-          which pnpm
-          head -10 pnpm-lock.yaml
-          grep -c "^---$" pnpm-lock.yaml || true
-          grep -c "lockfileVersion" pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
-          version: "9.15.9"
+          package_json_file: site/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Install pnpm
         run: corepack enable && corepack install
-        working-directory: .
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
-          version: 9
+          version: "9.15.9"
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,18 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
-        with:
-          package_json_file: site/package.json
-          standalone: true
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
-          cache: pnpm
-          cache-dependency-path: site/pnpm-lock.yaml
+
+      - name: Install pnpm
+        run: corepack enable && corepack install
+        working-directory: .
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -40,6 +40,14 @@ jobs:
           cache: pnpm
           cache-dependency-path: site/pnpm-lock.yaml
 
+      - name: Debug pnpm
+        run: |
+          pnpm --version
+          which pnpm
+          head -10 pnpm-lock.yaml
+          grep -c "^---$" pnpm-lock.yaml || true
+          grep -c "lockfileVersion" pnpm-lock.yaml
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -76,6 +76,8 @@ export default defineConfig({
             { label: "Overview", slug: "mcp-proxy/overview" },
             { label: "Installation", slug: "mcp-proxy/installation" },
             { label: "Configuration", slug: "mcp-proxy/configuration" },
+            { label: "Claude Desktop", slug: "mcp-proxy/claude-desktop" },
+            { label: "Claude Code", slug: "mcp-proxy/claude-code" },
           ],
         },
         {

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
             { label: "Configuration", slug: "mcp-proxy/configuration" },
             { label: "Claude Desktop", slug: "mcp-proxy/claude-desktop" },
             { label: "Claude Code", slug: "mcp-proxy/claude-code" },
+            { label: "Codex", slug: "mcp-proxy/codex" },
           ],
         },
         {

--- a/site/package.json
+++ b/site/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38
-        version: 0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
+        version: 0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
       astro:
         specifier: ^6
-        version: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
+        version: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
       sharp:
         specifier: ^0.34
         version: 0.34.5
@@ -403,41 +403,41 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@pagefind/darwin-arm64@1.5.0':
-    resolution: {integrity: sha512-OXQVlxALU9+Lz/LxkAa+RvaxY1cnRKUDCuwl9o8PY5Lg/znP573y4WIbVOOIz8Bv7uj7r00TGy7pD+NSLMJGBw==}
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pagefind/darwin-x64@1.5.0':
-    resolution: {integrity: sha512-+LK1Xq5n/B0hHc08DW61SnfIlfLKyXZ1oKcbfZ1MimE7Rn0Q6R0VI/TlC04f/JDPm+67zAOwPGizzvefOi5vqQ==}
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
     cpu: [x64]
     os: [darwin]
 
-  '@pagefind/default-ui@1.5.0':
-    resolution: {integrity: sha512-C8VZ5pDz1Kc89GicXsWZiIlAwTVwUtFDOzh0RzJt5FmbkJzsmPVICPkLUfOsWgBCyFAH/vYR+lUTaGPDxZ4IXw==}
+  '@pagefind/default-ui@1.5.2':
+    resolution: {integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==}
 
-  '@pagefind/freebsd-x64@1.5.0':
-    resolution: {integrity: sha512-kicDfUF9gn/z06NimTwNlZXF8z3pLsN3BIPPt6N8unuh0n55fr64tVs2p3a5RKYmQkJGjPfOE/C9GI5YTEpURg==}
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@pagefind/linux-arm64@1.5.0':
-    resolution: {integrity: sha512-e5rDB3wPm89bcSLiatKBDTrVTbsMQrrtkXRaAoUJYU0C1suXVvEzZfjmMvrUDvYhZBx/Ls8hGuGxlqSJBz3gDg==}
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
     cpu: [arm64]
     os: [linux]
 
-  '@pagefind/linux-x64@1.5.0':
-    resolution: {integrity: sha512-vh52DcBiF/mRMmq+Rwt3M3RgEWgl00jFk/M5NWhLEHJFq4+papQXwbyKbi7cNlxaeYrKx6wOfW3fm9cftfc/Kg==}
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
     cpu: [x64]
     os: [linux]
 
-  '@pagefind/windows-arm64@1.5.0':
-    resolution: {integrity: sha512-kg+szZwffZdyWn6SL6RHjAYjhSvJ2bT4qkv3KepGsbmD9fuSHUSC+2kydDneDVUA9qEDRf9uSFoEAsXsp1/JKA==}
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
     cpu: [arm64]
     os: [win32]
 
-  '@pagefind/windows-x64@1.5.0':
-    resolution: {integrity: sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg==}
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
 
@@ -1329,8 +1329,8 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  pagefind@1.5.0:
-    resolution: {integrity: sha512-7vQ2xh0ZmjPjsuWONR68nqzb+QNfpPh7pdT6n6YDAthWAQiUkSACVegSswY5zPNONGYFWebFVgdnS5/m/Qqn+w==}
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
     hasBin: true
 
   parse-entities@4.0.2:
@@ -1561,11 +1561,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -1794,12 +1789,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))':
+  '@astrojs/mdx@5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -1823,17 +1818,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))':
+  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
+      '@astrojs/mdx': 5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
       '@astrojs/sitemap': 3.7.2
-      '@pagefind/default-ui': 1.5.0
+      '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
-      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
+      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -1846,7 +1841,7 @@ snapshots:
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
-      pagefind: 1.5.0
+      pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
       remark-directive: 3.0.1
@@ -2140,27 +2135,27 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@pagefind/darwin-arm64@1.5.0':
+  '@pagefind/darwin-arm64@1.5.2':
     optional: true
 
-  '@pagefind/darwin-x64@1.5.0':
+  '@pagefind/darwin-x64@1.5.2':
     optional: true
 
-  '@pagefind/default-ui@1.5.0': {}
+  '@pagefind/default-ui@1.5.2': {}
 
-  '@pagefind/freebsd-x64@1.5.0':
+  '@pagefind/freebsd-x64@1.5.2':
     optional: true
 
-  '@pagefind/linux-arm64@1.5.0':
+  '@pagefind/linux-arm64@1.5.2':
     optional: true
 
-  '@pagefind/linux-x64@1.5.0':
+  '@pagefind/linux-x64@1.5.2':
     optional: true
 
-  '@pagefind/windows-arm64@1.5.0':
+  '@pagefind/windows-arm64@1.5.2':
     optional: true
 
-  '@pagefind/windows-x64@1.5.0':
+  '@pagefind/windows-x64@1.5.2':
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
@@ -2380,12 +2375,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)):
+  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)):
     dependencies:
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
       rehype-expressive-code: 0.41.7
 
-  astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3):
+  astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -2430,7 +2425,7 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -3506,15 +3501,15 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.5.0:
+  pagefind@1.5.2:
     optionalDependencies:
-      '@pagefind/darwin-arm64': 1.5.0
-      '@pagefind/darwin-x64': 1.5.0
-      '@pagefind/freebsd-x64': 1.5.0
-      '@pagefind/linux-arm64': 1.5.0
-      '@pagefind/linux-x64': 1.5.0
-      '@pagefind/windows-arm64': 1.5.0
-      '@pagefind/windows-x64': 1.5.0
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
 
   parse-entities@4.0.2:
     dependencies:
@@ -3879,14 +3874,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
+  tsconfck@3.1.6: {}
 
   tslib@2.8.1:
-    optional: true
-
-  typescript@5.9.3:
     optional: true
 
   ufo@1.6.3: {}

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38
-        version: 0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
+        version: 0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
       astro:
         specifier: ^6
-        version: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
+        version: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
       sharp:
         specifier: ^0.34
         version: 0.34.5
@@ -403,41 +403,41 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@pagefind/darwin-arm64@1.5.2':
-    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+  '@pagefind/darwin-arm64@1.5.0':
+    resolution: {integrity: sha512-OXQVlxALU9+Lz/LxkAa+RvaxY1cnRKUDCuwl9o8PY5Lg/znP573y4WIbVOOIz8Bv7uj7r00TGy7pD+NSLMJGBw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pagefind/darwin-x64@1.5.2':
-    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+  '@pagefind/darwin-x64@1.5.0':
+    resolution: {integrity: sha512-+LK1Xq5n/B0hHc08DW61SnfIlfLKyXZ1oKcbfZ1MimE7Rn0Q6R0VI/TlC04f/JDPm+67zAOwPGizzvefOi5vqQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@pagefind/default-ui@1.5.2':
-    resolution: {integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==}
+  '@pagefind/default-ui@1.5.0':
+    resolution: {integrity: sha512-C8VZ5pDz1Kc89GicXsWZiIlAwTVwUtFDOzh0RzJt5FmbkJzsmPVICPkLUfOsWgBCyFAH/vYR+lUTaGPDxZ4IXw==}
 
-  '@pagefind/freebsd-x64@1.5.2':
-    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+  '@pagefind/freebsd-x64@1.5.0':
+    resolution: {integrity: sha512-kicDfUF9gn/z06NimTwNlZXF8z3pLsN3BIPPt6N8unuh0n55fr64tVs2p3a5RKYmQkJGjPfOE/C9GI5YTEpURg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@pagefind/linux-arm64@1.5.2':
-    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+  '@pagefind/linux-arm64@1.5.0':
+    resolution: {integrity: sha512-e5rDB3wPm89bcSLiatKBDTrVTbsMQrrtkXRaAoUJYU0C1suXVvEzZfjmMvrUDvYhZBx/Ls8hGuGxlqSJBz3gDg==}
     cpu: [arm64]
     os: [linux]
 
-  '@pagefind/linux-x64@1.5.2':
-    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+  '@pagefind/linux-x64@1.5.0':
+    resolution: {integrity: sha512-vh52DcBiF/mRMmq+Rwt3M3RgEWgl00jFk/M5NWhLEHJFq4+papQXwbyKbi7cNlxaeYrKx6wOfW3fm9cftfc/Kg==}
     cpu: [x64]
     os: [linux]
 
-  '@pagefind/windows-arm64@1.5.2':
-    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+  '@pagefind/windows-arm64@1.5.0':
+    resolution: {integrity: sha512-kg+szZwffZdyWn6SL6RHjAYjhSvJ2bT4qkv3KepGsbmD9fuSHUSC+2kydDneDVUA9qEDRf9uSFoEAsXsp1/JKA==}
     cpu: [arm64]
     os: [win32]
 
-  '@pagefind/windows-x64@1.5.2':
-    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+  '@pagefind/windows-x64@1.5.0':
+    resolution: {integrity: sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg==}
     cpu: [x64]
     os: [win32]
 
@@ -1329,8 +1329,8 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  pagefind@1.5.2:
-    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+  pagefind@1.5.0:
+    resolution: {integrity: sha512-7vQ2xh0ZmjPjsuWONR68nqzb+QNfpPh7pdT6n6YDAthWAQiUkSACVegSswY5zPNONGYFWebFVgdnS5/m/Qqn+w==}
     hasBin: true
 
   parse-entities@4.0.2:
@@ -1561,6 +1561,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -1789,12 +1794,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))':
+  '@astrojs/mdx@5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -1818,17 +1823,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))':
+  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
+      '@astrojs/mdx': 5.0.3(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
       '@astrojs/sitemap': 3.7.2
-      '@pagefind/default-ui': 1.5.2
+      '@pagefind/default-ui': 1.5.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
-      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1))
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
+      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -1841,7 +1846,7 @@ snapshots:
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
-      pagefind: 1.5.2
+      pagefind: 1.5.0
       rehype: 13.0.2
       rehype-format: 5.0.1
       remark-directive: 3.0.1
@@ -2135,27 +2140,27 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@pagefind/darwin-arm64@1.5.2':
+  '@pagefind/darwin-arm64@1.5.0':
     optional: true
 
-  '@pagefind/darwin-x64@1.5.2':
+  '@pagefind/darwin-x64@1.5.0':
     optional: true
 
-  '@pagefind/default-ui@1.5.2': {}
+  '@pagefind/default-ui@1.5.0': {}
 
-  '@pagefind/freebsd-x64@1.5.2':
+  '@pagefind/freebsd-x64@1.5.0':
     optional: true
 
-  '@pagefind/linux-arm64@1.5.2':
+  '@pagefind/linux-arm64@1.5.0':
     optional: true
 
-  '@pagefind/linux-x64@1.5.2':
+  '@pagefind/linux-x64@1.5.0':
     optional: true
 
-  '@pagefind/windows-arm64@1.5.2':
+  '@pagefind/windows-arm64@1.5.0':
     optional: true
 
-  '@pagefind/windows-x64@1.5.2':
+  '@pagefind/windows-x64@1.5.0':
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
@@ -2375,12 +2380,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)):
+  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)):
     dependencies:
-      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)
+      astro: 6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)
       rehype-expressive-code: 0.41.7
 
-  astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1):
+  astro@6.1.5(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -2425,7 +2430,7 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      tsconfck: 3.1.6
+      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -3501,15 +3506,15 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.5.2:
+  pagefind@1.5.0:
     optionalDependencies:
-      '@pagefind/darwin-arm64': 1.5.2
-      '@pagefind/darwin-x64': 1.5.2
-      '@pagefind/freebsd-x64': 1.5.2
-      '@pagefind/linux-arm64': 1.5.2
-      '@pagefind/linux-x64': 1.5.2
-      '@pagefind/windows-arm64': 1.5.2
-      '@pagefind/windows-x64': 1.5.2
+      '@pagefind/darwin-arm64': 1.5.0
+      '@pagefind/darwin-x64': 1.5.0
+      '@pagefind/freebsd-x64': 1.5.0
+      '@pagefind/linux-arm64': 1.5.0
+      '@pagefind/linux-x64': 1.5.0
+      '@pagefind/windows-arm64': 1.5.0
+      '@pagefind/windows-x64': 1.5.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -3874,9 +3879,14 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tsconfck@3.1.6: {}
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3:
     optional: true
 
   ufo@1.6.3: {}

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -1,0 +1,102 @@
+---
+title: Claude Code Integration
+description: How to route Claude Code MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+Claude Code is a CLI-based agent that connects to MCP servers for tools like GitHub, databases, and file systems. The Agent Receipts proxy wraps any MCP server transparently — Claude Code doesn't know or care that the proxy is there.
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- A signing key pair generated (see below)
+- Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
+
+## Generate a signing key
+
+```bash
+mkdir -p ~/.agent-receipts
+openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
+openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
+  -out ~/.agent-receipts/github-proxy-pub.pem
+```
+
+Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+
+## Register the proxy with Claude Code
+
+Use `claude mcp add-json` to register a proxied server. The example below wraps `mcp-server-github`:
+
+```bash
+claude mcp add-json github-audited --scope user '{
+  "command": "/Users/YOU/go/bin/mcp-proxy",
+  "args": [
+    "-name", "github",
+    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "/opt/homebrew/bin/mcp-server-github"
+  ],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+  }
+}'
+```
+
+`--scope user` makes the server available across all projects. Omit it for project-local scope only.
+
+Verify the server is registered:
+
+```bash
+claude mcp list
+```
+
+## Project-scoped setup via .mcp.json
+
+For a shared team configuration, add a `.mcp.json` file at the project root. This is committed to version control — do not put tokens directly in it. Reference environment variables instead:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/go/bin/mcp-proxy",
+      "args": [
+        "-name", "github",
+        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+        "/opt/homebrew/bin/mcp-server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Each developer sets `GITHUB_PERSONAL_ACCESS_TOKEN` in their shell environment. The proxy path and key path will need to be consistent across the team, or handled via a wrapper script.
+
+## Verifying receipts
+
+After making tool calls through Claude Code, inspect the receipt store from your terminal:
+
+```bash
+# List all receipts
+mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+
+# Verify chain integrity
+mcp-proxy verify \
+  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -receipt-db ~/.agent-receipts/receipts.db \
+  <chain-id>
+```
+
+`list_issues`, `create_issue`, `get_file_contents` and other read operations will show `Action: read, Risk: low`. Write operations like `create_or_update_file` will show `Action: write, Risk: medium`.
+
+## Gotchas
+
+**Absolute paths required.** Claude Code launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
+
+**Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
+
+**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+
+**Old receipts show `unknown`.** If you upgraded from a version before v0.2.0, existing receipts in the DB will always show `Action: unknown` — the tool name was never stored. Clear the DB and start fresh after upgrading.

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -95,6 +95,27 @@ mcp-proxy verify \
 
 **Absolute paths required.** Claude Code launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
 
+**Port conflict when running Claude Desktop and Claude Code simultaneously.** Both clients spawn their own `mcp-proxy` instance, and both try to bind the approval HTTP server on `127.0.0.1:8080`. The second one fails with `bind: address already in use`. Fix by adding `-http 127.0.0.1:8081` to the Claude Code config:
+
+```bash
+claude mcp remove github-audited
+claude mcp add-json github-audited --scope user '{
+  "command": "/Users/YOU/go/bin/mcp-proxy",
+  "args": [
+    "-name", "github",
+    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "-http", "127.0.0.1:8081",
+    "/opt/homebrew/bin/mcp-server-github"
+  ],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+  }
+}'
+```
+
+See [#125](https://github.com/agent-receipts/ar/issues/125) for the underlying fix.
+
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -1,0 +1,74 @@
+---
+title: Claude Desktop Integration
+description: How to route Claude Desktop MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Agent Receipts proxy wraps any MCP server transparently — Claude Desktop doesn't know or care that the proxy is there.
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- A signing key pair generated (see below)
+
+## Generate a signing key
+
+```bash
+mkdir -p ~/.agent-receipts
+openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
+openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
+  -out ~/.agent-receipts/github-proxy-pub.pem
+```
+
+Use absolute paths everywhere — Claude Desktop launches MCP servers with a clean environment where `~` expansion and `$PATH` are not available.
+
+## Configure claude_desktop_config.json
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/go/bin/mcp-proxy",
+      "args": [
+        "-name", "github",
+        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+        "/opt/homebrew/bin/mcp-server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — every tool call goes through it transparently.
+
+> **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
+
+## Verifying receipts
+
+After making tool calls, inspect the receipt store from your terminal:
+
+```bash
+# List all receipts
+mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+
+# Verify chain integrity
+mcp-proxy verify \
+  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -receipt-db ~/.agent-receipts/receipts.db \
+  <chain-id>
+```
+
+## Gotchas
+
+**Absolute paths required.** Claude Desktop launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
+
+**Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
+
+**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+
+**Old receipts show `unknown`.** If you upgraded from a version before v0.2.0, existing receipts in the DB will always show `Action: unknown` — the tool name was never stored. Clear the DB and start fresh after upgrading.

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -1,0 +1,93 @@
+---
+title: Codex Integration
+description: How to route OpenAI Codex MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/config.toml`. The Agent Receipts proxy wraps any MCP server transparently — Codex doesn't know or care that the proxy is there.
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- A signing key pair generated (see below)
+- Codex installed (`npm install -g @openai/codex` or via the IDE extension)
+
+## Generate a signing key
+
+```bash
+mkdir -p ~/.agent-receipts
+openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
+openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
+  -out ~/.agent-receipts/github-proxy-pub.pem
+```
+
+Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+
+## Configure via CLI
+
+Use `codex mcp add` to register the proxy wrapping any MCP server:
+
+```bash
+codex mcp add github-audited \
+  --env GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_TOKEN \
+  -- /Users/YOU/go/bin/mcp-proxy \
+    -name github \
+    -key /Users/YOU/.agent-receipts/github-proxy.pem \
+    -receipt-db /Users/YOU/.agent-receipts/receipts.db \
+    /opt/homebrew/bin/mcp-server-github
+```
+
+Add `--scope user` to make the server available across all projects (default is project-scoped).
+
+## Configure via config.toml
+
+Alternatively, edit `~/.codex/config.toml` directly:
+
+```toml
+[mcp_servers.github-audited]
+command = "/Users/YOU/go/bin/mcp-proxy"
+args = [
+  "-name", "github",
+  "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+  "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+  "/opt/homebrew/bin/mcp-server-github"
+]
+enabled = true
+
+[mcp_servers.github-audited.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "YOUR_TOKEN"
+```
+
+For project-scoped setup, place the same config in `.codex/config.toml` at the project root (only applies in trusted projects).
+
+Verify the server is registered:
+
+```bash
+codex mcp get github-audited
+```
+
+Or check active servers inside the Codex TUI with `/mcp`.
+
+## Verifying receipts
+
+After making tool calls through Codex, inspect the receipt store from your terminal:
+
+```bash
+# List all receipts
+mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+
+# Verify chain integrity
+mcp-proxy verify \
+  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -receipt-db ~/.agent-receipts/receipts.db \
+  <chain-id>
+```
+
+## Gotchas
+
+**Absolute paths required.** Codex launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
+
+**TOML syntax for args.** Unlike JSON (Claude Desktop) or the `--` CLI pattern (Claude Code), Codex config.toml uses a TOML array for `args`. Each flag and its value must be a separate string in the array.
+
+**Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
+
+**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -6,7 +6,7 @@ description: Install and run the MCP Proxy.
 ## Install
 
 ```bash
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
 ```
 
 ## Requirements
@@ -35,7 +35,7 @@ openssl genpkey -algorithm Ed25519 -out private.pem
 openssl pkey -in private.pem -pubout -out public.pem
 
 # Run with persistent key
-mcp-proxy --key private.pem node /path/to/mcp-server.js
+mcp-proxy -key private.pem node /path/to/mcp-server.js
 ```
 
 ## Next steps

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -6,7 +6,7 @@ description: Install and run the MCP Proxy.
 ## Install
 
 ```bash
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.1
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 ```
 
 ## Requirements

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -6,7 +6,7 @@ description: Install and run the MCP Proxy.
 ## Install
 
 ```bash
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.1
 ```
 
 ## Requirements

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -42,17 +42,17 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```bash
 # Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
 
 # Wrap any MCP server
 mcp-proxy node /path/to/mcp-server.js
 
 # With configuration
 mcp-proxy \
-  --name github \
-  --key private.pem \
-  --rules rules.yaml \
-  --taxonomy taxonomy.json \
+  -name github \
+  -key private.pem \
+  -rules rules.yaml \
+  -taxonomy taxonomy.json \
   node /path/to/github-mcp-server.js
 ```
 
@@ -64,11 +64,16 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "github-audited": {
-      "command": "mcp-proxy",
+      "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
-        "--name", "github",
-        "node", "/path/to/github-mcp-server.js"
-      ]
+        "-name", "github",
+        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+        "/opt/homebrew/bin/mcp-server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+      }
     }
   }
 }

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -79,4 +79,6 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
+> **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
+
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -3,7 +3,7 @@ title: MCP Proxy
 description: Transparent audit proxy for MCP servers with receipt signing, policy enforcement, and risk scoring.
 ---
 
-The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, etc.) and any MCP server. It intercepts every tool call and provides cryptographic audit trails, risk scoring, and policy enforcement -- without modifying the server or client.
+The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call and provides cryptographic audit trails, risk scoring, and policy enforcement -- without modifying the server or client.
 
 **Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
 
@@ -22,7 +22,7 @@ The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP clien
 ## How it works
 
 ```
-MCP Client (Claude)
+MCP Client (Claude Desktop / Claude Code)
     |
     v
  mcp-proxy (stdin/stdout)
@@ -42,7 +42,7 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```bash
 # Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
 
 # Wrap any MCP server
 mcp-proxy node /path/to/mcp-server.js
@@ -80,5 +80,32 @@ Add to `claude_desktop_config.json`:
 ```
 
 > **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
+
+## Claude Code integration
+
+Claude Code uses `claude mcp add-json` to register servers. Use `--scope user` to make the proxy available across all projects:
+
+```bash
+claude mcp add-json github-audited --scope user '{
+  "command": "/Users/YOU/go/bin/mcp-proxy",
+  "args": [
+    "-name", "github",
+    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "/opt/homebrew/bin/mcp-server-github"
+  ],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+  }
+}'
+```
+
+Verify registration:
+
+```bash
+claude mcp list
+```
+
+See the [Claude Code integration guide](/mcp-proxy/claude-code/) for a full walkthrough including project-scoped setup and `.mcp.json` configuration.
 
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -42,7 +42,7 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```bash
 # Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.1
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 
 # Wrap any MCP server
 mcp-proxy node /path/to/mcp-server.js

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -42,7 +42,7 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```bash
 # Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.1
 
 # Wrap any MCP server
 mcp-proxy node /path/to/mcp-server.js


### PR DESCRIPTION
## Summary

- `overview.mdx` and `installation.mdx` both used double-dash flags (`--name`, `--key`) in code examples — the binary uses single-dash Go flags (`-name`, `-key`). Fixed throughout.
- `overview.mdx` Claude Desktop example updated to match a real working config (absolute paths, `mcp-server-github` as the wrapped binary, `-receipt-db` flag).
- Added security note about not committing tokens in `claude_desktop_config.json`.