### PR TITLE
feat: show server and tool_name in list/tail; improve remote-server docs

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -217,7 +217,7 @@ func writeReceiptRows(w io.Writer, receipts []receipt.AgentReceipt) {
 			server = subj.Action.Target.System
 		}
 		fmt.Fprintf(w, listRowFmt,
-			truncate(r.ID, 22),
+			truncate(r.ID, 23),
 			truncate(server, 14),
 			truncate(subj.Action.ToolName, 30),
 			truncate(subj.Action.Type, 22),

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -19,7 +19,7 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
 
-const listRowFmt = "%-40s %-22s %-6s %-8s %-14s %-22s %s\n"
+const listRowFmt = "%-22s %-14s %-30s %-22s %-8s %-8s %s\n"
 
 func openReceiptStore(path string) *store.Store {
 	if err := ensureDBDir(path); err != nil {
@@ -120,7 +120,7 @@ func cmdList(args []string) {
 			}
 		}
 	} else {
-		fmt.Printf(listRowFmt, "ID", "ACTION", "RISK", "STATUS", "ISSUER", "OPERATOR", "TIMESTAMP")
+		fmt.Printf(listRowFmt, "ID", "SERVER", "TOOL", "ACTION", "RISK", "STATUS", "TIMESTAMP")
 		fmt.Println("---")
 		writeReceiptRows(os.Stdout, receipts)
 		if !*follow {
@@ -212,17 +212,17 @@ func reverseReceipts(s []receipt.AgentReceipt) {
 func writeReceiptRows(w io.Writer, receipts []receipt.AgentReceipt) {
 	for _, r := range receipts {
 		subj := r.CredentialSubject
-		operator := ""
-		if r.Issuer.Operator != nil {
-			operator = r.Issuer.Operator.ID
+		server := ""
+		if subj.Action.Target != nil {
+			server = subj.Action.Target.System
 		}
 		fmt.Fprintf(w, listRowFmt,
-			truncate(r.ID, 40),
+			truncate(r.ID, 22),
+			truncate(server, 14),
+			truncate(subj.Action.ToolName, 30),
 			truncate(subj.Action.Type, 22),
 			subj.Action.RiskLevel,
 			subj.Outcome.Status,
-			truncate(r.Issuer.Name, 14),
-			truncate(operator, 22),
 			subj.Action.Timestamp,
 		)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -37,6 +37,74 @@ func storeFollowReceipt(t *testing.T, s *store.Store, kp receipt.KeyPair, seq in
 	return h
 }
 
+// TestWriteReceiptRows checks that writeReceiptRows renders SERVER, TOOL, and
+// ACTION columns correctly, including the Target==nil legacy case.
+func TestWriteReceiptRows(t *testing.T) {
+	cases := []struct {
+		name     string
+		action   receipt.Action
+		wantCols []string
+		wantNot  []string
+	}{
+		{
+			name: "with server and tool",
+			action: receipt.Action{
+				Type:      "data.api.write",
+				RiskLevel: receipt.RiskMedium,
+				ToolName:  "create_pull_request",
+				Target:    &receipt.ActionTarget{System: "github"},
+			},
+			wantCols: []string{"github", "create_pull_request", "data.api.write", "medium"},
+		},
+		{
+			name: "nil target (legacy receipt)",
+			action: receipt.Action{
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				ToolName:  "read",
+				Target:    nil,
+			},
+			wantCols: []string{"read", "filesystem.file.read", "low"},
+		},
+		{
+			name: "long tool name truncated",
+			action: receipt.Action{
+				Type:      "data.api.read",
+				RiskLevel: receipt.RiskLow,
+				ToolName:  "searchJiraIssuesUsingJqlAndSomeExtraTextThatExceedsThirtyChars",
+				Target:    &receipt.ActionTarget{System: "atlassian"},
+			},
+			wantCols: []string{"atlassian", "data.api.read"},
+			wantNot:  []string{"searchJiraIssuesUsingJqlAndSomeExtraTextThatExceedsThirtyChars"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := receipt.AgentReceipt{
+				ID: "urn:receipt:test-id",
+				CredentialSubject: receipt.CredentialSubject{
+					Action:  tc.action,
+					Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+				},
+			}
+			var buf bytes.Buffer
+			writeReceiptRows(&buf, []receipt.AgentReceipt{r})
+			out := buf.String()
+			for _, want := range tc.wantCols {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in output; got: %q", want, out)
+				}
+			}
+			for _, notWant := range tc.wantNot {
+				if strings.Contains(out, notWant) {
+					t.Errorf("expected %q to be absent (truncated) in output; got: %q", notWant, out)
+				}
+			}
+		})
+	}
+}
+
 // notifyWriter is an io.Writer that both captures output into a buffer and
 // posts a signal on each Write. Tests block on notify instead of sleeping +
 // polling so they stay reliable under slow / loaded runners.

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -125,7 +125,7 @@ This keeps an external approval UI able to route by port. See [Approval Server](
 **Fix:** run the full proxy command directly in a terminal first, complete the browser OAuth, then Ctrl+C and reconnect via `/mcp`:
 
 ```bash
-/Users/YOU/go/bin/mcp-proxy -name atlassian -key ~/.agent-receipts/atlassian-proxy.pem \
+$HOME/go/bin/mcp-proxy -name atlassian -key ~/.agent-receipts/atlassian-proxy.pem \
   -http 127.0.0.1:8082 \
   npx --registry https://registry.npmjs.org -y mcp-remote https://mcp.atlassian.com/v1/mcp
 ```

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -42,6 +42,10 @@ openssl pkey -in ~/.agent-receipts/atlassian-proxy.pem -pubout \
   -out ~/.agent-receipts/atlassian-proxy-pub.pem
 ```
 
+:::tip[Reuse an existing key]
+One signing key works for all servers. If you already have a key from a previous setup (e.g. `github-proxy.pem`), you can reuse it here — just point `-key` at that file instead.
+:::
+
 ## Worked example: Atlassian (Jira + Confluence)
 
 Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-remote <url>`. For Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
@@ -58,7 +62,7 @@ Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-r
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
-        "npx", "-y", "mcp-remote",
+        "npx", "--registry", "https://registry.npmjs.org", "-y", "mcp-remote",
         "https://mcp.atlassian.com/v1/mcp"
       ]
     }
@@ -73,16 +77,21 @@ claude mcp add-json atlassian-audited --scope user '{
   "command": "/Users/YOU/go/bin/mcp-proxy",
   "args": [
     "-name", "atlassian",
-    "-key", "/Users/YOU/.agent-receipts/atlassian-proxy.pem",
+    "-key", "'"$HOME"'/.agent-receipts/atlassian-proxy.pem",
     "-http", "127.0.0.1:8082",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
-    "npx", "-y", "mcp-remote",
+    "npx", "--registry", "https://registry.npmjs.org", "-y", "mcp-remote",
     "https://mcp.atlassian.com/v1/mcp"
   ]
 }'
 ```
+
+:::note[Path tips]
+- **Key path:** `$HOME` expands in the shell so you don't need to hard-code `/Users/you`. The snippet above uses single-quote escaping (`'"$HOME"'`) so the variable expands before the JSON is passed to `claude mcp add-json`.
+- **Binary path:** Claude Desktop doesn't inherit your shell `PATH`, so GUI-launched instances may fail to find `mcp-proxy` if it's in `~/go/bin`. Use the full path — run `which mcp-proxy` to find it.
+:::
 
 The first time the server is invoked, `mcp-remote` opens a browser tab to complete the OAuth flow with Atlassian. Subsequent runs reuse the cached token (managed by `mcp-remote`, not the proxy).
 
@@ -109,4 +118,19 @@ This keeps an external approval UI able to route by port. See [Approval Server](
 
 - **OAuth is invisible to the proxy.** `mcp-remote` owns the credential. The proxy can't include token identity in receipts and can't log auth refreshes. Tracked in [#227](https://github.com/agent-receipts/ar/issues/227).
 - **Naming collision.** There are several unrelated tools called `mcp-proxy` in the ecosystem — make sure your `command` path points at the Agent Receipts binary (the one you installed via `go install` or downloaded from this project).
-- **First-run OAuth.** Some MCP clients launch the server eagerly; the OAuth flow needs an interactive browser session, so the very first invocation may require running the proxy command manually in a terminal once before the client can use it.
+
+:::caution[First-run OAuth — do this before connecting via your MCP client]
+`mcp-remote` needs an interactive browser session to complete the initial OAuth flow. Claude Code or Claude Desktop will show the server as `failed` until this is done.
+
+**Fix:** run the full proxy command directly in a terminal first, complete the browser OAuth, then Ctrl+C and reconnect via `/mcp`:
+
+```bash
+/Users/YOU/go/bin/mcp-proxy -name atlassian -key ~/.agent-receipts/atlassian-proxy.pem \
+  -http 127.0.0.1:8082 \
+  npx --registry https://registry.npmjs.org -y mcp-remote https://mcp.atlassian.com/v1/mcp
+```
+
+Subsequent launches reuse the cached token managed by `mcp-remote`.
+:::
+
+- **Corporate npm registry.** If your npm is configured to use a private registry (e.g. AWS CodeArtifact), `npx mcp-remote` will fail with a `404 Not Found` error that looks like a missing package. The fix — already in the examples above — is to pass `--registry https://registry.npmjs.org` explicitly to `npx`.


### PR DESCRIPTION
Closes #231, closes #230

## Changes

**`mcp-proxy` CLI (`cli.go`)** — fixes #231

Replaces the `ISSUER` / `OPERATOR` columns in `list` / `tail` output with `SERVER` and `TOOL`, which are what actually change between receipts when running multiple audited servers:

```
Before:
ID                       ACTION                 RISK   STATUS   ISSUER         OPERATOR               TIMESTAMP

After:
ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
```

- `SERVER` = `credentialSubject.action.target.system` (the `-name` value)
- `TOOL` = `credentialSubject.action.tool_name`
- Safe nil-check for `Target` (old receipts without a target continue to work)
- Column widths chosen to fit common values without truncation (`filesystem.file.read`, `searchJiraIssuesUsingJql`, etc.)

**Remote MCP Servers docs (`remote-servers.mdx`)** — fixes #230

- Add `--registry https://registry.npmjs.org` to all `npx mcp-remote` invocations — fixes silent 404s in corporate environments using private npm registries
- Use `$HOME` for key path in the Claude Code CLI snippet (avoids the `/Users/YOU` placeholder)
- Add a tip callout: one signing key works for all servers, no need to generate a new one per server
- Promote first-run OAuth to a `:::caution` callout with a concrete terminal command — it's the most common setup stumbling block
- Add a "Corporate npm registry" caveat explaining the 404 error and the `--registry` fix