### PR TITLE
fix: make approval timeouts actionable in mcp-proxy

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -362,7 +362,7 @@ func serve() {
 									"risk_score":              riskScore,
 									"approval_id":             approvalID,
 									"approval_url":            approvalURL,
-									"approval_timeout_ms":     approvalWait.Milliseconds(),
+									"approval_timeout_ms":     (*approvalWait).Milliseconds(),
 									"approval_required":       true,
 									"approval_token_required": true,
 								},

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -89,6 +89,7 @@ func serve() {
 		principalDID = flag.String("principal", "did:user:unknown", "Principal DID")
 		chainID      = flag.String("chain", "", "Chain ID (auto-generated if empty)")
 		httpAddr     = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port)")
+		approvalWait = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -196,6 +197,7 @@ func serve() {
 	// Approval channels for pause actions.
 	approvalToken := generateToken(32)
 	approvals := audit.NewApprovalManager()
+	approvalURL := ""
 
 	// Receipt chain state.
 	sequence := 0
@@ -227,7 +229,7 @@ func serve() {
 		if err != nil {
 			log.Fatalf("mcp-proxy: http server: %v", err)
 		}
-		approvalURL := "http://" + ln.Addr().String()
+		approvalURL = "http://" + ln.Addr().String()
 		// Human-readable line (one copy-pasteable string, no log timestamp prefix).
 		fmt.Fprintf(os.Stderr, "mcp-proxy: approvals at %s (token: %s)\n", approvalURL, approvalToken)
 		// Machine-readable line — minimal discovery primitive for future tooling.
@@ -343,13 +345,28 @@ func serve() {
 					approvalID := generateToken(16)
 					log.Printf("mcp-proxy: PAUSED %s (rule: %s, risk: %d) — approval id: %s", toolName, decision.RuleName, riskScore, approvalID)
 					waitStart := time.Now()
-					approved := approvals.WaitForApproval(approvalID, 60*time.Second)
+					approvalStatus := approvals.WaitForApproval(approvalID, *approvalWait)
 					approvalWaitUs := time.Since(waitStart).Microseconds()
-					if !approved {
-						log.Printf("mcp-proxy: DENIED %s (timeout or explicit deny)", toolName)
+					if approvalStatus != audit.ApprovalApproved {
+						log.Printf("mcp-proxy: DENIED %s (%s)", toolName, approvalStatus)
 						return &proxy.HandlerResult{
-							Block:          true,
-							ClientResponse: proxy.MakeErrorResponse(msg.ID, -32002, "tool call denied: approval timeout or rejected"),
+							Block: true,
+							ClientResponse: proxy.MakeErrorResponseWithData(
+								msg.ID,
+								-32002,
+								buildApprovalDeniedMessage(toolName, decision.RuleName, riskScore, approvalID, approvalStatus, *approvalWait),
+								map[string]any{
+									"status":                  string(approvalStatus),
+									"tool_name":               toolName,
+									"rule_name":               decision.RuleName,
+									"risk_score":              riskScore,
+									"approval_id":             approvalID,
+									"approval_url":            approvalURL,
+									"approval_timeout_ms":     approvalWait.Milliseconds(),
+									"approval_required":       true,
+									"approval_token_required": true,
+								},
+							),
 						}
 					}
 					approvedBy = "http"
@@ -571,6 +588,17 @@ func serve() {
 	if err := p.Run(); err != nil {
 		log.Printf("mcp-proxy: %v", err)
 		os.Exit(1)
+	}
+}
+
+func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approvalID string, status audit.ApprovalStatus, timeout time.Duration) string {
+	switch status {
+	case audit.ApprovalDenied:
+		return fmt.Sprintf("tool call denied by approval workflow: tool=%s rule=%s risk=%d approval_id=%s", toolName, ruleName, riskScore, approvalID)
+	case audit.ApprovalTimedOut:
+		return fmt.Sprintf("tool call approval timed out after %s: tool=%s rule=%s risk=%d approval_id=%s", timeout, toolName, ruleName, riskScore, approvalID)
+	default:
+		return fmt.Sprintf("tool call denied by approval workflow: tool=%s rule=%s risk=%d approval_id=%s", toolName, ruleName, riskScore, approvalID)
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+)
+
+func TestBuildApprovalDeniedMessageTimeout(t *testing.T) {
+	got := buildApprovalDeniedMessage("create_pull_request", "pause_high_risk", 70, "abc123", audit.ApprovalTimedOut, 15*time.Second)
+
+	for _, want := range []string{
+		"timed out after 15s",
+		"tool=create_pull_request",
+		"rule=pause_high_risk",
+		"risk=70",
+		"approval_id=abc123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q to contain %q", got, want)
+		}
+	}
+}
+
+func TestBuildApprovalDeniedMessageExplicitDeny(t *testing.T) {
+	got := buildApprovalDeniedMessage("create_pull_request", "pause_high_risk", 70, "abc123", audit.ApprovalDenied, 15*time.Second)
+
+	if !strings.Contains(got, "denied by approval workflow") {
+		t.Fatalf("expected explicit deny message, got %q", got)
+	}
+	if strings.Contains(got, "timed out") {
+		t.Fatalf("explicit deny message should not mention timeout: %q", got)
+	}
+}

--- a/mcp-proxy/internal/audit/approval.go
+++ b/mcp-proxy/internal/audit/approval.go
@@ -5,6 +5,15 @@ import (
 	"time"
 )
 
+// ApprovalStatus describes the outcome of a pause/approval flow.
+type ApprovalStatus string
+
+const (
+	ApprovalApproved ApprovalStatus = "approved"
+	ApprovalDenied   ApprovalStatus = "denied"
+	ApprovalTimedOut ApprovalStatus = "timed_out"
+)
+
 // ApprovalManager handles pause/approve/deny flows for tool calls
 // that require human approval before proceeding.
 type ApprovalManager struct {
@@ -20,8 +29,8 @@ func NewApprovalManager() *ApprovalManager {
 }
 
 // WaitForApproval blocks until the given approval ID is approved, denied, or
-// the timeout elapses. Returns true if approved, false otherwise.
-func (a *ApprovalManager) WaitForApproval(id string, timeout time.Duration) bool {
+// the timeout elapses.
+func (a *ApprovalManager) WaitForApproval(id string, timeout time.Duration) ApprovalStatus {
 	ch := make(chan bool, 1)
 	a.mu.Lock()
 	a.pending[id] = ch
@@ -35,9 +44,12 @@ func (a *ApprovalManager) WaitForApproval(id string, timeout time.Duration) bool
 
 	select {
 	case approved := <-ch:
-		return approved
+		if approved {
+			return ApprovalApproved
+		}
+		return ApprovalDenied
 	case <-time.After(timeout):
-		return false
+		return ApprovalTimedOut
 	}
 }
 

--- a/mcp-proxy/internal/audit/approval_test.go
+++ b/mcp-proxy/internal/audit/approval_test.go
@@ -8,7 +8,7 @@ import (
 func TestApproveBeforeTimeout(t *testing.T) {
 	am := NewApprovalManager()
 
-	done := make(chan bool, 1)
+	done := make(chan ApprovalStatus, 1)
 	go func() {
 		done <- am.WaitForApproval("req-1", 5*time.Second)
 	}()
@@ -21,15 +21,15 @@ func TestApproveBeforeTimeout(t *testing.T) {
 	}
 
 	result := <-done
-	if !result {
-		t.Error("expected WaitForApproval to return true")
+	if result != ApprovalApproved {
+		t.Errorf("expected WaitForApproval to return %q, got %q", ApprovalApproved, result)
 	}
 }
 
 func TestDenyBeforeTimeout(t *testing.T) {
 	am := NewApprovalManager()
 
-	done := make(chan bool, 1)
+	done := make(chan ApprovalStatus, 1)
 	go func() {
 		done <- am.WaitForApproval("req-2", 5*time.Second)
 	}()
@@ -41,8 +41,8 @@ func TestDenyBeforeTimeout(t *testing.T) {
 	}
 
 	result := <-done
-	if result {
-		t.Error("expected WaitForApproval to return false after deny")
+	if result != ApprovalDenied {
+		t.Errorf("expected WaitForApproval to return %q after deny, got %q", ApprovalDenied, result)
 	}
 }
 
@@ -50,8 +50,8 @@ func TestApprovalTimeout(t *testing.T) {
 	am := NewApprovalManager()
 
 	result := am.WaitForApproval("req-3", 50*time.Millisecond)
-	if result {
-		t.Error("expected WaitForApproval to return false on timeout")
+	if result != ApprovalTimedOut {
+		t.Errorf("expected WaitForApproval to return %q on timeout, got %q", ApprovalTimedOut, result)
 	}
 }
 

--- a/mcp-proxy/internal/proxy/proxy.go
+++ b/mcp-proxy/internal/proxy/proxy.go
@@ -155,13 +155,24 @@ func (p *Proxy) pipe(src io.Reader, dst io.Writer, direction string) {
 
 // MakeErrorResponse creates a JSON-RPC error response for the given request ID.
 func MakeErrorResponse(id json.RawMessage, code int, message string) []byte {
+	return MakeErrorResponseWithData(id, code, message, nil)
+}
+
+// MakeErrorResponseWithData creates a JSON-RPC error response with optional
+// structured error data for the given request ID.
+func MakeErrorResponseWithData(id json.RawMessage, code int, message string, data map[string]any) []byte {
+	errObj := map[string]any{
+		"code":    code,
+		"message": message,
+	}
+	if data != nil {
+		errObj["data"] = data
+	}
+
 	resp := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      json.RawMessage(id),
-		"error": map[string]any{
-			"code":    code,
-			"message": message,
-		},
+		"error":   errObj,
 	}
 	b, _ := json.Marshal(resp)
 	return b

--- a/mcp-proxy/internal/proxy/proxy_test.go
+++ b/mcp-proxy/internal/proxy/proxy_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMakeErrorResponseWithData(t *testing.T) {
+	resp := MakeErrorResponseWithData(json.RawMessage(`1`), -32002, "denied", map[string]any{
+		"status": "timed_out",
+		"rule":   "pause_high_risk",
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	errObj, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %T", got["error"])
+	}
+
+	data, ok := errObj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error data object, got %T", errObj["data"])
+	}
+
+	if data["status"] != "timed_out" {
+		t.Fatalf("expected status %q, got %v", "timed_out", data["status"])
+	}
+}

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -21,6 +21,7 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 | `-principal` | `did:user:unknown` | Principal DID for receipts |
 | `-chain` | (auto UUID) | Chain ID for receipt chaining |
 | `-http` | `127.0.0.1:0` | HTTP address for the approval endpoint (default: random port, logged to stderr) |
+| `-approval-timeout` | `1m0s` | Maximum time to wait for HTTP approval before a paused call is auto-denied |
 
 ## Policy rules
 
@@ -63,7 +64,7 @@ rules:
 |--------|----------|
 | `pass` | Log only, forward normally |
 | `flag` | Log with highlight, forward normally |
-| `pause` | Hold for HTTP approval (60-second timeout, auto-denied on timeout) |
+| `pause` | Hold for HTTP approval (configurable timeout, auto-denied on timeout) |
 | `block` | Reject immediately with error |
 
 When multiple rules match, the most restrictive action wins (block > pause > flag > pass).
@@ -117,7 +118,7 @@ A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/
 
 When a tool call is paused by a policy rule:
 
-1. The proxy logs an approval ID and waits up to 60 seconds
+1. The proxy logs an approval ID and waits up to the configured `-approval-timeout` duration
 2. The approval URL and token are logged to stderr at startup, in two formats:
 
    ```
@@ -142,7 +143,15 @@ curl -X POST http://127.0.0.1:59850/api/tool-calls/{id}/deny \
   -H "Authorization: Bearer $APPROVAL_TOKEN"
 ```
 
-If no response within 60 seconds, the call is automatically denied.
+If no response arrives before `-approval-timeout` elapses, the call is automatically denied.
+
+Paused calls return a JSON-RPC error with structured details in `error.data`, including:
+
+- `status` (`denied` or `timed_out`)
+- `rule_name`
+- `risk_score`
+- `approval_id`
+- `approval_url`
 
 If you need a stable, predictable URL, pin the port with `-http 127.0.0.1:8080` (or any free port).
 


### PR DESCRIPTION
## What

Make paused-call approval failures in `mcp-proxy` much more actionable.

This change:

- adds `-approval-timeout` so the pause wait is configurable instead of hardcoded to 60 seconds
- distinguishes approval outcomes as `approved`, `denied`, and `timed_out`
- returns structured JSON-RPC `error.data` for paused-call denials, including the rule name, risk score, approval ID, approval URL, and timeout metadata
- updates the docs to explain the new flag and the approval error shape
- adds tests for approval status handling, structured JSON-RPC errors, and denial-message formatting

## Why

The existing proxy surfaced approval failures as a generic timeout-like error:

- `tool call denied: approval timeout or rejected`

That made it hard to tell whether the issue was:

- a policy pause rule firing
- an explicit deny
- an approval that timed out
- where approval was supposed to happen

This change makes the failure mode legible from the client side and easier to debug in real MCP workflows.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

Notes:
- `go test ./...` passed in `mcp-proxy`
- `go vet ./...` passed in `mcp-proxy`
- `pnpm build` passed in `site/`
- No spec or crypto behavior changes