### PR TITLE
fix: mcp-proxy exits immediately on port conflict, skips HTTP server when unneeded

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -191,8 +192,14 @@ func serve() {
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
 
-	// Start HTTP server for approvals.
-	go startHTTPServer(*httpAddr, approvals, approvalToken)
+	// Start HTTP server for approvals only when pause rules exist.
+	if engine.HasPauseRules() {
+		ln, err := net.Listen("tcp", *httpAddr)
+		if err != nil {
+			log.Fatalf("mcp-proxy: http server: %v", err)
+		}
+		go startHTTPServer(ln, approvals, approvalToken)
+	}
 
 	handler := func(direction string, raw []byte, msg *proxy.Message) *proxy.HandlerResult {
 		method := ""
@@ -490,8 +497,9 @@ func generateToken(n int) string {
 	return hex.EncodeToString(b)
 }
 
-func startHTTPServer(addr string, approvals *audit.ApprovalManager, token string) {
-	http.HandleFunc("/api/tool-calls/", func(w http.ResponseWriter, r *http.Request) {
+func startHTTPServer(ln net.Listener, approvals *audit.ApprovalManager, token string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tool-calls/", func(w http.ResponseWriter, r *http.Request) {
 		// Validate bearer token.
 		auth := r.Header.Get("Authorization")
 		if auth != "Bearer "+token {
@@ -527,9 +535,9 @@ func startHTTPServer(addr string, approvals *audit.ApprovalManager, token string
 		}
 	})
 
-	log.Printf("mcp-proxy: approval HTTP server on %s (token printed below)", addr)
+	log.Printf("mcp-proxy: approval HTTP server on %s (token printed below)", ln.Addr())
 	fmt.Fprintln(os.Stderr, "APPROVAL_TOKEN="+token)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	if err := http.Serve(ln, mux); err != nil {
 		log.Fatalf("mcp-proxy: http server: %v", err)
 	}
 }

--- a/mcp-proxy/internal/policy/engine.go
+++ b/mcp-proxy/internal/policy/engine.go
@@ -107,6 +107,17 @@ func (e *Engine) Evaluate(ctx EvalContext) Decision {
 	return best
 }
 
+// HasPauseRules reports whether any enabled rule uses the "pause" action.
+// When no pause rules exist, the approval HTTP server is unnecessary.
+func (e *Engine) HasPauseRules() bool {
+	for _, rule := range e.rules {
+		if rule.Enabled && rule.Action == "pause" {
+			return true
+		}
+	}
+	return false
+}
+
 func matchesRule(rule Rule, ctx EvalContext) bool {
 	if rule.ToolPattern != "" {
 		if !globMatch(rule.ToolPattern, ctx.ToolName) {

--- a/mcp-proxy/internal/policy/engine_test.go
+++ b/mcp-proxy/internal/policy/engine_test.go
@@ -120,3 +120,33 @@ func TestDisabledRulesSkipped(t *testing.T) {
 		t.Errorf("expected pass (rule disabled), got %s", d.Action)
 	}
 }
+
+func TestHasPauseRules(t *testing.T) {
+	// Default rules include pause_high_risk.
+	engine := NewEngine(DefaultRules())
+	if !engine.HasPauseRules() {
+		t.Error("expected HasPauseRules=true for default rules")
+	}
+
+	// Flag-only rules should not require the approval server.
+	engine = NewEngine([]Rule{
+		{Name: "flag_only", Enabled: true, Action: "flag"},
+	})
+	if engine.HasPauseRules() {
+		t.Error("expected HasPauseRules=false for flag-only rules")
+	}
+
+	// Empty rules.
+	engine = NewEngine([]Rule{})
+	if engine.HasPauseRules() {
+		t.Error("expected HasPauseRules=false for empty rules")
+	}
+
+	// Disabled pause rule should not count.
+	engine = NewEngine([]Rule{
+		{Name: "disabled_pause", Enabled: false, Action: "pause"},
+	})
+	if engine.HasPauseRules() {
+		t.Error("expected HasPauseRules=false when pause rule is disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- Bind the approval HTTP listener synchronously so port conflicts are fatal *before* the proxy starts handling messages, instead of racing in a goroutine
- Skip the HTTP server entirely when no policy rules use `pause`, avoiding unnecessary port conflicts when running multiple MCP clients (#125)
- Switch from global `http.DefaultServeMux` to a local `ServeMux`

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — includes new `TestHasPauseRules` covering default, flag-only, empty, and disabled-pause rule sets
- [x] `go vet ./...`

Closes #137