### PR TITLE
chore(mcp-proxy): drop replace directive, point to sdk/go v0.3.1

### DIFF
--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -2,14 +2,8 @@ module github.com/agent-receipts/ar/mcp-proxy
 
 go 1.26.1
 
-// Dev-time replace: build against the in-tree SDK so changes that add new
-// exported fields (e.g. store.Query.NewestFirst) are picked up before an
-// sdk/go release is cut. Drop this line — and bump the require below — when
-// a matching sdk/go version is released.
-replace github.com/agent-receipts/ar/sdk/go => ../sdk/go
-
 require (
-	github.com/agent-receipts/ar/sdk/go v0.3.0
+	github.com/agent-receipts/ar/sdk/go v0.3.1
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,3 +1,5 @@
+github.com/agent-receipts/ar/sdk/go v0.3.1 h1:20mU2aszom4gG7BvZyyT/mxMgeDJniBJv630771yqUI=
+github.com/agent-receipts/ar/sdk/go v0.3.1/go.mod h1:W/Lgz1a3s8mtlNP8MQq+2llwzWukokud+4NeMMOVhXI=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Unblocks the mcp-proxy v0.3.8 release.

- Released sdk/go v0.3.1 (includes `store.Query.NewestFirst`, `DataActions` taxonomy, golang.org/x/sys bump)
- Removed the dev-time `replace` directive from `mcp-proxy/go.mod`
- Bumped the `require` to `sdk/go v0.3.1`
- Ran `go mod tidy` to populate `go.sum`
- `go vet ./...` and `go test ./...` all pass