### PR TITLE
feat(mcp-proxy): bundle Atlassian taxonomy and document remote MCP setup

### DIFF
--- a/mcp-proxy/AGENTS.md
+++ b/mcp-proxy/AGENTS.md
@@ -19,7 +19,7 @@ internal/
   proxy/           # STDIO proxy, JSON-RPC parsing
   audit/           # SQLite audit store, classifier, risk scorer, redaction, encryption, intent tracker
   policy/          # YAML policy engine (pass/flag/pause/block)
-configs/           # Default policy rules
+configs/           # Default policy rules + bundled taxonomies (embedded into the binary via go:embed)
 ```
 
 ## Architecture

--- a/mcp-proxy/CLAUDE.md
+++ b/mcp-proxy/CLAUDE.md
@@ -26,7 +26,7 @@ internal/
   proxy/           # STDIO proxy, JSON-RPC parsing
   audit/           # SQLite audit store, classifier, risk scorer, redaction, encryption, intent tracker
   policy/          # YAML policy engine (pass/flag/pause/block)
-configs/           # Default policy rules
+configs/           # Default policy rules + bundled taxonomies (embedded into the binary via go:embed)
 ```
 
 ## Architecture

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/agent-receipts/ar/mcp-proxy/configs"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
@@ -79,21 +80,22 @@ func main() {
 
 func serve() {
 	var (
-		dbPath       = flag.String("db", defaultDBPath("audit.db"), "SQLite audit database path")
-		receiptDB    = flag.String("receipt-db", defaultDBPath("receipts.db"), "SQLite receipt store path")
-		keyPath      = flag.String("key", "", "Ed25519 private key (PEM file)")
-		taxonomyPath = flag.String("taxonomy", "", "Taxonomy mappings (JSON file)")
-		rulesPath    = flag.String("rules", "", "Policy rules (YAML file)")
-		serverName   = flag.String("name", "", "Server name for audit trail")
-		issuerDID    = flag.String("issuer", "did:agent:mcp-proxy", "Issuer DID")
-		issuerName   = flag.String("issuer-name", "", "Issuer name (e.g. Claude Code, Codex)")
-		issuerModel  = flag.String("issuer-model", "", "AI model identifier (e.g. claude-sonnet-4-6)")
-		operatorID   = flag.String("operator-id", "", "Operator DID (organisation running the agent)")
-		operatorName = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
-		principalDID = flag.String("principal", "did:user:unknown", "Principal DID")
-		chainID      = flag.String("chain", "", "Chain ID (auto-generated if empty)")
-		httpAddr     = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port; pass \"none\" to disable the approver)")
-		approvalWait = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
+		dbPath          = flag.String("db", defaultDBPath("audit.db"), "SQLite audit database path")
+		receiptDB       = flag.String("receipt-db", defaultDBPath("receipts.db"), "SQLite receipt store path")
+		keyPath         = flag.String("key", "", "Ed25519 private key (PEM file)")
+		taxonomyPath    = flag.String("taxonomy", "", "Taxonomy mappings (JSON file). Merged with bundled taxonomies; user mappings win on conflict.")
+		bundledTaxonomy = flag.Bool("bundled-taxonomies", true, "Include bundled taxonomies (e.g. GitHub, Atlassian). Set to false to use only -taxonomy.")
+		rulesPath       = flag.String("rules", "", "Policy rules (YAML file)")
+		serverName      = flag.String("name", "", "Server name for audit trail")
+		issuerDID       = flag.String("issuer", "did:agent:mcp-proxy", "Issuer DID")
+		issuerName      = flag.String("issuer-name", "", "Issuer name (e.g. Claude Code, Codex)")
+		issuerModel     = flag.String("issuer-model", "", "AI model identifier (e.g. claude-sonnet-4-6)")
+		operatorID      = flag.String("operator-id", "", "Operator DID (organisation running the agent)")
+		operatorName    = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
+		principalDID    = flag.String("principal", "did:user:unknown", "Principal DID")
+		chainID         = flag.String("chain", "", "Chain ID (auto-generated if empty)")
+		httpAddr        = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port; pass \"none\" to disable the approver)")
+		approvalWait    = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -167,13 +169,22 @@ func serve() {
 		fmt.Fprintln(os.Stderr, kp.PublicKey)
 	}
 
-	// Load taxonomy mappings.
+	// Load taxonomy mappings. User-provided -taxonomy entries are placed
+	// first so they win on tool_name conflict — ClassifyToolCall iterates
+	// in order and stops on first match.
 	var mappings []taxonomy.TaxonomyMapping
 	if *taxonomyPath != "" {
 		mappings, err = taxonomy.LoadTaxonomyConfig(*taxonomyPath)
 		if err != nil {
 			log.Fatalf("mcp-proxy: load taxonomy: %v", err)
 		}
+	}
+	if *bundledTaxonomy {
+		bundled, err := configs.BundledTaxonomies()
+		if err != nil {
+			log.Fatalf("mcp-proxy: load bundled taxonomies: %v", err)
+		}
+		mappings = append(mappings, bundled...)
 	}
 
 	// Load policy rules.

--- a/mcp-proxy/configs/atlassian_taxonomy.json
+++ b/mcp-proxy/configs/atlassian_taxonomy.json
@@ -1,0 +1,30 @@
+{
+  "mappings": [
+    {"tool_name": "atlassianUserInfo", "action_type": "data.api.read"},
+    {"tool_name": "getAccessibleAtlassianResources", "action_type": "data.api.read"},
+    {"tool_name": "lookupJiraAccountId", "action_type": "data.api.read"},
+
+    {"tool_name": "getVisibleJiraProjects", "action_type": "data.api.read"},
+    {"tool_name": "getJiraProjectIssueTypesMetadata", "action_type": "data.api.read"},
+    {"tool_name": "getJiraIssue", "action_type": "data.api.read"},
+    {"tool_name": "getTransitionsForJiraIssue", "action_type": "data.api.read"},
+    {"tool_name": "searchJiraIssuesUsingJql", "action_type": "data.api.read"},
+    {"tool_name": "createJiraIssue", "action_type": "data.api.write"},
+    {"tool_name": "editJiraIssue", "action_type": "data.api.write"},
+    {"tool_name": "transitionJiraIssue", "action_type": "data.api.write"},
+    {"tool_name": "addCommentToJiraIssue", "action_type": "data.api.write"},
+
+    {"tool_name": "getConfluenceSpaces", "action_type": "data.api.read"},
+    {"tool_name": "getPagesInConfluenceSpace", "action_type": "data.api.read"},
+    {"tool_name": "getConfluencePage", "action_type": "data.api.read"},
+    {"tool_name": "getConfluencePageAncestors", "action_type": "data.api.read"},
+    {"tool_name": "getConfluencePageDescendants", "action_type": "data.api.read"},
+    {"tool_name": "getConfluencePageFooterComments", "action_type": "data.api.read"},
+    {"tool_name": "getConfluencePageInlineComments", "action_type": "data.api.read"},
+    {"tool_name": "searchConfluenceUsingCql", "action_type": "data.api.read"},
+    {"tool_name": "createConfluencePage", "action_type": "data.api.write"},
+    {"tool_name": "updateConfluencePage", "action_type": "data.api.write"},
+    {"tool_name": "createConfluenceFooterComment", "action_type": "data.api.write"},
+    {"tool_name": "createConfluenceInlineComment", "action_type": "data.api.write"}
+  ]
+}

--- a/mcp-proxy/configs/configs.go
+++ b/mcp-proxy/configs/configs.go
@@ -1,0 +1,85 @@
+// Package configs exposes taxonomy mappings bundled into the mcp-proxy binary.
+//
+// Each *_taxonomy.json file in this directory is embedded at build time and
+// merged into the runtime mapping list. User-provided -taxonomy entries should
+// be applied first by callers so they win on tool_name conflict — the SDK's
+// ClassifyToolCall iterates in order and returns on first match.
+package configs
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+)
+
+//go:embed *_taxonomy.json
+var taxonomyFiles embed.FS
+
+// BundledTaxonomies returns the deduplicated set of mappings embedded in the
+// binary, sorted by source filename then by tool_name for deterministic order.
+// The first mapping wins on duplicate tool_name across files.
+func BundledTaxonomies() ([]taxonomy.TaxonomyMapping, error) {
+	entries, err := taxonomyFiles.ReadDir(".")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded taxonomies: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_taxonomy.json") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	seen := make(map[string]bool)
+	var out []taxonomy.TaxonomyMapping
+	for _, name := range names {
+		raw, err := taxonomyFiles.ReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		var cfg taxonomy.TaxonomyConfig
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", name, err)
+		}
+		for _, m := range cfg.Mappings {
+			if m.ToolName == "" || m.ActionType == "" {
+				return nil, fmt.Errorf("%s: invalid mapping: tool_name and action_type must be non-empty", name)
+			}
+			if seen[m.ToolName] {
+				continue
+			}
+			seen[m.ToolName] = true
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+// BundledNames returns the basenames (without _taxonomy.json suffix) of the
+// embedded files, sorted. Used for startup banners and diagnostics.
+func BundledNames() []string {
+	entries, err := taxonomyFiles.ReadDir(".")
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, "_taxonomy.json") {
+			continue
+		}
+		out = append(out, strings.TrimSuffix(name, "_taxonomy.json"))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/mcp-proxy/configs/configs.go
+++ b/mcp-proxy/configs/configs.go
@@ -20,8 +20,9 @@ import (
 var taxonomyFiles embed.FS
 
 // BundledTaxonomies returns the deduplicated set of mappings embedded in the
-// binary, sorted by source filename then by tool_name for deterministic order.
-// The first mapping wins on duplicate tool_name across files.
+// binary. Files are processed in sorted source filename order, and mappings
+// within each file are returned in their JSON order. The first mapping wins
+// on duplicate tool_name across files.
 func BundledTaxonomies() ([]taxonomy.TaxonomyMapping, error) {
 	entries, err := taxonomyFiles.ReadDir(".")
 	if err != nil {

--- a/mcp-proxy/configs/configs_test.go
+++ b/mcp-proxy/configs/configs_test.go
@@ -1,0 +1,51 @@
+package configs
+
+import (
+	"testing"
+)
+
+func TestBundledTaxonomiesIncludesGitHubAndAtlassian(t *testing.T) {
+	mappings, err := BundledTaxonomies()
+	if err != nil {
+		t.Fatalf("BundledTaxonomies: %v", err)
+	}
+	if len(mappings) == 0 {
+		t.Fatal("expected bundled mappings, got none")
+	}
+
+	want := map[string]string{
+		// GitHub MCP
+		"create_pull_request": "data.api.write",
+		"merge_pull_request":  "data.api.write",
+		"list_issues":         "data.api.read",
+		// Atlassian MCP
+		"createJiraIssue":          "data.api.write",
+		"editJiraIssue":            "data.api.write",
+		"searchJiraIssuesUsingJql": "data.api.read",
+		"createConfluencePage":     "data.api.write",
+	}
+	got := make(map[string]string, len(mappings))
+	for _, m := range mappings {
+		got[m.ToolName] = m.ActionType
+	}
+	for tool, action := range want {
+		if got[tool] != action {
+			t.Errorf("mapping for %q: want %q, got %q", tool, action, got[tool])
+		}
+	}
+}
+
+func TestBundledNames(t *testing.T) {
+	names := BundledNames()
+	want := map[string]bool{"github": false, "atlassian": false}
+	for _, n := range names {
+		if _, ok := want[n]; ok {
+			want[n] = true
+		}
+	}
+	for n, found := range want {
+		if !found {
+			t.Errorf("expected bundled name %q, not present in %v", n, names)
+		}
+	}
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
             { label: "Overview", slug: "mcp-proxy/overview" },
             { label: "Installation", slug: "mcp-proxy/installation" },
             { label: "Configuration", slug: "mcp-proxy/configuration" },
+            { label: "Remote MCP Servers", slug: "mcp-proxy/remote-servers" },
             { label: "Approval Server", slug: "mcp-proxy/approval-ui" },
             { label: "Claude Desktop", slug: "mcp-proxy/claude-desktop" },
             { label: "Claude Code", slug: "mcp-proxy/claude-code" },

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -10,7 +10,8 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 | `-db` | `$HOME/.agent-receipts/audit.db` | SQLite audit database path. Parent directory is created on first run (mode 0700 on Unix). |
 | `-receipt-db` | `$HOME/.agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created on first run (mode 0700 on Unix). |
 | `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
-| `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification |
+| `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification. Merged with bundled taxonomies; user mappings win on conflict. |
+| `-bundled-taxonomies` | `true` | Include bundled taxonomies (e.g. GitHub, Atlassian) embedded in the binary. Set to `false` to use only `-taxonomy`. |
 | `-rules` | (built-in defaults) | Policy rules YAML file |
 | `-name` | (inferred from command) | Server name for the audit trail |
 | `-issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
@@ -98,7 +99,7 @@ MCP tool names are automatically stripped of their `mcp__<server>__` prefix befo
 
 ## Taxonomy mappings
 
-For more precise classification than prefix-based inference, provide a `-taxonomy` JSON file mapping tool names to action types:
+For more precise classification than prefix-based inference, provide a `-taxonomy` JSON file mapping tool names to action types. Bundled taxonomies (see below) are loaded automatically; the `-taxonomy` file is merged on top and wins on tool-name conflicts.
 
 ```json
 {
@@ -112,7 +113,7 @@ For more precise classification than prefix-based inference, provide a `-taxonom
 
 Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [taxonomy spec](https://github.com/agent-receipts/ar/blob/main/spec/spec/taxonomy/action-types.json) for the full list.
 
-A bundled [`configs/github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) provides mappings for GitHub MCP server tools.
+The proxy ships with bundled mappings — currently [`github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) and [`atlassian_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/atlassian_taxonomy.json) — embedded into the binary. They are loaded automatically; no `-taxonomy` flag is needed for those servers. A user-supplied `-taxonomy` is merged on top and wins on tool-name conflicts. Pass `-bundled-taxonomies=false` to disable the embedded set.
 
 ## Approval workflow
 

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -17,7 +17,7 @@ If your MCP server exposes tools that can cross 50, either pin `-http 127.0.0.1:
 
 - **Risk scoring** -- scores every tool call 0-100 based on operation type, sensitive keywords, and patterns
 - **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
-- **Action taxonomy** -- classifies tool calls using configurable taxonomy mappings, with a bundled config for GitHub MCP server tools
+- **Action taxonomy** -- classifies tool calls using configurable taxonomy mappings; GitHub and Atlassian MCP servers are covered by bundled taxonomies out of the box
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy enforcement** -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** -- HTTP endpoints for async approval of paused operations
@@ -85,7 +85,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
-        "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
@@ -114,7 +113,6 @@ claude mcp add-json github-audited --scope user '{
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
-    "-taxonomy", "/Users/YOU/.agent-receipts/github_taxonomy.json",
     "/opt/homebrew/bin/github-mcp-server", "stdio"
   ],
   "env": {

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -96,12 +96,12 @@ The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.co
 
 `mcp-remote` listens on `127.0.0.1` for the local end of the OAuth callback, and the proxy itself binds an approval port. If you run multiple audited remote servers alongside local ones, give each its own approval port:
 
-| Server          | `-http` |
-| --------------- | ------- |
-| GitHub          | `8080`  |
-| Codex / Linear  | `8081`  |
-| Atlassian       | `8082`  |
-| Slack           | `8083`  |
+| Server          | `-http`            |
+| --------------- | ------------------ |
+| GitHub          | `127.0.0.1:8080`   |
+| Codex / Linear  | `127.0.0.1:8081`   |
+| Atlassian       | `127.0.0.1:8082`   |
+| Slack           | `127.0.0.1:8083`   |
 
 This keeps an external approval UI able to route by port. See [Approval Server](/mcp-proxy/approval-ui/) for the wider workflow.
 

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -1,0 +1,112 @@
+---
+title: Remote MCP Servers (Atlassian, Slack, Linear)
+description: How to audit remote HTTP/SSE MCP servers — like the Atlassian Remote MCP Server — by composing mcp-remote with the Agent Receipts proxy.
+---
+
+The Agent Receipts proxy expects an upstream MCP server it can spawn as a local stdio process. A growing class of MCP servers — **Atlassian, Slack, Linear, HubSpot, Notion, and others** — are hosted as remote HTTP/SSE endpoints behind OAuth instead. To audit those today, compose [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) in front of `mcp-proxy`: `mcp-remote` handles the OAuth dance and exposes a stdio MCP transport, which the proxy then wraps as it would any local server.
+
+:::note[Why this is its own page]
+The composition pattern works, but a few things differ from local-server setups: ports stack up, OAuth is invisible to the proxy, and bundled taxonomies are what give risk scoring meaning out of the box. Native HTTP/SSE support inside `mcp-proxy` is tracked in [issue #227](https://github.com/agent-receipts/ar/issues/227); until that lands, this page is the supported path.
+:::
+
+## How the composition works
+
+```
+MCP Client (Claude / Codex)
+        │  stdio
+        ▼
+   mcp-proxy   ◄── audits, scores, signs receipts
+        │  stdio
+        ▼
+   mcp-remote  ◄── OAuth flow, token refresh, transport bridge
+        │  HTTP/SSE + Bearer token
+        ▼
+Remote MCP Server (e.g. mcp.atlassian.com/v1/mcp)
+```
+
+`mcp-remote` is responsible for the OAuth flow and token refresh. The proxy never sees the bearer token, which is good for redaction (one less secret to leak into the audit log), but means receipts cannot tie an action to a specific token identity. If you need that, follow [#227](https://github.com/agent-receipts/ar/issues/227).
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- A signing key pair generated (see below)
+- Node.js (for `npx mcp-remote`)
+- A remote MCP endpoint and an account that can authorise it. The example below uses Atlassian's Remote MCP Server at `https://mcp.atlassian.com/v1/mcp`.
+
+## Generate a signing key
+
+```bash
+mkdir -p ~/.agent-receipts
+openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/atlassian-proxy.pem
+openssl pkey -in ~/.agent-receipts/atlassian-proxy.pem -pubout \
+  -out ~/.agent-receipts/atlassian-proxy-pub.pem
+```
+
+## Worked example: Atlassian (Jira + Confluence)
+
+Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-remote <url>`. For Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "atlassian-audited": {
+      "command": "/Users/YOU/go/bin/mcp-proxy",
+      "args": [
+        "-name", "atlassian",
+        "-key", "/Users/YOU/.agent-receipts/atlassian-proxy.pem",
+        "-http", "127.0.0.1:8082",
+        "-issuer-name", "Claude Desktop",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
+        "npx", "-y", "mcp-remote",
+        "https://mcp.atlassian.com/v1/mcp"
+      ]
+    }
+  }
+}
+```
+
+For Claude Code:
+
+```bash
+claude mcp add-json atlassian-audited --scope user '{
+  "command": "/Users/YOU/go/bin/mcp-proxy",
+  "args": [
+    "-name", "atlassian",
+    "-key", "/Users/YOU/.agent-receipts/atlassian-proxy.pem",
+    "-http", "127.0.0.1:8082",
+    "-issuer-name", "Claude Code",
+    "-operator-id", "did:web:anthropic.com",
+    "-operator-name", "Anthropic",
+    "npx", "-y", "mcp-remote",
+    "https://mcp.atlassian.com/v1/mcp"
+  ]
+}'
+```
+
+The first time the server is invoked, `mcp-remote` opens a browser tab to complete the OAuth flow with Atlassian. Subsequent runs reuse the cached token (managed by `mcp-remote`, not the proxy).
+
+## Bundled taxonomy
+
+The proxy ships with bundled mappings for Atlassian's Jira and Confluence tools (`createJiraIssue`, `editJiraIssue`, `searchJiraIssuesUsingJql`, `createConfluencePage`, `updateConfluencePage`, and others), so writes are scored as `data.api.write` and reads as `data.api.read` out of the box. No `-taxonomy` flag is required for those names. To extend or override, supply your own JSON file via `-taxonomy /path/to/file.json` — user mappings win on conflict. To disable the bundled set entirely, pass `-bundled-taxonomies=false`.
+
+The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy/configs) — open a PR to add or correct mappings.
+
+## Port assignment
+
+`mcp-remote` listens on `127.0.0.1` for the local end of the OAuth callback, and the proxy itself binds an approval port. If you run multiple audited remote servers alongside local ones, give each its own approval port:
+
+| Server          | `-http` |
+| --------------- | ------- |
+| GitHub          | `8080`  |
+| Codex / Linear  | `8081`  |
+| Atlassian       | `8082`  |
+| Slack           | `8083`  |
+
+This keeps an external approval UI able to route by port. See [Approval Server](/mcp-proxy/approval-ui/) for the wider workflow.
+
+## Caveats
+
+- **OAuth is invisible to the proxy.** `mcp-remote` owns the credential. The proxy can't include token identity in receipts and can't log auth refreshes. Tracked in [#227](https://github.com/agent-receipts/ar/issues/227).
+- **Naming collision.** There are several unrelated tools called `mcp-proxy` in the ecosystem — make sure your `command` path points at the Agent Receipts binary (the one you installed via `go install` or downloaded from this project).
+- **First-run OAuth.** Some MCP clients launch the server eagerly; the OAuth flow needs an interactive browser session, so the very first invocation may require running the proxy command manually in a terminal once before the client can use it.


### PR DESCRIPTION
Closes part of #226 (Options B and C). Native HTTP/SSE transport (Option A) is tracked separately in #227.

## Summary

- **Bundled taxonomies (Option C):** GitHub and Atlassian taxonomy JSON files are now embedded into the `mcp-proxy` binary via `go:embed`. They load automatically — no `-taxonomy` flag required for those servers. A user-supplied `-taxonomy` is merged on top and wins on tool-name conflict. New `-bundled-taxonomies` flag (default `true`) opts out.
- **Remote-server docs (Option B):** New page covering the `mcp-remote` + `mcp-proxy` composition pattern with Atlassian as the worked example. Lists port-assignment guidance and the OAuth-invisibility caveat (mcp-remote owns the credential, so receipts can't tie an action to a token identity — that needs Option A / #227).
- **Atlassian taxonomy:** 24 mappings covering Jira (`createJiraIssue`, `editJiraIssue`, `transitionJiraIssue`, `searchJiraIssuesUsingJql`, …) and Confluence (`createConfluencePage`, `updateConfluencePage`, comment writes, etc). Atlassian tool names are camelCase, so the existing prefix classifier (`create_*`, `delete_*`, …) doesn't catch them — bundling matters here.
- **Existing docs touch-ups:** removed redundant `-taxonomy` lines from the Claude Desktop / Code examples in `overview.mdx`, updated the configuration page (flag table + bundled-taxonomies note), and refreshed the `configs/` directory description in `AGENTS.md` / `CLAUDE.md`.

## Files

- New: `mcp-proxy/configs/atlassian_taxonomy.json`, `mcp-proxy/configs/configs.go` (+ test), `site/src/content/docs/mcp-proxy/remote-servers.mdx`
- Modified: `mcp-proxy/cmd/mcp-proxy/main.go`, `mcp-proxy/{AGENTS,CLAUDE}.md`, `site/astro.config.mjs`, `site/src/content/docs/mcp-proxy/{overview,configuration}.mdx`

## Test plan

- [x] `go test ./...` green for `mcp-proxy/...` and `sdk/go/...`
- [x] `go vet ./...` clean
- [x] `pnpm build` in `site/` produces 33 pages including `/mcp-proxy/remote-servers/`
- [x] Pre-commit hooks (lefthook: gofmt, go vet, conventional-commit) pass
- [ ] Manual: spin up the proxy against an Atlassian endpoint via `npx mcp-remote` and confirm a `createJiraIssue` call records as `data.api.write` without `-taxonomy`