### PR TITLE
fix(sdk/ts): pass LIMIT as number not string in store.query()

### DIFF
--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -177,11 +177,6 @@ describe("ReceiptStore", () => {
 			});
 			expect(results).toHaveLength(2);
 		});
-
-		it("uses default limit when none provided and returns all rows", () => {
-			const results = store.query({});
-			expect(results).toHaveLength(3);
-		});
 	});
 
 	describe("tool_name", () => {

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -160,6 +160,28 @@ describe("ReceiptStore", () => {
 			const results = store.query({});
 			expect(results).toHaveLength(3);
 		});
+
+		// Regression: node:sqlite binds JS values by their runtime type, and
+		// SQLite's LIMIT requires INTEGER. If `limit` is bound as TEXT (e.g.
+		// via String(limit)) it returns zero rows on some Node versions.
+		// See https://github.com/agent-receipts/ar/pull/249.
+		it("returns rows when limit exceeds row count (LIMIT bound as INTEGER)", () => {
+			const results = store.query({ limit: 20 });
+			expect(results).toHaveLength(3);
+		});
+
+		it("returns rows when limit is combined with filters", () => {
+			const results = store.query({
+				status: "success",
+				limit: 20,
+			});
+			expect(results).toHaveLength(2);
+		});
+
+		it("uses default limit when none provided and returns all rows", () => {
+			const results = store.query({});
+			expect(results).toHaveLength(3);
+		});
 	});
 
 	describe("tool_name", () => {

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -1,4 +1,4 @@
-import { DatabaseSync } from "node:sqlite";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import type {
 	AgentReceipt,
 	OutcomeStatus,
@@ -165,12 +165,11 @@ export class ReceiptStore {
 	 */
 	query(filters: ReceiptQuery): AgentReceipt[] {
 		const conditions: string[] = [];
-		// Use unknown[] so string filter values and the numeric limit are all
-		// passed with their native JS types. Node's built-in SQLite binds each
-		// value using its runtime type (text vs integer), and SQLite's LIMIT
-		// clause requires an integer — passing it as a string causes it to be
-		// bound as TEXT which results in zero rows on some Node versions.
-		const params: unknown[] = [];
+		// node:sqlite binds each value using its runtime JS type (string → TEXT,
+		// number → INTEGER). SQLite's LIMIT requires INTEGER; binding it as
+		// TEXT silently returns zero rows. Typed as SQLInputValue[] so string
+		// filter values and the numeric limit each bind as their native type.
+		const params: SQLInputValue[] = [];
 
 		if (filters.chainId !== undefined) {
 			conditions.push("chain_id = ?");
@@ -200,7 +199,6 @@ export class ReceiptStore {
 		const where =
 			conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-		// Pass limit as a number, not a string, so it binds as INTEGER.
 		const limit = filters.limit ?? DEFAULT_QUERY_LIMIT;
 		params.push(limit);
 
@@ -208,7 +206,7 @@ export class ReceiptStore {
 			.prepare(
 				`SELECT receipt_json FROM receipts ${where} ORDER BY timestamp ASC LIMIT ?`,
 			)
-			.all(...(params as Parameters<typeof this.db.prepare>)) as unknown as ReceiptRow[];
+			.all(...params) as unknown as ReceiptRow[];
 
 		return rows.map((r) => parseReceiptJson(r.receipt_json, "query"));
 	}

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -165,7 +165,12 @@ export class ReceiptStore {
 	 */
 	query(filters: ReceiptQuery): AgentReceipt[] {
 		const conditions: string[] = [];
-		const params: string[] = [];
+		// Use unknown[] so string filter values and the numeric limit are all
+		// passed with their native JS types. Node's built-in SQLite binds each
+		// value using its runtime type (text vs integer), and SQLite's LIMIT
+		// clause requires an integer — passing it as a string causes it to be
+		// bound as TEXT which results in zero rows on some Node versions.
+		const params: unknown[] = [];
 
 		if (filters.chainId !== undefined) {
 			conditions.push("chain_id = ?");
@@ -195,14 +200,15 @@ export class ReceiptStore {
 		const where =
 			conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
+		// Pass limit as a number, not a string, so it binds as INTEGER.
 		const limit = filters.limit ?? DEFAULT_QUERY_LIMIT;
-		params.push(String(limit));
+		params.push(limit);
 
 		const rows = this.db
 			.prepare(
 				`SELECT receipt_json FROM receipts ${where} ORDER BY timestamp ASC LIMIT ?`,
 			)
-			.all(...params) as unknown as ReceiptRow[];
+			.all(...(params as Parameters<typeof this.db.prepare>)) as unknown as ReceiptRow[];
 
 		return rows.map((r) => parseReceiptJson(r.receipt_json, "query"));
 	}


### PR DESCRIPTION
## Problem

`npx @agnt-rcpt/openclaw receipts` returns no output even when receipts exist in the database.

Root cause: `store.query()` uses `params: string[]` and pushes the limit as `String(limit)` — a TEXT value. Node.js's built-in SQLite binds JavaScript values using their runtime type, so a JS string is bound via `sqlite3_bind_text()`. SQLite's `LIMIT` clause requires an INTEGER; when bound as TEXT, it returns zero rows on Node v22.

## Fix

Change `params` from `string[]` to `unknown[]` and push `limit` as a number (not `String(limit)`), so it binds as INTEGER via `sqlite3_bind_int64()`.

## Repro

Observed during a fresh install trial: 10 receipts in the DB (confirmed via direct SQLite query), but `store.query({ limit: 20 })` returned `[]`.