### PR TITLE
chore: bump sdk-ts and sdk-py versions to 0.4.0

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Bump version strings ahead of the v0.4.0 release run.

- `sdk/ts/package.json`: `0.3.0` → `0.4.0`
- `sdk/py/pyproject.toml`: `0.3.0` → `0.4.0`

`scripts/release.sh` validates that the package version file matches the release tag before creating the GitHub release, so these bumps must land on `main` first.

The Go SDK (`sdk/go`) and `mcp-proxy` carry their version in the module path / git tag only — no file to bump.