### PR TITLE
feat(mcp-proxy): surface policy + approver state to prevent silent rejections

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
@@ -334,6 +337,153 @@ func cmdTiming(args []string) {
 			}
 		}
 	}
+
+	if len(st.PolicyActions) > 0 {
+		fmt.Println("\nPolicy actions:")
+		fmt.Printf("%-30s %6s %6s %6s %6s %10s\n", "TOOL", "PASS", "FLAG", "PAUSE", "BLOCK", "REJECTED")
+		for _, pa := range st.PolicyActions {
+			fmt.Printf("%-30s %6d %6d %6d %6d %10d\n",
+				truncate(pa.ToolName, 30),
+				pa.Pass, pa.Flag, pa.Pause, pa.Block, pa.Rejected,
+			)
+		}
+	}
+}
+
+// DoctorReport is the structured output of `mcp-proxy doctor`. Exposed for
+// test-only consumers; the CLI renders it to text or JSON.
+type DoctorReport struct {
+	RulesPath      string   `json:"rules_path"`
+	TotalRules     int      `json:"total_rules"`
+	EnabledRules   int      `json:"enabled_rules"`
+	PauseRules     []string `json:"pause_rules"`
+	BlockRules     []string `json:"block_rules"`
+	FlagRules      []string `json:"flag_rules"`
+	DisabledRules  []string `json:"disabled_rules,omitempty"`
+	ApproverURL    string   `json:"approver_url"`
+	ApproverReach  string   `json:"approver_reachable"` // reachable | unreachable | not_configured
+	ApproverDetail string   `json:"approver_detail,omitempty"`
+	Issues         []string `json:"issues"`
+	Healthy        bool     `json:"healthy"`
+}
+
+// DiagnoseConfig builds a DoctorReport from a rules path and approver URL.
+// Pure function — no I/O beyond reading the rules file and probing the URL.
+// Returns the report and an overall exit-code bool (true = healthy).
+func DiagnoseConfig(rulesPath, approverURL string, probe func(url string) (string, error)) (DoctorReport, bool) {
+	report := DoctorReport{
+		RulesPath:   rulesPath,
+		ApproverURL: approverURL,
+	}
+
+	var rules []policy.Rule
+	var err error
+	if rulesPath == "" {
+		rules = policy.DefaultRules()
+		report.RulesPath = "(built-in defaults)"
+	} else {
+		rules, err = policy.LoadRules(rulesPath)
+		if err != nil {
+			report.Issues = append(report.Issues, fmt.Sprintf("load rules: %v", err))
+			return report, false
+		}
+	}
+	engine := policy.NewEngine(rules)
+	summary := engine.Describe()
+	report.TotalRules = summary.TotalRules
+	report.EnabledRules = summary.EnabledRules
+	report.PauseRules = summary.PauseRules
+	report.BlockRules = summary.BlockRules
+	report.FlagRules = summary.FlagRules
+	report.DisabledRules = summary.DisabledRules
+
+	switch {
+	case approverURL == "":
+		report.ApproverReach = "not_configured"
+		if summary.NeedsApprover() {
+			report.Issues = append(report.Issues,
+				fmt.Sprintf("%d pause rule(s) loaded but no approver URL configured — pause calls will fail with -32003", len(summary.PauseRules)))
+		}
+	default:
+		detail, perr := probe(approverURL)
+		if perr == nil {
+			report.ApproverReach = "reachable"
+			report.ApproverDetail = detail
+		} else {
+			report.ApproverReach = "unreachable"
+			report.ApproverDetail = perr.Error()
+			report.Issues = append(report.Issues, fmt.Sprintf("approver at %s is unreachable: %v", approverURL, perr))
+		}
+	}
+
+	report.Healthy = len(report.Issues) == 0
+	return report, report.Healthy
+}
+
+// probeApprover makes a lightweight HEAD/GET against the approver URL to
+// check it's alive. It accepts any HTTP response — including 401/404 —
+// because the goal is reachability, not endpoint correctness. Only
+// connection-level failures (DNS, refused, TLS) are treated as unreachable.
+func probeApprover(url string) (string, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url + "/")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	return fmt.Sprintf("HTTP %d", resp.StatusCode), nil
+}
+
+func cmdDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
+	rulesPath := fs.String("rules", "", "Policy rules YAML (default: built-in)")
+	approverURL := fs.String("approver", "", "Approver URL to probe (default: none)")
+	asJSON := fs.Bool("json", false, "Output as JSON")
+	fs.Parse(args)
+
+	report, healthy := DiagnoseConfig(*rulesPath, *approverURL, probeApprover)
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(report)
+		if !healthy {
+			os.Exit(1)
+		}
+		return
+	}
+
+	fmt.Printf("mcp-proxy doctor\n")
+	fmt.Printf("  rules:         %s\n", report.RulesPath)
+	fmt.Printf("  loaded:        %d enabled (%d total)\n", report.EnabledRules, report.TotalRules)
+	if len(report.PauseRules) > 0 {
+		fmt.Printf("  pause rules:   %s\n", strings.Join(report.PauseRules, ", "))
+	}
+	if len(report.BlockRules) > 0 {
+		fmt.Printf("  block rules:   %s\n", strings.Join(report.BlockRules, ", "))
+	}
+	if len(report.FlagRules) > 0 {
+		fmt.Printf("  flag rules:    %s\n", strings.Join(report.FlagRules, ", "))
+	}
+	fmt.Printf("  approver:      %s", report.ApproverReach)
+	if report.ApproverURL != "" {
+		fmt.Printf(" (%s)", report.ApproverURL)
+	}
+	if report.ApproverDetail != "" {
+		fmt.Printf(" — %s", report.ApproverDetail)
+	}
+	fmt.Println()
+
+	if len(report.Issues) == 0 {
+		fmt.Println("\nOK — configuration is healthy.")
+		return
+	}
+
+	fmt.Println("\nIssues:")
+	for _, issue := range report.Issues {
+		fmt.Printf("  - %s\n", issue)
+	}
+	os.Exit(1)
 }
 
 func fmtOptInt(v *int64) string {

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -306,7 +306,11 @@ func cmdTiming(args []string) {
 		return
 	}
 
-	fmt.Printf("Tool call timing (%d calls)\n", st.Total)
+	if st.Total == st.TimedTotal {
+		fmt.Printf("Tool call timing (%d calls)\n", st.Total)
+	} else {
+		fmt.Printf("Tool call timing (%d calls, %d with duration)\n", st.Total, st.TimedTotal)
+	}
 
 	if len(st.ByTool) > 0 {
 		fmt.Println("\nPer-tool averages:")
@@ -368,7 +372,9 @@ type DoctorReport struct {
 }
 
 // DiagnoseConfig builds a DoctorReport from a rules path and approver URL.
-// Pure function — no I/O beyond reading the rules file and probing the URL.
+// Side effects are bounded: it may read the rules file from disk, and calls
+// the injected probe (which may perform network I/O). The probe function is
+// pluggable so tests can stub it out.
 // Returns the report and an overall exit-code bool (true = healthy).
 func DiagnoseConfig(rulesPath, approverURL string, probe func(url string) (string, error)) (DoctorReport, bool) {
 	report := DoctorReport{
@@ -420,18 +426,38 @@ func DiagnoseConfig(rulesPath, approverURL string, probe func(url string) (strin
 	return report, report.Healthy
 }
 
-// probeApprover makes a lightweight HEAD/GET against the approver URL to
-// check it's alive. It accepts any HTTP response — including 401/404 —
-// because the goal is reachability, not endpoint correctness. Only
-// connection-level failures (DNS, refused, TLS) are treated as unreachable.
+// probeApprover makes a lightweight HEAD against the approver URL to check
+// it's alive, falling back to GET if the server rejects HEAD. Any HTTP
+// response — including 401/404 — counts as reachable; the goal is liveness,
+// not endpoint correctness. Only connection-level failures (DNS, refused,
+// TLS) are treated as unreachable. Side effects on target servers are
+// minimised by trying HEAD first.
 func probeApprover(url string) (string, error) {
 	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(url + "/")
+	target := url + "/"
+
+	req, err := http.NewRequest(http.MethodHead, target, nil)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("build HEAD request: %w", err)
 	}
-	defer resp.Body.Close()
-	return fmt.Sprintf("HTTP %d", resp.StatusCode), nil
+	resp, headErr := client.Do(req)
+	if headErr == nil {
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusMethodNotAllowed && resp.StatusCode != http.StatusNotImplemented {
+			return fmt.Sprintf("HTTP %d", resp.StatusCode), nil
+		}
+	}
+
+	// HEAD failed or server didn't support it — fall back to GET.
+	getResp, getErr := client.Get(target)
+	if getErr != nil {
+		if headErr != nil {
+			return "", fmt.Errorf("HEAD: %v; GET: %w", headErr, getErr)
+		}
+		return "", getErr
+	}
+	defer getResp.Body.Close()
+	return fmt.Sprintf("HTTP %d", getResp.StatusCode), nil
 }
 
 func cmdDoctor(args []string) {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -65,6 +65,9 @@ func main() {
 		case "timing":
 			cmdTiming(os.Args[2:])
 			return
+		case "doctor":
+			cmdDoctor(os.Args[2:])
+			return
 		case "serve":
 			os.Args = append(os.Args[:1], os.Args[2:]...)
 			// Fall through to serve.
@@ -89,13 +92,13 @@ func serve() {
 		operatorName = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
 		principalDID = flag.String("principal", "did:user:unknown", "Principal DID")
 		chainID      = flag.String("chain", "", "Chain ID (auto-generated if empty)")
-		httpAddr     = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port)")
+		httpAddr     = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port; pass \"none\" to disable the approver)")
 		approvalWait = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
 		fmt.Fprintf(os.Stderr, "  Wraps an MCP server with audit, receipts, and policy enforcement.\n\n")
-		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing\n\n")
+		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing, doctor\n\n")
 		fmt.Fprintf(os.Stderr, "  -version\n\tPrint version and exit\n")
 		flag.PrintDefaults()
 	}
@@ -230,8 +233,10 @@ func serve() {
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
 
-	// Start HTTP server for approvals only when pause rules exist.
-	if engine.HasPauseRules() {
+	// Start HTTP server for approvals only when pause rules exist and the
+	// operator hasn't disabled the approver via -http=none.
+	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none") || *httpAddr == ""
+	if engine.HasPauseRules() && !approverDisabled {
 		ln, err := net.Listen("tcp", *httpAddr)
 		if err != nil {
 			log.Fatalf("mcp-proxy: http server: %v", err)
@@ -252,6 +257,11 @@ func serve() {
 		fmt.Fprintln(os.Stderr, string(endpointJSON))
 		go startHTTPServer(ln, approvals, approvalToken)
 	}
+
+	// Boot-time summary: one line covers the bulk of "why did my call fail?"
+	// debugging. A WARN variant fires when the approver is absent but the
+	// ruleset needs one, which is the #1 silent-failure mode.
+	emitStartupBanner(engine.Describe(), approvalURL)
 
 	handler := func(direction string, raw []byte, msg *proxy.Message) *proxy.HandlerResult {
 		method := ""
@@ -342,6 +352,21 @@ func serve() {
 
 				if decision.Action == "block" {
 					log.Printf("mcp-proxy: BLOCKED %s (rule: %s, risk: %d)", toolName, decision.RuleName, riskScore)
+					emitPolicyEvent(toolName, decision.RuleName, riskScore, "block", approvalURL, "blocked", 0)
+					pendingMu.Lock()
+					delete(pendingCalls, jsonrpcID)
+					pendingMu.Unlock()
+					recordRejectedToolCall(auditDB, sessionID, rejectedCall{
+						requestMsgID: msgID,
+						toolName:     toolName,
+						arguments:    redactedArgs,
+						opType:       opType,
+						riskScore:    riskScore,
+						reasons:      reasons,
+						policyAction: "block",
+						requestedAt:  time.Now(),
+						policyEvalUs: policyEvalUs,
+					})
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -352,16 +377,39 @@ func serve() {
 					approvalID := generateToken(16)
 					log.Printf("mcp-proxy: PAUSED %s (rule: %s, risk: %d) — approval id: %s", toolName, decision.RuleName, riskScore, approvalID)
 					waitStart := time.Now()
-					approvalStatus := approvals.WaitForApproval(approvalID, *approvalWait)
+					var approvalStatus audit.ApprovalStatus
+					if approvalURL == "" {
+						// No approver wired up — fail fast instead of timing out.
+						approvalStatus = audit.ApprovalNoApprover
+					} else {
+						approvalStatus = approvals.WaitForApproval(approvalID, *approvalWait)
+					}
 					approvalWaitUs := time.Since(waitStart).Microseconds()
 					if approvalStatus != audit.ApprovalApproved {
 						log.Printf("mcp-proxy: DENIED %s (%s)", toolName, approvalStatus)
+						emitPolicyEvent(toolName, decision.RuleName, riskScore, "pause", approvalURL, string(approvalStatus), approvalWaitUs/1000)
+						code, message := approvalRejectionResponse(toolName, decision.RuleName, riskScore, approvalID, approvalStatus, *approvalWait)
+						pendingMu.Lock()
+						delete(pendingCalls, jsonrpcID)
+						pendingMu.Unlock()
+						recordRejectedToolCall(auditDB, sessionID, rejectedCall{
+							requestMsgID:   msgID,
+							toolName:       toolName,
+							arguments:      redactedArgs,
+							opType:         opType,
+							riskScore:      riskScore,
+							reasons:        reasons,
+							policyAction:   "rejected",
+							requestedAt:    time.Now(),
+							policyEvalUs:   policyEvalUs,
+							approvalWaitUs: approvalWaitUs,
+						})
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(
 								msg.ID,
-								-32002,
-								buildApprovalDeniedMessage(toolName, decision.RuleName, riskScore, approvalID, approvalStatus, *approvalWait),
+								code,
+								message,
 								map[string]any{
 									"status":                  string(approvalStatus),
 									"tool_name":               toolName,
@@ -378,6 +426,7 @@ func serve() {
 					}
 					approvedBy = "http"
 					log.Printf("mcp-proxy: APPROVED %s", toolName)
+					emitPolicyEvent(toolName, decision.RuleName, riskScore, "pause", approvalURL, "approved", approvalWaitUs/1000)
 					pendingMu.Lock()
 					if pc, ok := pendingCalls[jsonrpcID]; ok {
 						pc.approvalWaitUs = approvalWaitUs
@@ -610,8 +659,121 @@ func buildApprovalDeniedMessage(toolName, ruleName string, riskScore int, approv
 		return fmt.Sprintf("tool call denied by approval workflow: tool=%s rule=%s risk=%d approval_id=%s", toolName, ruleName, riskScore, approvalID)
 	case audit.ApprovalTimedOut:
 		return fmt.Sprintf("tool call approval timed out after %s: tool=%s rule=%s risk=%d approval_id=%s", timeout, toolName, ruleName, riskScore, approvalID)
+	case audit.ApprovalNoApprover:
+		return fmt.Sprintf("tool call rejected: no approver configured for pause rule %q (pass -http=ADDR to enable, or -http=none to acknowledge): tool=%s risk=%d", ruleName, toolName, riskScore)
 	default:
 		return fmt.Sprintf("tool call denied by approval workflow: tool=%s rule=%s risk=%d approval_id=%s", toolName, ruleName, riskScore, approvalID)
+	}
+}
+
+// approvalRejectionResponse returns the JSON-RPC error code and message for a
+// non-approved pause outcome. -32002 covers the approved-channel cases (deny /
+// timeout). -32003 is used for the no-approver case so clients can distinguish
+// "configuration error" from "user rejected" and surface a different prompt.
+func approvalRejectionResponse(toolName, ruleName string, riskScore int, approvalID string, status audit.ApprovalStatus, timeout time.Duration) (int, string) {
+	code := -32002
+	if status == audit.ApprovalNoApprover {
+		code = -32003
+	}
+	return code, buildApprovalDeniedMessage(toolName, ruleName, riskScore, approvalID, status, timeout)
+}
+
+// emitStartupBanner prints a one-line policy/approver summary on stderr. When
+// the approver is missing but pause rules exist, the line is marked WARN so
+// operators spot the misconfiguration before their first failing tool call.
+func emitStartupBanner(summary policy.Summary, approvalURL string) {
+	pauseCount := len(summary.PauseRules)
+	blockCount := len(summary.BlockRules)
+	requireApproval := pauseCount + blockCount
+
+	approverState := approvalURL
+	if approverState == "" {
+		approverState = "NONE"
+	}
+
+	pauseBlockNames := append([]string{}, summary.PauseRules...)
+	pauseBlockNames = append(pauseBlockNames, summary.BlockRules...)
+
+	level := "INFO"
+	suffix := ""
+	if approvalURL == "" && pauseCount > 0 {
+		level = "WARN"
+		suffix = " — pause rules will fail (set -http=ADDR to enable approver, or -http=none to acknowledge)"
+	}
+
+	names := ""
+	if len(pauseBlockNames) > 0 {
+		names = fmt.Sprintf(" (%s)", strings.Join(pauseBlockNames, ", "))
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"mcp-proxy: [%s] policy: %d rules loaded, %d require approval%s; approver: %s%s\n",
+		level, summary.EnabledRules, requireApproval, names, approverState, suffix,
+	)
+
+	// Machine-readable companion line for tooling.
+	payload := map[string]any{
+		"event":        "policy_banner",
+		"level":        level,
+		"rules_loaded": summary.EnabledRules,
+		"pause_rules":  summary.PauseRules,
+		"block_rules":  summary.BlockRules,
+		"approver_url": approvalURL,
+		"approver_set": approvalURL != "",
+	}
+	if b, err := json.Marshal(payload); err == nil {
+		fmt.Fprintln(os.Stderr, string(b))
+	}
+}
+
+// emitPolicyEvent writes one structured key=value log line per pause/block
+// outcome. Cheap to grep, cheap to parse, small enough to ship to SIEMs.
+func emitPolicyEvent(tool, rule string, risk int, action, approverURL, outcome string, durationMs int64) {
+	approver := approverURL
+	if approver == "" {
+		approver = "NONE"
+	}
+	log.Printf("mcp-proxy: policy_event tool=%s rule=%s risk=%d action=%s approver=%s outcome=%s duration_ms=%d",
+		tool, rule, risk, action, approver, outcome, durationMs)
+}
+
+// rejectedCall is the subset of pendingCall fields needed to persist a
+// tool_calls row for a call that never reached the upstream server.
+type rejectedCall struct {
+	requestMsgID   int64
+	toolName       string
+	arguments      string
+	opType         string
+	riskScore      int
+	reasons        []string
+	policyAction   string
+	requestedAt    time.Time
+	policyEvalUs   int64
+	approvalWaitUs int64
+}
+
+func recordRejectedToolCall(db *audit.Store, sessionID string, rc rejectedCall) {
+	var approvalWait *int64
+	if rc.approvalWaitUs > 0 {
+		w := rc.approvalWaitUs
+		approvalWait = &w
+	}
+	eval := rc.policyEvalUs
+	if _, err := db.InsertToolCall(audit.ToolCallRecord{
+		SessionID:     sessionID,
+		RequestMsgID:  rc.requestMsgID,
+		ToolName:      rc.toolName,
+		Arguments:     rc.arguments,
+		OperationType: rc.opType,
+		RiskScore:     rc.riskScore,
+		RiskReasons:   rc.reasons,
+		PolicyAction:  rc.policyAction,
+		RequestedAt:   rc.requestedAt,
+		// RespondedAt intentionally zero — no upstream call happened.
+		PolicyEvalUs:   &eval,
+		ApprovalWaitUs: approvalWait,
+	}); err != nil {
+		log.Printf("mcp-proxy: insert rejected tool call: %v", err)
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -234,9 +234,11 @@ func serve() {
 	var pendingMu sync.Mutex
 
 	// Start HTTP server for approvals only when pause rules exist and the
-	// operator hasn't disabled the approver via -http=none.
-	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none") || *httpAddr == ""
-	if engine.HasPauseRules() && !approverDisabled {
+	// operator hasn't disabled the approver via -http=none. Only the literal
+	// "none" counts as an explicit opt-out; empty -http (e.g. `-http=`) is
+	// treated as not-configured so the banner still warns.
+	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none")
+	if engine.HasPauseRules() && !approverDisabled && *httpAddr != "" {
 		ln, err := net.Listen("tcp", *httpAddr)
 		if err != nil {
 			log.Fatalf("mcp-proxy: http server: %v", err)
@@ -334,6 +336,7 @@ func serve() {
 					}
 				}
 
+				requestedAt := time.Now()
 				pendingMu.Lock()
 				pendingCalls[jsonrpcID] = &pendingCall{
 					msgID:        msgID,
@@ -344,7 +347,7 @@ func serve() {
 					riskScore:    riskScore,
 					reasons:      reasons,
 					policyAct:    decision.Action,
-					timestamp:    time.Now(),
+					timestamp:    requestedAt,
 					policyEvalUs: policyEvalUs,
 				}
 				pendingMu.Unlock()
@@ -365,7 +368,7 @@ func serve() {
 						riskScore:    riskScore,
 						reasons:      reasons,
 						policyAction: "block",
-						requestedAt:  time.Now(),
+						requestedAt:  requestedAt,
 						policyEvalUs: policyEvalUs,
 					})
 					return &proxy.HandlerResult{
@@ -401,7 +404,7 @@ func serve() {
 							riskScore:      riskScore,
 							reasons:        reasons,
 							policyAction:   "rejected",
-							requestedAt:    time.Now(),
+							requestedAt:    requestedAt,
 							policyEvalUs:   policyEvalUs,
 							approvalWaitUs: approvalWaitUs,
 						})
@@ -716,9 +719,13 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 		blockDesc = fmt.Sprintf(", %d block (%s)", blockCount, strings.Join(summary.BlockRules, ", "))
 	}
 
+	rulesSuffix := ""
+	if summary.TotalRules != summary.EnabledRules {
+		rulesSuffix = fmt.Sprintf(" (%d disabled)", summary.TotalRules-summary.EnabledRules)
+	}
 	fmt.Fprintf(os.Stderr,
-		"mcp-proxy: [%s] policy: %d rules loaded, %d require approval%s%s; approver: %s%s\n",
-		level, summary.EnabledRules, pauseCount, pauseDesc, blockDesc, approverState, suffix,
+		"mcp-proxy: [%s] policy: %d rules enabled%s, %d require approval%s%s; approver: %s%s\n",
+		level, summary.EnabledRules, rulesSuffix, pauseCount, pauseDesc, blockDesc, approverState, suffix,
 	)
 
 	// Machine-readable companion line for tooling.

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -260,8 +260,9 @@ func serve() {
 
 	// Boot-time summary: one line covers the bulk of "why did my call fail?"
 	// debugging. A WARN variant fires when the approver is absent but the
-	// ruleset needs one, which is the #1 silent-failure mode.
-	emitStartupBanner(engine.Describe(), approvalURL)
+	// ruleset needs one, which is the #1 silent-failure mode. Explicit
+	// -http=none is NOT treated as misconfiguration.
+	emitStartupBanner(engine.Describe(), approvalURL, approverDisabled)
 
 	handler := func(direction string, raw []byte, msg *proxy.Message) *proxy.HandlerResult {
 		method := ""
@@ -679,47 +680,57 @@ func approvalRejectionResponse(toolName, ruleName string, riskScore int, approva
 }
 
 // emitStartupBanner prints a one-line policy/approver summary on stderr. When
-// the approver is missing but pause rules exist, the line is marked WARN so
-// operators spot the misconfiguration before their first failing tool call.
-func emitStartupBanner(summary policy.Summary, approvalURL string) {
+// pause rules exist without a reachable approver AND the operator didn't opt
+// out via -http=none, the line is marked WARN so misconfiguration is caught
+// before the first failing tool call.
+//
+// "require approval" is reserved for pause rules; block rules are enforced
+// without user interaction and are reported separately.
+func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisabled bool) {
 	pauseCount := len(summary.PauseRules)
 	blockCount := len(summary.BlockRules)
-	requireApproval := pauseCount + blockCount
 
 	approverState := approvalURL
-	if approverState == "" {
+	switch {
+	case approverDisabled:
+		approverState = "disabled"
+	case approverState == "":
 		approverState = "NONE"
 	}
 
-	pauseBlockNames := append([]string{}, summary.PauseRules...)
-	pauseBlockNames = append(pauseBlockNames, summary.BlockRules...)
-
 	level := "INFO"
 	suffix := ""
-	if approvalURL == "" && pauseCount > 0 {
+	// Only warn on the accidental case: pause rules loaded, no approver,
+	// and operator didn't explicitly opt out.
+	if approvalURL == "" && !approverDisabled && pauseCount > 0 {
 		level = "WARN"
 		suffix = " — pause rules will fail (set -http=ADDR to enable approver, or -http=none to acknowledge)"
 	}
 
-	names := ""
-	if len(pauseBlockNames) > 0 {
-		names = fmt.Sprintf(" (%s)", strings.Join(pauseBlockNames, ", "))
+	pauseDesc := ""
+	if pauseCount > 0 {
+		pauseDesc = fmt.Sprintf(" (%s)", strings.Join(summary.PauseRules, ", "))
+	}
+	blockDesc := ""
+	if blockCount > 0 {
+		blockDesc = fmt.Sprintf(", %d block (%s)", blockCount, strings.Join(summary.BlockRules, ", "))
 	}
 
 	fmt.Fprintf(os.Stderr,
-		"mcp-proxy: [%s] policy: %d rules loaded, %d require approval%s; approver: %s%s\n",
-		level, summary.EnabledRules, requireApproval, names, approverState, suffix,
+		"mcp-proxy: [%s] policy: %d rules loaded, %d require approval%s%s; approver: %s%s\n",
+		level, summary.EnabledRules, pauseCount, pauseDesc, blockDesc, approverState, suffix,
 	)
 
 	// Machine-readable companion line for tooling.
 	payload := map[string]any{
-		"event":        "policy_banner",
-		"level":        level,
-		"rules_loaded": summary.EnabledRules,
-		"pause_rules":  summary.PauseRules,
-		"block_rules":  summary.BlockRules,
-		"approver_url": approvalURL,
-		"approver_set": approvalURL != "",
+		"event":             "policy_banner",
+		"level":             level,
+		"rules_loaded":      summary.EnabledRules,
+		"pause_rules":       summary.PauseRules,
+		"block_rules":       summary.BlockRules,
+		"approver_url":      approvalURL,
+		"approver_set":      approvalURL != "",
+		"approver_disabled": approverDisabled,
 	}
 	if b, err := json.Marshal(payload); err == nil {
 		fmt.Fprintln(os.Stderr, string(b))
@@ -728,12 +739,14 @@ func emitStartupBanner(summary policy.Summary, approvalURL string) {
 
 // emitPolicyEvent writes one structured key=value log line per pause/block
 // outcome. Cheap to grep, cheap to parse, small enough to ship to SIEMs.
+// String values are %q-quoted so rule/tool names with spaces or "=" remain
+// unambiguous when parsed.
 func emitPolicyEvent(tool, rule string, risk int, action, approverURL, outcome string, durationMs int64) {
 	approver := approverURL
 	if approver == "" {
 		approver = "NONE"
 	}
-	log.Printf("mcp-proxy: policy_event tool=%s rule=%s risk=%d action=%s approver=%s outcome=%s duration_ms=%d",
+	log.Printf("mcp-proxy: policy_event tool=%q rule=%q risk=%d action=%q approver=%q outcome=%q duration_ms=%d",
 		tool, rule, risk, action, approver, outcome, durationMs)
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +12,7 @@ import (
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 )
 
 func TestBuildApprovalDeniedMessageTimeout(t *testing.T) {
@@ -106,5 +109,200 @@ func TestEnsureDBDirCreatesParent(t *testing.T) {
 func TestEnsureDBDirNoOpForBareFilename(t *testing.T) {
 	if err := ensureDBDir("audit.db"); err != nil {
 		t.Fatalf("ensureDBDir for bare filename should be a no-op, got %v", err)
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns the
+// captured output. Log package output is routed through the same pipe.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStderr := os.Stderr
+	oldLog := log.Writer()
+	os.Stderr = w
+	log.SetOutput(w)
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		log.SetOutput(oldLog)
+	})
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
+func TestStartupBannerWarnsWhenApproverMissing(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "") })
+
+	if !strings.Contains(out, "[WARN]") {
+		t.Errorf("expected WARN marker in banner, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: NONE") {
+		t.Errorf("expected 'approver: NONE' in banner, got: %s", out)
+	}
+	if !strings.Contains(out, "pause rules will fail") {
+		t.Errorf("expected pause-rules-will-fail hint, got: %s", out)
+	}
+	if !strings.Contains(out, "pause_high_risk") {
+		t.Errorf("expected pause rule name listed, got: %s", out)
+	}
+	if !strings.Contains(out, `"event":"policy_banner"`) {
+		t.Errorf("expected machine-readable companion line, got: %s", out)
+	}
+}
+
+func TestStartupBannerInfoWhenApproverSet(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "http://127.0.0.1:8081") })
+
+	if !strings.Contains(out, "[INFO]") {
+		t.Errorf("expected INFO marker, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: http://127.0.0.1:8081") {
+		t.Errorf("expected approver URL in banner, got: %s", out)
+	}
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN when approver is set, got: %s", out)
+	}
+}
+
+func TestStartupBannerNoPauseRulesNoWarn(t *testing.T) {
+	// Pure-flag ruleset: no approver needed, so empty URL should not warn.
+	summary := policy.NewEngine([]policy.Rule{
+		{Name: "flag_all", Enabled: true, Action: "flag"},
+	}).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "") })
+
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN for flag-only ruleset, got: %s", out)
+	}
+}
+
+func TestApprovalRejectionResponseDistinguishesCases(t *testing.T) {
+	cases := []struct {
+		status   audit.ApprovalStatus
+		wantCode int
+		wantMsg  string
+	}{
+		{audit.ApprovalDenied, -32002, "denied by approval workflow"},
+		{audit.ApprovalTimedOut, -32002, "timed out"},
+		{audit.ApprovalNoApprover, -32003, "no approver configured"},
+	}
+	for _, c := range cases {
+		t.Run(string(c.status), func(t *testing.T) {
+			code, msg := approvalRejectionResponse("create_pull_request", "pause_high_risk", 70, "abc", c.status, 15*time.Second)
+			if code != c.wantCode {
+				t.Errorf("code = %d, want %d", code, c.wantCode)
+			}
+			if !strings.Contains(msg, c.wantMsg) {
+				t.Errorf("msg = %q, should contain %q", msg, c.wantMsg)
+			}
+		})
+	}
+}
+
+func TestBuildApprovalDeniedMessageNoApprover(t *testing.T) {
+	got := buildApprovalDeniedMessage("create_pull_request", "pause_high_risk", 70, "abc", audit.ApprovalNoApprover, 15*time.Second)
+	for _, want := range []string{
+		"no approver configured",
+		"pause_high_risk",
+		"create_pull_request",
+		"-http",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in message, got %q", want, got)
+		}
+	}
+}
+
+func TestRecordRejectedToolCallPersists(t *testing.T) {
+	db, err := audit.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "test-sess"
+	if err := db.CreateSession(sessionID, "srv", "cmd"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	recordRejectedToolCall(db, sessionID, rejectedCall{
+		toolName:     "create_pull_request",
+		policyAction: "rejected",
+		opType:       "write",
+		riskScore:    70,
+		requestedAt:  time.Now(),
+	})
+
+	st, err := db.TimingStats(sessionID, 10)
+	if err != nil {
+		t.Fatalf("TimingStats: %v", err)
+	}
+	if len(st.PolicyActions) != 1 {
+		t.Fatalf("expected 1 policy-action row, got %d", len(st.PolicyActions))
+	}
+	row := st.PolicyActions[0]
+	if row.ToolName != "create_pull_request" {
+		t.Errorf("tool name = %q", row.ToolName)
+	}
+	if row.Rejected != 1 {
+		t.Errorf("expected Rejected=1, got %d", row.Rejected)
+	}
+}
+
+func TestDiagnoseConfigNoApproverWithPauseRules(t *testing.T) {
+	report, healthy := DiagnoseConfig("", "", func(url string) (string, error) {
+		t.Fatalf("probe should not be called when URL empty")
+		return "", nil
+	})
+
+	if healthy {
+		t.Errorf("expected unhealthy when pause rules exist but no approver, got healthy")
+	}
+	if len(report.Issues) == 0 {
+		t.Errorf("expected at least one issue")
+	}
+	if report.ApproverReach != "not_configured" {
+		t.Errorf("approver reach = %q, want not_configured", report.ApproverReach)
+	}
+	if len(report.PauseRules) == 0 {
+		t.Errorf("expected pause rules listed from defaults")
+	}
+}
+
+func TestDiagnoseConfigHealthyWithReachableApprover(t *testing.T) {
+	report, healthy := DiagnoseConfig("", "http://example.invalid", func(url string) (string, error) {
+		return "HTTP 200", nil
+	})
+
+	if !healthy {
+		t.Errorf("expected healthy when approver probe succeeds, got issues: %v", report.Issues)
+	}
+	if report.ApproverReach != "reachable" {
+		t.Errorf("approver reach = %q, want reachable", report.ApproverReach)
+	}
+}
+
+func TestDiagnoseConfigUnreachableApproverIsUnhealthy(t *testing.T) {
+	report, healthy := DiagnoseConfig("", "http://example.invalid", func(url string) (string, error) {
+		return "", errors.New("connection refused")
+	})
+
+	if healthy {
+		t.Errorf("expected unhealthy when approver unreachable")
+	}
+	if report.ApproverReach != "unreachable" {
+		t.Errorf("approver reach = %q, want unreachable", report.ApproverReach)
 	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -115,8 +115,10 @@ func TestEnsureDBDirNoOpForBareFilename(t *testing.T) {
 // captureStderr redirects os.Stderr for the duration of fn and returns the
 // captured output. Log package output is routed through the same pipe.
 //
-// Uses defer so the reader goroutine is unblocked even if fn() panics or
-// calls t.Fatal — otherwise the test would hang indefinitely on io.ReadAll.
+// fn() runs inside an IIFE with a deferred w.Close(), so the reader
+// goroutine unblocks even if fn() panics or calls t.Fatal — otherwise the
+// test would hang indefinitely on io.ReadAll. The write end is closed
+// exactly once.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -140,9 +142,10 @@ func captureStderr(t *testing.T, fn func()) string {
 		r.Close()
 	})
 
-	defer w.Close() // Ensure reader unblocks even on fn() panic/Fatal.
-	fn()
-	w.Close()
+	func() {
+		defer w.Close()
+		fn()
+	}()
 	return <-done
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -114,6 +114,9 @@ func TestEnsureDBDirNoOpForBareFilename(t *testing.T) {
 
 // captureStderr redirects os.Stderr for the duration of fn and returns the
 // captured output. Log package output is routed through the same pipe.
+//
+// Uses defer so the reader goroutine is unblocked even if fn() panics or
+// calls t.Fatal — otherwise the test would hang indefinitely on io.ReadAll.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -124,10 +127,6 @@ func captureStderr(t *testing.T, fn func()) string {
 	oldLog := log.Writer()
 	os.Stderr = w
 	log.SetOutput(w)
-	t.Cleanup(func() {
-		os.Stderr = oldStderr
-		log.SetOutput(oldLog)
-	})
 
 	done := make(chan string, 1)
 	go func() {
@@ -135,6 +134,13 @@ func captureStderr(t *testing.T, fn func()) string {
 		done <- string(b)
 	}()
 
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		log.SetOutput(oldLog)
+		r.Close()
+	})
+
+	defer w.Close() // Ensure reader unblocks even on fn() panic/Fatal.
 	fn()
 	w.Close()
 	return <-done
@@ -142,7 +148,7 @@ func captureStderr(t *testing.T, fn func()) string {
 
 func TestStartupBannerWarnsWhenApproverMissing(t *testing.T) {
 	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "") })
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", false) })
 
 	if !strings.Contains(out, "[WARN]") {
 		t.Errorf("expected WARN marker in banner, got: %s", out)
@@ -163,7 +169,7 @@ func TestStartupBannerWarnsWhenApproverMissing(t *testing.T) {
 
 func TestStartupBannerInfoWhenApproverSet(t *testing.T) {
 	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "http://127.0.0.1:8081") })
+	out := captureStderr(t, func() { emitStartupBanner(summary, "http://127.0.0.1:8081", false) })
 
 	if !strings.Contains(out, "[INFO]") {
 		t.Errorf("expected INFO marker, got: %s", out)
@@ -181,10 +187,22 @@ func TestStartupBannerNoPauseRulesNoWarn(t *testing.T) {
 	summary := policy.NewEngine([]policy.Rule{
 		{Name: "flag_all", Enabled: true, Action: "flag"},
 	}).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "") })
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", false) })
 
 	if strings.Contains(out, "WARN") {
 		t.Errorf("did not expect WARN for flag-only ruleset, got: %s", out)
+	}
+}
+
+func TestStartupBannerNoWarnWhenApproverExplicitlyDisabled(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", true) })
+
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN when approver explicitly disabled, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: disabled") {
+		t.Errorf("expected 'approver: disabled' in banner, got: %s", out)
 	}
 }
 

--- a/mcp-proxy/internal/audit/approval.go
+++ b/mcp-proxy/internal/audit/approval.go
@@ -9,9 +9,10 @@ import (
 type ApprovalStatus string
 
 const (
-	ApprovalApproved ApprovalStatus = "approved"
-	ApprovalDenied   ApprovalStatus = "denied"
-	ApprovalTimedOut ApprovalStatus = "timed_out"
+	ApprovalApproved   ApprovalStatus = "approved"
+	ApprovalDenied     ApprovalStatus = "denied"
+	ApprovalTimedOut   ApprovalStatus = "timed_out"
+	ApprovalNoApprover ApprovalStatus = "no_approver"
 )
 
 // ApprovalManager handles pause/approve/deny flows for tool calls

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -305,11 +305,23 @@ type Percentiles struct {
 	P99 int64 `json:"p99"`
 }
 
+// ToolPolicyBreakdown holds per-tool policy action counts.
+type ToolPolicyBreakdown struct {
+	ToolName string `json:"tool_name"`
+	Pass     int    `json:"pass"`
+	Flag     int    `json:"flag"`
+	Pause    int    `json:"pause"`
+	Block    int    `json:"block"`
+	Rejected int    `json:"rejected"`
+	Total    int    `json:"total"`
+}
+
 // TimingStats holds aggregate timing data for tool calls.
 type TimingStats struct {
-	Total       int                    `json:"total"`
-	ByTool      []ToolTiming           `json:"by_tool"`
-	Percentiles map[string]Percentiles `json:"percentiles"`
+	Total         int                    `json:"total"`
+	ByTool        []ToolTiming           `json:"by_tool"`
+	Percentiles   map[string]Percentiles `json:"percentiles"`
+	PolicyActions []ToolPolicyBreakdown  `json:"policy_actions"`
 }
 
 // TimingStats queries aggregate timing data from the tool_calls table.
@@ -330,6 +342,13 @@ func (s *Store) TimingStats(sessionID string, limit int) (TimingStats, error) {
 	if st.Total == 0 {
 		st.ByTool = []ToolTiming{}
 		st.Percentiles = map[string]Percentiles{}
+		// Still compute the policy breakdown — rejected/blocked rows have no
+		// duration_ms but callers need the counts to debug silent failures.
+		breakdown, err := s.policyActionBreakdown(sessionID, limit)
+		if err != nil {
+			return TimingStats{}, err
+		}
+		st.PolicyActions = breakdown
 		return st, nil
 	}
 
@@ -373,6 +392,13 @@ func (s *Store) TimingStats(sessionID string, limit int) (TimingStats, error) {
 		return TimingStats{}, err
 	}
 
+	// Policy action breakdown — includes blocked/rejected rows (no duration).
+	breakdown, err := s.policyActionBreakdown(sessionID, limit)
+	if err != nil {
+		return TimingStats{}, err
+	}
+	st.PolicyActions = breakdown
+
 	// Percentiles via ordered subqueries.
 	st.Percentiles = map[string]Percentiles{}
 	phases := []struct {
@@ -395,6 +421,72 @@ func (s *Store) TimingStats(sessionID string, limit int) (TimingStats, error) {
 	}
 
 	return st, nil
+}
+
+// policyActionBreakdown counts rows grouped by tool_name and policy_action.
+// Unlike TimingStats this includes rows without a duration (blocked/rejected
+// calls that never reached the upstream server).
+func (s *Store) policyActionBreakdown(sessionID string, limit int) ([]ToolPolicyBreakdown, error) {
+	q := `SELECT tool_name, policy_action, COUNT(*) FROM tool_calls`
+	args := []any{}
+	if sessionID != "" {
+		q += " WHERE session_id = ?"
+		args = append(args, sessionID)
+	}
+	q += " GROUP BY tool_name, policy_action"
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	byTool := map[string]*ToolPolicyBreakdown{}
+	order := []string{}
+	for rows.Next() {
+		var tool, action string
+		var count int
+		if err := rows.Scan(&tool, &action, &count); err != nil {
+			return nil, err
+		}
+		b, ok := byTool[tool]
+		if !ok {
+			b = &ToolPolicyBreakdown{ToolName: tool}
+			byTool[tool] = b
+			order = append(order, tool)
+		}
+		switch action {
+		case "pass":
+			b.Pass += count
+		case "flag":
+			b.Flag += count
+		case "pause":
+			b.Pause += count
+		case "block":
+			b.Block += count
+		case "rejected":
+			b.Rejected += count
+		}
+		b.Total += count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]ToolPolicyBreakdown, 0, len(order))
+	for _, name := range order {
+		result = append(result, *byTool[name])
+	}
+	// Sort by total descending so hot tools appear first.
+	for i := 1; i < len(result); i++ {
+		for j := i; j > 0 && result[j].Total > result[j-1].Total; j-- {
+			result[j], result[j-1] = result[j-1], result[j]
+		}
+	}
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
 }
 
 // percentiles computes p50/p95/p99 for a column using ordered offset.

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -489,9 +489,13 @@ func (s *Store) policyActionBreakdown(sessionID string, limit int) ([]ToolPolicy
 	for _, name := range order {
 		result = append(result, *byTool[name])
 	}
-	// Sort by total descending so hot tools appear first.
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Total > result[j].Total
+	// Sort by total descending so hot tools appear first. Break ties on tool
+	// name so CLI output and JSON snapshots stay deterministic.
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Total != result[j].Total {
+			return result[i].Total > result[j].Total
+		}
+		return result[i].ToolName < result[j].ToolName
 	})
 	if limit > 0 && len(result) > limit {
 		result = result[:limit]

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -317,8 +318,13 @@ type ToolPolicyBreakdown struct {
 }
 
 // TimingStats holds aggregate timing data for tool calls.
+//
+// Total counts every tool_calls row, including blocked/rejected calls that
+// never reached upstream and therefore have no duration. TimedTotal is the
+// subset used for duration-based averages and percentiles.
 type TimingStats struct {
 	Total         int                    `json:"total"`
+	TimedTotal    int                    `json:"timed_total"`
 	ByTool        []ToolTiming           `json:"by_tool"`
 	Percentiles   map[string]Percentiles `json:"percentiles"`
 	PolicyActions []ToolPolicyBreakdown  `json:"policy_actions"`
@@ -329,17 +335,23 @@ type TimingStats struct {
 func (s *Store) TimingStats(sessionID string, limit int) (TimingStats, error) {
 	var st TimingStats
 
-	// Total count.
-	countQuery := "SELECT COUNT(*) FROM tool_calls WHERE duration_ms IS NOT NULL"
+	// Two counts: Total is every row (including blocked/rejected), TimedTotal
+	// is the subset that has a duration and drives percentiles/averages.
+	totalQuery := "SELECT COUNT(*) FROM tool_calls"
+	timedQuery := "SELECT COUNT(*) FROM tool_calls WHERE duration_ms IS NOT NULL"
 	args := []any{}
 	if sessionID != "" {
-		countQuery += " AND session_id = ?"
+		totalQuery += " WHERE session_id = ?"
+		timedQuery += " AND session_id = ?"
 		args = append(args, sessionID)
 	}
-	if err := s.db.QueryRow(countQuery, args...).Scan(&st.Total); err != nil {
+	if err := s.db.QueryRow(totalQuery, args...).Scan(&st.Total); err != nil {
 		return TimingStats{}, err
 	}
-	if st.Total == 0 {
+	if err := s.db.QueryRow(timedQuery, args...).Scan(&st.TimedTotal); err != nil {
+		return TimingStats{}, err
+	}
+	if st.TimedTotal == 0 {
 		st.ByTool = []ToolTiming{}
 		st.Percentiles = map[string]Percentiles{}
 		// Still compute the policy breakdown — rejected/blocked rows have no
@@ -478,11 +490,9 @@ func (s *Store) policyActionBreakdown(sessionID string, limit int) ([]ToolPolicy
 		result = append(result, *byTool[name])
 	}
 	// Sort by total descending so hot tools appear first.
-	for i := 1; i < len(result); i++ {
-		for j := i; j > 0 && result[j].Total > result[j-1].Total; j-- {
-			result[j], result[j-1] = result[j-1], result[j]
-		}
-	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Total > result[j].Total
+	})
 	if limit > 0 && len(result) > limit {
 		result = result[:limit]
 	}

--- a/mcp-proxy/internal/policy/engine.go
+++ b/mcp-proxy/internal/policy/engine.go
@@ -118,6 +118,43 @@ func (e *Engine) HasPauseRules() bool {
 	return false
 }
 
+// Summary describes the loaded ruleset at a glance, for boot-time diagnostics.
+type Summary struct {
+	TotalRules    int
+	EnabledRules  int
+	PauseRules    []string
+	BlockRules    []string
+	FlagRules     []string
+	DisabledRules []string
+}
+
+// NeedsApprover reports whether at least one enabled rule requires an
+// approver to be configured in order to resolve — i.e. any pause rule.
+func (s Summary) NeedsApprover() bool {
+	return len(s.PauseRules) > 0
+}
+
+// Describe returns a structured snapshot of the loaded rules.
+func (e *Engine) Describe() Summary {
+	s := Summary{TotalRules: len(e.rules)}
+	for _, r := range e.rules {
+		if !r.Enabled {
+			s.DisabledRules = append(s.DisabledRules, r.Name)
+			continue
+		}
+		s.EnabledRules++
+		switch r.Action {
+		case "pause":
+			s.PauseRules = append(s.PauseRules, r.Name)
+		case "block":
+			s.BlockRules = append(s.BlockRules, r.Name)
+		case "flag":
+			s.FlagRules = append(s.FlagRules, r.Name)
+		}
+	}
+	return s
+}
+
 func matchesRule(rule Rule, ctx EvalContext) bool {
 	if rule.ToolPattern != "" {
 		if !globMatch(rule.ToolPattern, ctx.ToolName) {

--- a/mcp-proxy/internal/policy/engine_test.go
+++ b/mcp-proxy/internal/policy/engine_test.go
@@ -121,6 +121,62 @@ func TestDisabledRulesSkipped(t *testing.T) {
 	}
 }
 
+func TestDescribe(t *testing.T) {
+	engine := NewEngine(DefaultRules())
+	s := engine.Describe()
+
+	if s.TotalRules != 6 {
+		t.Errorf("expected 6 total rules, got %d", s.TotalRules)
+	}
+	if s.EnabledRules != 6 {
+		t.Errorf("expected 6 enabled rules, got %d", s.EnabledRules)
+	}
+
+	wantPause := "pause_high_risk"
+	found := false
+	for _, r := range s.PauseRules {
+		if r == wantPause {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected pause rule %q in Describe().PauseRules, got %v", wantPause, s.PauseRules)
+	}
+
+	if !s.NeedsApprover() {
+		t.Error("expected Summary.NeedsApprover() to be true when pause rules exist")
+	}
+}
+
+func TestDescribeEmpty(t *testing.T) {
+	engine := NewEngine([]Rule{})
+	s := engine.Describe()
+	if s.TotalRules != 0 || s.EnabledRules != 0 {
+		t.Errorf("expected empty summary, got %+v", s)
+	}
+	if s.NeedsApprover() {
+		t.Error("expected NeedsApprover=false with no rules")
+	}
+}
+
+func TestDescribeDisabled(t *testing.T) {
+	engine := NewEngine([]Rule{
+		{Name: "off_pause", Enabled: false, Action: "pause"},
+		{Name: "on_flag", Enabled: true, Action: "flag"},
+	})
+	s := engine.Describe()
+	if s.EnabledRules != 1 {
+		t.Errorf("expected 1 enabled rule, got %d", s.EnabledRules)
+	}
+	if len(s.PauseRules) != 0 {
+		t.Errorf("expected no pause rules (disabled), got %v", s.PauseRules)
+	}
+	if len(s.DisabledRules) != 1 || s.DisabledRules[0] != "off_pause" {
+		t.Errorf("expected [off_pause] in DisabledRules, got %v", s.DisabledRules)
+	}
+}
+
 func TestHasPauseRules(t *testing.T) {
 	// Default rules include pause_high_risk.
 	engine := NewEngine(DefaultRules())

--- a/mcp-proxy/internal/policy/engine_test.go
+++ b/mcp-proxy/internal/policy/engine_test.go
@@ -122,14 +122,23 @@ func TestDisabledRulesSkipped(t *testing.T) {
 }
 
 func TestDescribe(t *testing.T) {
-	engine := NewEngine(DefaultRules())
+	rules := DefaultRules()
+	engine := NewEngine(rules)
 	s := engine.Describe()
 
-	if s.TotalRules != 6 {
-		t.Errorf("expected 6 total rules, got %d", s.TotalRules)
+	wantTotal := len(rules)
+	wantEnabled := 0
+	for _, r := range rules {
+		if r.Enabled {
+			wantEnabled++
+		}
 	}
-	if s.EnabledRules != 6 {
-		t.Errorf("expected 6 enabled rules, got %d", s.EnabledRules)
+
+	if s.TotalRules != wantTotal {
+		t.Errorf("expected %d total rules, got %d", wantTotal, s.TotalRules)
+	}
+	if s.EnabledRules != wantEnabled {
+		t.Errorf("expected %d enabled rules, got %d", wantEnabled, s.EnabledRules)
 	}
 
 	wantPause := "pause_high_risk"


### PR DESCRIPTION
## Summary

Four coordinated observability improvements so `-32002` / `-32003` debugging doesn't take hours. Context in [#157 comment](https://github.com/agent-receipts/ar/issues/157#issuecomment-4308580739).

1. **Startup banner** — `[INFO]`/`[WARN]` one-liner on stderr summarising loaded rules and approver URL. WARN fires when pause rules exist but no approver is wired up (the #1 silent-failure mode). JSON companion line for tooling.
2. **Distinguished error paths** — new `-32003` code + `no approver configured ...` message for the no-approver case; timeout/deny keep `-32002` with their wording. `-http=none` explicitly opts out. One structured `policy_event tool=... rule=... outcome=... duration_ms=...` log line per pause/block event.
3. **Persist blocked/rejected rows** — `tool_calls` now records calls that never reached upstream, so `mcp-proxy timing` reflects this session's activity instead of only historical pass-through calls.
4. **`mcp-proxy doctor` subcommand** — dry-run diagnostic (loads rules, probes optional `--approver` URL, lists issues, non-zero exit + JSON output). Pure `DiagnoseConfig` function is test-friendly and usable from install scripts / CI.

Also adds a per-tool `pass / flag / pause / block / rejected` breakdown table to `mcp-proxy timing`.

Refs #157 (closes most of it — verbose/`-log-file` left for a follow-up), #149 (failure modes now distinguishable), #172 (structured events give shutdown something to drain).

## Test plan

- [x] `go test ./...` — passes (new tests for Describe, banner INFO/WARN, distinguished errors, rejected-row persistence, doctor healthy / no-approver / unreachable paths).
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` — clean.
- [x] `mcp-proxy doctor` manual smoke test (default rules, unreachable URL).
- [ ] Follow-up in a separate PR: verbose log level + `-log-file` (remainder of #157).