### PR TITLE
docs(openclaw): fill in installation page

### DIFF
--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -107,10 +107,13 @@ Options:
 
 With `"high"` enabled, a `system.command.execute` receipt includes:
 
-```json
-"parameters_hash": "sha256:9c84a8c9...",
-"parameters_preview": {
-  "command": "echo \"Testing agent-receipts plugin fix\""
+```jsonc
+{
+  // ...other receipt fields
+  "parameters_hash": "sha256:9c84a8c9...",
+  "parameters_preview": {
+    "command": "echo \"Testing agent-receipts plugin fix\""
+  }
 }
 ```
 

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -3,8 +3,6 @@ title: Installation
 description: Install and configure the OpenClaw plugin for Agent Receipts.
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
-
 The plugin is published to npm as [`@agnt-rcpt/openclaw`](https://www.npmjs.com/package/@agnt-rcpt/openclaw).
 
 ## Install
@@ -37,7 +35,7 @@ installing you must allowlist the two agent-receipts tools in your `openclaw.jso
 Without this, the plugin still loads — hooks fire and receipts are
 generated — but the agent cannot call the query or verify tools itself.
 
-You can also allowlist the entire plugin by ID, or switch to the `"full"` profile:
+You can also allowlist the entire plugin by ID:
 
 ```jsonc
 {

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -1,10 +1,82 @@
 ---
 title: Installation
-description: Install and configure the OpenClaw plugin.
+description: Install and configure the OpenClaw plugin for Agent Receipts.
 ---
 
-:::note
-Coming soon. Installation instructions will be published once the plugin reaches an initial release.
-:::
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-In the meantime, see the [plugin repository](https://github.com/agent-receipts/openclaw) for development status and early usage instructions.
+The plugin is published to npm as [`@agnt-rcpt/openclaw`](https://www.npmjs.com/package/@agnt-rcpt/openclaw).
+
+## Install
+
+```bash
+openclaw plugins install @agnt-rcpt/openclaw
+```
+
+For development against a local clone:
+
+```bash
+openclaw plugins install /path/to/openclaw-agent-receipts --link
+```
+
+## Tool visibility
+
+OpenClaw's tool policy pipeline filters which tools the agent can see.
+The default `"coding"` profile does not include plugin tools, so after
+installing you must allowlist the two agent-receipts tools in your `openclaw.json`:
+
+```jsonc
+{
+  "tools": {
+    "profile": "coding",
+    "alsoAllow": ["ar_query_receipts", "ar_verify_chain"]
+  }
+}
+```
+
+Without this, the plugin still loads — hooks fire and receipts are
+generated — but the agent cannot call the query or verify tools itself.
+
+You can also allowlist the entire plugin by ID, or switch to the `"full"` profile:
+
+```jsonc
+{
+  "tools": {
+    "alsoAllow": ["openclaw-agent-receipts"]
+  }
+}
+```
+
+## Configuration
+
+All configuration is optional. Defaults are shown below:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "dbPath": "~/.openclaw/agent-receipts/receipts.db",
+          "keyPath": "~/.openclaw/agent-receipts/keys.json",
+          "taxonomyPath": null  // path to a custom taxonomy JSON file
+        }
+      }
+    }
+  }
+}
+```
+
+## Verify the install
+
+Restart the gateway and confirm the plugin loaded:
+
+```bash
+openclaw plugins list
+```
+
+You should see `Agent Receipts` with status `loaded`. Ask the agent to
+call `ar_query_receipts` or `ar_verify_chain` to confirm the tools are
+visible.

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -98,7 +98,7 @@ By default, action parameters are hashed but not stored in plaintext. Enable `pa
 
 Options:
 
-| Value | Behaviour |
+| Value | Behavior |
 |-------|-----------|
 | `false` | Hashes only — no plaintext (default) |
 | `true` | Preview enabled for all action types |

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -67,6 +67,44 @@ All configuration is optional. Defaults are shown below:
 }
 ```
 
+## Parameter preview
+
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data elsewhere.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "config": {
+          "parameterPreview": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+Options:
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` | Hashes only — no plaintext (default) |
+| `true` | Preview enabled for all action types |
+| `"high"` | Preview enabled for `high` and `critical` risk actions only |
+| `["system.command.execute"]` | Preview enabled for specific action types |
+
+With `"high"` enabled, a `system.command.execute` receipt includes:
+
+```json
+"parameters_hash": "sha256:9c84a8c9...",
+"parameters_preview": {
+  "command": "echo \"Testing agent-receipts plugin fix\""
+}
+```
+
+The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
+
 ## Verify the install
 
 Restart the gateway and confirm the plugin loaded:

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -35,7 +35,17 @@ installing you must allowlist the two agent-receipts tools in your `openclaw.jso
 Without this, the plugin still loads — hooks fire and receipts are
 generated — but the agent cannot call the query or verify tools itself.
 
-You can also allowlist the entire plugin by ID:
+Alternatively, switch to the `"full"` profile to allow all registered tools:
+
+```jsonc
+{
+  "tools": {
+    "profile": "full"
+  }
+}
+```
+
+Or allowlist the entire plugin by ID:
 
 ```jsonc
 {
@@ -59,7 +69,8 @@ All configuration is optional. Defaults are shown below:
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
-          "taxonomyPath": null  // path to a custom taxonomy JSON file
+          "taxonomyPath": null,           // path to a custom taxonomy JSON file
+          "parameterPreview": false       // false | true | "high" | string[]
         }
       }
     }
@@ -69,7 +80,7 @@ All configuration is optional. Defaults are shown below:
 
 ## Parameter preview
 
-By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data elsewhere.
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
 
 ```jsonc
 {


### PR DESCRIPTION
The `@agnt-rcpt/openclaw` plugin is already published on npm at v0.3.0 and has full install instructions in `docs/INSTALL.md` in the plugin repo, but the docs site still shows a "Coming soon" notice.

This PR replaces the placeholder with the actual content:

- `openclaw plugins install @agnt-rcpt/openclaw`
- Tool visibility / `alsoAllow` config (required to expose `ar_query_receipts` and `ar_verify_chain` to the agent under the `coding` profile)
- Optional `openclaw.json` config block (`dbPath`, `keyPath`, `taxonomyPath`)
- Verification step (`openclaw plugins list`)

Content sourced from [`agent-receipts/openclaw/docs/INSTALL.md`](https://github.com/agent-receipts/openclaw/blob/main/docs/INSTALL.md).