### PR TITLE
chore(mcp-proxy): bump sdk/go to v0.5.0

### DIFF
--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/mcp-proxy
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.4.0
+	github.com/agent-receipts/ar/sdk/go v0.5.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,7 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.3.1 h1:20mU2aszom4gG7BvZyyT/mxMgeDJniBJv630771yqUI=
-github.com/agent-receipts/ar/sdk/go v0.3.1/go.mod h1:W/Lgz1a3s8mtlNP8MQq+2llwzWukokud+4NeMMOVhXI=
-github.com/agent-receipts/ar/sdk/go v0.4.0 h1:BqybWy9ha8ePQKckG9dC2FS5Y6mCuO1Eens/JJgK/wI=
-github.com/agent-receipts/ar/sdk/go v0.4.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/sdk/go v0.5.0 h1:N5tvD3t4gqyv3OTUrwDV1LaAS0ObrdjfAygj/A8gm8Y=
+github.com/agent-receipts/ar/sdk/go v0.5.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary

- Bumps `mcp-proxy`'s `sdk/go` require from `v0.4.0` to `v0.5.0`.
- Needed before tagging `mcp-proxy/v0.6.0`: the new `list --follow` mode calls `QueryAfterRowIDContext` / `QueryReceiptsWithWatermarkContext`, which land in `sdk/go v0.5.0`. Locally these resolved via `go.work`; the pinned require needs to match so goreleaser and downstream consumers see the right version.

## Test plan

- [x] `go build ./...` and `go test ./...` in `mcp-proxy/`
- [x] `go vet ./...` in `mcp-proxy/`
- [x] `go.sum` regenerated via `go mod tidy`