### PR TITLE
docs(mcp-proxy): clarify mcpServers merges with existing Claude Desktop config

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -40,6 +40,7 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
   "args": [
     "-name", "github",
     "-key", "$HOME/.agent-receipts/github-proxy.pem",
+    "-db", "$HOME/.agent-receipts/audit.db",
     "-receipt-db", "$HOME/.agent-receipts/receipts.db",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
@@ -71,10 +72,11 @@ For a shared team configuration, add a `.mcp.json` file at the project root. Thi
 Since JSON files can't shell-expand, print the absolute paths you need first and paste them into the template below:
 
 ```bash
-echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which github-mcp-server)"
+echo "command:    $(which mcp-proxy)"
+echo "key:        $HOME/.agent-receipts/github-proxy.pem"
+echo "audit-db:   $HOME/.agent-receipts/audit.db"
+echo "receipt-db: $HOME/.agent-receipts/receipts.db"
+echo "server:     $(which github-mcp-server)"
 ```
 
 ```json
@@ -85,6 +87,7 @@ echo "server:  $(which github-mcp-server)"
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-db", "/Users/YOU/.agent-receipts/audit.db",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -44,9 +44,11 @@ echo "server:     $(which github-mcp-server)"
 
 On Windows (PowerShell), use `(Get-Command mcp-proxy).Source`, `$env:USERPROFILE`, and `(Get-Command github-mcp-server).Source` to obtain the equivalent values.
 
-If the file doesn't exist yet, create it. If it exists but only contains app preferences (e.g. `{"preferences": {...}}`), that's normal — `mcpServers` is a top-level sibling key; add it alongside whatever is already there rather than replacing the file.
+If the file doesn't exist yet, create it.
 
-Substitute the four printed values into the `mcpServers` block:
+If it already contains app preferences (for example, `{"preferences": {...}}`), that's normal. Add `mcpServers` as another top-level key rather than replacing the file — the result should look like `{"preferences": {...}, "mcpServers": {...}}` (mind the comma between sibling keys).
+
+Substitute the printed absolute paths and binary values into the `mcpServers` block below, and replace `YOUR_TOKEN` in `env` with your actual GitHub personal access token:
 
 ```json
 {

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -35,10 +35,11 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
 Claude Desktop doesn't shell-expand config values, so paste absolute paths. On macOS/Linux, print yours:
 
 ```bash
-echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which github-mcp-server)"
+echo "command:    $(which mcp-proxy)"
+echo "key:        $HOME/.agent-receipts/github-proxy.pem"
+echo "audit-db:   $HOME/.agent-receipts/audit.db"
+echo "receipt-db: $HOME/.agent-receipts/receipts.db"
+echo "server:     $(which github-mcp-server)"
 ```
 
 On Windows (PowerShell), use `(Get-Command mcp-proxy).Source`, `$env:USERPROFILE`, and `(Get-Command github-mcp-server).Source` to obtain the equivalent values.
@@ -55,6 +56,7 @@ Substitute the four printed values into the `mcpServers` block:
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-db", "/Users/YOU/.agent-receipts/audit.db",
         "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -43,7 +43,9 @@ echo "server:  $(which github-mcp-server)"
 
 On Windows (PowerShell), use `(Get-Command mcp-proxy).Source`, `$env:USERPROFILE`, and `(Get-Command github-mcp-server).Source` to obtain the equivalent values.
 
-Then substitute the four values into the template:
+If the file doesn't exist yet, create it. If it exists but only contains app preferences (e.g. `{"preferences": {...}}`), that's normal — `mcpServers` is a top-level sibling key; add it alongside whatever is already there rather than replacing the file.
+
+Substitute the four printed values into the `mcpServers` block:
 
 ```json
 {

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -39,6 +39,7 @@ codex mcp add github-audited \
   -- "$(which mcp-proxy)" \
     -name github \
     -key "$HOME/.agent-receipts/github-proxy.pem" \
+    -db "$HOME/.agent-receipts/audit.db" \
     -receipt-db "$HOME/.agent-receipts/receipts.db" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
@@ -55,10 +56,11 @@ Add `--scope user` to make the server available across all projects (default is 
 Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, so print your absolute paths first:
 
 ```bash
-echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
-echo "server:  $(which github-mcp-server)"
+echo "command:    $(which mcp-proxy)"
+echo "key:        $HOME/.agent-receipts/github-proxy.pem"
+echo "audit-db:   $HOME/.agent-receipts/audit.db"
+echo "receipt-db: $HOME/.agent-receipts/receipts.db"
+echo "server:     $(which github-mcp-server)"
 ```
 
 Then substitute them into the template:
@@ -69,6 +71,7 @@ command = "/Users/YOU/go/bin/mcp-proxy"
 args = [
   "-name", "github",
   "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+  "-db", "/Users/YOU/.agent-receipts/audit.db",
   "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",


### PR DESCRIPTION
## Summary

Users following the Claude Desktop integration guide may find that `~/Library/Application Support/Claude/claude_desktop_config.json` already exists with app preferences (e.g. `{"preferences": {...}}`) and mistake that for a sign the file is the wrong one or that they need to replace it. Adds a line clarifying that `mcpServers` is a top-level sibling key to merge alongside whatever is already there.

## Test plan

- [ ] Re-render the Claude Desktop page and confirm the new line sits above the JSON template.
