### PR TITLE
fix(mcp-proxy): SQL-mutation risk heuristic no longer false-positives on prose

### DIFF
--- a/mcp-proxy/internal/audit/classifier.go
+++ b/mcp-proxy/internal/audit/classifier.go
@@ -1,8 +1,15 @@
 package audit
 
 import (
+	"regexp"
 	"strings"
 )
+
+// whereClauseRe matches the SQL keyword "where" with token boundaries, so
+// words like "somewhere" or "whereabouts" do not falsely suppress the
+// mutation signal. Case-insensitive; boundaries are start/end of string or
+// any non-letter character.
+var whereClauseRe = regexp.MustCompile(`(?i)(^|[^a-z])where([^a-z]|$)`)
 
 // ClassifyOperation determines the operation type from a tool name.
 func ClassifyOperation(toolName string) string {
@@ -79,7 +86,9 @@ func sqlValContainsMutation(args map[string]any, sqlContextKeys, mutations []str
 			for _, ctxKey := range sqlContextKeys {
 				if kLower == ctxKey {
 					s := strings.ToLower(val)
-					if strings.Contains(s, "where") {
+					// Token-boundary check: "somewhere" / "whereabouts"
+					// must not count as a WHERE clause.
+					if whereClauseRe.MatchString(s) {
 						break
 					}
 					for _, m := range mutations {
@@ -93,6 +102,30 @@ func sqlValContainsMutation(args map[string]any, sqlContextKeys, mutations []str
 		case map[string]any:
 			// Recurse into nested argument objects.
 			if sqlValContainsMutation(val, sqlContextKeys, mutations) {
+				return true
+			}
+		case []any:
+			// Recurse into arrays: SQL-context keys may live inside list
+			// elements (e.g. batch: [{"query": "..."}, ...]).
+			if sqlSliceContainsMutation(val, sqlContextKeys, mutations) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sqlSliceContainsMutation walks a []any and recurses into each element,
+// delegating maps to sqlValContainsMutation and slices back to itself.
+func sqlSliceContainsMutation(arr []any, sqlContextKeys, mutations []string) bool {
+	for _, item := range arr {
+		switch v := item.(type) {
+		case map[string]any:
+			if sqlValContainsMutation(v, sqlContextKeys, mutations) {
+				return true
+			}
+		case []any:
+			if sqlSliceContainsMutation(v, sqlContextKeys, mutations) {
 				return true
 			}
 		}

--- a/mcp-proxy/internal/audit/classifier.go
+++ b/mcp-proxy/internal/audit/classifier.go
@@ -1,7 +1,6 @@
 package audit
 
 import (
-	"encoding/json"
 	"strings"
 )
 
@@ -68,6 +67,39 @@ func ClassifyOperation(toolName string) string {
 	return "unknown"
 }
 
+// sqlValContainsMutation walks args recursively and returns true when a value
+// stored under a SQL-context key (sql, query, statement, command) contains one
+// of the mutation keywords but does NOT contain "where". This scoping prevents
+// natural-English prose in unrelated argument fields from tripping the check.
+func sqlValContainsMutation(args map[string]any, sqlContextKeys, mutations []string) bool {
+	for k, v := range args {
+		kLower := strings.ToLower(k)
+		switch val := v.(type) {
+		case string:
+			for _, ctxKey := range sqlContextKeys {
+				if kLower == ctxKey {
+					s := strings.ToLower(val)
+					if strings.Contains(s, "where") {
+						break
+					}
+					for _, m := range mutations {
+						if strings.Contains(s, m) {
+							return true
+						}
+					}
+					break
+				}
+			}
+		case map[string]any:
+			// Recurse into nested argument objects.
+			if sqlValContainsMutation(val, sqlContextKeys, mutations) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ScoreRisk computes a risk score (0-100) for a tool call.
 func ScoreRisk(toolName string, arguments map[string]any) (int, []string) {
 	score := 0
@@ -104,17 +136,17 @@ func ScoreRisk(toolName string, arguments map[string]any) (int, []string) {
 		}
 	}
 
-	// Check for SQL mutation without WHERE.
+	// Check for SQL mutation without WHERE clause.
+	// We only inspect values that live under SQL-context keys (sql, query,
+	// statement, command) to avoid false-positives when natural-English prose
+	// in unrelated fields (e.g. a PR title containing "update") matches the
+	// mutation keywords.
 	if arguments != nil {
-		argJSON, _ := json.Marshal(arguments)
-		argStr := strings.ToLower(string(argJSON))
+		sqlContextKeys := []string{"sql", "query", "statement", "command"}
 		sqlMutations := []string{"drop ", "delete ", "update ", "truncate ", "alter "}
-		for _, m := range sqlMutations {
-			if strings.Contains(argStr, m) && !strings.Contains(argStr, "where") {
-				score += 30
-				reasons = append(reasons, "SQL mutation without WHERE clause")
-				break
-			}
+		if sqlValContainsMutation(arguments, sqlContextKeys, sqlMutations) {
+			score += 30
+			reasons = append(reasons, "SQL mutation without WHERE clause")
 		}
 	}
 

--- a/mcp-proxy/internal/audit/classifier_test.go
+++ b/mcp-proxy/internal/audit/classifier_test.go
@@ -162,4 +162,65 @@ func TestScoreRisk_SQLMutationHeuristic(t *testing.T) {
 	if containsReason(reasons, sqlMutationReason) {
 		t.Errorf("create_pull_request prose delete title: SQL mutation reason must not be present, reasons=%v", reasons)
 	}
+
+	// 7. Array recursion: {"batch": [{"query": "UPDATE users SET x=1"}]} — should trigger.
+	score, reasons = ScoreRisk("run_query", map[string]any{
+		"batch": []any{
+			map[string]any{"query": "UPDATE users SET x=1"},
+		},
+	})
+	// run_query is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("array batch UPDATE: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("array batch UPDATE: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 8. Nested map-in-array: {"params": {"items": [{"sql": "DROP TABLE foo"}]}} — should trigger.
+	score, reasons = ScoreRisk("exec_command", map[string]any{
+		"params": map[string]any{
+			"items": []any{
+				map[string]any{"sql": "DROP TABLE foo"},
+			},
+		},
+	})
+	// exec_command is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("nested map-in-array DROP: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("nested map-in-array DROP: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 9. "somewhere" must not suppress the mutation signal —
+	//    {"query": "UPDATE users SET note='find somewhere else'"} should trigger.
+	score, reasons = ScoreRisk("run_query", map[string]any{
+		"query": "UPDATE users SET note='find somewhere else'",
+	})
+	// run_query is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("UPDATE with 'somewhere' in value: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("UPDATE with 'somewhere' in value: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 10. Real WHERE clause still suppresses — uppercase.
+	score, _ = ScoreRisk("run_query", map[string]any{
+		"query": "UPDATE users SET x=1 WHERE id=1",
+	})
+	// run_query is execute (+30) only
+	if score != 30 {
+		t.Errorf("UPDATE with uppercase WHERE: expected 30, got %d", score)
+	}
+
+	// 11. Real where clause still suppresses — lowercase.
+	score, _ = ScoreRisk("run_query", map[string]any{
+		"query": "UPDATE users SET x=1 where id=1",
+	})
+	// run_query is execute (+30) only
+	if score != 30 {
+		t.Errorf("UPDATE with lowercase where: expected 30, got %d", score)
+	}
 }

--- a/mcp-proxy/internal/audit/classifier_test.go
+++ b/mcp-proxy/internal/audit/classifier_test.go
@@ -73,3 +73,93 @@ func TestScoreRisk(t *testing.T) {
 		t.Errorf("delete_auth_config with SQL: expected 100, got %d", score)
 	}
 }
+
+// TestScoreRisk_SQLMutationHeuristic covers the false-positive fix: the SQL
+// mutation check must only fire on values under SQL-context keys (sql, query,
+// statement, command), not on arbitrary prose that happens to contain mutation
+// keywords.
+func TestScoreRisk_SQLMutationHeuristic(t *testing.T) {
+	sqlMutationReason := "SQL mutation without WHERE clause"
+
+	containsReason := func(reasons []string, r string) bool {
+		for _, s := range reasons {
+			if s == r {
+				return true
+			}
+		}
+		return false
+	}
+
+	// 1. create_pull_request with a title containing "update" — write only (20),
+	//    the SQL mutation reason must NOT appear.
+	score, reasons := ScoreRisk("create_pull_request", map[string]any{
+		"title": "docs: update ecosystem framing",
+		"body":  "This PR updates the ecosystem section.",
+	})
+	if score != 20 {
+		t.Errorf("create_pull_request with prose title: expected score 20, got %d", score)
+	}
+	if containsReason(reasons, sqlMutationReason) {
+		t.Errorf("create_pull_request with prose title: SQL mutation reason must not be present, reasons=%v", reasons)
+	}
+
+	// 2. Tool with {"query": "UPDATE users SET x=1"} — no WHERE, should add +30.
+	score, reasons = ScoreRisk("run_query", map[string]any{
+		"query": "UPDATE users SET x=1",
+	})
+	// run_query is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("run_query UPDATE without WHERE: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("run_query UPDATE without WHERE: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 3. Tool with {"query": "UPDATE users SET x=1 WHERE id=1"} — has WHERE, should NOT add +30.
+	score, _ = ScoreRisk("run_query", map[string]any{
+		"query": "UPDATE users SET x=1 WHERE id=1",
+	})
+	// run_query is execute (+30), no extra SQL mutation
+	if score != 30 {
+		t.Errorf("run_query UPDATE with WHERE: expected 30, got %d", score)
+	}
+
+	// 4. Tool with {"sql": "DROP TABLE foo"} — should trigger +30.
+	score, reasons = ScoreRisk("exec_command", map[string]any{
+		"sql": "DROP TABLE foo",
+	})
+	// exec_command is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("exec_command DROP TABLE: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("exec_command DROP TABLE: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 5. Nested args {"params": {"statement": "DELETE FROM t"}} — should trigger.
+	score, reasons = ScoreRisk("run_query", map[string]any{
+		"params": map[string]any{
+			"statement": "DELETE FROM t",
+		},
+	})
+	// run_query is execute (+30) + SQL mutation (+30) = 60
+	if score != 60 {
+		t.Errorf("nested statement DELETE: expected 60, got %d", score)
+	}
+	if !containsReason(reasons, sqlMutationReason) {
+		t.Errorf("nested statement DELETE: SQL mutation reason must be present, reasons=%v", reasons)
+	}
+
+	// 6. Tool with {"title": "docs: delete stale section", "body": "…"} — should NOT trigger.
+	score, reasons = ScoreRisk("create_pull_request", map[string]any{
+		"title": "docs: delete stale section",
+		"body":  "Removes outdated content.",
+	})
+	// create_pull_request is write (+20), no SQL mutation
+	if score != 20 {
+		t.Errorf("create_pull_request prose delete title: expected 20, got %d", score)
+	}
+	if containsReason(reasons, sqlMutationReason) {
+		t.Errorf("create_pull_request prose delete title: SQL mutation reason must not be present, reasons=%v", reasons)
+	}
+}


### PR DESCRIPTION
## Bug

The `ScoreRisk` function in `mcp-proxy/internal/audit/classifier.go` serialised the entire tool-call arguments map to JSON and searched the raw string for SQL mutation keywords (`drop`, `delete`, `update`, `truncate`, `alter`). Any tool whose arguments contained those words in natural-English prose tripped the heuristic.

**Concrete example from production:**

```
create_pull_request | write | 50 | rejected |
  ["write operation", "SQL mutation without WHERE clause"]
```

A `create_pull_request` call with `title: "docs: update ecosystem framing"` scored:
- +20 write operation
- +30 SQL mutation (the word "update " appears in the title, no "where" nearby)
- **Total: 50 — hits the default `pause_high_risk` threshold**

Sibling tools like `create_branch` / `push_files` escaped only because their argument values happened not to contain the exact tokens.

## Fix

Gate the mutation check on SQL-context argument keys (`sql`, `query`, `statement`, `command`, case-insensitive) rather than scanning the full JSON blob. A new helper `sqlValContainsMutation` walks the arguments map recursively so nested argument objects are also covered. The WHERE-clause guard and the +30 magnitude are unchanged.

Key properties of the fix:
- `ScoreRisk` signature is unchanged — fully backward compatible
- Recursive walk handles nested args (e.g. `{"params": {"statement": "…"}}`)
- Values under non-SQL keys (title, body, branch, message, …) are never inspected
- Case-insensitive key and value matching is preserved

## Tests added (`TestScoreRisk_SQLMutationHeuristic`)

| # | Input | Expected score | SQL mutation reason? |
|---|-------|----------------|----------------------|
| 1 | `create_pull_request` title `"docs: update ecosystem framing"` | 20 (write only) | absent |
| 2 | `{"query": "UPDATE users SET x=1"}` | 60 (execute + SQL) | present |
| 3 | `{"query": "UPDATE users SET x=1 WHERE id=1"}` | 30 (execute only) | absent |
| 4 | `{"sql": "DROP TABLE foo"}` | 60 (execute + SQL) | present |
| 5 | `{"params": {"statement": "DELETE FROM t"}}` (nested) | 60 (execute + SQL) | present |
| 6 | `{"title": "docs: delete stale section"}` | 20 (write only) | absent |

The existing `TestScoreRisk` case at line 69 (`{"query": "drop table secrets"}`) continues to pass.