### PR TITLE
fix(mcp-proxy): push Homebrew bumps to a feature branch

### DIFF
--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -44,11 +44,16 @@ brews:
       owner: agent-receipts
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-      # Open a PR instead of pushing directly so `brew audit` (required
-      # status check on the tap's main branch) runs before the formula
-      # becomes visible to users.
+      # Push the formula to a feature branch, then open a PR against
+      # main. Without an explicit branch, GoReleaser pushes to the
+      # default branch (main) and tries to open a main→main PR, which
+      # the GitHub API rejects — so the formula sneaks onto main and
+      # skips the `brew audit` gate.
+      branch: "bump-{{.ProjectName}}-{{.Version}}"
       pull_request:
         enabled: true
+        base:
+          branch: main
     directory: Formula
     url_template: "https://github.com/agent-receipts/ar/releases/download/mcp-proxy%2Fv{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/agent-receipts/ar/tree/main/mcp-proxy"


### PR DESCRIPTION
## Summary

v0.5.0 shipped the formula directly to `homebrew-tap:main` instead of via a PR. Root cause: `pull_request.enabled: true` alone doesn't steer GoReleaser to a feature branch — it pushes to `repository.branch` (default: `main`) and then tries to open a `main → main` PR, which the GitHub API rejects. The commit is already on main by the time the PR step runs, so `brew audit` never gates it.

Also flipped `enforce_admins: true` on the tap's main branch protection (out-of-band via API) so an admin-scoped PAT can't bypass the gate either.

## Test plan

- [x] Tag `mcp-proxy/v0.5.1` after merge, confirm release workflow opens a PR at `bump-mcp-proxy-0.5.1` on the tap
- [x] Confirm `brew-audit` runs and passes on that PR
- [x] Merge the bot PR, confirm `brew upgrade mcp-proxy` picks it up