### PR TITLE
docs(openclaw): address Copilot follow-up review on installation page

### DIFF
--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -69,7 +69,7 @@ All configuration is optional. Defaults are shown below:
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
-          "taxonomyPath": null,           // path to a custom taxonomy JSON file
+          // "taxonomyPath": "/path/to/custom-taxonomy.json",  // optional — overrides bundled taxonomy
           "parameterPreview": false       // false | true | "high" | string[]
         }
       }
@@ -99,7 +99,7 @@ By default, action parameters are hashed but not stored in plaintext. Enable `pa
 Options:
 
 | Value | Behavior |
-|-------|-----------|
+|-------|----------|
 | `false` | Hashes only — no plaintext (default) |
 | `true` | Preview enabled for all action types |
 | `"high"` | Preview enabled for `high` and `critical` risk actions only |
@@ -117,7 +117,7 @@ With `"high"` enabled, a `system.command.execute` receipt includes:
 }
 ```
 
-The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
+The hash always covers the full original parameters regardless of preview config. Only the **first** matching field from the taxonomy's `preview_fields` list is included in `parameters_preview`, and non-string values are JSON-stringified. Previewed values are stored verbatim — do not list fields that may contain secrets.
 
 ## Verify the install
 


### PR DESCRIPTION
## Summary

Follow-up to [#247](https://github.com/agent-receipts/ar/pull/247) addressing two issues Copilot flagged that landed after the merge. Mirrors the same fixes going into [agent-receipts/openclaw#109](https://github.com/agent-receipts/openclaw/pull/109).

- **\`taxonomyPath\` violates the configSchema.** [\`openclaw.plugin.json\`](https://github.com/agent-receipts/openclaw/blob/main/openclaw.plugin.json) declares \`taxonomyPath\` as \`type: string\`, but the default-config example sets it to \`null\`. Comment the line out with an "optional override" hint — preserves discoverability without violating the schema.
- **Parameter preview behaviour was inaccurate.** The closing paragraph implied multiple structured fields could appear in \`parameters_preview\`. The actual implementation ([\`extractPreview\` in \`src/hooks.ts\`](https://github.com/agent-receipts/openclaw/blob/main/src/hooks.ts)) only emits the **first** matching field from the taxonomy's \`preview_fields\` list, with non-string values JSON-stringified. Reword to match, plus add a verbatim-storage warning.

## Test plan

- [ ] Read the rendered Installation page on the PR — \`taxonomyPath\` is shown as a commented-out optional override; the closing paragraph of *Parameter preview* now describes the first-match / stringify behaviour and warns against listing secret-bearing fields.