### PR TITLE
docs(mcp-proxy): use -issuer-name in Claude Code and Codex examples

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -33,6 +33,9 @@ claude mcp add-json github-audited --scope user '{
     "-name", "github",
     "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
     "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "-issuer-name", "Claude Code",
+    "-operator-id", "did:web:anthropic.com",
+    "-operator-name", "Anthropic",
     "/opt/homebrew/bin/mcp-server-github"
   ],
   "env": {
@@ -42,6 +45,8 @@ claude mcp add-json github-audited --scope user '{
 ```
 
 `--scope user` makes the server available across all projects. Omit it for project-local scope only.
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Claude Code` here (and to `Codex` in the [Codex integration](/mcp-proxy/codex/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the default `did:agent:mcp-proxy` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
 
 Verify the server is registered:
 
@@ -62,6 +67,9 @@ For a shared team configuration, add a `.mcp.json` file at the project root. Thi
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+        "-issuer-name", "Claude Code",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
         "/opt/homebrew/bin/mcp-server-github"
       ],
       "env": {

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -33,10 +33,15 @@ codex mcp add github-audited \
     -name github \
     -key /Users/YOU/.agent-receipts/github-proxy.pem \
     -receipt-db /Users/YOU/.agent-receipts/receipts.db \
+    -issuer-name Codex \
+    -operator-id did:web:openai.com \
+    -operator-name OpenAI \
     /opt/homebrew/bin/mcp-server-github
 ```
 
 Add `--scope user` to make the server available across all projects (default is project-scoped).
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Codex` here (and to `Claude Code` in the [Claude Code integration](/mcp-proxy/claude-code/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the default `did:agent:mcp-proxy` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
 
 ## Configure via config.toml
 
@@ -49,6 +54,9 @@ args = [
   "-name", "github",
   "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
   "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+  "-issuer-name", "Codex",
+  "-operator-id", "did:web:openai.com",
+  "-operator-name", "OpenAI",
   "/opt/homebrew/bin/mcp-server-github"
 ]
 enabled = true


### PR DESCRIPTION
## Summary

- Added `-issuer-name`, `-operator-id`, and `-operator-name` to the `claude mcp add-json` + `.mcp.json` examples (Claude Code) and to the `codex mcp add` + `config.toml` examples (Codex), matching the pattern already used on the MCP Proxy overview page.
- Added a short callout after each example explaining that `-issuer-name` is what lets you tell at receipt-inspection time whether a given call came from Claude Code or Codex — without it, receipts just show the default `did:agent:mcp-proxy` issuer.

## Motivation

The flags are documented in the [configuration CLI reference](https://agentreceipts.ai/mcp-proxy/configuration/#cli-flags) but were missing from the integration walkthroughs, so anyone following those pages ended up with indistinguishable receipts across clients.

## Test plan

- [x] `pnpm --filter site build` (or `astro build`) succeeds with the updated MDX
- [x] Rendered Claude Code page shows the three flags in both the CLI and `.mcp.json` examples
- [x] Rendered Codex page shows the three flags in both the CLI and `config.toml` examples
- [x] Cross-links between the two integration pages resolve
