### PR TITLE
fix(mcp-proxy): classify request_/assign_ prefixes as write operations

### DIFF
--- a/mcp-proxy/internal/audit/classifier.go
+++ b/mcp-proxy/internal/audit/classifier.go
@@ -24,7 +24,7 @@ func ClassifyOperation(toolName string) string {
 		}
 	}
 
-	writePrefixes := []string{"create_", "update_", "set_", "add_", "put_", "edit_", "modify_", "write_"}
+	writePrefixes := []string{"create_", "update_", "set_", "add_", "put_", "edit_", "modify_", "write_", "request_", "assign_"}
 	for _, p := range writePrefixes {
 		if strings.HasPrefix(lower, p) {
 			return "write"

--- a/mcp-proxy/internal/audit/classifier_test.go
+++ b/mcp-proxy/internal/audit/classifier_test.go
@@ -28,6 +28,10 @@ func TestClassifyOperation(t *testing.T) {
 		{"command_exec", "execute"},
 		{"file_write", "write"},
 
+		// Copilot / assignment tools (github-mcp-server).
+		{"request_copilot_review", "write"},
+		{"assign_copilot_to_issue", "write"},
+
 		// Ambiguous: `_read` appears mid-name but name ends with `_mode`,
 		// so this must not match the `_read` suffix.
 		{"repository_read_only_mode", "unknown"},


### PR DESCRIPTION
## Summary

The prefix-based fallback classifier in `mcp-proxy/internal/audit/classifier.go` returned `"unknown"` for GitHub MCP tools like `request_copilot_review` and `assign_copilot_to_issue`, producing receipts with `action.type = "unknown"` (and a default `medium` risk_level) whenever the `-taxonomy` config was not loaded.

Example of an affected receipt:

```json
"action": {
  "tool_name": "request_copilot_review",
  "type": "unknown",
  "risk_level": "medium",
  ...
}
```

## Change

- Added `request_` and `assign_` to `writePrefixes` in `ClassifyOperation` so these tools classify as `write` (which then maps to `RiskMedium` via the existing fallback switch in `cmd/mcp-proxy/main.go`).
- Added regression tests in `classifier_test.go`.

The bundled `mcp-proxy/configs/github_taxonomy.json` already maps both tools to `data.api.write` — this just ensures the fallback classifier agrees when no taxonomy config is passed.

## Test plan

- [x] `go test ./...` in `mcp-proxy/` passes
- [x] `go vet ./...` clean
- [x] New test cases cover `request_copilot_review` and `assign_copilot_to_issue`
