### PR TITLE
fix(mcp-proxy): classify resource-first tool names via suffix match

### DIFF
--- a/mcp-proxy/internal/audit/classifier.go
+++ b/mcp-proxy/internal/audit/classifier.go
@@ -38,6 +38,33 @@ func ClassifyOperation(toolName string) string {
 		}
 	}
 
+	// Suffix checks cover resource-first naming like `pull_request_read`
+	// (github-mcp-server) where the action word trails the resource.
+	deleteSuffixes := []string{"_delete", "_remove"}
+	for _, s := range deleteSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "delete"
+		}
+	}
+
+	execSuffixes := []string{"_run", "_exec"}
+	for _, s := range execSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "execute"
+		}
+	}
+
+	writeSuffixes := []string{"_create", "_update", "_write"}
+	for _, s := range writeSuffixes {
+		if strings.HasSuffix(lower, s) {
+			return "write"
+		}
+	}
+
+	if strings.HasSuffix(lower, "_read") {
+		return "read"
+	}
+
 	return "unknown"
 }
 

--- a/mcp-proxy/internal/audit/classifier_test.go
+++ b/mcp-proxy/internal/audit/classifier_test.go
@@ -17,6 +17,20 @@ func TestClassifyOperation(t *testing.T) {
 		{"run_query", "execute"},
 		{"exec_command", "execute"},
 		{"some_random_tool", "unknown"},
+
+		// Resource-first naming (e.g. github-mcp-server).
+		{"pull_request_read", "read"},
+		{"pull_request_create", "write"},
+		{"pull_request_update", "write"},
+		{"repository_delete", "delete"},
+		{"repository_remove", "delete"},
+		{"workflow_run", "execute"},
+		{"command_exec", "execute"},
+		{"file_write", "write"},
+
+		// Ambiguous: `_read` appears mid-name but name ends with `_mode`,
+		// so this must not match the `_read` suffix.
+		{"repository_read_only_mode", "unknown"},
 	}
 	for _, tt := range tests {
 		got := ClassifyOperation(tt.tool)


### PR DESCRIPTION
Closes #208

## Summary

`audit.ClassifyOperation` only matched action-first tool names, so calls proxied to servers using resource-first naming (e.g. the official `github-mcp-server` with `pull_request_read`, `repository_delete`) fell through to `unknown` and defaulted to medium risk.

This adds suffix checks (`_read`, `_create`/`_update`/`_write`, `_delete`/`_remove`, `_run`/`_exec`) after the existing prefix checks. Prefix checks still run first, so current names don't regress, and taxonomy mappings remain the per-tool override.

The fallback at `mcp-proxy/cmd/mcp-proxy/main.go:493` keys off `actionType`, so risk levels align automatically (`pull_request_read` → read/low, `repository_delete` → delete/high).

## Test plan

- `go test ./...` — new cases for `pull_request_read`, `pull_request_create`, `pull_request_update`, `repository_delete`, `repository_remove`, `workflow_run`, `command_exec`, `file_write`, plus `repository_read_only_mode` → `unknown` to lock in non-substring behavior.
- `go vet ./...`
- `go build ./...`