### PR TITLE
fix(mcp-proxy): canonicalize args before hashing in integration tests (#118)

### DIFF
--- a/mcp-proxy/integration_test.go
+++ b/mcp-proxy/integration_test.go
@@ -3,7 +3,6 @@
 package integration_test
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -106,8 +105,11 @@ func TestAuditPipelineToolCall(t *testing.T) {
 		{ToolName: "read_file", ActionType: "filesystem.file.read"},
 	})
 
-	argsJSON, _ := json.Marshal(args)
-	argsHash := receipt.SHA256Hash(string(argsJSON))
+	canonical, err := receipt.Canonicalize(args)
+	if err != nil {
+		t.Fatalf("canonicalize args: %v", err)
+	}
+	argsHash := receipt.SHA256Hash(canonical)
 
 	sequence++
 	unsigned := receipt.Create(receipt.CreateInput{
@@ -233,8 +235,11 @@ func TestToolNameInReceipt(t *testing.T) {
 		}
 	}
 
-	argsJSON, _ := json.Marshal(args)
-	argsHash := receipt.SHA256Hash(string(argsJSON))
+	canonical, err := receipt.Canonicalize(args)
+	if err != nil {
+		t.Fatalf("canonicalize args: %v", err)
+	}
+	argsHash := receipt.SHA256Hash(canonical)
 
 	unsigned := receipt.Create(receipt.CreateInput{
 		Issuer:    receipt.Issuer{ID: "did:agent:test"},


### PR DESCRIPTION
## Summary

Closes #118.

The proxy binary already uses `receipt.Canonicalize` to compute `parameters_hash` ([`main.go:584`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/cmd/mcp-proxy/main.go#L584)). The integration tests still mirrored the old `json.Marshal` pattern, which does not guarantee key order on Go maps and therefore can't match RFC 8785 (JCS) hashes from other SDKs.

This PR aligns both call sites in `mcp-proxy/integration_test.go` (`TestAuditPipelineToolCall`, `TestToolNameInReceipt`) with the proxy's pattern and drops the now-unused `encoding/json` import.

### Scope check

- TS SDK (`sdk/ts/`) and Python SDK (`sdk/py/`) do **not** compute `parameters_hash` — it's pass-through optional in both. Both already expose RFC 8785 `canonicalize()` for `response_hash`. No changes needed.
- Other `json.Marshal` call sites in mcp-proxy (e.g. `main.go:339`) are for audit-log redaction storage, not parameters hashing — out of scope.
- No regression test added: existing canonicalization coverage in [`sdk/go/receipt/hash_test.go`](https://github.com/agent-receipts/ar/blob/main/sdk/go/receipt/hash_test.go) and [`sdk/go/receipt/canonicalization_vectors_test.go`](https://github.com/agent-receipts/ar/blob/main/sdk/go/receipt/canonicalization_vectors_test.go) (cross-SDK frozen vectors) already covers Canonicalize correctness more rigorously than a duplicate test in the integration file would.

## Test plan

- [x] `cd mcp-proxy && go vet ./...` — clean
- [x] `cd mcp-proxy && go test -tags=integration -count=1 ./...` — all 6 packages pass
- [x] `cd sdk/go && go test -count=1 ./...` — all 3 packages pass
