### PR TITLE
docs(openclaw): add Parameter Preview section to installation.mdx

### DIFF
--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -8,3 +8,41 @@ Coming soon. Installation instructions will be published once the plugin reaches
 :::
 
 In the meantime, see the [plugin repository](https://github.com/agent-receipts/openclaw) for development status and early usage instructions.
+
+## Parameter preview
+
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data elsewhere.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "config": {
+          "parameterPreview": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+Options:
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` | Hashes only — no plaintext (default) |
+| `true` | Preview enabled for all action types |
+| `"high"` | Preview enabled for `high` and `critical` risk actions only |
+| `["system.command.execute"]` | Preview enabled for specific action types |
+
+With `"high"` enabled, a `system.command.execute` receipt includes:
+
+```json
+"parameters_hash": "sha256:9c84a8c9...",
+"parameters_preview": {
+  "command": "echo \"Testing agent-receipts plugin fix\""
+}
+```
+
+The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.


### PR DESCRIPTION
Documents the `parameterPreview` config option on the OpenClaw plugin installation page, corresponding to `parameters_preview` support added in `@agnt-rcpt/sdk-ts` v0.5.0 (PR #257).

## Changes

- `site/src/content/docs/openclaw/installation.mdx` — add **Parameter Preview** section with config snippet, options table, and example receipt output