### PR TITLE
feat(site): add /ecosystem landscape page

### DIFF
--- a/docs/ecosystem/landscape.md
+++ b/docs/ecosystem/landscape.md
@@ -1,6 +1,6 @@
 # Agent Security Tooling Landscape — April 2026
 
-An overview of the agent security, policy enforcement, and governance space as of mid-April 2026. Compiled to inform the Agent Receipts pivot decision.
+An overview of the agent security, policy enforcement, and governance space as of mid-April 2026.
 
 ---
 
@@ -29,7 +29,7 @@ These are the tools most relevant to an individual builder or small team enterin
 | **Language** | Python (primary), TS, .NET, Rust, Go SDKs | Go | Python | Go + system-level | Node.js | Rust |
 | **License** | MIT | Apache 2.0 | AGPL-3.0 (commercial available) | Source-available (commercial) | MIT | MIT |
 | **Stars** | New (days old) | 29 | ~50+ | ~100+ | ~30 | ~20 |
-| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pretooluse hook |
+| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pre-tool-use hook |
 | **MCP proxy** | No (framework adapters) | Yes (stdio) | Yes (stdio) | No (syscall-level) | Yes (stdio) | No (hook-based) |
 | **HTTP/egress proxy** | No | Yes (7-layer scanner) | No | Yes (network proxy) | No | No |
 | **Shell/command control** | No | No | No | Yes (shell shim, ptrace) | No | No |
@@ -113,28 +113,6 @@ Areas that remain underserved despite the crowded landscape:
 | **Browser automation governance** | Intercepting Puppeteer/Playwright/CDP actions with policy enforcement | Nobody (GitHub Copilot firewall explicitly doesn't cover this) |
 | **Policy portability standard** | A way to express agent policies that works across tools | Microsoft AGT supports 3 languages but no cross-tool standard exists |
 | **Agent identity federation** | Verifying agent identity across organizational boundaries | Microsoft AGT (SPIFFE/SVID) is closest; still early |
-
----
-
-## Implications for Agent Receipts Pivot
-
-### What's validated
-- The cryptographic primitives (Ed25519, SHA-256, DIDs) are now industry consensus — Agent Receipts picked correctly
-- The audit trail problem is real and widely acknowledged
-- The "security team says yes" workflow is the actual blocker for enterprise adoption
-
-### What's changed
-- The MCP proxy/firewall space is saturated (6+ serious implementations)
-- Microsoft AGT covers policy + identity + compliance with 5 language SDKs under MIT license
-- Canyon Road is building the deep kernel enforcement + commercial control plane
-- Building another standalone agent security tool requires a genuinely differentiated angle
-
-### Options to consider
-1. **Contribute to an existing project** — Microsoft AGT (Go SDK, policy engine) or Pipelock (Go, Apache 2.0, similar architecture to Beacon)
-2. **Build the reporting/compliance layer** — the gap between raw audit logs and CISO-ready artifacts is real and underserved
-3. **Build the cross-channel correlation layer** — the "unified event schema" problem nobody has solved in open source
-4. **Focus on the employer-specific problem** — build internal tooling that consumes these projects rather than competing with them
-5. **Specialize in W3C VC envelope** — Agent Receipts' unique primitive; could be contributed upstream to AGT or similar
 
 ---
 

--- a/docs/ecosystem/landscape.md
+++ b/docs/ecosystem/landscape.md
@@ -39,7 +39,7 @@ These are the tools most relevant to an individual builder or small team enterin
 | **Prompt injection detection** | MCP scanner module | Yes (response scanning) | Yes (8 inbound checks) | No | Yes | No |
 | **Cryptographic identity** | Ed25519 DIDs + ML-DSA-65 | Ed25519 signing | Ed25519 audit chain | No | No | No |
 | **Audit logging** | Structured + OTEL | JSON + Prometheus | JSON + signed hash chain | Structured + OTEL | JSON | No |
-| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC2, OWASP | OWASP mapping | DORA, FINMA, SOC2 | No | No | No |
+| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC 2, OWASP | OWASP mapping | DORA, FINMA, SOC 2 | No | No | No |
 | **Dashboard** | No | Prometheus/stats endpoint | Yes (web UI) | Via Watchtower (commercial) | Yes (web UI) | No |
 | **Framework integrations** | 12+ (LangChain, CrewAI, AutoGen, etc.) | Claude Code, Cursor | Claude Desktop, Cursor, any MCP client | Vercel, E2B, Daytona, Cloudflare, etc. | Any MCP client | Claude Code, Copilot CLI |
 | **Trust model** | Same-process middleware | Capability separation (proxy has no secrets) | Same-process proxy | Kernel-enforced isolation | Same-process proxy | Hook-based |

--- a/docs/ecosystem/landscape.md
+++ b/docs/ecosystem/landscape.md
@@ -1,0 +1,141 @@
+# Agent Security Tooling Landscape — April 2026
+
+An overview of the agent security, policy enforcement, and governance space as of mid-April 2026. Compiled to inform the Agent Receipts pivot decision.
+
+---
+
+## Executive Summary
+
+The agent security space has rapidly matured. Every major architectural approach — MCP proxying, egress firewalling, kernel-level enforcement, application-level policy engines, and enterprise gateways — now has at least one serious implementation. Microsoft's entry (Agent Governance Toolkit, April 2026) is the most comprehensive single project, covering policy, identity, compliance, and SRE across five language SDKs.
+
+The space segments into four layers:
+
+| Layer | What it does | Key players |
+|---|---|---|
+| **MCP Gateways** (commercial) | Managed proxy for MCP traffic with auth, audit, rate limiting | MintMCP, Peta, TrueFoundry, Lasso, Gravitee, Traefik Hub |
+| **Agent Firewalls** (open-source) | Intercept + scan agent traffic (MCP and/or HTTP) | Pipelock, mcp-firewall (ressl), Agent Wall, mcp-firewall (dzervas) |
+| **Kernel-Level Enforcement** | OS-level syscall interception, sandboxing | agentsh / Canyon Road, Anthropic sandbox-runtime |
+| **Governance Frameworks** | Application-level policy engine, identity, compliance | Microsoft AGT, GitHub Agentic Workflows |
+
+---
+
+## Detailed Comparison: Open-Source Agent Security Tools
+
+These are the tools most relevant to an individual builder or small team entering the space.
+
+| | **Microsoft AGT** | **Pipelock** | **mcp-firewall (ressl)** | **agentsh (Canyon Road)** | **Agent Wall** | **mcp-firewall (dzervas)** |
+|---|---|---|---|---|---|---|
+| **Released** | Apr 2026 | Jan 2026 | Feb 2026 | 2025–2026 | Feb 2026 | 2026 |
+| **Language** | Python (primary), TS, .NET, Rust, Go SDKs | Go | Python | Go + system-level | Node.js | Rust |
+| **License** | MIT | Apache 2.0 | AGPL-3.0 (commercial available) | Source-available (commercial) | MIT | MIT |
+| **Stars** | New (days old) | 29 | ~50+ | ~100+ | ~30 | ~20 |
+| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pretooluse hook |
+| **MCP proxy** | No (framework adapters) | Yes (stdio) | Yes (stdio) | No (syscall-level) | Yes (stdio) | No (hook-based) |
+| **HTTP/egress proxy** | No | Yes (7-layer scanner) | No | Yes (network proxy) | No | No |
+| **Shell/command control** | No | No | No | Yes (shell shim, ptrace) | No | No |
+| **File I/O control** | No | Integrity monitoring | No | Yes (FUSE, Landlock) | No | No |
+| **Policy engine** | YAML + OPA/Rego + Cedar | YAML config | YAML + OPA/Rego | YAML policy | YAML config | Jsonnet |
+| **DLP / secret scanning** | No | Yes (regex, entropy, env leak) | Yes (response scanning) | Yes (output redaction) | Yes | No |
+| **Prompt injection detection** | MCP scanner module | Yes (response scanning) | Yes (8 inbound checks) | No | Yes | No |
+| **Cryptographic identity** | Ed25519 DIDs + ML-DSA-65 | Ed25519 signing | Ed25519 audit chain | No | No | No |
+| **Audit logging** | Structured + OTEL | JSON + Prometheus | JSON + signed hash chain | Structured + OTEL | JSON | No |
+| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC2, OWASP | OWASP mapping | DORA, FINMA, SOC2 | No | No | No |
+| **Dashboard** | No | Prometheus/stats endpoint | Yes (web UI) | Via Watchtower (commercial) | Yes (web UI) | No |
+| **Framework integrations** | 12+ (LangChain, CrewAI, AutoGen, etc.) | Claude Code, Cursor | Claude Desktop, Cursor, any MCP client | Vercel, E2B, Daytona, Cloudflare, etc. | Any MCP client | Claude Code, Copilot CLI |
+| **Trust model** | Same-process middleware | Capability separation (proxy has no secrets) | Same-process proxy | Kernel-enforced isolation | Same-process proxy | Hook-based |
+
+---
+
+## Detailed Comparison: Commercial MCP Gateways
+
+| | **MintMCP** | **Peta (Agent Vault)** | **TrueFoundry** | **Lasso Security** | **Gravitee** | **Traefik Hub** |
+|---|---|---|---|---|---|---|
+| **Type** | Managed SaaS | Credential vault + gateway | AI platform + gateway | Security platform + OSS gateway | API gateway + MCP | Reverse proxy + MCP middleware |
+| **OSS component** | LLM Proxy (partial) | No | No | Yes (mcp-gateway, Apache 2.0) | No | No |
+| **Key differentiator** | One-click deploy, pre-built connectors | Zero-trust vault, agents never see raw keys | Low latency (3–4ms), 350+ rps | Plugin-based guardrails, PII detection (Presidio) | Protocol-aware, method-level governance | Extends existing Traefik deployments |
+| **Auth model** | OAuth 2.0 | Scoped time-limited tokens | OAuth 2.0 OBO | API key + plugins | Standard API gateway auth | Standard Traefik auth |
+| **Human-in-the-loop** | No | Yes (approval workflows) | No | No | No | No |
+| **Compliance** | SOC 2 | SOC 2 | Varies | Gartner Cool Vendor 2024 | Enterprise certifications | Enterprise certifications |
+| **Best for** | Fast deployment, non-security-specialist teams | Regulated industries, credential management | High-throughput, perf-sensitive deployments | Security-first orgs wanting OSS flexibility | Orgs already on Gravitee | Orgs already on Traefik |
+
+---
+
+## Platform-Native Solutions
+
+| | **GitHub Agentic Workflows** | **Cloudflare Enterprise MCP** | **GitHub Copilot Agent Firewall** |
+|---|---|---|---|
+| **Scope** | Full defense-in-depth for GH Actions agents | WAF + AI Gateway for MCP servers | Domain allowlist for Copilot cloud agent |
+| **Architecture** | Kernel isolation + MCP gateway + integrity filtering | WAF in front of MCP, portal pattern (N servers → 2 tools) | iptables-based egress filtering |
+| **Policy model** | Declarative YAML (network, integrity levels) | WAF rules + AI Gateway config | Domain allowlist (org or repo level) |
+| **Limitations** | GitHub Actions only | Cloudflare stack only | Only covers agent-started processes, not MCP servers; bypassable |
+| **Notable** | Trust-scored content filtering (merged/approved/unapproved) | Published April 15, 2026 — their own internal deployment | Honest about limitations in their own docs |
+
+---
+
+## Architectural Approaches Compared
+
+| Approach | Enforcement guarantee | Bypass risk | Setup complexity | Coverage scope |
+|---|---|---|---|---|
+| **Kernel-level** (agentsh) | Strongest — syscall interception | Very low (requires kernel exploit) | High (kernel 6.7+, FUSE, capabilities) | Shell, filesystem, network, processes |
+| **Egress proxy** (Pipelock) | Strong for network — capability separation | Medium (agent could use alternative channels) | Low (single binary) | Network egress, MCP responses |
+| **MCP stdio proxy** (mcp-firewall, Agent Wall) | Moderate — protocol-level interception | Medium (only covers MCP channel) | Low (wrap command) | MCP tool calls and responses only |
+| **Application middleware** (Microsoft AGT) | Weakest — same trust boundary as agent | High (agent can bypass if compromised) | Low (pip install) | Whatever the framework exposes |
+| **Hook-based** (dzervas/mcp-firewall) | Moderate — pre-execution check | Medium (depends on client enforcement) | Very low | Tool calls in supported clients |
+
+---
+
+## Key Primitives Convergence
+
+Multiple projects have independently converged on the same cryptographic and protocol primitives:
+
+| Primitive | Used by |
+|---|---|
+| **Ed25519 signing** | Microsoft AGT, Pipelock, mcp-firewall (ressl), Agent Receipts |
+| **SHA-256 hash chaining** | mcp-firewall (ressl), Agent Receipts |
+| **DIDs (Decentralized Identifiers)** | Microsoft AGT, Agent Receipts |
+| **OPA/Rego policies** | Microsoft AGT, mcp-firewall (ressl) |
+| **Cedar policies** | Microsoft AGT |
+| **W3C Verifiable Credentials** | Agent Receipts (unique in this space) |
+| **OWASP Agentic AI Top 10** | Microsoft AGT, Pipelock, mcp-firewall (ressl) |
+| **YAML policy config** | All projects |
+
+---
+
+## Gap Analysis
+
+Areas that remain underserved despite the crowded landscape:
+
+| Gap | Description | Who's closest |
+|---|---|---|
+| **Unified cross-channel audit** | Correlating MCP calls + REST calls + shell commands + browser actions into one timeline per agent session | Canyon Road (Watchtower) — but commercial/closed |
+| **CISO-ready reporting** | PDF/HTML reports a security team can review to approve agentic AI adoption | mcp-firewall (ressl) has compliance reports; Microsoft AGT has framework mappings; neither produces turnkey CISO artifacts |
+| **HTTP/OpenAPI interception** | Policy-enforced proxy for agent REST API calls (not just MCP) | Pipelock (egress proxy); agentsh (network proxy) — but neither is OpenAPI-schema-aware |
+| **Browser automation governance** | Intercepting Puppeteer/Playwright/CDP actions with policy enforcement | Nobody (GitHub Copilot firewall explicitly doesn't cover this) |
+| **Policy portability standard** | A way to express agent policies that works across tools | Microsoft AGT supports 3 languages but no cross-tool standard exists |
+| **Agent identity federation** | Verifying agent identity across organizational boundaries | Microsoft AGT (SPIFFE/SVID) is closest; still early |
+
+---
+
+## Implications for Agent Receipts Pivot
+
+### What's validated
+- The cryptographic primitives (Ed25519, SHA-256, DIDs) are now industry consensus — Agent Receipts picked correctly
+- The audit trail problem is real and widely acknowledged
+- The "security team says yes" workflow is the actual blocker for enterprise adoption
+
+### What's changed
+- The MCP proxy/firewall space is saturated (6+ serious implementations)
+- Microsoft AGT covers policy + identity + compliance with 5 language SDKs under MIT license
+- Canyon Road is building the deep kernel enforcement + commercial control plane
+- Building another standalone agent security tool requires a genuinely differentiated angle
+
+### Options to consider
+1. **Contribute to an existing project** — Microsoft AGT (Go SDK, policy engine) or Pipelock (Go, Apache 2.0, similar architecture to Beacon)
+2. **Build the reporting/compliance layer** — the gap between raw audit logs and CISO-ready artifacts is real and underserved
+3. **Build the cross-channel correlation layer** — the "unified event schema" problem nobody has solved in open source
+4. **Focus on the employer-specific problem** — build internal tooling that consumes these projects rather than competing with them
+5. **Specialize in W3C VC envelope** — Agent Receipts' unique primitive; could be contributed upstream to AGT or similar
+
+---
+
+*Last updated: April 16, 2026*

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
             { label: "Configuration", slug: "reference/configuration" },
           ],
         },
+        { label: "Ecosystem", slug: "ecosystem" },
       ],
     }),
   ],

--- a/site/src/content/docs/ecosystem/index.mdx
+++ b/site/src/content/docs/ecosystem/index.mdx
@@ -32,7 +32,7 @@ These are the tools most relevant to an individual builder or small team enterin
 | **Language** | Python (primary), TS, .NET, Rust, Go SDKs | Go | Python | Go + system-level | Node.js | Rust |
 | **License** | MIT | Apache 2.0 | AGPL-3.0 (commercial available) | Source-available (commercial) | MIT | MIT |
 | **Stars** | New (days old) | 29 | ~50+ | ~100+ | ~30 | ~20 |
-| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pretooluse hook |
+| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pre-tool-use hook |
 | **MCP proxy** | No (framework adapters) | Yes (stdio) | Yes (stdio) | No (syscall-level) | Yes (stdio) | No (hook-based) |
 | **HTTP/egress proxy** | No | Yes (7-layer scanner) | No | Yes (network proxy) | No | No |
 | **Shell/command control** | No | No | No | Yes (shell shim, ptrace) | No | No |

--- a/site/src/content/docs/ecosystem/index.mdx
+++ b/site/src/content/docs/ecosystem/index.mdx
@@ -38,7 +38,7 @@ These are the tools most relevant to an individual builder or small team enterin
 | **Prompt injection detection** | MCP scanner module | Yes (response scanning) | Yes (8 inbound checks) | No | Yes | No |
 | **Cryptographic identity** | Ed25519 DIDs + ML-DSA-65 | Ed25519 signing | Ed25519 audit chain | No | No | No |
 | **Audit logging** | Structured + OTEL | JSON + Prometheus | JSON + signed hash chain | Structured + OTEL | JSON | No |
-| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC2, OWASP | OWASP mapping | DORA, FINMA, SOC2 | No | No | No |
+| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC 2, OWASP | OWASP mapping | DORA, FINMA, SOC 2 | No | No | No |
 | **Dashboard** | No | Prometheus/stats endpoint | Yes (web UI) | Via Watchtower (commercial) | Yes (web UI) | No |
 | **Framework integrations** | 12+ (LangChain, CrewAI, AutoGen, etc.) | Claude Code, Cursor | Claude Desktop, Cursor, any MCP client | Vercel, E2B, Daytona, Cloudflare, etc. | Any MCP client | Claude Code, Copilot CLI |
 | **Trust model** | Same-process middleware | Capability separation (proxy has no secrets) | Same-process proxy | Kernel-enforced isolation | Same-process proxy | Hook-based |

--- a/site/src/content/docs/ecosystem/index.mdx
+++ b/site/src/content/docs/ecosystem/index.mdx
@@ -3,10 +3,6 @@ title: Agent Security Tooling Landscape — April 2026
 description: A neutral overview of the agent security, policy enforcement, and governance space as of April 2026.
 ---
 
-A neutral overview of the agent security, policy enforcement, and governance space as of April 2026.
-
----
-
 ## Executive Summary
 
 The agent security space has rapidly matured. Every major architectural approach — MCP proxying, egress firewalling, kernel-level enforcement, application-level policy engines, and enterprise gateways — now has at least one serious implementation. Microsoft's entry (Agent Governance Toolkit, April 2026) is the most comprehensive single project, covering policy, identity, compliance, and SRE across five language SDKs.

--- a/site/src/content/docs/ecosystem/index.mdx
+++ b/site/src/content/docs/ecosystem/index.mdx
@@ -1,0 +1,122 @@
+---
+title: Agent Security Tooling Landscape — April 2026
+description: A neutral overview of the agent security, policy enforcement, and governance space as of April 2026.
+---
+
+A neutral overview of the agent security, policy enforcement, and governance space as of April 2026.
+
+---
+
+## Executive Summary
+
+The agent security space has rapidly matured. Every major architectural approach — MCP proxying, egress firewalling, kernel-level enforcement, application-level policy engines, and enterprise gateways — now has at least one serious implementation. Microsoft's entry (Agent Governance Toolkit, April 2026) is the most comprehensive single project, covering policy, identity, compliance, and SRE across five language SDKs.
+
+The space segments into four layers:
+
+| Layer | What it does | Key players |
+|---|---|---|
+| **MCP Gateways** (commercial) | Managed proxy for MCP traffic with auth, audit, rate limiting | MintMCP, Peta, TrueFoundry, Lasso, Gravitee, Traefik Hub |
+| **Agent Firewalls** (open-source) | Intercept + scan agent traffic (MCP and/or HTTP) | Pipelock, mcp-firewall (ressl), Agent Wall, mcp-firewall (dzervas) |
+| **Kernel-Level Enforcement** | OS-level syscall interception, sandboxing | agentsh / Canyon Road, Anthropic sandbox-runtime |
+| **Governance Frameworks** | Application-level policy engine, identity, compliance | Microsoft AGT, GitHub Agentic Workflows |
+
+---
+
+## Detailed Comparison: Open-Source Agent Security Tools
+
+These are the tools most relevant to an individual builder or small team entering the space.
+
+| | **Microsoft AGT** | **Pipelock** | **mcp-firewall (ressl)** | **agentsh (Canyon Road)** | **Agent Wall** | **mcp-firewall (dzervas)** |
+|---|---|---|---|---|---|---|
+| **Released** | Apr 2026 | Jan 2026 | Feb 2026 | 2025–2026 | Feb 2026 | 2026 |
+| **Language** | Python (primary), TS, .NET, Rust, Go SDKs | Go | Python | Go + system-level | Node.js | Rust |
+| **License** | MIT | Apache 2.0 | AGPL-3.0 (commercial available) | Source-available (commercial) | MIT | MIT |
+| **Stars** | New (days old) | 29 | ~50+ | ~100+ | ~30 | ~20 |
+| **Approach** | Application middleware | Egress proxy + MCP proxy | MCP stdio proxy + SDK library | Kernel enforcement (Landlock, FUSE, ptrace, seccomp) | MCP stdio proxy | Claude Code pretooluse hook |
+| **MCP proxy** | No (framework adapters) | Yes (stdio) | Yes (stdio) | No (syscall-level) | Yes (stdio) | No (hook-based) |
+| **HTTP/egress proxy** | No | Yes (7-layer scanner) | No | Yes (network proxy) | No | No |
+| **Shell/command control** | No | No | No | Yes (shell shim, ptrace) | No | No |
+| **File I/O control** | No | Integrity monitoring | No | Yes (FUSE, Landlock) | No | No |
+| **Policy engine** | YAML + OPA/Rego + Cedar | YAML config | YAML + OPA/Rego | YAML policy | YAML config | Jsonnet |
+| **DLP / secret scanning** | No | Yes (regex, entropy, env leak) | Yes (response scanning) | Yes (output redaction) | Yes | No |
+| **Prompt injection detection** | MCP scanner module | Yes (response scanning) | Yes (8 inbound checks) | No | Yes | No |
+| **Cryptographic identity** | Ed25519 DIDs + ML-DSA-65 | Ed25519 signing | Ed25519 audit chain | No | No | No |
+| **Audit logging** | Structured + OTEL | JSON + Prometheus | JSON + signed hash chain | Structured + OTEL | JSON | No |
+| **Compliance reporting** | EU AI Act, NIST, HIPAA, SOC2, OWASP | OWASP mapping | DORA, FINMA, SOC2 | No | No | No |
+| **Dashboard** | No | Prometheus/stats endpoint | Yes (web UI) | Via Watchtower (commercial) | Yes (web UI) | No |
+| **Framework integrations** | 12+ (LangChain, CrewAI, AutoGen, etc.) | Claude Code, Cursor | Claude Desktop, Cursor, any MCP client | Vercel, E2B, Daytona, Cloudflare, etc. | Any MCP client | Claude Code, Copilot CLI |
+| **Trust model** | Same-process middleware | Capability separation (proxy has no secrets) | Same-process proxy | Kernel-enforced isolation | Same-process proxy | Hook-based |
+
+---
+
+## Detailed Comparison: Commercial MCP Gateways
+
+| | **MintMCP** | **Peta (Agent Vault)** | **TrueFoundry** | **Lasso Security** | **Gravitee** | **Traefik Hub** |
+|---|---|---|---|---|---|---|
+| **Type** | Managed SaaS | Credential vault + gateway | AI platform + gateway | Security platform + OSS gateway | API gateway + MCP | Reverse proxy + MCP middleware |
+| **OSS component** | LLM Proxy (partial) | No | No | Yes (mcp-gateway, Apache 2.0) | No | No |
+| **Key differentiator** | One-click deploy, pre-built connectors | Zero-trust vault, agents never see raw keys | Low latency (3–4ms), 350+ rps | Plugin-based guardrails, PII detection (Presidio) | Protocol-aware, method-level governance | Extends existing Traefik deployments |
+| **Auth model** | OAuth 2.0 | Scoped time-limited tokens | OAuth 2.0 OBO | API key + plugins | Standard API gateway auth | Standard Traefik auth |
+| **Human-in-the-loop** | No | Yes (approval workflows) | No | No | No | No |
+| **Compliance** | SOC 2 | SOC 2 | Varies | Gartner Cool Vendor 2024 | Enterprise certifications | Enterprise certifications |
+| **Best for** | Fast deployment, non-security-specialist teams | Regulated industries, credential management | High-throughput, perf-sensitive deployments | Security-first orgs wanting OSS flexibility | Orgs already on Gravitee | Orgs already on Traefik |
+
+---
+
+## Platform-Native Solutions
+
+| | **GitHub Agentic Workflows** | **Cloudflare Enterprise MCP** | **GitHub Copilot Agent Firewall** |
+|---|---|---|---|
+| **Scope** | Full defense-in-depth for GH Actions agents | WAF + AI Gateway for MCP servers | Domain allowlist for Copilot cloud agent |
+| **Architecture** | Kernel isolation + MCP gateway + integrity filtering | WAF in front of MCP, portal pattern (N servers → 2 tools) | iptables-based egress filtering |
+| **Policy model** | Declarative YAML (network, integrity levels) | WAF rules + AI Gateway config | Domain allowlist (org or repo level) |
+| **Limitations** | GitHub Actions only | Cloudflare stack only | Only covers agent-started processes, not MCP servers; bypassable |
+| **Notable** | Trust-scored content filtering (merged/approved/unapproved) | Published April 15, 2026 — their own internal deployment | Honest about limitations in their own docs |
+
+---
+
+## Architectural Approaches Compared
+
+| Approach | Enforcement guarantee | Bypass risk | Setup complexity | Coverage scope |
+|---|---|---|---|---|
+| **Kernel-level** (agentsh) | Strongest — syscall interception | Very low (requires kernel exploit) | High (kernel 6.7+, FUSE, capabilities) | Shell, filesystem, network, processes |
+| **Egress proxy** (Pipelock) | Strong for network — capability separation | Medium (agent could use alternative channels) | Low (single binary) | Network egress, MCP responses |
+| **MCP stdio proxy** (mcp-firewall, Agent Wall) | Moderate — protocol-level interception | Medium (only covers MCP channel) | Low (wrap command) | MCP tool calls and responses only |
+| **Application middleware** (Microsoft AGT) | Weakest — same trust boundary as agent | High (agent can bypass if compromised) | Low (pip install) | Whatever the framework exposes |
+| **Hook-based** (dzervas/mcp-firewall) | Moderate — pre-execution check | Medium (depends on client enforcement) | Very low | Tool calls in supported clients |
+
+---
+
+## Key Primitives Convergence
+
+Multiple projects have independently converged on the same cryptographic and protocol primitives:
+
+| Primitive | Used by |
+|---|---|
+| **Ed25519 signing** | Microsoft AGT, Pipelock, mcp-firewall (ressl), Agent Receipts |
+| **SHA-256 hash chaining** | mcp-firewall (ressl), Agent Receipts |
+| **DIDs (Decentralized Identifiers)** | Microsoft AGT, Agent Receipts |
+| **OPA/Rego policies** | Microsoft AGT, mcp-firewall (ressl) |
+| **Cedar policies** | Microsoft AGT |
+| **W3C Verifiable Credentials** | Agent Receipts (unique in this space) |
+| **OWASP Agentic AI Top 10** | Microsoft AGT, Pipelock, mcp-firewall (ressl) |
+| **YAML policy config** | All projects |
+
+---
+
+## Gap Analysis
+
+Areas that remain underserved despite the crowded landscape:
+
+| Gap | Description | Who's closest |
+|---|---|---|
+| **Unified cross-channel audit** | Correlating MCP calls + REST calls + shell commands + browser actions into one timeline per agent session | Canyon Road (Watchtower) — but commercial/closed |
+| **CISO-ready reporting** | PDF/HTML reports a security team can review to approve agentic AI adoption | mcp-firewall (ressl) has compliance reports; Microsoft AGT has framework mappings; neither produces turnkey CISO artifacts |
+| **HTTP/OpenAPI interception** | Policy-enforced proxy for agent REST API calls (not just MCP) | Pipelock (egress proxy); agentsh (network proxy) — but neither is OpenAPI-schema-aware |
+| **Browser automation governance** | Intercepting Puppeteer/Playwright/CDP actions with policy enforcement | Nobody (GitHub Copilot firewall explicitly doesn't cover this) |
+| **Policy portability standard** | A way to express agent policies that works across tools | Microsoft AGT supports 3 languages but no cross-tool standard exists |
+| **Agent identity federation** | Verifying agent identity across organizational boundaries | Microsoft AGT (SPIFFE/SVID) is closest; still early |
+
+---
+
+*Last updated: April 16, 2026*


### PR DESCRIPTION
## Summary

- Adds `docs/ecosystem/landscape.md` as the raw-markdown source for the agent security landscape (public-safe scope — internal pivot notes have been stripped)
- Adds `site/src/content/docs/ecosystem/index.mdx` as the Starlight-rendered version with frontmatter; content matches `docs/` modulo title/description
- Adds "Ecosystem" to the sidebar nav in `astro.config.mjs`

## Test plan

- [ ] Run `pnpm dev` in `site/` and navigate to `/ecosystem` — verify page renders with correct title and no duplicated lede
- [ ] Confirm "Ecosystem" appears in the sidebar nav
- [ ] Confirm `docs/ecosystem/landscape.md` does not contain any pivot-decision or internal-strategy content
- [ ] Confirm the two files stay in sync modulo MDX frontmatter