### PR TITLE
chore: add CLAUDE.md that imports AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a `CLAUDE.md` that uses Claude Code's `@filename` import to pull in `AGENTS.md`, so Claude Code users get the same instructions as other agents without duplicating content or relying on a symlink.