### PR TITLE
chore: ignore codex worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ go.work.sum
 
 # Local dev files
 .claude/
+.codex-worktrees/
 *.db
 *.db-shm
 *.db-wal


### PR DESCRIPTION
## What

Ignore `.codex-worktrees/` in the repo `.gitignore`.

## Why

This repo now accumulates local Codex worktrees under `.codex-worktrees/`. They are local development artifacts and should not show up as untracked files in the main working tree.

## Checklist

- [x] Tests pass for all changed components
- [ ] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

Notes:
- `.gitignore`-only change
- No code or spec changes