### PR TITLE
docs: update mcp-proxy docs for v0.3.1 features

### DIFF
--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -14,6 +14,10 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 | `-rules` | (built-in defaults) | Policy rules YAML file |
 | `-name` | (inferred from command) | Server name for the audit trail |
 | `-issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
+| `-issuer-name` | (none) | Issuer name, e.g. `Claude Code` or `Codex` |
+| `-issuer-model` | (none) | AI model identifier, e.g. `claude-sonnet-4-6`. Static per session — omit if the client can switch models mid-session |
+| `-operator-id` | (none) | Operator DID (organisation running the agent), e.g. `did:web:anthropic.com` |
+| `-operator-name` | (none) | Operator name, e.g. `Anthropic` |
 | `-principal` | `did:user:unknown` | Principal DID for receipts |
 | `-chain` | (auto UUID) | Chain ID for receipt chaining |
 | `-http` | `127.0.0.1:8080` | HTTP address for the approval endpoint |
@@ -89,7 +93,25 @@ Tool names are classified by prefix (case-insensitive):
 | read | get\_, read\_, list\_, search\_, describe\_, show\_ |
 | unknown | (fallback) |
 
-For more precise classification, provide a `-taxonomy` JSON file mapping tool names to action types from the Agent Receipts taxonomy.
+MCP tool names are automatically stripped of their `mcp__<server>__` prefix before classification. For example, `mcp__github-audited__create_branch` is classified as `create_branch` (write). This means taxonomy mappings and policy rules use bare tool names.
+
+## Taxonomy mappings
+
+For more precise classification than prefix-based inference, provide a `-taxonomy` JSON file mapping tool names to action types:
+
+```json
+{
+  "mappings": [
+    {"tool_name": "merge_pull_request", "action_type": "data.api.write"},
+    {"tool_name": "list_issues", "action_type": "data.api.read"},
+    {"tool_name": "delete_file", "action_type": "data.api.delete"}
+  ]
+}
+```
+
+Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [taxonomy spec](https://github.com/agent-receipts/ar/blob/main/spec/spec/taxonomy/action-types.json) for the full list.
+
+A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) provides mappings for all 85 GitHub MCP server tools.
 
 ## Approval workflow
 

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -111,7 +111,7 @@ For more precise classification than prefix-based inference, provide a `-taxonom
 
 Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [taxonomy spec](https://github.com/agent-receipts/ar/blob/main/spec/spec/taxonomy/action-types.json) for the full list.
 
-A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) provides mappings for all 85 GitHub MCP server tools.
+A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) provides mappings for GitHub MCP server tools.
 
 ## Approval workflow
 

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -156,3 +156,29 @@ BEACON_ENCRYPTION_KEY="my-passphrase" mcp-proxy node server.js
 ```
 
 Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored with an `enc:` prefix and transparently decrypted on retrieval.
+
+## Troubleshooting
+
+### Port conflict when multiple MCP clients use the proxy
+
+Each `mcp-proxy` instance binds an HTTP server for the approval workflow (default `127.0.0.1:8080`). If two or more MCP clients launch the same proxy simultaneously — for example, Claude Desktop and Claude Code, or Cursor and a custom agent — the second instance will fail with:
+
+```
+listen tcp 127.0.0.1:8080: bind: address already in use
+```
+
+**Fix:** assign each instance a different port with `-http`:
+
+```bash
+# First client uses the default
+mcp-proxy -name github ... /path/to/server
+
+# Second client uses a different port
+mcp-proxy -name github -http 127.0.0.1:8081 ... /path/to/server
+```
+
+Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log.
+
+:::note
+The approval HTTP server is only needed when policy rules use the `pause` action. If you don't use approval workflows, the port conflict is harmless — the proxy logs the error but continues to function normally.
+:::

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -11,9 +11,12 @@ The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP clien
 
 - **Risk scoring** -- scores every tool call 0-100 based on operation type, sensitive keywords, and patterns
 - **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
+- **Action taxonomy** -- classify tool calls using configurable taxonomy mappings, with a bundled config for GitHub MCP server tools
+- **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy enforcement** -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** -- HTTP endpoints for async approval of paused operations
 - **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, hash-chained per session
+- **Issuer identity** -- receipts identify the AI agent, model, and operator via CLI flags
 - **Intent tracking** -- groups related tool calls by temporal proximity
 - **Data redaction** -- JSON-aware and pattern-based redaction of secrets before storage
 - **Encryption at rest** -- optional AES-256-GCM encryption of audit data
@@ -58,7 +61,7 @@ mcp-proxy \
 
 ## Claude Desktop integration
 
-Add to `claude_desktop_config.json`:
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
 
 ```json
 {
@@ -68,7 +71,12 @@ Add to `claude_desktop_config.json`:
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-db", "/Users/YOU/.agent-receipts/audit.db",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+        "-issuer-name", "Claude Desktop",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
+        "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
         "/opt/homebrew/bin/mcp-server-github"
       ],
       "env": {
@@ -91,7 +99,13 @@ claude mcp add-json github-audited --scope user '{
   "args": [
     "-name", "github",
     "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+    "-db", "/Users/YOU/.agent-receipts/audit.db",
     "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "-http", "127.0.0.1:8081",
+    "-issuer-name", "Claude Code",
+    "-operator-id", "did:web:anthropic.com",
+    "-operator-name", "Anthropic",
+    "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
     "/opt/homebrew/bin/mcp-server-github"
   ],
   "env": {
@@ -107,5 +121,43 @@ claude mcp list
 ```
 
 See the [Claude Code integration guide](/mcp-proxy/claude-code/) for a full walkthrough including project-scoped setup and `.mcp.json` configuration.
+
+:::note
+If both Claude Desktop and Claude Code run simultaneously, the second instance will fail to bind the default approval port. Use `-http 127.0.0.1:8081` (or any free port) on one of them to avoid the conflict.
+:::
+
+## What receipts look like
+
+Each tool call produces a signed W3C Verifiable Credential:
+
+```json
+{
+  "issuer": {
+    "id": "did:agent:mcp-proxy",
+    "name": "Claude Code",
+    "operator": {
+      "id": "did:web:anthropic.com",
+      "name": "Anthropic"
+    }
+  },
+  "credentialSubject": {
+    "principal": { "id": "did:user:otto" },
+    "action": {
+      "type": "data.api.read",
+      "tool_name": "get_issue",
+      "risk_level": "low",
+      "target": { "system": "github" }
+    },
+    "outcome": { "status": "success" },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "9351bc33-..."
+    }
+  }
+}
+```
+
+Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `inspect`, and `verify` to query and validate them.
 
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -11,7 +11,7 @@ The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP clien
 
 - **Risk scoring** -- scores every tool call 0-100 based on operation type, sensitive keywords, and patterns
 - **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
-- **Action taxonomy** -- classify tool calls using configurable taxonomy mappings, with a bundled config for GitHub MCP server tools
+- **Action taxonomy** -- classifies tool calls using configurable taxonomy mappings, with a bundled config for GitHub MCP server tools
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy enforcement** -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** -- HTTP endpoints for async approval of paused operations
@@ -45,7 +45,7 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```bash
 # Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@mcp-proxy/v0.2.0
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 
 # Wrap any MCP server
 mcp-proxy node /path/to/mcp-server.js
@@ -128,7 +128,7 @@ Running multiple MCP clients simultaneously? See [Troubleshooting: port conflict
 
 ## What receipts look like
 
-Each tool call produces a signed W3C Verifiable Credential:
+Each tool call produces a signed W3C Verifiable Credential. Key fields shown (abbreviated — full receipts include `@context`, `id`, `type`, `issuanceDate`, and `proof`):
 
 ```json
 {
@@ -158,6 +158,6 @@ Each tool call produces a signed W3C Verifiable Credential:
 }
 ```
 
-Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `inspect`, and `verify` to query and validate them.
+Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `mcp-proxy inspect`, and `mcp-proxy verify` to query and validate them.
 
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -122,8 +122,8 @@ claude mcp list
 
 See the [Claude Code integration guide](/mcp-proxy/claude-code/) for a full walkthrough including project-scoped setup and `.mcp.json` configuration.
 
-:::note
-If both Claude Desktop and Claude Code run simultaneously, the second instance will fail to bind the default approval port. Use `-http 127.0.0.1:8081` (or any free port) on one of them to avoid the conflict.
+:::tip
+Running multiple MCP clients simultaneously? See [Troubleshooting: port conflicts](/mcp-proxy/configuration/#port-conflict-when-multiple-mcp-clients-use-the-proxy) in the configuration guide.
 :::
 
 ## What receipts look like


### PR DESCRIPTION
## Summary
- Add new CLI flags to configuration reference (issuer-name, issuer-model, operator-id, operator-name)
- Document MCP prefix stripping and taxonomy mappings with JSON format example
- Update Claude Desktop and Claude Code integration examples with issuer identity and taxonomy flags
- Add port conflict note for running both clients simultaneously
- Add "What receipts look like" section showing a real receipt with issuer identity and action target

## Test plan
- [x] Site renders correctly on dev server (verified via preview)
- [x] All new sections present: Features bullets, Taxonomy mappings, Claude Code integration, What receipts look like
- [x] No broken links