### PR TITLE
fix: show -version flag in mcp-proxy help output

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -94,6 +94,7 @@ func serve() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
 		fmt.Fprintf(os.Stderr, "  Wraps an MCP server with audit, receipts, and policy enforcement.\n\n")
 		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats\n\n")
+		fmt.Fprintf(os.Stderr, "  -version\n\tPrint version and exit\n")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- Add `-version` to the usage text printed by `mcp-proxy -help`, so users can discover it alongside other flags

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `mcp-proxy` (no args) now shows `-version` in the output

Fixes #143