### PR TITLE
docs(landscape): note hook-based emitters as a recognised primitive

### DIFF
--- a/docs/ecosystem/landscape.md
+++ b/docs/ecosystem/landscape.md
@@ -98,6 +98,7 @@ Multiple projects have independently converged on the same cryptographic and pro
 | **W3C Verifiable Credentials** | Agent Receipts (unique in this space) |
 | **OWASP Agentic AI Top 10** | Microsoft AGT, Pipelock, mcp-firewall (ressl) |
 | **YAML policy config** | All projects |
+| **Hook-based emission** | Claude Code (full tool-surface coverage), Codex CLI (partial — no WebSearch, partial shell); Agent Receipts adopts both via `claude_code_hook` and `codex_hook` channels (ADRs in progress) |
 
 ---
 
@@ -116,4 +117,4 @@ Areas that remain underserved despite the crowded landscape:
 
 ---
 
-*Last updated: April 16, 2026*
+*Last updated: April 25, 2026*

--- a/docs/ecosystem/landscape.md
+++ b/docs/ecosystem/landscape.md
@@ -1,6 +1,6 @@
 # Agent Security Tooling Landscape — April 2026
 
-An overview of the agent security, policy enforcement, and governance space as of mid-April 2026.
+An overview of the agent security, policy enforcement, and governance space as of late April 2026.
 
 ---
 
@@ -98,7 +98,7 @@ Multiple projects have independently converged on the same cryptographic and pro
 | **W3C Verifiable Credentials** | Agent Receipts (unique in this space) |
 | **OWASP Agentic AI Top 10** | Microsoft AGT, Pipelock, mcp-firewall (ressl) |
 | **YAML policy config** | All projects |
-| **Hook-based emission** | Claude Code (full tool-surface coverage), Codex CLI (partial — no WebSearch, partial shell); Agent Receipts adopts both via `claude_code_hook` and `codex_hook` channels (ADRs in progress) |
+| **Hook-based emission** | Claude Code (full tool-surface coverage), Codex CLI (partial — no WebSearch, partial shell); Agent Receipts is aligning with both hook surfaces, with channel naming and documentation still in progress |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a "Hook-based emission" row to **Key Primitives Convergence** in `docs/ecosystem/landscape.md`, citing Claude Code (full tool-surface coverage) and Codex CLI (partial — no WebSearch, partial shell), and noting that Agent Receipts is aligning with both hook surfaces with channel naming and documentation still in progress.
- Bump the intro and footer to late April 2026 so freshness signals are consistent.

## Notes
- The original task also asked for a bullet under an "Implications for Agent Receipts Pivot" → "What's validated" subsection, but that section does not currently exist in `docs/ecosystem/landscape.md`. Per follow-up, that step was skipped. Happy to add the section in a follow-up PR if desired.
- Copilot review feedback addressed in e8ffed0: avoided naming undefined channel identifiers (`claude_code_hook`/`codex_hook`) ahead of the ADRs, and aligned the intro date with the footer.

## Test plan
- [ ] Visual review of `docs/ecosystem/landscape.md` rendering on GitHub.
- [ ] Confirm the new row in the Key Primitives Convergence table reads correctly.
- [ ] Confirm the intro and "Last updated" date are consistent.