### PR TITLE
docs: refresh CLI list examples with new SERVER/TOOL columns

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -124,14 +124,14 @@ ID                     SERVER         TOOL                           ACTION     
 ---
 urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
 urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
-urn:receipt:67fede57... github         add_reply_to_pull_reques...    write                  medium   success  2026-04-24T00:51:57Z
-urn:receipt:013bfc43... github         request_copilot_review         unknown                medium   success  2026-04-24T00:43:40Z
-urn:receipt:7ae4f1b2... github         issue_write                    write                  medium   success  2026-04-24T00:19:35Z
+urn:receipt:67fede57... github         add_reply_to_pull_reques...    data.api.write         medium   success  2026-04-24T00:51:57Z
+urn:receipt:013bfc43... github         request_copilot_review         data.api.write         medium   success  2026-04-24T00:43:40Z
+urn:receipt:7ae4f1b2... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:35Z
 
 5 receipts
 ```
 
-Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low`; write tools like `issue_write` show `write / medium`. The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`.
+Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low`; write tools like `issue_write` show `data.api.write / medium`. The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`.
 
 ## Gotchas
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -118,7 +118,20 @@ mcp-proxy verify \
   <chain-id>
 ```
 
-`list_issues`, `create_issue`, `get_file_contents` and other read operations will show `Action: read, Risk: low`. Write operations like `create_or_update_file` will show `Action: write, Risk: medium`.
+```
+$ mcp-proxy list
+ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
+---
+urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
+urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
+urn:receipt:67fede57... github         add_reply_to_pull_reques...    write                  medium   success  2026-04-24T00:51:57Z
+urn:receipt:013bfc43... github         request_copilot_review         unknown                medium   success  2026-04-24T00:43:40Z
+urn:receipt:7ae4f1b2... github         issue_write                    write                  medium   success  2026-04-24T00:19:35Z
+
+5 receipts
+```
+
+Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low`; write tools like `issue_write` show `write / medium`. The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`.
 
 ## Gotchas
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -91,6 +91,20 @@ mcp-proxy verify \
   <chain-id>
 ```
 
+```
+$ mcp-proxy list
+ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
+---
+urn:receipt:64b00b98... github         issue_write                    write                  medium   success  2026-04-24T01:55:09Z
+urn:receipt:276a6c2a... github         issue_write                    write                  medium   success  2026-04-24T01:48:55Z
+urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
+urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
+
+4 receipts
+```
+
+The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Read operations show `data.api.read / low`; writes show `write / medium`.
+
 ## Gotchas
 
 **Absolute paths required.** Claude Desktop launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -95,15 +95,15 @@ mcp-proxy verify \
 $ mcp-proxy list
 ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
 ---
-urn:receipt:64b00b98... github         issue_write                    write                  medium   success  2026-04-24T01:55:09Z
-urn:receipt:276a6c2a... github         issue_write                    write                  medium   success  2026-04-24T01:48:55Z
+urn:receipt:64b00b98... github         issue_write                    data.api.write         medium   success  2026-04-24T01:55:09Z
+urn:receipt:276a6c2a... github         issue_write                    data.api.write         medium   success  2026-04-24T01:48:55Z
 urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
 urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
 
 4 receipts
 ```
 
-The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Read operations show `data.api.read / low`; writes show `write / medium`.
+The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Read operations show `data.api.read / low`; writes show `data.api.write / medium`.
 
 ## Gotchas
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -120,7 +120,7 @@ urn:receipt:ccc6860a... github         list_issues                    data.api.r
 4 receipts
 ```
 
-The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. The `-issuer-name Codex` flag stamps each receipt so you can tell Codex sessions apart from Claude Code or Claude Desktop when reviewing a shared audit store — that issuer/operator metadata doesn't appear in the tabular view, but it's visible via `mcp-proxy inspect` or `mcp-proxy list -json`.
+The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. The `-issuer-name Codex` flag stamps each receipt so you can tell Codex sessions apart from Claude Code or Claude Desktop when reviewing a shared audit store — that issuer/operator metadata doesn't appear in the tabular view, but it's visible via `mcp-proxy list -json`.
 
 ## Gotchas
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -108,6 +108,20 @@ mcp-proxy verify \
   <chain-id>
 ```
 
+```
+$ mcp-proxy list
+ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
+---
+urn:receipt:58b9c7ff... github         create_pull_request            write                  medium   success  2026-04-15T00:06:48Z
+urn:receipt:3384715f... github         get_pull_request               data.api.read          low      success  2026-04-15T00:06:26Z
+urn:receipt:c2e7b34f... github         push_files                     write                  medium   success  2026-04-15T00:01:39Z
+urn:receipt:ccc6860a... github         list_issues                    data.api.read          low      success  2026-04-14T23:54:09Z
+
+4 receipts
+```
+
+The SERVER column reflects the `-name github` flag you passed to `mcp-proxy` and the `-issuer-name Codex` flag stamps receipts so you can tell Codex sessions apart from Claude Code or Claude Desktop sessions when reviewing a shared audit store.
+
 ## Gotchas
 
 **Absolute paths required.** Codex launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -112,15 +112,15 @@ mcp-proxy verify \
 $ mcp-proxy list
 ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
 ---
-urn:receipt:58b9c7ff... github         create_pull_request            write                  medium   success  2026-04-15T00:06:48Z
+urn:receipt:58b9c7ff... github         create_pull_request            data.api.write         medium   success  2026-04-15T00:06:48Z
 urn:receipt:3384715f... github         get_pull_request               data.api.read          low      success  2026-04-15T00:06:26Z
-urn:receipt:c2e7b34f... github         push_files                     write                  medium   success  2026-04-15T00:01:39Z
+urn:receipt:c2e7b34f... github         push_files                     data.api.write         medium   success  2026-04-15T00:01:39Z
 urn:receipt:ccc6860a... github         list_issues                    data.api.read          low      success  2026-04-14T23:54:09Z
 
 4 receipts
 ```
 
-The SERVER column reflects the `-name github` flag you passed to `mcp-proxy` and the `-issuer-name Codex` flag stamps receipts so you can tell Codex sessions apart from Claude Code or Claude Desktop sessions when reviewing a shared audit store.
+The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. The `-issuer-name Codex` flag stamps each receipt so you can tell Codex sessions apart from Claude Code or Claude Desktop when reviewing a shared audit store — that issuer/operator metadata doesn't appear in the tabular view, but it's visible via `mcp-proxy inspect` or `mcp-proxy list -json`.
 
 ## Gotchas
 

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -167,4 +167,20 @@ Each tool call produces a signed W3C Verifiable Credential. Key fields shown (ab
 
 Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `mcp-proxy inspect`, and `mcp-proxy verify` to query and validate them.
 
+`mcp-proxy list` gives a compact tabular view. When you proxy multiple MCP servers — for example GitHub and Atlassian — the SERVER and TOOL columns let you scan activity across all of them at once:
+
+```
+$ mcp-proxy list
+ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
+---
+urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.read          low      success  2026-04-24T02:05:19Z
+urn:receipt:103200d1... github         issue_write                    write                  medium   success  2026-04-24T01:58:45Z
+urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
+urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
+urn:receipt:276a6c2a... github         issue_write                    write                  medium   success  2026-04-24T01:48:55Z
+urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
+
+6 receipts
+```
+
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -174,10 +174,10 @@ $ mcp-proxy list
 ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
 ---
 urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.read          low      success  2026-04-24T02:05:19Z
-urn:receipt:103200d1... github         issue_write                    write                  medium   success  2026-04-24T01:58:45Z
+urn:receipt:103200d1... github         issue_write                    data.api.write         medium   success  2026-04-24T01:58:45Z
 urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
 urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
-urn:receipt:276a6c2a... github         issue_write                    write                  medium   success  2026-04-24T01:48:55Z
+urn:receipt:276a6c2a... github         issue_write                    data.api.write         medium   success  2026-04-24T01:48:55Z
 urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
 
 6 receipts

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -167,7 +167,7 @@ Each tool call produces a signed W3C Verifiable Credential. Key fields shown (ab
 
 Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `mcp-proxy inspect`, and `mcp-proxy verify` to query and validate them.
 
-`mcp-proxy list` gives a compact tabular view. When you proxy multiple MCP servers — for example GitHub and Atlassian — the SERVER and TOOL columns let you scan activity across all of them at once:
+`mcp-proxy list` gives a compact tabular view. The SERVER column is populated from the server name (defaulting to the wrapped command's basename if `-name` is omitted). When you proxy multiple MCP servers — for example GitHub and Atlassian — the SERVER and TOOL columns let you scan activity across all of them at once:
 
 ```
 $ mcp-proxy list

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -23,7 +23,7 @@ List receipts from the audit store. Results are sorted **newest first** — the 
 ```bash
 mcp-proxy list                            # latest 50 receipts, newest first
 mcp-proxy list -risk high                 # filter by risk level
-mcp-proxy list -action read_file          # filter by action type
+mcp-proxy list -action data.api.read      # filter by action type (taxonomy value)
 mcp-proxy list -chain <chain-id>          # filter by chain
 mcp-proxy list -limit 100                 # limit results
 mcp-proxy list -json                      # JSON output
@@ -62,7 +62,7 @@ urn:receipt:d52ba1fd... github         issue_write                    data.api.w
 
 SERVER comes from the `-name` flag passed to `mcp-proxy` when it was started; it identifies which MCP server handled the call. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
 
-The `-action` filter matches the ACTION column (taxonomy type, e.g. `data.api.read`), not the TOOL column. Issuer and operator identity isn't shown in the tabular view — use `mcp-proxy inspect` or `mcp-proxy list -json` to see it.
+The `-action` filter matches the ACTION column (taxonomy type, e.g. `data.api.read`), not the TOOL column. Issuer and operator identity isn't shown in the tabular view — use `mcp-proxy list -json` to see it.
 
 ## `mcp-proxy inspect`
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -60,7 +60,7 @@ urn:receipt:d52ba1fd... github         issue_write                    data.api.w
 8 receipts
 ```
 
-SERVER comes from the `-name` flag passed to `mcp-proxy` when it was started; it identifies which MCP server handled the call. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
+SERVER identifies which MCP server handled the call. It comes from the `-name` flag, defaulting to the wrapped command's basename if `-name` is omitted. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
 
 The `-action` filter matches the ACTION column (taxonomy type, e.g. `data.api.read`), not the TOOL column. Issuer and operator identity isn't shown in the tabular view — use `mcp-proxy list -json` to see it.
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -46,18 +46,21 @@ mcp-proxy list --follow --interval 1s     # custom poll interval
 
 ```
 $ mcp-proxy list
-ID                                       ACTION                 RISK   STATUS   ISSUER         OPERATOR               TIMESTAMP
+ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
 ---
-urn:receipt:58b9c7ff-cbed-45ed-a5bd-2... read                   low    success  codex          did:web:openai.com     2026-04-15T00:06:48Z
-urn:receipt:3384715f-d633-4031-b96f-c... read                   low    success  codex          did:web:openai.com     2026-04-15T00:06:26Z
-urn:receipt:c2e7b34f-04b2-42d1-a2f5-5... write                  medium success  Claude Code    did:web:anthropic.com  2026-04-15T00:01:39Z
-urn:receipt:ccf92d30-8369-411d-af29-d... read                   low    success                                        2026-04-14T23:56:09Z
-urn:receipt:ccc6860a-f1b5-4e2f-b3ea-a... read                   low    success  Claude Code    did:web:anthropic.com  2026-04-14T23:54:09Z
+urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.read          low      success  2026-04-24T02:05:19Z
+urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
+urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
+urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
+urn:receipt:67fede57... github         add_reply_to_pull_reques...    write                  medium   success  2026-04-24T00:51:57Z
+urn:receipt:013bfc43... github         request_copilot_review         unknown                medium   success  2026-04-24T00:43:40Z
+urn:receipt:7ae4f1b2... github         issue_write                    write                  medium   success  2026-04-24T00:19:35Z
+urn:receipt:d52ba1fd... github         issue_write                    write                  medium   success  2026-04-24T00:19:25Z
 
-50 receipts
+8 receipts
 ```
 
-ISSUER is the agent name set via `--name`; OPERATOR is the operator DID set via `--operator`. Both are empty when the proxy is run without those flags.
+SERVER comes from the `-name` flag passed to `mcp-proxy` when it was started; it identifies which MCP server handled the call. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
 
 ## `mcp-proxy inspect`
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -52,15 +52,17 @@ urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.r
 urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
 urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
 urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
-urn:receipt:67fede57... github         add_reply_to_pull_reques...    write                  medium   success  2026-04-24T00:51:57Z
-urn:receipt:013bfc43... github         request_copilot_review         unknown                medium   success  2026-04-24T00:43:40Z
-urn:receipt:7ae4f1b2... github         issue_write                    write                  medium   success  2026-04-24T00:19:35Z
-urn:receipt:d52ba1fd... github         issue_write                    write                  medium   success  2026-04-24T00:19:25Z
+urn:receipt:67fede57... github         add_reply_to_pull_reques...    data.api.write         medium   success  2026-04-24T00:51:57Z
+urn:receipt:013bfc43... github         request_copilot_review         data.api.write         medium   success  2026-04-24T00:43:40Z
+urn:receipt:7ae4f1b2... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:35Z
+urn:receipt:d52ba1fd... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:25Z
 
 8 receipts
 ```
 
 SERVER comes from the `-name` flag passed to `mcp-proxy` when it was started; it identifies which MCP server handled the call. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
+
+The `-action` filter matches the ACTION column (taxonomy type, e.g. `data.api.read`), not the TOOL column. Issuer and operator identity isn't shown in the tabular view — use `mcp-proxy inspect` or `mcp-proxy list -json` to see it.
 
 ## `mcp-proxy inspect`
 


### PR DESCRIPTION
## Summary

- Refreshes the canonical `mcp-proxy list` example in `reference/cli-commands.mdx` from the old five-column format (ACTION / RISK / STATUS / ISSUER / OPERATOR / TIMESTAMP) to the new seven-column format (ID / SERVER / TOOL / ACTION / RISK / STATUS / TIMESTAMP), using mixed github + atlassian data to show off the multi-server case.
- Adds a sample `mcp-proxy list` output block to the "Verifying receipts" section of each integration guide — [claude-code.mdx](site/src/content/docs/mcp-proxy/claude-code.mdx), [codex.mdx](site/src/content/docs/mcp-proxy/codex.mdx), [claude-desktop.mdx](site/src/content/docs/mcp-proxy/claude-desktop.mdx) — so readers see what they'll actually get after following each guide.
- Adds a short multi-server teaser with a github + atlassian example to [mcp-proxy/overview.mdx](site/src/content/docs/mcp-proxy/overview.mdx), next to the existing receipt JSON sample.
- Fixes stale prose in `claude-code.mdx` that still described pre-taxonomy action values (`Action: read, Risk: low`) — now matches the taxonomy format actually printed (`data.api.read / low`).

All example rows are sorted newest-first to match the documented CLI behaviour, and row counts in each example reflect what's shown.

## Test plan

- [x] `pnpm install && pnpm build` in `site/` completes cleanly (33 pages, no warnings)
- [x] Rendered HTML preserves column alignment inside the `plaintext` code fences
- [x] Column headers and widths match the actual `cli.go` format string (`"%-22s %-14s %-30s %-22s %-8s %-8s %s"`)
- [ ] Visually spot-check each updated page at the deployed preview