### PR TITLE
fix(mcp-proxy): default approval HTTP server to random port

### DIFF
--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -112,11 +112,13 @@ rules:
 
 Actions: `pass` (log only), `flag` (log + highlight), `pause` (wait for approval), `block` (reject).
 
-When a tool call is paused, approve or deny via HTTP:
+When a tool call is paused, approve or deny via HTTP. The approval URL and bearer token are logged to stderr at startup (the default port is random; pass `-http 127.0.0.1:PORT` to pin):
 
 ```sh
-curl -X POST http://localhost:8080/api/tool-calls/{id}/approve
-curl -X POST http://localhost:8080/api/tool-calls/{id}/deny
+curl -X POST http://127.0.0.1:PORT/api/tool-calls/{id}/approve \
+  -H "Authorization: Bearer $APPROVAL_TOKEN"
+curl -X POST http://127.0.0.1:PORT/api/tool-calls/{id}/deny \
+  -H "Authorization: Bearer $APPROVAL_TOKEN"
 ```
 
 Paused calls auto-deny after 60 seconds (fail-safe).

--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -112,9 +112,11 @@ rules:
 
 Actions: `pass` (log only), `flag` (log + highlight), `pause` (wait for approval), `block` (reject).
 
-When a tool call is paused, approve or deny via HTTP. The approval URL and bearer token are logged to stderr at startup (the default port is random; pass `-http 127.0.0.1:PORT` to pin):
+When a tool call is paused, approve or deny via HTTP. The approval URL and bearer token are logged to stderr at startup (the default port is random; pass `-http 127.0.0.1:PORT` to pin). Copy the token from the startup line and export it before running the curls:
 
 ```sh
+export APPROVAL_TOKEN=<token-from-stderr>
+
 curl -X POST http://127.0.0.1:PORT/api/tool-calls/{id}/approve \
   -H "Authorization: Bearer $APPROVAL_TOKEN"
 curl -X POST http://127.0.0.1:PORT/api/tool-calls/{id}/deny \

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -228,14 +228,18 @@ func serve() {
 			log.Fatalf("mcp-proxy: http server: %v", err)
 		}
 		approvalURL := "http://" + ln.Addr().String()
-		// Human-readable line (one copy-pasteable string).
-		log.Printf("mcp-proxy: approvals at %s (token: %s)", approvalURL, approvalToken)
+		// Human-readable line (one copy-pasteable string, no log timestamp prefix).
+		fmt.Fprintf(os.Stderr, "mcp-proxy: approvals at %s (token: %s)\n", approvalURL, approvalToken)
 		// Machine-readable line — minimal discovery primitive for future tooling.
-		endpointJSON, _ := json.Marshal(map[string]string{
+		endpointJSON, err := json.Marshal(map[string]string{
 			"event": "approval_endpoint",
 			"url":   approvalURL,
 			"token": approvalToken,
 		})
+		if err != nil {
+			log.Printf("mcp-proxy: marshal approval endpoint discovery payload: %v", err)
+			endpointJSON = []byte(`{"event":"approval_endpoint"}`)
+		}
 		fmt.Fprintln(os.Stderr, string(endpointJSON))
 		go startHTTPServer(ln, approvals, approvalToken)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -88,7 +88,7 @@ func serve() {
 		operatorName = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
 		principalDID = flag.String("principal", "did:user:unknown", "Principal DID")
 		chainID      = flag.String("chain", "", "Chain ID (auto-generated if empty)")
-		httpAddr     = flag.String("http", "127.0.0.1:8080", "HTTP address for approval endpoints")
+		httpAddr     = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port)")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -227,6 +227,16 @@ func serve() {
 		if err != nil {
 			log.Fatalf("mcp-proxy: http server: %v", err)
 		}
+		approvalURL := "http://" + ln.Addr().String()
+		// Human-readable line (one copy-pasteable string).
+		log.Printf("mcp-proxy: approvals at %s (token: %s)", approvalURL, approvalToken)
+		// Machine-readable line — minimal discovery primitive for future tooling.
+		endpointJSON, _ := json.Marshal(map[string]string{
+			"event": "approval_endpoint",
+			"url":   approvalURL,
+			"token": approvalToken,
+		})
+		fmt.Fprintln(os.Stderr, string(endpointJSON))
 		go startHTTPServer(ln, approvals, approvalToken)
 	}
 
@@ -606,8 +616,6 @@ func startHTTPServer(ln net.Listener, approvals *audit.ApprovalManager, token st
 		}
 	})
 
-	log.Printf("mcp-proxy: approval HTTP server on %s (token printed below)", ln.Addr())
-	fmt.Fprintln(os.Stderr, "APPROVAL_TOKEN="+token)
 	if err := http.Serve(ln, mux); err != nil {
 		log.Fatalf("mcp-proxy: http server: %v", err)
 	}

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -95,26 +95,7 @@ mcp-proxy verify \
 
 **Absolute paths required.** Claude Code launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
 
-**Port conflict when running Claude Desktop and Claude Code simultaneously.** Both clients spawn their own `mcp-proxy` instance, and both try to bind the approval HTTP server on `127.0.0.1:8080`. The second one fails with `bind: address already in use`. Fix by adding `-http 127.0.0.1:8081` to the Claude Code config:
-
-```bash
-claude mcp remove github-audited
-claude mcp add-json github-audited --scope user '{
-  "command": "/Users/YOU/go/bin/mcp-proxy",
-  "args": [
-    "-name", "github",
-    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
-    "-http", "127.0.0.1:8081",
-    "/opt/homebrew/bin/mcp-server-github"
-  ],
-  "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
-  }
-}'
-```
-
-See [#125](https://github.com/agent-receipts/ar/issues/125) for the underlying fix.
+**Approval server picks a random port.** By default the proxy binds the approval HTTP server on a random free port (logged to stderr at startup) so multiple MCP clients — Claude Desktop, Claude Code, Codex — can run simultaneously without conflicting. If you want a stable, predictable URL (for an external approval UI, for example), pass `-http 127.0.0.1:8080` (or any free port) explicitly.
 
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -91,3 +91,5 @@ mcp-proxy verify \
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+
+**Approval server picks a random port.** By default the proxy binds the approval HTTP server on a random free port (logged to stderr at startup), so Codex can run alongside other MCP clients (Claude Code, Claude Desktop) with no port-conflict configuration. If you want a stable URL, add `-http 127.0.0.1:8080` (or any free port) to the args array.

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -20,7 +20,7 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 | `-operator-name` | (none) | Operator name, e.g. `Anthropic` |
 | `-principal` | `did:user:unknown` | Principal DID for receipts |
 | `-chain` | (auto UUID) | Chain ID for receipt chaining |
-| `-http` | `127.0.0.1:8080` | HTTP address for the approval endpoint |
+| `-http` | `127.0.0.1:0` | HTTP address for the approval endpoint (default: random port, logged to stderr) |
 
 ## Policy rules
 
@@ -118,20 +118,30 @@ A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/
 When a tool call is paused by a policy rule:
 
 1. The proxy logs an approval ID and waits up to 60 seconds
-2. An approval token is printed to stderr on startup
-3. Approve or deny via HTTP:
+2. The approval URL and token are logged to stderr at startup, in two formats:
+
+   ```
+   mcp-proxy: approvals at http://127.0.0.1:59850 (token: 5fce4e79...)
+   {"event":"approval_endpoint","url":"http://127.0.0.1:59850","token":"5fce4e79..."}
+   ```
+
+   The JSON line is a stable contract for tooling that wants to discover the endpoint without parsing the human line.
+
+3. Approve or deny via HTTP (substitute the URL from your stderr):
 
 ```bash
 # Approve
-curl -X POST http://localhost:8080/api/tool-calls/{id}/approve \
+curl -X POST http://127.0.0.1:59850/api/tool-calls/{id}/approve \
   -H "Authorization: Bearer $APPROVAL_TOKEN"
 
 # Deny
-curl -X POST http://localhost:8080/api/tool-calls/{id}/deny \
+curl -X POST http://127.0.0.1:59850/api/tool-calls/{id}/deny \
   -H "Authorization: Bearer $APPROVAL_TOKEN"
 ```
 
 If no response within 60 seconds, the call is automatically denied.
+
+If you need a stable, predictable URL, pin the port with `-http 127.0.0.1:8080` (or any free port).
 
 ## Data redaction
 
@@ -159,26 +169,22 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 
 ## Troubleshooting
 
-### Port conflict when multiple MCP clients use the proxy
+### Multiple MCP clients running the proxy simultaneously
 
-Each `mcp-proxy` instance binds an HTTP server for the approval workflow (default `127.0.0.1:8080`). If two or more MCP clients launch the same proxy simultaneously — for example, Claude Desktop and Claude Code, or Cursor and a custom agent — the second instance will fail with:
+Each `mcp-proxy` instance binds its own HTTP server for the approval workflow. By default the OS picks a random free port, so multiple instances (Claude Desktop + Claude Code, Codex alongside either, etc.) coexist without configuration. The actual address is logged to stderr at startup.
 
-```
-listen tcp 127.0.0.1:8080: bind: address already in use
-```
-
-**Fix:** assign each instance a different port with `-http`:
+If you want a fixed port for each client (e.g. so an external approval UI can connect reliably), pin it with `-http`:
 
 ```bash
-# First client uses the default
-mcp-proxy -name github ... /path/to/server
+# Pin one client to 8080
+mcp-proxy -name github -http 127.0.0.1:8080 ... /path/to/server
 
-# Second client uses a different port
+# Pin another to 8081
 mcp-proxy -name github -http 127.0.0.1:8081 ... /path/to/server
 ```
 
 Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log.
 
 :::note
-The approval HTTP server is only needed when policy rules use the `pause` action. If you don't use approval workflows, the port conflict is harmless — the proxy logs the error but continues to function normally.
+The approval HTTP server is only needed when policy rules use the `pause` action. If you don't use approval workflows, the random-port default has no observable effect.
 :::

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -127,9 +127,12 @@ When a tool call is paused by a policy rule:
 
    The JSON line is a stable contract for tooling that wants to discover the endpoint without parsing the human line.
 
-3. Approve or deny via HTTP (substitute the URL from your stderr):
+3. Approve or deny via HTTP (substitute the URL from your stderr, and export the token first):
 
 ```bash
+# Copy the token from the stderr line above (or parse the JSON event).
+export APPROVAL_TOKEN=5fce4e79...
+
 # Approve
 curl -X POST http://127.0.0.1:59850/api/tool-calls/{id}/approve \
   -H "Authorization: Bearer $APPROVAL_TOKEN"


### PR DESCRIPTION
## Summary

- Default `-http` to `127.0.0.1:0` so the OS assigns a free port instead of crashing the second instance with `bind: address already in use`. This fixes the case where Codex + Claude Code (or two Claude sessions) run simultaneously and the client sees `connection closed: initialize response`.
- Log the bound address + token to stderr in two formats: a human-readable copy-pasteable line, and a JSON event line as a minimal discovery primitive for future approval tooling.
- Drop the now-obsolete port-conflict workaround from the Claude Code and Codex gotcha sections; replace with a one-line note. Users who want a stable URL can still pin with `-http 127.0.0.1:PORT`.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` passes
- [x] Handshake works with default (random port) while another `mcp-proxy` already owns 8080
- [x] Handshake works with explicit `-http 127.0.0.1:18099` (escape hatch)
- [x] Explicit pin to a busy port still fails fast with `log.Fatalf` (correct behaviour — user explicitly asked for that port)
- [x] `8080` references audited; remaining ones are intentional ("pin to 8080 if you want stability" examples) plus the unrelated dashboard binary