### PR TITLE
fix(mcp-proxy/classifier): add suffix matching for resource-first tool names

### DIFF
--- a/mcp-proxy/internal/audit/classifier.go
+++ b/mcp-proxy/internal/audit/classifier.go
@@ -38,6 +38,36 @@ func ClassifyOperation(toolName string) string {
 		}
 	}
 
+	// Suffix checks for resource-first naming (e.g. github-mcp-server's pull_request_read).
+	// Same priority order as prefix checks: delete > execute > write > read.
+	deleteSuffixes := []string{"_delete", "_remove"}
+	for _, s := range deleteSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "delete"
+		}
+	}
+
+	execSuffixes := []string{"_run", "_exec"}
+	for _, s := range execSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "execute"
+		}
+	}
+
+	writeSuffixes := []string{"_create", "_update", "_write"}
+	for _, s := range writeSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "write"
+		}
+	}
+
+	readSuffixes := []string{"_read"}
+	for _, s := range readSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "read"
+		}
+	}
+
 	return "unknown"
 }
 

--- a/mcp-proxy/internal/audit/classifier_test.go
+++ b/mcp-proxy/internal/audit/classifier_test.go
@@ -17,6 +17,12 @@ func TestClassifyOperation(t *testing.T) {
 		{"run_query", "execute"},
 		{"exec_command", "execute"},
 		{"some_random_tool", "unknown"},
+		// Resource-first naming (github-mcp-server style).
+		{"pull_request_read", "read"},
+		{"pull_request_create", "write"},
+		{"repository_delete", "delete"},
+		// Ambiguous: contains _read but does not end with it → unknown.
+		{"repository_read_only_mode", "unknown"},
 	}
 	for _, tt := range tests {
 		got := ClassifyOperation(tt.tool)


### PR DESCRIPTION
## Summary

- Extends `ClassifyOperation` in `classifier.go` to check `_read`/`_create`/`_update`/`_write`/`_delete`/`_remove`/`_run`/`_exec` **suffixes** after the existing prefix checks
- Prefix checks run first — no regression to already-working tool names
- Taxonomy mappings remain the per-tool override escape hatch

## Test plan

- [ ] `pull_request_read` → `read`
- [ ] `pull_request_create` → `write`
- [ ] `repository_delete` → `delete`
- [ ] `repository_read_only_mode` → `unknown` (ambiguous; does not end with `_read`)
- [ ] Existing prefix-based cases unchanged (`read_file`, `delete_file`, etc.)
- [ ] `go test ./internal/audit/...` passes

Closes #208