### PR TITLE
feat(mcp-proxy): newest-first list + ISSUER/OPERATOR columns

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -34,7 +34,7 @@ func cmdList(args []string) {
 	s := openReceiptStore(*db)
 	defer s.Close()
 
-	q := store.Query{Limit: limit}
+	q := store.Query{Limit: limit, NewestFirst: true}
 	if *chainID != "" {
 		q.ChainID = chainID
 	}
@@ -59,15 +59,22 @@ func cmdList(args []string) {
 		return
 	}
 
-	fmt.Printf("%-40s %-30s %-8s %-10s %s\n", "ID", "ACTION", "RISK", "STATUS", "TIMESTAMP")
+	const rowFmt = "%-40s %-22s %-6s %-8s %-14s %-22s %s\n"
+	fmt.Printf(rowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
 	fmt.Println("---")
 	for _, r := range receipts {
 		subj := r.CredentialSubject
-		fmt.Printf("%-40s %-30s %-8s %-10s %s\n",
+		operator := ""
+		if r.Issuer.Operator != nil {
+			operator = r.Issuer.Operator.ID
+		}
+		fmt.Printf(rowFmt,
 			truncate(r.ID, 40),
-			subj.Action.Type,
+			truncate(subj.Action.Type, 22),
 			subj.Action.RiskLevel,
 			subj.Outcome.Status,
+			truncate(r.Issuer.Name, 14),
+			truncate(operator, 22),
 			subj.Action.Timestamp,
 		)
 	}

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -2,6 +2,12 @@ module github.com/agent-receipts/ar/mcp-proxy
 
 go 1.26.1
 
+// Dev-time replace: build against the in-tree SDK so changes that add new
+// exported fields (e.g. store.Query.NewestFirst) are picked up before an
+// sdk/go release is cut. Drop this line — and bump the require below — when
+// a matching sdk/go version is released.
+replace github.com/agent-receipts/ar/sdk/go => ../sdk/go
+
 require (
 	github.com/agent-receipts/ar/sdk/go v0.3.0
 	github.com/google/uuid v1.6.0

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,5 +1,3 @@
-github.com/agent-receipts/ar/sdk/go v0.3.0 h1:pKrOeVWL53fmbU8XgmkTNggsCrfyua5jCcoIjVwydrA=
-github.com/agent-receipts/ar/sdk/go v0.3.0/go.mod h1:RrF1FArgaVJ64rO/eDe8sH5p76zUKl3GGrHw6taccbg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -61,6 +61,10 @@ type Query struct {
 	After      *string // ISO 8601 timestamp
 	Before     *string // ISO 8601 timestamp
 	Limit      *int    // Default 10000
+	// NewestFirst reverses the default ascending-timestamp ordering so the
+	// most recent receipts are returned first. Default is false (ascending)
+	// to preserve historical behavior.
+	NewestFirst bool
 }
 
 // Stats holds aggregate statistics for the store.
@@ -242,9 +246,13 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 		limit = *q.Limit
 	}
 
+	order := "ASC"
+	if q.NewestFirst {
+		order = "DESC"
+	}
 	query := fmt.Sprintf(
-		"SELECT receipt_json FROM receipts %s ORDER BY timestamp ASC LIMIT ?",
-		where,
+		"SELECT receipt_json FROM receipts %s ORDER BY timestamp %s LIMIT ?",
+		where, order,
 	)
 	args = append(args, limit)
 

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -176,6 +176,64 @@ func TestInsertDuplicateChainSequence(t *testing.T) {
 	}
 }
 
+func TestQueryReceiptsOrdering(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	// Insert three receipts with timestamps a few seconds apart by
+	// stamping them post-Create (Create sets the Action.Timestamp to now).
+	timestamps := []string{
+		"2024-01-01T00:00:01Z",
+		"2024-01-01T00:00:02Z",
+		"2024-01-01T00:00:03Z",
+	}
+	for i, ts := range timestamps {
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:agent:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				Timestamp: ts,
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: i + 1, ChainID: "chain-1"},
+		})
+		signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, _ := receipt.HashReceipt(signed)
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Ascending by default.
+	asc, err := s.QueryReceipts(Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(asc) != 3 {
+		t.Fatalf("expected 3 receipts, got %d", len(asc))
+	}
+	if got := asc[0].CredentialSubject.Action.Timestamp; got != timestamps[0] {
+		t.Errorf("default ordering: expected oldest %s first, got %s", timestamps[0], got)
+	}
+
+	// Newest-first when opted in.
+	desc, err := s.QueryReceipts(Query{NewestFirst: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(desc) != 3 {
+		t.Fatalf("expected 3 receipts, got %d", len(desc))
+	}
+	if got := desc[0].CredentialSubject.Action.Timestamp; got != timestamps[2] {
+		t.Errorf("NewestFirst: expected newest %s first, got %s", timestamps[2], got)
+	}
+}
+
 func TestQueryReceiptsCombinedFilters(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()


### PR DESCRIPTION
## Summary

Fixes a confusing interaction between `mcp-proxy list`'s defaults:

- `cmd/mcp-proxy/cli.go:31` — `-limit` defaulted to 50
- `sdk/go/store/store.go:246` — `QueryReceipts` ordered `timestamp ASC`

Together, these hid recent receipts. In a store with >50 receipts, a newly-configured client's receipts (e.g. Codex starting to use the proxy for the first time) would land at the tail of the timeline and never appear in `list` output — looking as if the writes had been dropped, when in fact they were just past the window.

While I was in there: surface `issuer.name` and `issuer.operator.id` in the table, so you can tell at a glance which client and operator produced each receipt without reaching for `-json | jq`.

## Changes

- **`sdk/go/store/store.go`** — add `Query.NewestFirst bool`. Default `false` preserves the long-standing ASC ordering the SDK has always used; setting it to `true` reverses the order. Library callers that depend on stable ordering are unaffected.
- **`mcp-proxy/cmd/mcp-proxy/cli.go`** — set `NewestFirst: true` in `cmdList`, and add ISSUER / OPERATOR columns to the table output.
- **`sdk/go/store/store_test.go`** — test covering both default-ASC and `NewestFirst: true` behavior.
- **`mcp-proxy/go.mod`** — temporary `replace` directive so mcp-proxy can build against the in-tree `sdk/go` before a matching release is cut. Should be dropped (and the require bumped) at the next `sdk/go` release, same pattern as `bc675a9` / `2e87a0e`.

## Before / after

Against the same `receipts.db` containing Codex calls at positions ~139–140 of the timeline:

**Before:**
```
$ mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
# returns oldest 50 receipts — none from Codex
```

**After:**
```
ID                                       ACTION                 RISK   STATUS   ISSUER         OPERATOR               TIMESTAMP
---
urn:receipt:a9004cc5-...                 read                   low    success  Claude Code    did:web:anthropic.com  2026-04-15T00:15:18Z
urn:receipt:590480e2-...                 read                   low    success  Claude Code    did:web:anthropic.com  2026-04-15T00:11:05Z
urn:receipt:58b9c7ff-...                 read                   low    success  codex          did:web:anthropic.com  2026-04-15T00:06:48Z
urn:receipt:3384715f-...                 read                   low    success  codex          did:web:anthropic.com  2026-04-15T00:06:26Z
urn:receipt:c2e7b34f-...                 write                  medium success  Claude Code    did:web:anthropic.com  2026-04-15T00:01:39Z
urn:receipt:ccf92d30-...                 read                   low    success                                        2026-04-14T23:56:09Z
...
```

Receipts written before `-issuer-name` was added to the config correctly show an empty issuer (last rows above) — nothing in this change retroactively fills those in.

## Test plan

- [x] `cd sdk/go && go vet ./... && go test ./...`
- [x] `cd mcp-proxy && go vet ./... && go test ./... && go test -tags integration .`
- [x] Built binary, ran against real receipts.db — newest-first ordering + new columns render correctly
- [x] Reviewer spot-checks that the `replace` directive in `mcp-proxy/go.mod` is acceptable for this monorepo's cross-module development flow
