### PR TITLE
fix(mcp-proxy): nest pull_request under repository in goreleaser config

### DIFF
--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -44,6 +44,11 @@ brews:
       owner: agent-receipts
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      # Open a PR instead of pushing directly so `brew audit` (required
+      # status check on the tap's main branch) runs before the formula
+      # becomes visible to users.
+      pull_request:
+        enabled: true
     directory: Formula
     url_template: "https://github.com/agent-receipts/ar/releases/download/mcp-proxy%2Fv{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/agent-receipts/ar/tree/main/mcp-proxy"
@@ -53,11 +58,6 @@ brews:
       name: agent-receipts-bot
       email: bot@agentreceipts.ai
     commit_msg_template: "chore(mcp-proxy): bump to v{{ .Version }}"
-    # Open a PR instead of pushing directly so `brew audit` (required
-    # status check on the tap's main branch) runs before the formula
-    # becomes visible to users.
-    pull_request:
-      enabled: true
     install: |
       bin.install "mcp-proxy"
     test: |


### PR DESCRIPTION
## Summary

v0.5.0 release failed at GoReleaser with `field pull_request not found in type config.Homebrew` — the field belongs under `repository`, not at the top level of the brew entry. Moves it one level down; no other changes.

## Repro / verification

Failed run: https://github.com/agent-receipts/ar/actions/runs/24817798858

Relevant error:
```
yaml: unmarshal errors:
  line 59: field pull_request not found in type config.Homebrew
```

After merge: delete tag `mcp-proxy/v0.5.0` and recreate to retry the release.

## Test plan

- [ ] Merge, retag `mcp-proxy/v0.5.0`, confirm release workflow succeeds
- [ ] Confirm a PR lands on `agent-receipts/homebrew-tap` (not a direct push)