### PR TITLE
docs(mcp-proxy): fix installation and integration guides end-to-end

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -10,13 +10,13 @@ Claude Code is a CLI-based agent that connects to MCP servers for tools like Git
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
 - Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
-- The MCP server you want to audit. The examples below wrap the GitHub MCP server:
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
 
   ```bash
-  npm install -g @modelcontextprotocol/server-github
+  brew install github-mcp-server
   ```
 
-  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
 ## Generate a signing key
 
@@ -31,7 +31,7 @@ Use absolute paths everywhere — Claude Code launches MCP servers with a clean 
 
 ## Register the proxy with Claude Code
 
-Use `claude mcp add-json` to register a proxied server. The example below wraps `mcp-server-github`. The heredoc lets your shell resolve the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`):
+Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. The heredoc lets your shell resolve the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`):
 
 ```bash
 claude mcp add-json github-audited --scope user "$(cat <<JSON
@@ -44,7 +44,7 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
-    "$(which mcp-server-github)"
+    "$(which github-mcp-server)"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
@@ -74,7 +74,7 @@ Since JSON files can't shell-expand, print the absolute paths you need first and
 echo "command: $(go env GOPATH)/bin/mcp-proxy"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which mcp-server-github)"
+echo "server:  $(which github-mcp-server)"
 ```
 
 ```json
@@ -89,7 +89,7 @@ echo "server:  $(which mcp-server-github)"
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
-        "/opt/homebrew/bin/mcp-server-github"
+        "/opt/homebrew/bin/github-mcp-server"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -36,7 +36,7 @@ Use `claude mcp add-json` to register a proxied server. The example below wraps 
 ```bash
 claude mcp add-json github-audited --scope user "$(cat <<JSON
 {
-  "command": "$(go env GOPATH)/bin/mcp-proxy",
+  "command": "$(which mcp-proxy)",
   "args": [
     "-name", "github",
     "-key", "$HOME/.agent-receipts/github-proxy.pem",
@@ -71,7 +71,7 @@ For a shared team configuration, add a `.mcp.json` file at the project root. Thi
 Since JSON files can't shell-expand, print the absolute paths you need first and paste them into the template below:
 
 ```bash
-echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -24,24 +24,27 @@ Use absolute paths everywhere — Claude Code launches MCP servers with a clean 
 
 ## Register the proxy with Claude Code
 
-Use `claude mcp add-json` to register a proxied server. The example below wraps `mcp-server-github`:
+Use `claude mcp add-json` to register a proxied server. The example below wraps `mcp-server-github`. The heredoc lets your shell resolve the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`):
 
 ```bash
-claude mcp add-json github-audited --scope user '{
-  "command": "/Users/YOU/go/bin/mcp-proxy",
+claude mcp add-json github-audited --scope user "$(cat <<JSON
+{
+  "command": "$(go env GOPATH)/bin/mcp-proxy",
   "args": [
     "-name", "github",
-    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
+    "-key", "$HOME/.agent-receipts/github-proxy.pem",
+    "-receipt-db", "$HOME/.agent-receipts/receipts.db",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
-    "/opt/homebrew/bin/mcp-server-github"
+    "$(which mcp-server-github)"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
   }
-}'
+}
+JSON
+)"
 ```
 
 `--scope user` makes the server available across all projects. Omit it for project-local scope only.
@@ -56,7 +59,16 @@ claude mcp list
 
 ## Project-scoped setup via .mcp.json
 
-For a shared team configuration, add a `.mcp.json` file at the project root. This is committed to version control — do not put tokens directly in it. Reference environment variables instead:
+For a shared team configuration, add a `.mcp.json` file at the project root. This is committed to version control — do not put tokens directly in it. Reference environment variables instead.
+
+Since JSON files can't shell-expand, print the absolute paths you need first and paste them into the template below:
+
+```bash
+echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "key:     $HOME/.agent-receipts/github-proxy.pem"
+echo "db:      $HOME/.agent-receipts/receipts.db"
+echo "server:  $(which mcp-server-github)"
+```
 
 ```json
 {

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -10,6 +10,13 @@ Claude Code is a CLI-based agent that connects to MCP servers for tools like Git
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
 - Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
+- The MCP server you want to audit. The examples below wrap the GitHub MCP server:
+
+  ```bash
+  npm install -g @modelcontextprotocol/server-github
+  ```
+
+  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
 
 ## Generate a signing key
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -44,7 +44,7 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
-    "$(which github-mcp-server)"
+    "$(which github-mcp-server)", "stdio"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
@@ -89,7 +89,7 @@ echo "server:  $(which github-mcp-server)"
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
-        "/opt/homebrew/bin/github-mcp-server"
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -9,13 +9,13 @@ Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Age
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
-- The MCP server you want to audit. The example below wraps the GitHub MCP server:
+- The MCP server you want to audit. The example below wraps GitHub's official MCP server:
 
   ```bash
-  npm install -g @modelcontextprotocol/server-github
+  brew install github-mcp-server
   ```
 
-  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
 ## Generate a signing key
 
@@ -38,7 +38,7 @@ Claude Desktop doesn't shell-expand config values, so paste absolute paths. Prin
 echo "command: $(go env GOPATH)/bin/mcp-proxy"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which mcp-server-github)"
+echo "server:  $(which github-mcp-server)"
 ```
 
 Then substitute the four values into the template:
@@ -52,7 +52,7 @@ Then substitute the four values into the template:
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
-        "/opt/homebrew/bin/mcp-server-github"
+        "/opt/homebrew/bin/github-mcp-server"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -23,7 +23,18 @@ Use absolute paths everywhere — Claude Desktop launches MCP servers with a cle
 
 ## Configure claude_desktop_config.json
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
+
+Claude Desktop doesn't shell-expand config values, so paste absolute paths. Print yours:
+
+```bash
+echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "key:     $HOME/.agent-receipts/github-proxy.pem"
+echo "db:      $HOME/.agent-receipts/receipts.db"
+echo "server:  $(which mcp-server-github)"
+```
+
+Then substitute the four values into the template:
 
 ```json
 {

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -32,14 +32,16 @@ Use absolute paths everywhere — Claude Desktop launches MCP servers with a cle
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
 
-Claude Desktop doesn't shell-expand config values, so paste absolute paths. Print yours:
+Claude Desktop doesn't shell-expand config values, so paste absolute paths. On macOS/Linux, print yours:
 
 ```bash
-echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"
 ```
+
+On Windows (PowerShell), use `(Get-Command mcp-proxy).Source`, `$env:USERPROFILE`, and `(Get-Command github-mcp-server).Source` to obtain the equivalent values.
 
 Then substitute the four values into the template:
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -52,7 +52,7 @@ Then substitute the four values into the template:
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
-        "/opt/homebrew/bin/github-mcp-server"
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -9,6 +9,13 @@ Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Age
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
+- The MCP server you want to audit. The example below wraps the GitHub MCP server:
+
+  ```bash
+  npm install -g @modelcontextprotocol/server-github
+  ```
+
+  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
 
 ## Generate a signing key
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -10,13 +10,13 @@ OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/confi
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
 - Codex installed (`npm install -g @openai/codex` or via the IDE extension)
-- The MCP server you want to audit. The examples below wrap the GitHub MCP server:
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
 
   ```bash
-  npm install -g @modelcontextprotocol/server-github
+  brew install github-mcp-server
   ```
 
-  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
 ## Generate a signing key
 
@@ -43,7 +43,7 @@ codex mcp add github-audited \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
-    "$(which mcp-server-github)"
+    "$(which github-mcp-server)"
 ```
 
 Add `--scope user` to make the server available across all projects (default is project-scoped).
@@ -58,7 +58,7 @@ Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, 
 echo "command: $(go env GOPATH)/bin/mcp-proxy"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which mcp-server-github)"
+echo "server:  $(which github-mcp-server)"
 ```
 
 Then substitute them into the template:
@@ -73,7 +73,7 @@ args = [
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",
   "-operator-name", "OpenAI",
-  "/opt/homebrew/bin/mcp-server-github"
+  "/opt/homebrew/bin/github-mcp-server"
 ]
 enabled = true
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -24,19 +24,19 @@ Use absolute paths everywhere — Codex launches MCP servers with a clean enviro
 
 ## Configure via CLI
 
-Use `codex mcp add` to register the proxy wrapping any MCP server:
+Use `codex mcp add` to register the proxy wrapping any MCP server. The shell resolves the proxy, key, and server paths at paste time (replace only `YOUR_TOKEN`):
 
 ```bash
 codex mcp add github-audited \
   --env GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_TOKEN \
-  -- /Users/YOU/go/bin/mcp-proxy \
+  -- "$(go env GOPATH)/bin/mcp-proxy" \
     -name github \
-    -key /Users/YOU/.agent-receipts/github-proxy.pem \
-    -receipt-db /Users/YOU/.agent-receipts/receipts.db \
+    -key "$HOME/.agent-receipts/github-proxy.pem" \
+    -receipt-db "$HOME/.agent-receipts/receipts.db" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
-    /opt/homebrew/bin/mcp-server-github
+    "$(which mcp-server-github)"
 ```
 
 Add `--scope user` to make the server available across all projects (default is project-scoped).
@@ -45,7 +45,16 @@ Add `--scope user` to make the server available across all projects (default is 
 
 ## Configure via config.toml
 
-Alternatively, edit `~/.codex/config.toml` directly:
+Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, so print your absolute paths first:
+
+```bash
+echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "key:     $HOME/.agent-receipts/github-proxy.pem"
+echo "db:      $HOME/.agent-receipts/receipts.db"
+echo "server:  $(which mcp-server-github)"
+```
+
+Then substitute them into the template:
 
 ```toml
 [mcp_servers.github-audited]

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -36,7 +36,7 @@ Use `codex mcp add` to register the proxy wrapping any MCP server. The shell res
 ```bash
 codex mcp add github-audited \
   --env GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_TOKEN \
-  -- "$(go env GOPATH)/bin/mcp-proxy" \
+  -- "$(which mcp-proxy)" \
     -name github \
     -key "$HOME/.agent-receipts/github-proxy.pem" \
     -receipt-db "$HOME/.agent-receipts/receipts.db" \
@@ -55,7 +55,7 @@ Add `--scope user` to make the server available across all projects (default is 
 Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, so print your absolute paths first:
 
 ```bash
-echo "command: $(go env GOPATH)/bin/mcp-proxy"
+echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -10,6 +10,13 @@ OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/confi
 - [mcp-proxy installed](/mcp-proxy/installation/)
 - A signing key pair generated (see below)
 - Codex installed (`npm install -g @openai/codex` or via the IDE extension)
+- The MCP server you want to audit. The examples below wrap the GitHub MCP server:
+
+  ```bash
+  npm install -g @modelcontextprotocol/server-github
+  ```
+
+  This puts an `mcp-server-github` binary on your `$PATH`. Verify with `which mcp-server-github`.
 
 ## Generate a signing key
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -43,7 +43,7 @@ codex mcp add github-audited \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
-    "$(which github-mcp-server)"
+    "$(which github-mcp-server)" stdio
 ```
 
 Add `--scope user` to make the server available across all projects (default is project-scoped).
@@ -73,7 +73,7 @@ args = [
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",
   "-operator-name", "OpenAI",
-  "/opt/homebrew/bin/github-mcp-server"
+  "/opt/homebrew/bin/github-mcp-server", "stdio"
 ]
 enabled = true
 

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -35,7 +35,7 @@ fish_add_path (go env GOPATH)/bin
 
 ## Basic usage
 
-Wrap any MCP server by passing its command as arguments. For a quick smoke test, use the official filesystem MCP server:
+Wrap any MCP server by passing its command as arguments. For a quick smoke test, use the official filesystem MCP server (requires Node.js/`npx` — if you don't have it, substitute any MCP server command you already have):
 
 ```bash
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -33,13 +33,15 @@ fish_add_path (go env GOPATH)/bin
 
 ## Basic usage
 
-Wrap any MCP server by passing its command as arguments:
+Wrap any MCP server by passing its command as arguments. For a quick smoke test, use the official filesystem MCP server:
 
 ```bash
-mcp-proxy node /path/to/mcp-server.js
+mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
-The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. By default it generates an ephemeral Ed25519 key pair for signing receipts.
+The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. By default it generates an ephemeral Ed25519 key pair for signing receipts. Press `Ctrl-C` to stop.
+
+For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), or [Codex](/mcp-proxy/codex/).
 
 ## Persistent signing key
 
@@ -51,7 +53,7 @@ openssl genpkey -algorithm Ed25519 -out private.pem
 openssl pkey -in private.pem -pubout -out public.pem
 
 # Run with persistent key
-mcp-proxy -key private.pem node /path/to/mcp-server.js
+mcp-proxy -key private.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
 ## Next steps

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -21,12 +21,14 @@ No CGO or external C libraries required -- the proxy uses pure Go SQLite.
 mcp-proxy -version
 ```
 
-If your shell reports `Unknown command: mcp-proxy`, the Go bin directory isn't on your `$PATH`. `go install` places binaries in `$(go env GOPATH)/bin` (usually `~/go/bin`). Add it to your shell profile:
+If `mcp-proxy` isn't found (bash/zsh say `command not found`; fish says `Unknown command`), the Go bin directory isn't on your `$PATH`. `go install` writes binaries to `$GOBIN` when it's set, otherwise to `$(go env GOPATH)/bin` (usually `~/go/bin`). Add whichever applies to your shell profile:
 
 ```bash
 # bash / zsh
 export PATH="$(go env GOPATH)/bin:$PATH"
+```
 
+```fish
 # fish
 fish_add_path (go env GOPATH)/bin
 ```

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -21,6 +21,16 @@ No CGO or external C libraries required -- the proxy uses pure Go SQLite.
 mcp-proxy -version
 ```
 
+If your shell reports `Unknown command: mcp-proxy`, the Go bin directory isn't on your `$PATH`. `go install` places binaries in `$(go env GOPATH)/bin` (usually `~/go/bin`). Add it to your shell profile:
+
+```bash
+# bash / zsh
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+# fish
+fish_add_path (go env GOPATH)/bin
+```
+
 ## Basic usage
 
 Wrap any MCP server by passing its command as arguments:

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -47,16 +47,16 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 # Install
 go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 
-# Wrap any MCP server
-mcp-proxy node /path/to/mcp-server.js
+# Wrap any MCP server (example: the filesystem server via npx)
+mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 
-# With configuration
+# With configuration (example: GitHub's official MCP server — brew install github-mcp-server)
 mcp-proxy \
   -name github \
   -key private.pem \
   -rules rules.yaml \
   -taxonomy taxonomy.json \
-  node /path/to/github-mcp-server.js
+  github-mcp-server
 ```
 
 ## Claude Desktop integration
@@ -77,7 +77,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
         "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
-        "/opt/homebrew/bin/mcp-server-github"
+        "/opt/homebrew/bin/github-mcp-server"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
@@ -106,7 +106,7 @@ claude mcp add-json github-audited --scope user '{
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
     "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
-    "/opt/homebrew/bin/mcp-server-github"
+    "/opt/homebrew/bin/github-mcp-server"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -56,7 +56,7 @@ mcp-proxy \
   -key private.pem \
   -rules rules.yaml \
   -taxonomy taxonomy.json \
-  github-mcp-server
+  github-mcp-server stdio
 ```
 
 ## Claude Desktop integration
@@ -77,7 +77,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
         "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
-        "/opt/homebrew/bin/github-mcp-server"
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
@@ -106,7 +106,7 @@ claude mcp add-json github-audited --scope user '{
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
     "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
-    "/opt/homebrew/bin/github-mcp-server"
+    "/opt/homebrew/bin/github-mcp-server", "stdio"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"


### PR DESCRIPTION
## Summary

Originally a one-line PATH troubleshooting note; grew to fix every dead end users actually hit while following the install guide end-to-end.

**Installation page**
- Add PATH troubleshooting note for `mcp-proxy` not found after `go install` (bash/zsh + fish, mentions `GOBIN`).
- Replace unrunnable `/path/to/mcp-server.js` placeholder with a runnable `npx @modelcontextprotocol/server-filesystem` smoke test; note the Node.js dependency.

**Integration docs (Claude Code, Claude Desktop, Codex, Overview)**
- Switch from the deprecated `@modelcontextprotocol/server-github` npm package to GitHub's official `github-mcp-server` (`brew install github-mcp-server`) and pass its required `stdio` subcommand.
- Use `$(which mcp-proxy)` / `$(which github-mcp-server)` in CLI examples so paths resolve at paste time regardless of `GOBIN` or install method.
- Add a helper `echo` block above each static JSON/TOML template that prints the exact absolute paths to paste.
- Add an "install the wrapped MCP server" prerequisite to all three integration pages.
- Scope echo helpers to macOS/Linux and add a PowerShell note for Windows readers of the Claude Desktop guide.

## Test plan

- [ ] Render docs locally and confirm the updated code fences render correctly.
- [ ] Walk through the Claude Code install guide top-to-bottom on a clean shell and confirm `claude mcp list` shows the audited server connected.
