### PR TITLE
feat(mcp-proxy): add --follow/-f flag to list for tail-like streaming

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -79,14 +79,19 @@ func cmdList(args []string) {
 		os.Exit(1)
 	}
 
+	// In follow mode the streamed rows are chronological (oldest → newest)
+	// via rowid ASC. Flip the initial batch so the overall output reads in
+	// one consistent direction and feels tail-like.
+	if *follow {
+		reverseReceipts(receipts)
+	}
+
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		if *follow {
 			// NDJSON — stream-compatible with the follow loop's output.
-			// QueryReceipts returned newest-first for display parity, but
-			// flip it here so the stream is chronological.
-			for i := len(receipts) - 1; i >= 0; i-- {
-				if err := enc.Encode(receipts[i]); err != nil {
+			for _, r := range receipts {
+				if err := enc.Encode(r); err != nil {
 					fmt.Fprintf(os.Stderr, "Error encoding receipt: %v\n", err)
 					os.Exit(1)
 				}
@@ -156,6 +161,15 @@ func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store
 				writeReceiptRows(w, newRows)
 			}
 		}
+	}
+}
+
+// reverseReceipts reverses s in place. Used in follow mode so the initial
+// newest-first batch is flipped to chronological order, matching the
+// subsequent streamed rows.
+func reverseReceipts(s []receipt.AgentReceipt) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
@@ -14,6 +18,8 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
+
+const listRowFmt = "%-40s %-22s %-6s %-8s %-14s %-22s %s\n"
 
 func openReceiptStore(path string) *store.Store {
 	if err := ensureDBDir(path); err != nil {
@@ -36,6 +42,9 @@ func cmdList(args []string) {
 	actionType := fs.String("action", "", "Filter by action type")
 	asJSON := fs.Bool("json", false, "Output as JSON")
 	limit := fs.Int("limit", 50, "Max results")
+	follow := fs.Bool("follow", false, "Stream new rows as they are inserted (tail -f)")
+	fs.BoolVar(follow, "f", false, "Alias for -follow")
+	interval := fs.Duration("interval", 500*time.Millisecond, "Poll interval for --follow mode")
 	fs.Parse(args)
 
 	s := openReceiptStore(*db)
@@ -63,19 +72,87 @@ func cmdList(args []string) {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		enc.Encode(receipts)
+	} else {
+		fmt.Printf(listRowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
+		fmt.Println("---")
+		writeReceiptRows(os.Stdout, receipts)
+		if !*follow {
+			fmt.Printf("\n%d receipts\n", len(receipts))
+		}
+	}
+
+	if !*follow {
 		return
 	}
 
-	const rowFmt = "%-40s %-22s %-6s %-8s %-14s %-22s %s\n"
-	fmt.Printf(rowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
-	fmt.Println("---")
+	startRowID, err := s.MaxRowID()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading watermark: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Follow mode strips NewestFirst/Limit: we want all new rows in insertion
+	// order as they arrive.
+	followQ := q
+	followQ.NewestFirst = false
+	followQ.Limit = nil
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := runFollowLoop(ctx, s, startRowID, followQ, *interval, *asJSON, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "Error in follow loop: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runFollowLoop polls the store on every tick for rows past lastRowID and
+// writes them to w. Exits cleanly when ctx is canceled (e.g. Ctrl-C).
+func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store.Query, interval time.Duration, asJSON bool, w io.Writer) error {
+	if interval <= 0 {
+		interval = 500 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			newRows, maxRowID, err := s.QueryAfterRowID(q, lastRowID)
+			if err != nil {
+				return err
+			}
+			lastRowID = maxRowID
+			if len(newRows) == 0 {
+				continue
+			}
+			if asJSON {
+				enc := json.NewEncoder(w)
+				for _, r := range newRows {
+					if err := enc.Encode(r); err != nil {
+						return err
+					}
+				}
+			} else {
+				writeReceiptRows(w, newRows)
+			}
+			if f, ok := w.(interface{ Sync() error }); ok {
+				_ = f.Sync()
+			}
+		}
+	}
+}
+
+func writeReceiptRows(w io.Writer, receipts []receipt.AgentReceipt) {
 	for _, r := range receipts {
 		subj := r.CredentialSubject
 		operator := ""
 		if r.Issuer.Operator != nil {
 			operator = r.Issuer.Operator.ID
 		}
-		fmt.Printf(rowFmt,
+		fmt.Fprintf(w, listRowFmt,
 			truncate(r.ID, 40),
 			truncate(subj.Action.Type, 22),
 			subj.Action.RiskLevel,
@@ -85,7 +162,6 @@ func cmdList(args []string) {
 			subj.Action.Timestamp,
 		)
 	}
-	fmt.Printf("\n%d receipts\n", len(receipts))
 }
 
 func cmdInspect(args []string) {

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -47,6 +47,11 @@ func cmdList(args []string) {
 	interval := fs.Duration("interval", 500*time.Millisecond, "Poll interval for --follow mode")
 	fs.Parse(args)
 
+	if *follow && *interval <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: --interval must be positive, got %s\n", *interval)
+		os.Exit(2)
+	}
+
 	s := openReceiptStore(*db)
 	defer s.Close()
 
@@ -98,7 +103,10 @@ func cmdList(args []string) {
 			}
 		} else {
 			enc.SetIndent("", "  ")
-			enc.Encode(receipts)
+			if err := enc.Encode(receipts); err != nil {
+				fmt.Fprintf(os.Stderr, "Error encoding receipts: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	} else {
 		fmt.Printf(listRowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
@@ -132,7 +140,7 @@ func cmdList(args []string) {
 // writes them to w. Exits cleanly when ctx is canceled (e.g. Ctrl-C).
 func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store.Query, interval time.Duration, asJSON bool, w io.Writer) error {
 	if interval <= 0 {
-		interval = 500 * time.Millisecond
+		return fmt.Errorf("run follow loop: interval must be positive, got %s", interval)
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -47,8 +47,8 @@ func cmdList(args []string) {
 	interval := fs.Duration("interval", 500*time.Millisecond, "Poll interval for --follow mode")
 	fs.Parse(args)
 
-	if *follow && *interval <= 0 {
-		fmt.Fprintf(os.Stderr, "Error: --interval must be positive, got %s\n", *interval)
+	if err := validateFollowFlags(*follow, *interval); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(2)
 	}
 
@@ -134,6 +134,16 @@ func cmdList(args []string) {
 		fmt.Fprintf(os.Stderr, "Error in follow loop: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// validateFollowFlags returns an error when --follow is set with a
+// non-positive --interval. Pulled out of cmdList so it can be tested
+// without invoking os.Exit.
+func validateFollowFlags(follow bool, interval time.Duration) error {
+	if follow && interval <= 0 {
+		return fmt.Errorf("--interval must be positive, got %s", interval)
+	}
+	return nil
 }
 
 // runFollowLoop polls the store on every tick for rows past lastRowID and

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -67,6 +67,17 @@ func cmdList(args []string) {
 		q.ActionType = actionType
 	}
 
+	// Set up the signal context up front in follow mode so Ctrl-C can
+	// interrupt the startup watermark query too (the DB may be busy/locked).
+	var (
+		ctx  context.Context
+		stop context.CancelFunc
+	)
+	if *follow {
+		ctx, stop = signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+	}
+
 	// In follow mode we capture the watermark atomically with the initial
 	// query so a row inserted between the two can't be silently skipped.
 	var (
@@ -75,7 +86,7 @@ func cmdList(args []string) {
 		err        error
 	)
 	if *follow {
-		receipts, startRowID, err = s.QueryReceiptsWithWatermark(q)
+		receipts, startRowID, err = s.QueryReceiptsWithWatermarkContext(ctx, q)
 	} else {
 		receipts, err = s.QueryReceipts(q)
 	}
@@ -127,9 +138,6 @@ func cmdList(args []string) {
 	followQ.NewestFirst = false
 	followQ.Limit = nil
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
 	if err := runFollowLoop(ctx, s, startRowID, followQ, *interval, *asJSON, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "Error in follow loop: %v\n", err)
 		os.Exit(1)
@@ -155,13 +163,24 @@ func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	// One encoder per invocation: reused across ticks to avoid per-poll
+	// allocations and to keep encoding configuration in one place.
+	var enc *json.Encoder
+	if asJSON {
+		enc = json.NewEncoder(w)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			newRows, maxRowID, err := s.QueryAfterRowID(q, lastRowID)
+			newRows, maxRowID, err := s.QueryAfterRowIDContext(ctx, q, lastRowID)
 			if err != nil {
+				// Treat cancellation as a clean exit, not an error.
+				if ctx.Err() != nil {
+					return nil
+				}
 				return err
 			}
 			lastRowID = maxRowID
@@ -169,7 +188,6 @@ func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store
 				continue
 			}
 			if asJSON {
-				enc := json.NewEncoder(w)
 				for _, r := range newRows {
 					if err := enc.Encode(r); err != nil {
 						return err

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -62,7 +62,18 @@ func cmdList(args []string) {
 		q.ActionType = actionType
 	}
 
-	receipts, err := s.QueryReceipts(q)
+	// In follow mode we capture the watermark atomically with the initial
+	// query so a row inserted between the two can't be silently skipped.
+	var (
+		receipts   []receipt.AgentReceipt
+		startRowID int64
+		err        error
+	)
+	if *follow {
+		receipts, startRowID, err = s.QueryReceiptsWithWatermark(q)
+	} else {
+		receipts, err = s.QueryReceipts(q)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error querying receipts: %v\n", err)
 		os.Exit(1)
@@ -70,8 +81,20 @@ func cmdList(args []string) {
 
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		enc.Encode(receipts)
+		if *follow {
+			// NDJSON — stream-compatible with the follow loop's output.
+			// QueryReceipts returned newest-first for display parity, but
+			// flip it here so the stream is chronological.
+			for i := len(receipts) - 1; i >= 0; i-- {
+				if err := enc.Encode(receipts[i]); err != nil {
+					fmt.Fprintf(os.Stderr, "Error encoding receipt: %v\n", err)
+					os.Exit(1)
+				}
+			}
+		} else {
+			enc.SetIndent("", "  ")
+			enc.Encode(receipts)
+		}
 	} else {
 		fmt.Printf(listRowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
 		fmt.Println("---")
@@ -83,12 +106,6 @@ func cmdList(args []string) {
 
 	if !*follow {
 		return
-	}
-
-	startRowID, err := s.MaxRowID()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading watermark: %v\n", err)
-		os.Exit(1)
 	}
 
 	// Follow mode strips NewestFirst/Limit: we want all new rows in insertion
@@ -137,9 +154,6 @@ func runFollowLoop(ctx context.Context, s *store.Store, lastRowID int64, q store
 				}
 			} else {
 				writeReceiptRows(w, newRows)
-			}
-			if f, ok := w.(interface{ Sync() error }); ok {
-				_ = f.Sync()
 			}
 		}
 	}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -37,8 +37,52 @@ func storeFollowReceipt(t *testing.T, s *store.Store, kp receipt.KeyPair, seq in
 	return h
 }
 
+// notifyWriter is an io.Writer that both captures output into a buffer and
+// posts a signal on each Write. Tests block on notify instead of sleeping +
+// polling so they stay reliable under slow / loaded runners.
+type notifyWriter struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	notify chan struct{}
+}
+
+func newNotifyWriter() *notifyWriter {
+	// Buffered so writes never block when the reader is between selects.
+	return &notifyWriter{notify: make(chan struct{}, 16)}
+}
+
+func (n *notifyWriter) Write(p []byte) (int, error) {
+	n.mu.Lock()
+	nn, err := n.buf.Write(p)
+	n.mu.Unlock()
+	select {
+	case n.notify <- struct{}{}:
+	default:
+	}
+	return nn, err
+}
+
+func (n *notifyWriter) String() string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.buf.String()
+}
+
+// waitForWrite blocks until at least one Write has happened since the last
+// call (or the deadline passes). Returns the current buffer contents.
+func (n *notifyWriter) waitForWrite(t *testing.T, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case <-n.notify:
+		return n.String()
+	case <-time.After(timeout):
+		t.Fatalf("timed out after %s waiting for write; buffer=%q", timeout, n.String())
+		return ""
+	}
+}
+
 // TestRunFollowLoopStreamsNewRows is the acceptance-criteria test from #216:
-// start follow, insert a row, see it in output.
+// start follow, insert a row, block until the write lands, assert content.
 func TestRunFollowLoopStreamsNewRows(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -51,48 +95,36 @@ func TestRunFollowLoopStreamsNewRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Start watermark on an empty store (rowid 0).
 	startRowID, err := s.MaxRowID()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var buf bytes.Buffer
-	var mu sync.Mutex
+	w := newNotifyWriter()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	done := make(chan error, 1)
 	go func() {
-		// Wrap buf behind a mutex so the test goroutine can read it safely
-		// while the loop writes.
-		done <- runFollowLoop(ctx, s, startRowID, store.Query{}, 20*time.Millisecond, false, &lockedWriter{w: &buf, mu: &mu})
+		done <- runFollowLoop(ctx, s, startRowID, store.Query{}, 10*time.Millisecond, false, w)
 	}()
 
-	// Give the loop a moment to enter its first tick, then insert.
-	time.Sleep(50 * time.Millisecond)
+	// Insert is safe any time — an empty store yields no rows on early
+	// ticks, so the watermark never advances past 0 until real rows land.
 	storeFollowReceipt(t, s, kp, 1, "chain-follow", nil)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		out := buf.String()
-		mu.Unlock()
-		if strings.Contains(out, "filesystem.file.read") {
-			cancel()
-			if err := <-done; err != nil {
-				t.Fatalf("follow loop returned error: %v", err)
-			}
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	out := w.waitForWrite(t, 2*time.Second)
+	if !strings.Contains(out, "filesystem.file.read") {
+		// Rare: the first write might be from something else. Wait once more.
+		out = w.waitForWrite(t, 2*time.Second)
+	}
+	if !strings.Contains(out, "filesystem.file.read") {
+		t.Fatalf("inserted receipt never appeared in follow output: %q", out)
 	}
 	cancel()
-	<-done
-	mu.Lock()
-	out := buf.String()
-	mu.Unlock()
-	t.Fatalf("inserted receipt never appeared in follow output: %q", out)
+	if err := <-done; err != nil {
+		t.Fatalf("follow loop returned error: %v", err)
+	}
 }
 
 // TestRunFollowLoopExitsOnContextCancel verifies Ctrl-C-style cancellation
@@ -138,53 +170,36 @@ func TestRunFollowLoopHonoursFilters(t *testing.T) {
 	chainA := "chain-a"
 	q := store.Query{ChainID: &chainA}
 
-	var buf bytes.Buffer
-	var mu sync.Mutex
+	w := newNotifyWriter()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runFollowLoop(ctx, s, 0, q, 20*time.Millisecond, true, &lockedWriter{w: &buf, mu: &mu})
+		done <- runFollowLoop(ctx, s, 0, q, 10*time.Millisecond, true, w)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
-	storeFollowReceipt(t, s, kp, 1, "chain-b", nil) // filtered out
-	storeFollowReceipt(t, s, kp, 1, chainA, nil)    // should appear
+	// chain-b is inserted first and must be filtered out; chain-a is
+	// inserted second and must stream.
+	storeFollowReceipt(t, s, kp, 1, "chain-b", nil)
+	storeFollowReceipt(t, s, kp, 1, chainA, nil)
 
+	// Wait until chain-a shows up (it may take a couple of write events
+	// if chain-b somehow slipped through — which would then fail the check).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		out := buf.String()
-		mu.Unlock()
+		out := w.waitForWrite(t, 2*time.Second)
 		if strings.Contains(out, chainA) {
 			cancel()
 			<-done
-			mu.Lock()
-			final := buf.String()
-			mu.Unlock()
-			// chain-b must be absent — it was inserted first but doesn't match the filter.
+			final := w.String()
 			if strings.Contains(final, "chain-b") {
 				t.Fatalf("chain-b should have been filtered out: %q", final)
 			}
 			return
 		}
-		time.Sleep(20 * time.Millisecond)
 	}
 	cancel()
 	<-done
-	t.Fatal("chain-a receipt never appeared in follow output")
-}
-
-// lockedWriter serializes Write calls so the test goroutine can safely
-// snapshot output while the follow loop is writing.
-type lockedWriter struct {
-	w  *bytes.Buffer
-	mu *sync.Mutex
-}
-
-func (lw *lockedWriter) Write(p []byte) (int, error) {
-	lw.mu.Lock()
-	defer lw.mu.Unlock()
-	return lw.w.Write(p)
+	t.Fatalf("chain-a receipt never appeared in follow output: %q", w.String())
 }

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -191,7 +191,9 @@ func TestRunFollowLoopHonoursFilters(t *testing.T) {
 		out := w.waitForWrite(t, 2*time.Second)
 		if strings.Contains(out, chainA) {
 			cancel()
-			<-done
+			if err := <-done; err != nil {
+				t.Fatalf("follow loop returned error: %v", err)
+			}
 			final := w.String()
 			if strings.Contains(final, "chain-b") {
 				t.Fatalf("chain-b should have been filtered out: %q", final)
@@ -200,6 +202,8 @@ func TestRunFollowLoopHonoursFilters(t *testing.T) {
 		}
 	}
 	cancel()
-	<-done
+	if err := <-done; err != nil {
+		t.Fatalf("follow loop returned error: %v", err)
+	}
 	t.Fatalf("chain-a receipt never appeared in follow output: %q", w.String())
 }

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// storeFollowReceipt inserts a freshly signed receipt into the store.
+// Helper for cmdList follow tests.
+func storeFollowReceipt(t *testing.T, s *store.Store, kp receipt.KeyPair, seq int, chainID string, prevHash *string) string {
+	t.Helper()
+	unsigned := receipt.Create(receipt.CreateInput{
+		Issuer:    receipt.Issuer{ID: "did:agent:test", Name: "test-agent"},
+		Principal: receipt.Principal{ID: "did:user:test"},
+		Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow, ToolName: "read"},
+		Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain:     receipt.Chain{Sequence: seq, PreviousReceiptHash: prevHash, ChainID: chainID},
+	})
+	signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := receipt.HashReceipt(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Insert(signed, h); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// TestRunFollowLoopStreamsNewRows is the acceptance-criteria test from #216:
+// start follow, insert a row, see it in output.
+func TestRunFollowLoopStreamsNewRows(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start watermark on an empty store (rowid 0).
+	startRowID, err := s.MaxRowID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// Wrap buf behind a mutex so the test goroutine can read it safely
+		// while the loop writes.
+		done <- runFollowLoop(ctx, s, startRowID, store.Query{}, 20*time.Millisecond, false, &lockedWriter{w: &buf, mu: &mu})
+	}()
+
+	// Give the loop a moment to enter its first tick, then insert.
+	time.Sleep(50 * time.Millisecond)
+	storeFollowReceipt(t, s, kp, 1, "chain-follow", nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		out := buf.String()
+		mu.Unlock()
+		if strings.Contains(out, "filesystem.file.read") {
+			cancel()
+			if err := <-done; err != nil {
+				t.Fatalf("follow loop returned error: %v", err)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	mu.Lock()
+	out := buf.String()
+	mu.Unlock()
+	t.Fatalf("inserted receipt never appeared in follow output: %q", out)
+}
+
+// TestRunFollowLoopExitsOnContextCancel verifies Ctrl-C-style cancellation
+// ends the loop promptly.
+func TestRunFollowLoopExitsOnContextCancel(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runFollowLoop(ctx, s, 0, store.Query{}, 20*time.Millisecond, false, &bytes.Buffer{})
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("follow loop returned error on cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follow loop did not exit on context cancel")
+	}
+}
+
+// TestRunFollowLoopHonoursFilters checks chain filter scoping: a chain-a watch
+// should ignore chain-b inserts.
+func TestRunFollowLoopHonoursFilters(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chainA := "chain-a"
+	q := store.Query{ChainID: &chainA}
+
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runFollowLoop(ctx, s, 0, q, 20*time.Millisecond, true, &lockedWriter{w: &buf, mu: &mu})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	storeFollowReceipt(t, s, kp, 1, "chain-b", nil) // filtered out
+	storeFollowReceipt(t, s, kp, 1, chainA, nil)    // should appear
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		out := buf.String()
+		mu.Unlock()
+		if strings.Contains(out, chainA) {
+			cancel()
+			<-done
+			mu.Lock()
+			final := buf.String()
+			mu.Unlock()
+			// chain-b must be absent — it was inserted first but doesn't match the filter.
+			if strings.Contains(final, "chain-b") {
+				t.Fatalf("chain-b should have been filtered out: %q", final)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	t.Fatal("chain-a receipt never appeared in follow output")
+}
+
+// lockedWriter serializes Write calls so the test goroutine can safely
+// snapshot output while the follow loop is writing.
+type lockedWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (lw *lockedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
+}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -81,6 +81,38 @@ func (n *notifyWriter) waitForWrite(t *testing.T, timeout time.Duration) string 
 	}
 }
 
+// TestValidateFollowFlags covers the CLI argument-validation path so a
+// non-positive --interval with --follow fails fast instead of silently
+// resetting. cmdList turns the returned error into an exit 2.
+func TestValidateFollowFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		follow   bool
+		interval time.Duration
+		wantErr  bool
+	}{
+		{"follow with zero interval", true, 0, true},
+		{"follow with negative interval", true, -1 * time.Second, true},
+		{"follow with positive interval", true, 100 * time.Millisecond, false},
+		{"no follow, zero interval is fine", false, 0, false},
+		{"no follow, negative interval is fine", false, -5 * time.Second, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFollowFlags(tc.follow, tc.interval)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "must be positive") {
+				t.Errorf("error message missing \"must be positive\": %v", err)
+			}
+		})
+	}
+}
+
 // TestRunFollowLoopStreamsNewRows is the acceptance-criteria test from #216:
 // start follow, insert a row, block until the write lands, assert content.
 func TestRunFollowLoopStreamsNewRows(t *testing.T) {

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -264,6 +264,91 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 	return scanReceipts(rows)
 }
 
+// MaxRowID returns the largest SQLite rowid currently in the receipts table.
+// Returns 0 when the table is empty. Intended as the watermark for follow-mode
+// streaming — callers pass it to QueryAfterRowID to fetch rows inserted later.
+func (s *Store) MaxRowID() (int64, error) {
+	var max int64
+	if err := s.db.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&max); err != nil {
+		return 0, err
+	}
+	return max, nil
+}
+
+// QueryAfterRowID returns receipts with rowid > afterRowID that match the
+// non-ordering filters in q, ordered ascending by rowid. The returned int64
+// is the largest rowid in the result set, or afterRowID when no rows match —
+// callers feed it back in to poll for subsequent inserts.
+//
+// NewestFirst is ignored (follow-mode rows are always chronological). Limit
+// defaults to 10000 like QueryReceipts but is typically set much lower when
+// polling.
+func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
+	conds := []string{"rowid > ?"}
+	args := []any{afterRowID}
+
+	if q.ChainID != nil {
+		conds = append(conds, "chain_id = ?")
+		args = append(args, *q.ChainID)
+	}
+	if q.ActionType != nil {
+		conds = append(conds, "action_type = ?")
+		args = append(args, *q.ActionType)
+	}
+	if q.RiskLevel != nil {
+		conds = append(conds, "risk_level = ?")
+		args = append(args, string(*q.RiskLevel))
+	}
+	if q.Status != nil {
+		conds = append(conds, "status = ?")
+		args = append(args, string(*q.Status))
+	}
+	if q.After != nil {
+		conds = append(conds, "timestamp >= ?")
+		args = append(args, *q.After)
+	}
+	if q.Before != nil {
+		conds = append(conds, "timestamp <= ?")
+		args = append(args, *q.Before)
+	}
+
+	limit := 10000
+	if q.Limit != nil {
+		limit = *q.Limit
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(
+		"SELECT rowid, receipt_json FROM receipts WHERE %s ORDER BY rowid ASC LIMIT ?",
+		strings.Join(conds, " AND "),
+	)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, afterRowID, err
+	}
+	defer rows.Close()
+
+	var receipts []receipt.AgentReceipt
+	maxRowID := afterRowID
+	for rows.Next() {
+		var rowid int64
+		var rJSON string
+		if err := rows.Scan(&rowid, &rJSON); err != nil {
+			return nil, maxRowID, err
+		}
+		var r receipt.AgentReceipt
+		if err := json.Unmarshal([]byte(rJSON), &r); err != nil {
+			return nil, maxRowID, fmt.Errorf("corrupt receipt in store: %w", err)
+		}
+		receipts = append(receipts, r)
+		if rowid > maxRowID {
+			maxRowID = rowid
+		}
+	}
+	return receipts, maxRowID, rows.Err()
+}
+
 // Stats returns aggregate statistics for the store.
 func (s *Store) Stats() (Stats, error) {
 	var st Stats

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -212,7 +212,7 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 	query, args := buildQueryReceiptsSQL(q)
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query receipts: %w", err)
 	}
 	defer rows.Close()
 	return scanReceipts(rows)

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -2,6 +2,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -208,6 +209,80 @@ func (s *Store) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 
 // QueryReceipts retrieves receipts matching the given filters.
 func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
+	query, args := buildQueryReceiptsSQL(q)
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanReceipts(rows)
+}
+
+// MaxRowID returns the largest SQLite rowid currently in the receipts table.
+// Returns 0 when the table is empty. Intended as the watermark for follow-mode
+// streaming — callers pass it to QueryAfterRowID to fetch rows inserted later.
+func (s *Store) MaxRowID() (int64, error) {
+	var max int64
+	if err := s.db.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&max); err != nil {
+		return 0, fmt.Errorf("max rowid: %w", err)
+	}
+	return max, nil
+}
+
+// QueryAfterRowID returns receipts with rowid > afterRowID that match the
+// non-ordering filters in q, ordered ascending by rowid. The returned int64
+// is the largest rowid in the result set, or afterRowID when no rows match —
+// callers feed it back in to poll for subsequent inserts.
+//
+// NewestFirst is ignored (follow-mode rows are always chronological). Limit
+// defaults to 10000 like QueryReceipts but is typically set much lower when
+// polling.
+func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
+	query, args := buildQueryAfterRowIDSQL(q, afterRowID)
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, afterRowID, fmt.Errorf("query after rowid %d: %w", afterRowID, err)
+	}
+	defer rows.Close()
+	return scanRowIDReceipts(rows, afterRowID)
+}
+
+// QueryReceiptsWithWatermark runs the standard filtered receipt query and
+// captures the table's MaxRowID atomically in a single read transaction.
+// Intended for follow-mode startup: the returned watermark is consistent with
+// the rows emitted, eliminating the race where a row inserted between a
+// naive Query + MaxRowID pair can be silently skipped.
+func (s *Store) QueryReceiptsWithWatermark(q Query) ([]receipt.AgentReceipt, int64, error) {
+	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("begin read transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	query, args := buildQueryReceiptsSQL(q)
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query receipts: %w", err)
+	}
+	receipts, err := scanReceipts(rows)
+	rows.Close()
+	if err != nil {
+		return nil, 0, fmt.Errorf("scan receipts: %w", err)
+	}
+
+	var maxRowID int64
+	if err := tx.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&maxRowID); err != nil {
+		return nil, 0, fmt.Errorf("max rowid: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("commit read transaction: %w", err)
+	}
+	return receipts, maxRowID, nil
+}
+
+// buildQueryReceiptsSQL builds the SQL and args for QueryReceipts. Extracted
+// so QueryReceiptsWithWatermark can run the same query inside a transaction.
+func buildQueryReceiptsSQL(q Query) (string, []any) {
 	var conds []string
 	var args []any
 
@@ -245,7 +320,6 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 	if q.Limit != nil {
 		limit = *q.Limit
 	}
-
 	order := "ASC"
 	if q.NewestFirst {
 		order = "DESC"
@@ -255,35 +329,11 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 		where, order,
 	)
 	args = append(args, limit)
-
-	rows, err := s.db.Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return scanReceipts(rows)
+	return query, args
 }
 
-// MaxRowID returns the largest SQLite rowid currently in the receipts table.
-// Returns 0 when the table is empty. Intended as the watermark for follow-mode
-// streaming — callers pass it to QueryAfterRowID to fetch rows inserted later.
-func (s *Store) MaxRowID() (int64, error) {
-	var max int64
-	if err := s.db.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&max); err != nil {
-		return 0, err
-	}
-	return max, nil
-}
-
-// QueryAfterRowID returns receipts with rowid > afterRowID that match the
-// non-ordering filters in q, ordered ascending by rowid. The returned int64
-// is the largest rowid in the result set, or afterRowID when no rows match —
-// callers feed it back in to poll for subsequent inserts.
-//
-// NewestFirst is ignored (follow-mode rows are always chronological). Limit
-// defaults to 10000 like QueryReceipts but is typically set much lower when
-// polling.
-func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
+// buildQueryAfterRowIDSQL builds the rowid-watermark query SQL + args.
+func buildQueryAfterRowIDSQL(q Query, afterRowID int64) (string, []any) {
 	conds := []string{"rowid > ?"}
 	args := []any{afterRowID}
 
@@ -322,20 +372,17 @@ func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentRecei
 		"SELECT rowid, receipt_json FROM receipts WHERE %s ORDER BY rowid ASC LIMIT ?",
 		strings.Join(conds, " AND "),
 	)
+	return query, args
+}
 
-	rows, err := s.db.Query(query, args...)
-	if err != nil {
-		return nil, afterRowID, err
-	}
-	defer rows.Close()
-
+func scanRowIDReceipts(rows *sql.Rows, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
 	var receipts []receipt.AgentReceipt
 	maxRowID := afterRowID
 	for rows.Next() {
 		var rowid int64
 		var rJSON string
 		if err := rows.Scan(&rowid, &rJSON); err != nil {
-			return nil, maxRowID, err
+			return nil, maxRowID, fmt.Errorf("scan receipt row: %w", err)
 		}
 		var r receipt.AgentReceipt
 		if err := json.Unmarshal([]byte(rJSON), &r); err != nil {
@@ -346,7 +393,10 @@ func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentRecei
 			maxRowID = rowid
 		}
 	}
-	return receipts, maxRowID, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, maxRowID, fmt.Errorf("iterate receipt rows: %w", err)
+	}
+	return receipts, maxRowID, nil
 }
 
 // Stats returns aggregate statistics for the store.

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -237,9 +237,20 @@ func (s *Store) MaxRowID() (int64, error) {
 // NewestFirst is ignored (follow-mode rows are always chronological). Limit
 // defaults to 10000 like QueryReceipts but is typically set much lower when
 // polling.
+//
+// Callers that want to bound query latency (e.g. so Ctrl-C in follow mode
+// stops a busy/locked query promptly) should use QueryAfterRowIDContext.
 func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
+	return s.QueryAfterRowIDContext(context.Background(), q, afterRowID)
+}
+
+// QueryAfterRowIDContext is the context-aware form of QueryAfterRowID. When
+// ctx is canceled, the in-flight SQLite query is interrupted so callers (e.g.
+// follow-mode pollers) don't have to wait on busy_timeout before shutting
+// down.
+func (s *Store) QueryAfterRowIDContext(ctx context.Context, q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
 	query, args := buildQueryAfterRowIDSQL(q, afterRowID)
-	rows, err := s.db.Query(query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, afterRowID, fmt.Errorf("query after rowid %d: %w", afterRowID, err)
 	}
@@ -252,15 +263,26 @@ func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentRecei
 // Intended for follow-mode startup: the returned watermark is consistent with
 // the rows emitted, eliminating the race where a row inserted between a
 // naive Query + MaxRowID pair can be silently skipped.
+//
+// Callers that want Ctrl-C to interrupt the startup query should use
+// QueryReceiptsWithWatermarkContext.
 func (s *Store) QueryReceiptsWithWatermark(q Query) ([]receipt.AgentReceipt, int64, error) {
-	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	return s.QueryReceiptsWithWatermarkContext(context.Background(), q)
+}
+
+// QueryReceiptsWithWatermarkContext is the context-aware form of
+// QueryReceiptsWithWatermark. The supplied context governs both the
+// transaction and each query inside it, so cancellation interrupts in-flight
+// work instead of waiting for busy_timeout.
+func (s *Store) QueryReceiptsWithWatermarkContext(ctx context.Context, q Query) ([]receipt.AgentReceipt, int64, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return nil, 0, fmt.Errorf("begin read transaction: %w", err)
 	}
 	defer tx.Rollback()
 
 	query, args := buildQueryReceiptsSQL(q)
-	rows, err := tx.Query(query, args...)
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("query receipts: %w", err)
 	}
@@ -271,7 +293,7 @@ func (s *Store) QueryReceiptsWithWatermark(q Query) ([]receipt.AgentReceipt, int
 	}
 
 	var maxRowID int64
-	if err := tx.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&maxRowID); err != nil {
+	if err := tx.QueryRowContext(ctx, "SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&maxRowID); err != nil {
 		return nil, 0, fmt.Errorf("max rowid: %w", err)
 	}
 	if err := tx.Commit(); err != nil {

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -275,12 +275,18 @@ func TestMaxRowIDEmpty(t *testing.T) {
 
 func TestMaxRowIDAfterInsert(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -298,12 +304,18 @@ func TestMaxRowIDAfterInsert(t *testing.T) {
 
 func TestQueryAfterRowIDReturnsOnlyNewRows(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var prevHash *string
 	for i := 1; i <= 2; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -318,7 +330,10 @@ func TestQueryAfterRowIDReturnsOnlyNewRows(t *testing.T) {
 	// Insert two more after the watermark.
 	for i := 3; i <= 4; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -351,12 +366,18 @@ func TestQueryAfterRowIDReturnsOnlyNewRows(t *testing.T) {
 
 func TestQueryReceiptsWithWatermarkReturnsConsistentPair(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -377,7 +398,10 @@ func TestQueryReceiptsWithWatermarkReturnsConsistentPair(t *testing.T) {
 	// Insert another row and confirm the watermark from above makes
 	// QueryAfterRowID return only the new row.
 	r := makeSignedReceipt(t, kp, 4, "chain-1", prevHash)
-	h, _ := receipt.HashReceipt(r)
+	h, err := receipt.HashReceipt(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
 	}
@@ -392,12 +416,18 @@ func TestQueryReceiptsWithWatermarkReturnsConsistentPair(t *testing.T) {
 
 func TestQueryAfterRowIDAppliesFilters(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Insert into two different chains.
 	for i, chain := range []string{"chain-a", "chain-b"} {
 		r := makeSignedReceipt(t, kp, i+1, chain, nil)
-		h, _ := receipt.HashReceipt(r)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -262,6 +262,119 @@ func TestQueryReceiptsCombinedFilters(t *testing.T) {
 	}
 }
 
+func TestMaxRowIDEmpty(t *testing.T) {
+	s := setupStore(t)
+	max, err := s.MaxRowID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if max != 0 {
+		t.Errorf("expected 0 for empty store, got %d", max)
+	}
+}
+
+func TestMaxRowIDAfterInsert(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	var prevHash *string
+	for i := 1; i <= 3; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	max, err := s.MaxRowID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if max != 3 {
+		t.Errorf("expected rowid 3 after 3 inserts, got %d", max)
+	}
+}
+
+func TestQueryAfterRowIDReturnsOnlyNewRows(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	var prevHash *string
+	for i := 1; i <= 2; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	watermark, err := s.MaxRowID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert two more after the watermark.
+	for i := 3; i <= 4; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	results, newMax, err := s.QueryAfterRowID(Query{}, watermark)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 new rows, got %d", len(results))
+	}
+	if newMax != 4 {
+		t.Errorf("expected newMax rowid 4, got %d", newMax)
+	}
+	// Second call with the advanced watermark should return nothing and
+	// leave the watermark unchanged.
+	results, same, err := s.QueryAfterRowID(Query{}, newMax)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 rows after advancing watermark, got %d", len(results))
+	}
+	if same != newMax {
+		t.Errorf("expected watermark to stay at %d, got %d", newMax, same)
+	}
+}
+
+func TestQueryAfterRowIDAppliesFilters(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	// Insert into two different chains.
+	for i, chain := range []string{"chain-a", "chain-b"} {
+		r := makeSignedReceipt(t, kp, i+1, chain, nil)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	chainA := "chain-a"
+	results, _, err := s.QueryAfterRowID(Query{ChainID: &chainA}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for chain-a filter, got %d", len(results))
+	}
+	if results[0].CredentialSubject.Chain.ChainID != chainA {
+		t.Errorf("wrong chain: %s", results[0].CredentialSubject.Chain.ChainID)
+	}
+}
+
 func TestCloseMultipleTimes(t *testing.T) {
 	s, err := Open(":memory:")
 	if err != nil {

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -349,6 +349,47 @@ func TestQueryAfterRowIDReturnsOnlyNewRows(t *testing.T) {
 	}
 }
 
+func TestQueryReceiptsWithWatermarkReturnsConsistentPair(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	var prevHash *string
+	for i := 1; i <= 3; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	receipts, watermark, err := s.QueryReceiptsWithWatermark(Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 3 {
+		t.Errorf("expected 3 receipts, got %d", len(receipts))
+	}
+	if watermark != 3 {
+		t.Errorf("expected watermark 3, got %d", watermark)
+	}
+
+	// Insert another row and confirm the watermark from above makes
+	// QueryAfterRowID return only the new row.
+	r := makeSignedReceipt(t, kp, 4, "chain-1", prevHash)
+	h, _ := receipt.HashReceipt(r)
+	if err := s.Insert(r, h); err != nil {
+		t.Fatal(err)
+	}
+	newRows, _, err := s.QueryAfterRowID(Query{}, watermark)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newRows) != 1 {
+		t.Errorf("expected 1 new row after watermark, got %d", len(newRows))
+	}
+}
+
 func TestQueryAfterRowIDAppliesFilters(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -27,6 +27,8 @@ mcp-proxy list -action read_file          # filter by action type
 mcp-proxy list -chain <chain-id>          # filter by chain
 mcp-proxy list -limit 100                 # limit results
 mcp-proxy list -json                      # JSON output
+mcp-proxy list -f                         # tail-like: stream new receipts live
+mcp-proxy list --follow --interval 1s     # custom poll interval
 ```
 
 | Flag | Description |
@@ -35,7 +37,9 @@ mcp-proxy list -json                      # JSON output
 | `-action` | Filter by action type |
 | `-chain` | Filter by chain ID |
 | `-limit` | Maximum number of receipts to return (default: `50`) |
-| `-json` | Output as JSON |
+| `-json` | Output as JSON (NDJSON — one object per line — in `--follow` mode) |
+| `-follow`, `-f` | After the initial listing, keep polling and stream new receipts as they are inserted (`tail -f`-style). Exit with `Ctrl-C`. |
+| `-interval` | Poll interval in `--follow` mode (default: `500ms`) |
 | `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 
 ### Example output

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -38,7 +38,7 @@ mcp-proxy list --follow --interval 1s     # custom poll interval
 | `-chain` | Filter by chain ID |
 | `-limit` | Maximum number of receipts to return (default: `50`) |
 | `-json` | Output as JSON (NDJSON — one object per line — in `--follow` mode) |
-| `-follow`, `-f` | After the initial listing, keep polling and stream new receipts as they are inserted (`tail -f`-style). Exit with `Ctrl-C`. |
+| `-follow`, `-f` | After the initial listing, keep polling and stream new receipts as they are inserted (`tail -f`-style). Exit with `Ctrl-C`. In `--follow` mode, the startup batch is printed in chronological order (oldest → newest) so it reads continuously with the streamed tail. |
 | `-interval` | Poll interval in `--follow` mode (default: `500ms`) |
 | `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
 


### PR DESCRIPTION
## Summary

- Adds `--follow`/`-f` to `mcp-proxy list` — after the initial listing, polls the receipt store and streams new rows as they're inserted (`tail -f`-style). Exits cleanly on `Ctrl-C`.
- `sdk-go/store`: new `MaxRowID()` and `QueryAfterRowID()` using SQLite `rowid` as a watermark.
- `mcp-proxy list`: new `--follow`/`-f` and `--interval` (default `500ms`) flags; honours existing `-chain`/`-risk`/`-action` filters; JSON mode streams NDJSON (one object per line) so the output is pipe-friendly.

Closes #216.

## Acceptance criteria

- [x] `-f` / `--follow` flag added to the `list` subcommand
- [x] Existing rows are printed on startup. Note: in `--follow` mode the startup batch is printed in chronological order (oldest → newest) so it reads continuously with the streamed tail; non-follow `list` output is unchanged (newest-first).
- [x] New rows are streamed to stdout as they are inserted
- [x] Process exits cleanly on `Ctrl-C` (SIGINT + SIGTERM via `signal.NotifyContext`)
- [x] Poll interval is reasonable (default 500 ms) and configurable via `--interval` (non-positive values fail fast with exit 2)
- [x] Unit/integration test: insert a row after follow starts and assert it appears in output (`TestRunFollowLoopStreamsNewRows`, plus filter-honouring + context-cancel tests and store-layer `TestQueryAfterRowID*` / `TestMaxRowID*`)

## Test plan

- [x] `go test ./...` in `sdk/go` and `mcp-proxy`
- [x] `go vet ./...` in both modules
- [x] Manual smoke: `mcp-proxy list -receipt-db <tmp> -f -interval 100ms` while inserting a signed receipt via the store — row appears in stdout, `Ctrl-C` exits cleanly