### PR TITLE
feat(mcp-proxy): Homebrew tap + GoReleaser release pipeline

### DIFF
--- a/.github/workflows/release-mcp-proxy.yml
+++ b/.github/workflows/release-mcp-proxy.yml
@@ -29,29 +29,12 @@ jobs:
           echo "MCP_PROXY_VERSION=${VERSION}" >> "$GITHUB_ENV"
           git tag "${VERSION}" HEAD
 
-      - name: Build binaries and archives
-        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean --skip=validate,homebrew,announce
-          workdir: mcp-proxy
-        env:
-          GORELEASER_CURRENT_TAG: ${{ env.MCP_PROXY_VERSION }}
-
-      - name: Create GitHub release and upload binaries
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "mcp-proxy ${MCP_PROXY_VERSION}" \
-            --generate-notes \
-            mcp-proxy/dist/*.tar.gz \
-            mcp-proxy/dist/checksums.txt
-
-      # Second GoReleaser run publishes the Homebrew formula. Rebuilds are
-      # unavoidable (no --skip=build flag) but cheap (~30s for 4 targets).
-      - name: Publish Homebrew formula
+      # Single GoReleaser run: builds, archives, pushes Homebrew formula.
+      # Release creation + binary upload happen in the next step with `gh`
+      # so the same dist/ artifacts (and therefore matching SHA256s) are
+      # used for both the formula and the release assets — re-running
+      # GoReleaser would produce different tar hashes.
+      - name: Build and publish Homebrew formula
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
         with:
           distribution: goreleaser
@@ -61,3 +44,13 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: ${{ env.MCP_PROXY_VERSION }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Create GitHub release with binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "mcp-proxy ${MCP_PROXY_VERSION}" \
+            --generate-notes \
+            mcp-proxy/dist/*.tar.gz \
+            mcp-proxy/dist/checksums.txt

--- a/.github/workflows/release-mcp-proxy.yml
+++ b/.github/workflows/release-mcp-proxy.yml
@@ -1,0 +1,63 @@
+name: "Release: mcp-proxy"
+
+on:
+  push:
+    tags:
+      - "mcp-proxy/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      # GoReleaser can't parse the prefixed tag `mcp-proxy/vX.Y.Z` as semver.
+      # Create a local lightweight `vX.Y.Z` tag at the same commit so
+      # GoReleaser computes a clean .Version; this tag is never pushed.
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#mcp-proxy/}"
+          echo "MCP_PROXY_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          git tag "${VERSION}" HEAD
+
+      - name: Build binaries and archives
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=validate,homebrew,announce
+          workdir: mcp-proxy
+        env:
+          GORELEASER_CURRENT_TAG: ${{ env.MCP_PROXY_VERSION }}
+
+      - name: Create GitHub release and upload binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "mcp-proxy ${MCP_PROXY_VERSION}" \
+            --generate-notes \
+            mcp-proxy/dist/*.tar.gz \
+            mcp-proxy/dist/checksums.txt
+
+      # Second GoReleaser run publishes the Homebrew formula. Rebuilds are
+      # unavoidable (no --skip=build flag) but cheap (~30s for 4 targets).
+      - name: Publish Homebrew formula
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=validate,announce
+          workdir: mcp-proxy
+        env:
+          GORELEASER_CURRENT_TAG: ${{ env.MCP_PROXY_VERSION }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release-mcp-proxy.yml
+++ b/.github/workflows/release-mcp-proxy.yml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release and push to the Homebrew tap. Configure at:
+    # https://github.com/agent-receipts/ar/settings/environments
+    environment: release-mcp-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/mcp-proxy/.gitignore
+++ b/mcp-proxy/.gitignore
@@ -1,0 +1,6 @@
+# GoReleaser build output
+dist/
+
+# LICENSE is copied from the repo root by a GoReleaser `before` hook
+# so archives can include it without path traversal gymnastics.
+LICENSE

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -1,0 +1,59 @@
+version: 2
+
+project_name: mcp-proxy
+
+before:
+  hooks:
+    - go mod download
+    - sh -c "cp ../LICENSE LICENSE"
+
+builds:
+  - id: mcp-proxy
+    main: ./cmd/mcp-proxy
+    binary: mcp-proxy
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version=v{{.Version}}
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+
+# GitHub release is created outside GoReleaser (against the prefixed tag
+# `mcp-proxy/vX.Y.Z`). GoReleaser only builds archives and publishes the
+# Homebrew formula; the workflow uploads binaries with `gh`.
+release:
+  disable: true
+
+brews:
+  - name: mcp-proxy
+    repository:
+      owner: agent-receipts
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    url_template: "https://github.com/agent-receipts/ar/releases/download/mcp-proxy%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/agent-receipts/ar/tree/main/mcp-proxy"
+    description: "MCP proxy with action receipts, policy engine, and intent tracking"
+    license: "Apache-2.0"
+    commit_author:
+      name: agent-receipts-bot
+      email: bot@agentreceipts.ai
+    commit_msg_template: "chore(mcp-proxy): bump to v{{ .Version }}"
+    install: |
+      bin.install "mcp-proxy"
+    test: |
+      system "#{bin}/mcp-proxy", "--version"

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -53,6 +53,11 @@ brews:
       name: agent-receipts-bot
       email: bot@agentreceipts.ai
     commit_msg_template: "chore(mcp-proxy): bump to v{{ .Version }}"
+    # Open a PR instead of pushing directly so `brew audit` (required
+    # status check on the tap's main branch) runs before the formula
+    # becomes visible to users.
+    pull_request:
+      enabled: true
     install: |
       bin.install "mcp-proxy"
     test: |

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -57,3 +57,14 @@ brews:
       bin.install "mcp-proxy"
     test: |
       system "#{bin}/mcp-proxy", "--version"
+    # `brew outdated` and `brew livecheck` use this to detect new releases.
+    # The `ar` repo ships multiple taggable components, so we can't use
+    # `:github_latest` (which returns repo-wide latest). `:github_releases`
+    # scans all releases; regex extracts version from the `mcp-proxy/vX.Y.Z`
+    # tag prefix.
+    custom_block: |
+      livecheck do
+        url "https://github.com/agent-receipts/ar"
+        strategy :github_releases
+        regex(/^mcp-proxy\/v?(\d+(?:\.\d+)+)$/i)
+      end

--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -30,8 +30,20 @@ Single binary. No external dependencies. Drop-in for any MCP server.
 
 ## Install
 
+### Homebrew (macOS, Linux)
+
 ```sh
-go install github.com/agent-receipts/mcp-proxy/cmd/mcp-proxy@latest
+brew install agent-receipts/tap/mcp-proxy
+```
+
+### Prebuilt binaries
+
+Download from the [releases page](https://github.com/agent-receipts/ar/releases?q=mcp-proxy) (darwin and linux, amd64 and arm64).
+
+### From source
+
+```sh
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 ```
 
 ## Usage

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -5,15 +5,23 @@ description: Install and run the MCP Proxy.
 
 ## Install
 
+### Homebrew (macOS, Linux)
+
+```bash
+brew install agent-receipts/tap/mcp-proxy
+```
+
+### Prebuilt binaries
+
+Download a tarball for your platform (darwin/linux, amd64/arm64) from the [releases page](https://github.com/agent-receipts/ar/releases?q=mcp-proxy) and move `mcp-proxy` onto your `$PATH`.
+
+### From source
+
 ```bash
 go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 ```
 
-## Requirements
-
-- Go 1.26+
-
-No CGO or external C libraries required -- the proxy uses pure Go SQLite.
+Requires Go 1.26+. No CGO or external C libraries — the proxy uses pure Go SQLite.
 
 ## Verify installation
 
@@ -21,7 +29,7 @@ No CGO or external C libraries required -- the proxy uses pure Go SQLite.
 mcp-proxy -version
 ```
 
-If `mcp-proxy` isn't found (bash/zsh say `command not found`; fish says `Unknown command`), the Go bin directory isn't on your `$PATH`. `go install` writes binaries to `$GOBIN` when it's set, otherwise to `$(go env GOPATH)/bin` (usually `~/go/bin`). Add whichever applies to your shell profile:
+If `mcp-proxy` isn't found after `go install` (bash/zsh say `command not found`; fish says `Unknown command`), the Go bin directory isn't on your `$PATH`. `go install` writes binaries to `$GOBIN` when it's set, otherwise to `$(go env GOPATH)/bin` (usually `~/go/bin`). Add whichever applies to your shell profile:
 
 ```bash
 # bash / zsh

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -44,8 +44,9 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 ## Quick start
 
 ```bash
-# Install
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
+# Install (Homebrew, macOS/Linux)
+brew install agent-receipts/tap/mcp-proxy
+# …or from source: go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 
 # Wrap any MCP server (example: the filesystem server via npx)
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents


### PR DESCRIPTION
Closes #212.

## Summary

- Adds `mcp-proxy/.goreleaser.yaml` that cross-compiles darwin/linux × amd64/arm64 and publishes a Homebrew formula to [agent-receipts/homebrew-tap](https://github.com/agent-receipts/homebrew-tap).
- Adds `.github/workflows/release-mcp-proxy.yml`, tag-triggered on `mcp-proxy/v*`. Two-phase: build + archive → `gh release create` with binaries → publish formula. Ordering avoids a window where the formula points at a missing tarball.
- Updates README + site install docs to lead with `brew install agent-receipts/tap/mcp-proxy`.

Users get:

```sh
brew install agent-receipts/tap/mcp-proxy
```

## Design notes

- GoReleaser OSS doesn't support `monorepo.tag_prefix` (Pro-only). Workaround: the workflow strips the `mcp-proxy/` prefix and sets `GORELEASER_CURRENT_TAG` so `.Version` resolves cleanly; the GitHub release is created by `gh` against the real prefixed tag so this repo's tag convention stays intact.
- `release.disable: true` in the GoReleaser config — we control release creation + binary upload via `gh` to keep the prefixed tag.
- Brew formula `url_template` URL-encodes `mcp-proxy%2Fv{{ .Version }}` to point at the prefixed release asset path.
- `brews` is being phased out in favor of `homebrew_casks` per GoReleaser's deprecation notice. Still works and is standard for CLI tools; migrate in a follow-up if needed.

## Prereqs already done

- `agent-receipts/homebrew-tap` repo created with `Formula/` scaffold.
- `HOMEBREW_TAP_TOKEN` repo secret set (fine-grained PAT, `contents: write` on the tap).

## Test plan

- [ ] Merge PR
- [ ] Push tag `mcp-proxy/v0.5.0`
- [ ] Workflow green
- [ ] Release page shows 4 archives + checksums.txt
- [ ] Tap repo has `Formula/mcp-proxy.rb` pointing at the new release
- [ ] `brew install agent-receipts/tap/mcp-proxy` succeeds on macOS
- [ ] `mcp-proxy --version` prints `v0.5.0`