### PR TITLE
chore(release): bump sdk-ts to 0.4.1

### DIFF
--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Bumps the TypeScript SDK from `0.4.0` → `0.4.1`.

## Changes since 0.4.0

- `c25126c` fix(sdk/ts): optional-null type narrowing and null normalisation (ADR-0009)
- `54c5354` fix(sdk/ts): drop type assertions, guard non-plain objects, test legacy
- `4922edc` fix(sdk/ts): prototype-based plain-object check, runtime fixture guards
- `317dad3` fix(sdk/ts): drop last as-cast in canonicalize error path
- `8c3b911` fix(sdk/ts): document stripOptionalNulls scope, validate fixture receipts
- `a08b41b` chore(deps-dev): bump the npm_and_yarn group in /sdk/ts with 3 updates

## Release checklist

- [x] `package.json` version bumped to `0.4.1`
- [x] `src/version.ts` regenerated via `sync-version`
- [x] 173 tests pass
- [x] TypeScript typecheck passes
- [ ] After merge: create GitHub Release with tag `sdk-ts-v0.4.1` to trigger npm publish