### PR TITLE
feat(mcp-proxy): default -db/-receipt-db to $HOME/.agent-receipts

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -23,7 +23,7 @@ func openReceiptStore(path string) *store.Store {
 
 func cmdList(args []string) {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
-	db := fs.String("receipt-db", "receipts.db", "Receipt store path")
+	db := fs.String("receipt-db", defaultDBPath("receipts.db"), "Receipt store path")
 	chainID := fs.String("chain", "", "Filter by chain ID")
 	riskLevel := fs.String("risk", "", "Filter by risk level")
 	actionType := fs.String("action", "", "Filter by action type")
@@ -83,7 +83,7 @@ func cmdList(args []string) {
 
 func cmdInspect(args []string) {
 	fs := flag.NewFlagSet("inspect", flag.ExitOnError)
-	db := fs.String("receipt-db", "receipts.db", "Receipt store path")
+	db := fs.String("receipt-db", defaultDBPath("receipts.db"), "Receipt store path")
 	pubKeyPath := fs.String("key", "", "Public key (PEM file) for signature verification")
 	fs.Parse(args)
 
@@ -138,7 +138,7 @@ func cmdInspect(args []string) {
 
 func cmdVerify(args []string) {
 	fs := flag.NewFlagSet("verify", flag.ExitOnError)
-	db := fs.String("receipt-db", "receipts.db", "Receipt store path")
+	db := fs.String("receipt-db", defaultDBPath("receipts.db"), "Receipt store path")
 	pubKeyPath := fs.String("key", "", "Public key (PEM file) — required")
 	fs.Parse(args)
 
@@ -188,7 +188,7 @@ func cmdVerify(args []string) {
 
 func cmdExport(args []string) {
 	fs := flag.NewFlagSet("export", flag.ExitOnError)
-	db := fs.String("receipt-db", "receipts.db", "Receipt store path")
+	db := fs.String("receipt-db", defaultDBPath("receipts.db"), "Receipt store path")
 	fs.Parse(args)
 
 	if fs.NArg() < 1 {
@@ -220,7 +220,7 @@ func cmdExport(args []string) {
 
 func cmdStats(args []string) {
 	fs := flag.NewFlagSet("stats", flag.ExitOnError)
-	db := fs.String("receipt-db", "receipts.db", "Receipt store path")
+	db := fs.String("receipt-db", defaultDBPath("receipts.db"), "Receipt store path")
 	asJSON := fs.Bool("json", false, "Output as JSON")
 	fs.Parse(args)
 
@@ -273,7 +273,7 @@ func openAuditStore(path string) *audit.Store {
 
 func cmdTiming(args []string) {
 	fs := flag.NewFlagSet("timing", flag.ExitOnError)
-	db := fs.String("db", "audit.db", "Audit database path")
+	db := fs.String("db", defaultDBPath("audit.db"), "Audit database path")
 	session := fs.String("session", "", "Filter by session ID")
 	asJSON := fs.Bool("json", false, "Output as JSON")
 	limit := fs.Int("limit", 20, "Max tools to show")

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -13,6 +13,10 @@ import (
 )
 
 func openReceiptStore(path string) *store.Store {
+	if err := ensureDBDir(path); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating receipt store directory: %v\n", err)
+		os.Exit(1)
+	}
 	s, err := store.Open(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error opening receipt store: %v\n", err)
@@ -263,6 +267,10 @@ func cmdStats(args []string) {
 }
 
 func openAuditStore(path string) *audit.Store {
+	if err := ensureDBDir(path); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating audit store directory: %v\n", err)
+		os.Exit(1)
+	}
 	s, err := audit.Open(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error opening audit store: %v\n", err)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -615,13 +615,15 @@ func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approv
 	}
 }
 
-// defaultDBPath returns an absolute path under $HOME/.agent-receipts/ for the
-// given filename. MCP clients (Claude Desktop, Claude Code, Codex) spawn the
-// proxy with an unwritable cwd, so a relative default would crash on first
-// open. Falls back to the bare filename if the home directory is unavailable.
+// defaultDBPath returns an absolute path under the user's home directory
+// (`~/.agent-receipts/<name>`) for the given filename. MCP clients (Claude
+// Desktop, Claude Code, Codex) spawn the proxy with an unwritable cwd, so a
+// relative default would crash on first open. Falls back to the bare filename
+// only if the home directory cannot be resolved to an absolute path — callers
+// are expected to surface a clear error when that fallback is hit.
 func defaultDBPath(name string) string {
 	home, err := os.UserHomeDir()
-	if err != nil {
+	if err != nil || home == "" || !filepath.IsAbs(home) {
 		return name
 	}
 	return filepath.Join(home, ".agent-receipts", name)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -615,6 +615,11 @@ func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approv
 	}
 }
 
+// userHomeDir is overridable in tests so the fallback path in defaultDBPath
+// can be exercised deterministically (clearing $HOME isn't enough on Unix —
+// os.UserHomeDir can still resolve via /etc/passwd).
+var userHomeDir = os.UserHomeDir
+
 // defaultDBPath returns an absolute path under the user's home directory
 // (`~/.agent-receipts/<name>`) for the given filename. MCP clients (Claude
 // Desktop, Claude Code, Codex) spawn the proxy with an unwritable cwd, so a
@@ -622,7 +627,7 @@ func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approv
 // only if the home directory cannot be resolved to an absolute path — callers
 // are expected to surface a clear error when that fallback is hit.
 func defaultDBPath(name string) string {
-	home, err := os.UserHomeDir()
+	home, err := userHomeDir()
 	if err != nil || home == "" || !filepath.IsAbs(home) {
 		return name
 	}
@@ -636,7 +641,10 @@ func ensureDBDir(path string) error {
 	if dir == "" || dir == "." {
 		return nil
 	}
-	return os.MkdirAll(dir, 0o700)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create database directory %q: %w", dir, err)
+	}
+	return nil
 }
 
 func generateToken(n int) string {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -75,8 +76,8 @@ func main() {
 
 func serve() {
 	var (
-		dbPath       = flag.String("db", "audit.db", "SQLite audit database path")
-		receiptDB    = flag.String("receipt-db", "receipts.db", "SQLite receipt store path")
+		dbPath       = flag.String("db", defaultDBPath("audit.db"), "SQLite audit database path")
+		receiptDB    = flag.String("receipt-db", defaultDBPath("receipts.db"), "SQLite receipt store path")
 		keyPath      = flag.String("key", "", "Ed25519 private key (PEM file)")
 		taxonomyPath = flag.String("taxonomy", "", "Taxonomy mappings (JSON file)")
 		rulesPath    = flag.String("rules", "", "Policy rules (YAML file)")
@@ -121,6 +122,9 @@ func serve() {
 	}
 
 	// Open audit store.
+	if err := ensureDBDir(*dbPath); err != nil {
+		log.Fatalf("mcp-proxy: create audit db directory: %v", err)
+	}
 	auditDB, err := audit.Open(*dbPath)
 	if err != nil {
 		log.Fatalf("mcp-proxy: open audit db: %v", err)
@@ -134,6 +138,9 @@ func serve() {
 	defer auditDB.EndSession(sessionID)
 
 	// Open receipt store.
+	if err := ensureDBDir(*receiptDB); err != nil {
+		log.Fatalf("mcp-proxy: create receipt db directory: %v", err)
+	}
 	rStore, err := receiptStore.Open(*receiptDB)
 	if err != nil {
 		log.Fatalf("mcp-proxy: open receipt store: %v", err)
@@ -606,6 +613,28 @@ func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approv
 	default:
 		return fmt.Sprintf("tool call denied by approval workflow: tool=%s rule=%s risk=%d approval_id=%s", toolName, ruleName, riskScore, approvalID)
 	}
+}
+
+// defaultDBPath returns an absolute path under $HOME/.agent-receipts/ for the
+// given filename. MCP clients (Claude Desktop, Claude Code, Codex) spawn the
+// proxy with an unwritable cwd, so a relative default would crash on first
+// open. Falls back to the bare filename if the home directory is unavailable.
+func defaultDBPath(name string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return name
+	}
+	return filepath.Join(home, ".agent-receipts", name)
+}
+
+// ensureDBDir creates the parent directory of path with 0o700 permissions.
+// SQLite can create the database file itself but not the directory holding it.
+func ensureDBDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o700)
 }
 
 func generateToken(n int) string {

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -32,5 +35,59 @@ func TestBuildApprovalDeniedMessageExplicitDeny(t *testing.T) {
 	}
 	if strings.Contains(got, "timed out") {
 		t.Fatalf("explicit deny message should not mention timeout: %q", got)
+	}
+}
+
+func TestDefaultDBPathUsesHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	got := defaultDBPath("audit.db")
+	want := filepath.Join(home, ".agent-receipts", "audit.db")
+	if got != want {
+		t.Fatalf("defaultDBPath(audit.db) = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDBPathFallsBackWhenHomeUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.UserHomeDir on Windows reads multiple env vars; fallback path is hard to force portably")
+	}
+	t.Setenv("HOME", "")
+
+	got := defaultDBPath("audit.db")
+	if got != "audit.db" {
+		t.Fatalf("expected fallback to bare filename, got %q", got)
+	}
+}
+
+func TestEnsureDBDirCreatesParent(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "nested", "sub", "audit.db")
+
+	if err := ensureDBDir(dbPath); err != nil {
+		t.Fatalf("ensureDBDir: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Dir(dbPath))
+	if err != nil {
+		t.Fatalf("stat parent dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("parent is not a directory")
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o700 {
+			t.Fatalf("parent dir perm = %o, want 0700", perm)
+		}
+	}
+}
+
+func TestEnsureDBDirNoOpForBareFilename(t *testing.T) {
+	if err := ensureDBDir("audit.db"); err != nil {
+		t.Fatalf("ensureDBDir for bare filename should be a no-op, got %v", err)
 	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -38,12 +39,16 @@ func TestBuildApprovalDeniedMessageExplicitDeny(t *testing.T) {
 	}
 }
 
+func withHomeDirResolver(t *testing.T, resolver func() (string, error)) {
+	t.Helper()
+	prev := userHomeDir
+	userHomeDir = resolver
+	t.Cleanup(func() { userHomeDir = prev })
+}
+
 func TestDefaultDBPathUsesHomeDir(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
-	if runtime.GOOS == "windows" {
-		t.Setenv("USERPROFILE", home)
-	}
+	withHomeDirResolver(t, func() (string, error) { return home, nil })
 
 	got := defaultDBPath("audit.db")
 	want := filepath.Join(home, ".agent-receipts", "audit.db")
@@ -52,32 +57,26 @@ func TestDefaultDBPathUsesHomeDir(t *testing.T) {
 	}
 }
 
-func TestDefaultDBPathFallsBackWhenHomeUnavailable(t *testing.T) {
-	// On Unix, os.UserHomeDir() can succeed via /etc/passwd lookup even when
-	// HOME is empty, but defaultDBPath also rejects empty/non-absolute home
-	// strings, so this test stays deterministic across platforms.
-	if runtime.GOOS == "windows" {
-		t.Setenv("USERPROFILE", "")
-		t.Setenv("HOMEDRIVE", "")
-		t.Setenv("HOMEPATH", "")
-	} else {
-		t.Setenv("HOME", "")
-	}
+func TestDefaultDBPathFallsBackOnResolverError(t *testing.T) {
+	withHomeDirResolver(t, func() (string, error) { return "", errors.New("no home") })
 
-	got := defaultDBPath("audit.db")
-	if got != "audit.db" {
+	if got := defaultDBPath("audit.db"); got != "audit.db" {
 		t.Fatalf("expected fallback to bare filename, got %q", got)
 	}
 }
 
-func TestDefaultDBPathRejectsRelativeHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("UserHomeDir on Windows reads multiple env vars; relative-home injection is not portable")
-	}
-	t.Setenv("HOME", "relative/path")
+func TestDefaultDBPathFallsBackOnEmptyHome(t *testing.T) {
+	withHomeDirResolver(t, func() (string, error) { return "", nil })
 
-	got := defaultDBPath("audit.db")
-	if got != "audit.db" {
+	if got := defaultDBPath("audit.db"); got != "audit.db" {
+		t.Fatalf("expected fallback for empty home, got %q", got)
+	}
+}
+
+func TestDefaultDBPathRejectsRelativeHome(t *testing.T) {
+	withHomeDirResolver(t, func() (string, error) { return "relative/path", nil })
+
+	if got := defaultDBPath("audit.db"); got != "audit.db" {
 		t.Fatalf("expected fallback for non-absolute home, got %q", got)
 	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -53,14 +53,32 @@ func TestDefaultDBPathUsesHomeDir(t *testing.T) {
 }
 
 func TestDefaultDBPathFallsBackWhenHomeUnavailable(t *testing.T) {
+	// On Unix, os.UserHomeDir() can succeed via /etc/passwd lookup even when
+	// HOME is empty, but defaultDBPath also rejects empty/non-absolute home
+	// strings, so this test stays deterministic across platforms.
 	if runtime.GOOS == "windows" {
-		t.Skip("os.UserHomeDir on Windows reads multiple env vars; fallback path is hard to force portably")
+		t.Setenv("USERPROFILE", "")
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+	} else {
+		t.Setenv("HOME", "")
 	}
-	t.Setenv("HOME", "")
 
 	got := defaultDBPath("audit.db")
 	if got != "audit.db" {
 		t.Fatalf("expected fallback to bare filename, got %q", got)
+	}
+}
+
+func TestDefaultDBPathRejectsRelativeHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("UserHomeDir on Windows reads multiple env vars; relative-home injection is not portable")
+	}
+	t.Setenv("HOME", "relative/path")
+
+	got := defaultDBPath("audit.db")
+	if got != "audit.db" {
+		t.Fatalf("expected fallback for non-absolute home, got %q", got)
 	}
 }
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -40,7 +40,6 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
   "args": [
     "-name", "github",
     "-key", "$HOME/.agent-receipts/github-proxy.pem",
-    "-receipt-db", "$HOME/.agent-receipts/receipts.db",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -73,7 +72,6 @@ Since JSON files can't shell-expand, print the absolute paths you need first and
 ```bash
 echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"
 ```
 
@@ -85,7 +83,6 @@ echo "server:  $(which github-mcp-server)"
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -106,13 +103,12 @@ Each developer sets `GITHUB_PERSONAL_ACCESS_TOKEN` in their shell environment. T
 After making tool calls through Claude Code, inspect the receipt store from your terminal:
 
 ```bash
-# List all receipts
-mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+# List all receipts (uses the default ~/.agent-receipts/receipts.db)
+mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
   -key ~/.agent-receipts/github-proxy-pub.pem \
-  -receipt-db ~/.agent-receipts/receipts.db \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -37,13 +37,12 @@ Claude Desktop doesn't shell-expand config values, so paste absolute paths. On m
 ```bash
 echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"
 ```
 
 On Windows (PowerShell), use `(Get-Command mcp-proxy).Source`, `$env:USERPROFILE`, and `(Get-Command github-mcp-server).Source` to obtain the equivalent values.
 
-Then substitute the four values into the template:
+Then substitute the three values into the template:
 
 ```json
 {
@@ -53,7 +52,6 @@ Then substitute the four values into the template:
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
@@ -73,13 +71,12 @@ Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — ever
 After making tool calls, inspect the receipt store from your terminal:
 
 ```bash
-# List all receipts
-mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+# List all receipts (uses the default ~/.agent-receipts/receipts.db)
+mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
   -key ~/.agent-receipts/github-proxy-pub.pem \
-  -receipt-db ~/.agent-receipts/receipts.db \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -39,7 +39,6 @@ codex mcp add github-audited \
   -- "$(which mcp-proxy)" \
     -name github \
     -key "$HOME/.agent-receipts/github-proxy.pem" \
-    -receipt-db "$HOME/.agent-receipts/receipts.db" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
@@ -57,7 +56,6 @@ Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, 
 ```bash
 echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
-echo "db:      $HOME/.agent-receipts/receipts.db"
 echo "server:  $(which github-mcp-server)"
 ```
 
@@ -69,7 +67,6 @@ command = "/Users/YOU/go/bin/mcp-proxy"
 args = [
   "-name", "github",
   "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-  "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",
   "-operator-name", "OpenAI",
@@ -96,13 +93,12 @@ Or check active servers inside the Codex TUI with `/mcp`.
 After making tool calls through Codex, inspect the receipt store from your terminal:
 
 ```bash
-# List all receipts
-mcp-proxy list -receipt-db ~/.agent-receipts/receipts.db
+# List all receipts (uses the default ~/.agent-receipts/receipts.db)
+mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
   -key ~/.agent-receipts/github-proxy-pub.pem \
-  -receipt-db ~/.agent-receipts/receipts.db \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -7,8 +7,8 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `$HOME/.agent-receipts/audit.db` | SQLite audit database path. Parent directory is created (mode 0700) on first run. |
-| `-receipt-db` | `$HOME/.agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created (mode 0700) on first run. |
+| `-db` | `$HOME/.agent-receipts/audit.db` | SQLite audit database path. Parent directory is created on first run (mode 0700 on Unix). |
+| `-receipt-db` | `$HOME/.agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created on first run (mode 0700 on Unix). |
 | `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
 | `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
 | `-rules` | (built-in defaults) | Policy rules YAML file |

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -7,8 +7,8 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `audit.db` | SQLite audit database path |
-| `-receipt-db` | `receipts.db` | SQLite receipt store path |
+| `-db` | `$HOME/.agent-receipts/audit.db` | SQLite audit database path. Parent directory is created (mode 0700) on first run. |
+| `-receipt-db` | `$HOME/.agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created (mode 0700) on first run. |
 | `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
 | `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
 | `-rules` | (built-in defaults) | Policy rules YAML file |
@@ -195,7 +195,7 @@ mcp-proxy -name github -http 127.0.0.1:8080 ... /path/to/server
 mcp-proxy -name github -http 127.0.0.1:8081 ... /path/to/server
 ```
 
-Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log.
+Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log. By default both point at `$HOME/.agent-receipts/`, so all clients share one audit log unless you override them.
 
 :::note
 The approval HTTP server is only needed when policy rules use the `pause` action. If you don't use approval workflows, the random-port default has no observable effect.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -71,8 +71,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-db", "/Users/YOU/.agent-receipts/audit.db",
-        "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -99,8 +97,6 @@ claude mcp add-json github-audited --scope user '{
   "args": [
     "-name", "github",
     "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-    "-db", "/Users/YOU/.agent-receipts/audit.db",
-    "-receipt-db", "/Users/YOU/.agent-receipts/receipts.db",
     "-http", "127.0.0.1:8081",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -5,6 +5,8 @@ description: Command reference for the MCP Proxy audit CLI.
 
 The MCP Proxy includes subcommands for querying and verifying the audit trail.
 
+> The default `-db` and `-receipt-db` paths shown below resolve via Go's `os.UserHomeDir()`. On Unix and macOS this is `$HOME`; on Windows it is `%USERPROFILE%`.
+
 ## `mcp-proxy -version`
 
 Print the version and exit.

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -5,7 +5,7 @@ description: Command reference for the MCP Proxy audit CLI.
 
 The MCP Proxy includes subcommands for querying and verifying the audit trail.
 
-> The default `-db` and `-receipt-db` paths shown below resolve via Go's `os.UserHomeDir()`. On Unix and macOS this is `$HOME`; on Windows it is `%USERPROFILE%`.
+> The default `-db` and `-receipt-db` paths shown below resolve via Go's `os.UserHomeDir()`. On Unix and macOS this is `$HOME`; on Windows this uses the OS user home directory, typically `%USERPROFILE%`.
 
 ## `mcp-proxy -version`
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -34,7 +34,7 @@ mcp-proxy list -json                      # JSON output
 | `-chain` | Filter by chain ID |
 | `-limit` | Maximum number of receipts to return (default: `50`) |
 | `-json` | Output as JSON |
-| `-receipt-db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ### Example output
 
@@ -65,7 +65,7 @@ mcp-proxy inspect -key public.pem <receipt-id>   # verify signature
 | Flag | Description |
 |------|-------------|
 | `-key` | Public key PEM file to verify the receipt signature |
-| `-receipt-db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ## `mcp-proxy verify`
 
@@ -78,7 +78,7 @@ mcp-proxy verify -key public.pem <chain-id>
 | Flag | Description |
 |------|-------------|
 | `-key` | Public key PEM file (required) |
-| `-receipt-db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ## `mcp-proxy export`
 
@@ -91,7 +91,7 @@ mcp-proxy export <chain-id> > chain.json
 
 | Flag | Description |
 |------|-------------|
-| `-receipt-db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ## `mcp-proxy stats`
 
@@ -105,7 +105,7 @@ mcp-proxy stats -json
 | Flag | Description |
 |------|-------------|
 | `-json` | Output as JSON |
-| `-receipt-db` | Receipt store path (default: `receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ## `mcp-proxy timing`
 
@@ -120,7 +120,7 @@ mcp-proxy timing -limit 10                    # top 10 tools
 
 | Flag | Description |
 |------|-------------|
-| `-db` | Audit database path (default: `audit.db`) |
+| `-db` | Audit database path (default: `$HOME/.agent-receipts/audit.db`) |
 | `-session` | Filter by session ID |
 | `-limit` | Maximum number of tools to show (default: `20`) |
 | `-json` | Output as JSON |
@@ -128,7 +128,7 @@ mcp-proxy timing -limit 10                    # top 10 tools
 ### Example output
 
 ```
-$ mcp-proxy timing -db ~/.agent-receipts/audit.db
+$ mcp-proxy timing
 Tool call timing (73 calls)
 
 Per-tool averages:


### PR DESCRIPTION
## Summary

- Default `-db` and `-receipt-db` to `$HOME/.agent-receipts/{audit,receipts}.db`, creating the parent directory with mode 0700 on first open.
- Apply the same defaults to `list`/`inspect`/`verify`/`export`/`stats`/`timing` so the audit CLI works from any cwd.
- Drop the now-redundant `-db`/`-receipt-db` flags from minimal integration examples and update the configuration + CLI references.

## Motivation

MCP clients (Claude Desktop, Claude Code, Codex) spawn the proxy with an unwritable cwd, so the previous relative defaults caused `unable to open database file (14)` before `initialize`. Every integration guide worked around it by pinning absolute paths — fix the default instead.

Closes #207.

## Test plan

- [x] `go vet ./...`, `go build ./...`, `go test ./...`
- [x] `go test -tags=integration .`
- [x] `go test -tags=e2e .`
- [x] Manually wire an MCP client with no `-db`/`-receipt-db` flags and confirm `~/.agent-receipts/` is created on first use