### PR TITLE
docs: link new blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 |---|---|
 | **Project site & docs** | [agentreceipts.ai](https://agentreceipts.ai) |
 | **API reference** | [Go](https://agentreceipts.ai/sdk-go/api-reference/) · [TypeScript](https://agentreceipts.ai/sdk-ts/api-reference/) · [Python](https://agentreceipts.ai/sdk-py/api-reference/) |
-| **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) |
+| **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) · [Every MCP Tool Call My AI Makes Now Gets a Signed Receipt](https://jongerius.solutions/post/auditing-github-mcp-agent-receipts/) |
 | **Go** | [sdk/go](https://pkg.go.dev/github.com/agent-receipts/ar/sdk/go) · [mcp-proxy](https://pkg.go.dev/github.com/agent-receipts/ar/mcp-proxy) · [dashboard](https://pkg.go.dev/github.com/agent-receipts/dashboard) |
 | **npm** | [@agnt-rcpt/sdk-ts](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts) |
 | **PyPI** | [agent-receipts](https://pypi.org/project/agent-receipts/) |


### PR DESCRIPTION
Adds a link to the new blog post "Every MCP Tool Call My AI Makes Now Gets a Signed Receipt" in the Blog row of the README table.