### PR TITLE
fix(spec): align proofValue encoding to base64url throughout

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -122,7 +122,7 @@ The canonical definitions live in [`spec/taxonomy/action-types.json`](spec/taxon
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z3FXQjecWufY46yKJFGcSxtKzKHQi6VwuADnBJ4viNckGy2s"
+    "proofValue": "u3FXQjecWufY46yKJFGcSxtKzKHQi6VwuADnBJ4viNckGy2s"
   }
 }
 ```

--- a/spec/README.md
+++ b/spec/README.md
@@ -122,7 +122,7 @@ The canonical definitions live in [`spec/taxonomy/action-types.json`](spec/taxon
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u3FXQjecWufY46yKJFGcSxtKzKHQi6VwuADnBJ4viNckGy2s"
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
   }
 }
 ```

--- a/spec/examples/chain-receipt-1.json
+++ b/spec/examples/chain-receipt-1.json
@@ -40,6 +40,6 @@
     "created": "2026-03-31T10:00:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z2WjXcKNmNqR8sTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNa"
+    "proofValue": "u2WjXcKNmNqR8sTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNa"
   }
 }

--- a/spec/examples/chain-receipt-1.json
+++ b/spec/examples/chain-receipt-1.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b501",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:file-manager-agent-001",
@@ -40,6 +43,6 @@
     "created": "2026-03-31T10:00:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u2WjXcKNmNqR8sTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNaPqRsTuVwXyZaBcDeFgHJkNmNa"
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
   }
 }

--- a/spec/examples/chain-receipt-2.json
+++ b/spec/examples/chain-receipt-2.json
@@ -46,6 +46,6 @@
     "created": "2026-03-31T10:01:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z3XkYmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnAp"
+    "proofValue": "u3XkYmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnAp"
   }
 }

--- a/spec/examples/chain-receipt-2.json
+++ b/spec/examples/chain-receipt-2.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b502",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:file-manager-agent-001",
@@ -46,6 +49,6 @@
     "created": "2026-03-31T10:01:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u3XkYmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnApQrStUvWxYzAbCdEfGhJjKmMnAp"
+    "proofValue": "uccX9yc-qpoh7pkdehRKVMHSJKwpVG3WVMU1yiRCWlNLtvW6ortDHE-KfPJF3PZ0-7Gdm510L_IkVvPNrY72xAw"
   }
 }

--- a/spec/examples/chain-receipt-3.json
+++ b/spec/examples/chain-receipt-3.json
@@ -41,6 +41,6 @@
     "created": "2026-03-31T10:02:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z4YmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAbPcQdResfTgUhVWjXkYmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAb"
+    "proofValue": "u4YmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAbPcQdResfTgUhVWjXkYmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAb"
   }
 }

--- a/spec/examples/chain-receipt-3.json
+++ b/spec/examples/chain-receipt-3.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b503",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:file-manager-agent-001",
@@ -41,6 +44,6 @@
     "created": "2026-03-31T10:02:01Z",
     "verificationMethod": "did:agent:file-manager-agent-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u4YmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAbPcQdResfTgUhVWjXkYmZmAnBaCpDqErFsGtHuJvJwKxMyMzNaAb"
+    "proofValue": "uW82_6Iui_boSwcb1RSK8svNzJrK_EpksmNjTLGZ3yviH3MFngDgoO0N4WPgXCJ4tvWXuQW1H-Yf97Bg8KNAODg"
   }
 }

--- a/spec/examples/delegation-receipt.json
+++ b/spec/examples/delegation-receipt.json
@@ -47,6 +47,6 @@
     "created": "2026-03-31T15:00:01Z",
     "verificationMethod": "did:agent:sub-agent-research-002#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z5ZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPdQeRfSgThUVjWkXmYmZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPd"
+    "proofValue": "u5ZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPdQeRfSgThUVjWkXmYmZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPd"
   }
 }

--- a/spec/examples/delegation-receipt.json
+++ b/spec/examples/delegation-receipt.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:f897b83b-a36b-472e-a5e9-8a064bf57cf9",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:sub-agent-research-002",
@@ -47,6 +50,6 @@
     "created": "2026-03-31T15:00:01Z",
     "verificationMethod": "did:agent:sub-agent-research-002#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u5ZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPdQeRfSgThUVjWkXmYmZnAaBpCqDrEsFtGuHvJwJxKyNzMaNbAcPd"
+    "proofValue": "uSvZnk-poxWvjjpttEGrWps_CnIamNjBitlM054xCFtITkC-pzY4tvpbOJaEl3ZbQ0ymE5rXEAx3Eqjr-MOYXAQ"
   }
 }

--- a/spec/examples/full-receipt.json
+++ b/spec/examples/full-receipt.json
@@ -66,6 +66,6 @@
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z4hDJKeC2x8yQBKg7TFvGr9NQRHyJSRcxp1BHoANGvSapfEw2KYRbXcUZ1vABTEwVLmJyAAitRviAoJK7eDsq3sLj"
+    "proofValue": "u4hDJKeC2x8yQBKg7TFvGr9NQRHyJSRcxp1BHoANGvSapfEw2KYRbXcUZ1vABTEwVLmJyAAitRviAoJK7eDsq3sLj"
   }
 }

--- a/spec/examples/full-receipt.json
+++ b/spec/examples/full-receipt.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:claude-cowork-instance-abc123",
@@ -51,7 +54,10 @@
       }
     },
     "authorization": {
-      "scopes": ["email:send", "drive:read"],
+      "scopes": [
+        "email:send",
+        "drive:read"
+      ],
       "granted_at": "2026-03-31T14:00:00Z",
       "expires_at": "2026-03-31T15:00:00Z"
     },
@@ -66,6 +72,6 @@
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u4hDJKeC2x8yQBKg7TFvGr9NQRHyJSRcxp1BHoANGvSapfEw2KYRbXcUZ1vABTEwVLmJyAAitRviAoJK7eDsq3sLj"
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
   }
 }

--- a/spec/examples/minimal-receipt.json
+++ b/spec/examples/minimal-receipt.json
@@ -34,6 +34,6 @@
     "created": "2026-03-31T14:31:01Z",
     "verificationMethod": "did:agent:example-agent-instance-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z3MvGcVxzRYMCEBHsRuzVoweEL1GEjVnmRpkuFxPDXBigSxABTEwVLmJyAAitRviAoJK7eDsq3sLjg6KYRbXcUZ1v"
+    "proofValue": "u3MvGcVxzRYMCEBHsRuzVoweEL1GEjVnmRpkuFxPDXBigSxABTEwVLmJyAAitRviAoJK7eDsq3sLjg6KYRbXcUZ1v"
   }
 }

--- a/spec/examples/minimal-receipt.json
+++ b/spec/examples/minimal-receipt.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:660e8400-e29b-41d4-a716-446655440001",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.1.0",
   "issuer": {
     "id": "did:agent:example-agent-instance-001"
@@ -34,6 +37,6 @@
     "created": "2026-03-31T14:31:01Z",
     "verificationMethod": "did:agent:example-agent-instance-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u3MvGcVxzRYMCEBHsRuzVoweEL1GEjVnmRpkuFxPDXBigSxABTEwVLmJyAAitRviAoJK7eDsq3sLjg6KYRbXcUZ1v"
+    "proofValue": "uccX9yc-qpoh7pkdehRKVMHSJKwpVG3WVMU1yiRCWlNLtvW6ortDHE-KfPJF3PZ0-7Gdm510L_IkVvPNrY72xAw"
   }
 }

--- a/spec/examples/v0-2-response-hash-receipt.json
+++ b/spec/examples/v0-2-response-hash-receipt.json
@@ -45,6 +45,6 @@
     "created": "2026-04-22T09:15:01Z",
     "verificationMethod": "did:agent:data-agent-instance-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z5aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
+    "proofValue": "u5aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
   }
 }

--- a/spec/examples/v0-2-response-hash-receipt.json
+++ b/spec/examples/v0-2-response-hash-receipt.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:b2c3d4e5-f6a7-48b9-c0d1-e2f3a4b5c6d7",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.2.0",
   "issuer": {
     "id": "did:agent:data-agent-instance-001",
@@ -45,6 +48,6 @@
     "created": "2026-04-22T09:15:01Z",
     "verificationMethod": "did:agent:data-agent-instance-001#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u5aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
+    "proofValue": "uW82_6Iui_boSwcb1RSK8svNzJrK_EpksmNjTLGZ3yviH3MFngDgoO0N4WPgXCJ4tvWXuQW1H-Yf97Bg8KNAODg"
   }
 }

--- a/spec/examples/v0-2-terminal-chain-receipt-3.json
+++ b/spec/examples/v0-2-terminal-chain-receipt-3.json
@@ -41,6 +41,6 @@
     "created": "2026-04-22T10:02:01Z",
     "verificationMethod": "did:agent:file-manager-agent-002#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z6aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
+    "proofValue": "u6aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
   }
 }

--- a/spec/examples/v0-2-terminal-chain-receipt-3.json
+++ b/spec/examples/v0-2-terminal-chain-receipt-3.json
@@ -4,7 +4,10 @@
     "https://agentreceipts.ai/context/v1"
   ],
   "id": "urn:receipt:c3d4e5f6-a7b8-49c0-d1e2-f3a4b5c6d7e9",
-  "type": ["VerifiableCredential", "AgentReceipt"],
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
   "version": "0.2.0",
   "issuer": {
     "id": "did:agent:file-manager-agent-002",
@@ -41,6 +44,6 @@
     "created": "2026-04-22T10:02:01Z",
     "verificationMethod": "did:agent:file-manager-agent-002#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u6aBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPqRsTuVwXyZaBcDeFgHJkMnPq"
+    "proofValue": "uSvZnk-poxWvjjpttEGrWps_CnIamNjBitlM054xCFtITkC-pzY4tvpbOJaEl3ZbQ0ymE5rXEAx3Eqjr-MOYXAQ"
   }
 }

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -402,7 +402,7 @@
         },
         "proofValue": {
           "type": "string",
-          "pattern": "^u[A-Za-z0-9_-]+$",
+          "pattern": "^u[A-Za-z0-9_-]{86}$",
           "description": "Multibase-encoded (u-prefixed base64url, no padding) Ed25519 signature over the canonical receipt (proof field excluded)."
         }
       }

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -402,8 +402,8 @@
         },
         "proofValue": {
           "type": "string",
-          "pattern": "^z[1-9A-HJ-NP-Za-km-z]+$",
-          "description": "Multibase-encoded (z-prefixed base58btc) Ed25519 signature over the canonical receipt (proof field excluded)."
+          "pattern": "^u[A-Za-z0-9_-]+$",
+          "description": "Multibase-encoded (u-prefixed base64url, no padding) Ed25519 signature over the canonical receipt (proof field excluded)."
         }
       }
     }

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -161,7 +161,7 @@ The agent (or agent platform) that performed the action and produced the receipt
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z..."
+    "proofValue": "u..."
   }
 }
 ```
@@ -201,7 +201,7 @@ For lightweight or high-frequency actions, a minimal receipt containing only req
     "created": "2026-03-31T14:31:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z..."
+    "proofValue": "u..."
   }
 }
 ```
@@ -300,7 +300,7 @@ The `intent` fields link an action to the context that triggered it. Because age
 | `created` | Yes | ISO 8601 datetime when the proof was created. |
 | `verificationMethod` | Yes | DID URL of the signing key (e.g. `did:agent:...#key-1`). |
 | `proofPurpose` | Yes | MUST be `"assertionMethod"`. |
-| `proofValue` | Yes | Multibase-encoded (`z`-prefixed base58btc) Ed25519 signature over the canonical receipt (proof field excluded). |
+| `proofValue` | Yes | Multibase-encoded (`u`-prefixed base64url, no padding) Ed25519 signature over the canonical receipt (proof field excluded). |
 
 ### 4.4 JSON Schema
 
@@ -424,7 +424,7 @@ Risk levels are assigned by action type as defaults. Implementations MAY escalat
 
 ### 7.1 Canonical form
 
-For hashing and signing, receipts MUST be serialized using the JSON Canonicalization Scheme (RFC 8785) with the `proof` field removed before hashing. This canonicalization step is aligned with the use of RFC 8785 in the W3C Verifiable Credentials Data Integrity specification; however, the overall signing procedure defined in this document (see §7.2 and §10.2) is intentionally simplified and is not a full implementation of the W3C Data Integrity algorithm.
+For hashing and signing, receipts MUST be serialized using the JSON Canonicalization Scheme (RFC 8785) with the `proof` field removed before hashing. This canonicalization step is aligned with the use of RFC 8785 in the W3C Verifiable Credentials Data Integrity specification; however, the overall signing procedure defined in this document (see §7.2 and §10) is intentionally simplified and is not a full implementation of the W3C Data Integrity algorithm.
 
 #### 7.1.1 Null and optional field handling
 
@@ -437,7 +437,7 @@ This rule ensures all three SDKs produce byte-identical canonical output for the
 
 ### 7.2 Signing
 
-The issuer MUST sign the canonical receipt (proof field excluded) with its Ed25519 private key. The signature MUST be encoded as a multibase string (`z`-prefixed base58btc) and placed in `proof.proofValue`.
+The issuer MUST sign the canonical receipt (proof field excluded) with its Ed25519 private key. The signature MUST be encoded as a multibase string (`u`-prefixed base64url, no padding) and placed in `proof.proofValue`.
 
 ### 7.3 Chain integrity verification
 
@@ -514,7 +514,7 @@ To verify a single Agent Receipt:
 
 1. **Schema validation.** Validate the receipt against the JSON Schema (§4.4). If validation fails, verification fails with `MALFORMED_RECEIPT`.
 2. **DID resolution.** Resolve the DID URL in `proof.verificationMethod` to obtain the issuer's public key. The resolution mechanism depends on the DID method used (see §9.6). If the DID cannot be resolved, verification fails with `UNRESOLVABLE_DID`.
-3. **Signature verification.** Compute the RFC 8785 canonical serialization (UTF-8 bytes) of the receipt with the `proof` field removed. Verify the Ed25519 signature in `proof.proofValue` (decoded from multibase z-base58btc) directly over these canonical bytes using the resolved public key. If verification fails, the receipt is `INVALID_SIGNATURE`.
+3. **Signature verification.** Compute the RFC 8785 canonical serialization (UTF-8 bytes) of the receipt with the `proof` field removed. Verify the Ed25519 signature in `proof.proofValue` (decoded from multibase `u`-prefixed base64url) directly over these canonical bytes using the resolved public key. If verification fails, the receipt is `INVALID_SIGNATURE`.
 4. **Timestamp validation.** If `action.trusted_timestamp` is present, verify it per §7.7. If the trusted timestamp is invalid, the receipt is `INVALID_TIMESTAMP`. If no trusted timestamp is present, the receipt relies on `issuanceDate` and `action.timestamp` which are issuer-asserted and not independently verifiable.
 5. **Chain context.** If verifying as part of a chain, perform chain integrity checks per §7.3. If verifying a standalone receipt, chain fields indicate the issuer-asserted position in a chain. A verifier MAY perform local consistency checks (e.g., that `sequence` is a positive integer and `previous_receipt_hash` is well-formed), but the receipt's actual chain position cannot be confirmed without at least the preceding receipt.
 6. **Delegation context.** If the receipt includes a `delegation` field, verify per §7.6.
@@ -581,3 +581,5 @@ A receipt that passes steps 1–4 is individually valid. Steps 5–6 provide cha
 7. **Revocation is append-only.** Reversal is recorded by issuing a new receipt, not by mutating the original. The chain is always append-only.
 
 8. **Key lifecycle is out of scope for v0.1.** Agent key generation, secure storage, rotation, and revocation are not specified by this version of the protocol. Implementers SHOULD treat key management as a critical security concern: a compromised agent key allows production of validly-signed but fraudulent receipts that are indistinguishable from legitimate ones. MolTrust (listed in §8) or a dedicated key management specification may address this in future. At minimum, implementations SHOULD document their key generation and storage practices.
+
+9. **base64url for `proofValue`.** The `proofValue` field uses multibase `u`-prefixed base64url (no padding) rather than the W3C Data Integrity default of base58btc (`z`). base64url avoids the need for a base58 library, is natively supported in all target runtimes, and is slightly more compact. This is an intentional deviation from the W3C default.

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -161,7 +161,7 @@ The agent (or agent platform) that performed the action and produced the receipt
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u..."
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
   }
 }
 ```
@@ -201,7 +201,7 @@ For lightweight or high-frequency actions, a minimal receipt containing only req
     "created": "2026-03-31T14:31:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u..."
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
   }
 }
 ```

--- a/spec/spec/diagrams/chain-linking.md
+++ b/spec/spec/diagrams/chain-linking.md
@@ -29,7 +29,7 @@ flowchart TD
   A["Receipt fields\n(proof not yet present)"] --> C["RFC 8785\nJSON Canonicalization"]
   C --> D["Canonical JSON bytes"]
   D --> E["Ed25519 sign\nwith issuer's private key"]
-  E --> F["Base58btc encode\n(z-prefix)"]
+  E --> F["Base64url encode\n(u-prefix, no padding)"]
   F --> G["Attach as\nproof.proofValue"]
   G --> H["Signed Agent Receipt"]
 


### PR DESCRIPTION
## Summary

Fixes #78. The spec and JSON schema specified `z`-prefixed base58btc for `proofValue`, but all three SDK implementations (Go, TypeScript, Python) already use `u`-prefixed base64url. This caused the JSON schema to reject every receipt produced by the SDKs.

The fix updates all spec and schema references to match the implementations — the path of least resistance since no SDK changes are needed.

## Changes

- **`spec/spec/agent-receipt-spec-v0.1.md`**
  - §4.3.3 table: `z`-prefixed base58btc → `u`-prefixed base64url, no padding
  - §7.2 signing: same
  - §7.8 end-to-end verification: same (also improves formatting consistency)
  - Two inline example receipts: `"proofValue": "z..."` → `"proofValue": "u..."`
  - §7.1 canonicalization note: fix dangling `§10.2` reference → `§10`
  - §10: add item 9 documenting the intentional deviation from the W3C Data Integrity base58btc default

- **`spec/schema/agent-receipt.schema.json`**
  - `proofValue` pattern: `^z[1-9A-HJ-NP-Za-km-z]+$` → `^u[A-Za-z0-9_-]+$`
  - Description updated to match

- **`spec/examples/*.json`** (8 files): all illustrative `proofValue` values updated from `z`-prefix to `u`-prefix

- **`spec/README.md`**: inline example `proofValue` updated

- **`spec/spec/diagrams/chain-linking.md`**: signing flow diagram updated from "Base58btc encode (z-prefix)" to "Base64url encode (u-prefix, no padding)"

## Reviewer notes

- No SDK changes — all three SDKs were already correct
- Cross-SDK test vectors (`cross-sdk-tests/`) are unaffected — they already use `u`-prefixed values
- The example file `proofValue` values are illustrative placeholders, not cryptographically valid signatures (this was true before and after this change)