### PR TITLE
fix(mcp-proxy): make approval listener opt-in (closes #262)

### DIFF
--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -124,7 +124,7 @@ rules:
 
 Actions: `pass` (log only), `flag` (log + highlight), `pause` (wait for approval), `block` (reject).
 
-When a tool call is paused, approve or deny via HTTP. The approval URL and bearer token are logged to stderr at startup (the default port is random; pass `-http 127.0.0.1:PORT` to pin). Copy the token from the startup line and export it before running the curls:
+When a tool call is paused, approve or deny via HTTP. **The listener is off by default** — pass `-http 127.0.0.1:PORT` to enable it (without that flag, paused calls fail fast with JSON-RPC code `-32003`). The approval URL and bearer token are logged to stderr at startup. Copy the token from the startup line and export it before running the curls:
 
 ```sh
 export APPROVAL_TOKEN=<token-from-stderr>

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -261,11 +261,7 @@ func serve() {
 	if !approverDisabled && *httpAddr != "" {
 		ln, err := net.Listen("tcp", *httpAddr)
 		if err != nil {
-			// Actionable error: name the address and offer both remediation paths.
-			fmt.Fprintf(os.Stderr,
-				"mcp-proxy: cannot bind approval listener on %s: %v\n"+
-					"  Fix: use -http 127.0.0.1:0 for a random free port, or -http=none to disable the listener.\n",
-				*httpAddr, err)
+			fmt.Fprint(os.Stderr, formatBindFailure(*httpAddr, err))
 			os.Exit(1)
 		}
 		approvalURL = "http://" + ln.Addr().String()
@@ -707,15 +703,29 @@ func approvalRejectionResponse(toolName, ruleName string, riskScore int, approva
 	return code, buildApprovalDeniedMessage(toolName, ruleName, riskScore, approvalID, status, timeout)
 }
 
-// emitStartupBanner prints a one-line policy/approver summary on stderr. When
-// pause rules exist without a reachable approver AND the operator didn't opt
-// out via -http=none, the line is marked WARN so misconfiguration is caught
-// before the first failing tool call.
+// formatBindFailure builds the actionable error printed when -http binds to a
+// busy address. Extracted so the test asserts against the real string the
+// operator sees rather than re-implementing the format.
+func formatBindFailure(addr string, err error) string {
+	return fmt.Sprintf(
+		"mcp-proxy: cannot bind approval listener on %s: %v\n"+
+			"  Fix: use -http 127.0.0.1:0 for a random free port, or -http=none to disable the listener.\n",
+		addr, err)
+}
+
+// emitStartupBanner prints a one-line policy/approver summary on stderr plus a
+// machine-readable JSON companion line. The banner always prints; what varies
+// by configuration is the level (INFO vs WARN) and the trailing suffix:
 //
-// httpExplicit distinguishes "default none" (operator didn't set -http at all)
-// from "explicit none" (operator passed -http=none). The two cases produce
-// different messages: default-none emits a soft info line describing opt-in,
-// explicit-none is silent.
+//   - Approver wired (approvalURL set): INFO, no suffix.
+//   - Default off (approverDisabled, httpExplicit=false) with pause rules:
+//     INFO with " — approver off by default; pass -http <addr> to enable".
+//   - Explicit -http=none (approverDisabled, httpExplicit=true): INFO, no
+//     suffix — operator made an informed choice, no nudge needed.
+//   - No approver and not explicitly disabled with pause rules loaded
+//     (approverDisabled=false, approvalURL=""): WARN, suffix flags the
+//     misconfiguration. Should be unreachable in normal operation since the
+//     default value of -http is "none".
 //
 // "require approval" is reserved for pause rules; block rules are enforced
 // without user interaction and are reported separately.

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -94,7 +94,7 @@ func serve() {
 		operatorName    = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
 		principalDID    = flag.String("principal", "did:user:unknown", "Principal DID")
 		chainID         = flag.String("chain", "", "Chain ID (auto-generated if empty)")
-		httpAddr        = flag.String("http", "127.0.0.1:0", "HTTP address for approval endpoints (default: random port; pass \"none\" to disable the approver)")
+		httpAddr        = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
 		approvalWait    = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 	)
 	flag.Usage = func() {
@@ -105,6 +105,16 @@ func serve() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	// Detect whether -http was explicitly set on the command line.
+	// flag.Visit only visits flags that were actually provided; if -http is
+	// absent the flag retains its default ("none") and httpExplicit stays false.
+	httpExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "http" {
+			httpExplicit = true
+		}
+	})
 
 	args := flag.Args()
 	if len(args) == 0 {
@@ -244,15 +254,19 @@ func serve() {
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
 
-	// Start HTTP server for approvals only when pause rules exist and the
-	// operator hasn't disabled the approver via -http=none. Only the literal
-	// "none" counts as an explicit opt-out; empty -http (e.g. `-http=`) is
-	// treated as not-configured so the banner still warns.
+	// Start HTTP server for approvals only when the operator explicitly opts in
+	// via -http <addr>. "none" is the default — no listener, no port, no
+	// collision between concurrent sessions.
 	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none")
-	if engine.HasPauseRules() && !approverDisabled && *httpAddr != "" {
+	if !approverDisabled && *httpAddr != "" {
 		ln, err := net.Listen("tcp", *httpAddr)
 		if err != nil {
-			log.Fatalf("mcp-proxy: http server: %v", err)
+			// Actionable error: name the address and offer both remediation paths.
+			fmt.Fprintf(os.Stderr,
+				"mcp-proxy: cannot bind approval listener on %s: %v\n"+
+					"  Fix: use -http 127.0.0.1:0 for a random free port, or -http=none to disable the listener.\n",
+				*httpAddr, err)
+			os.Exit(1)
 		}
 		approvalURL = "http://" + ln.Addr().String()
 		// Human-readable line (one copy-pasteable string, no log timestamp prefix).
@@ -275,7 +289,7 @@ func serve() {
 	// debugging. A WARN variant fires when the approver is absent but the
 	// ruleset needs one, which is the #1 silent-failure mode. Explicit
 	// -http=none is NOT treated as misconfiguration.
-	emitStartupBanner(engine.Describe(), approvalURL, approverDisabled)
+	emitStartupBanner(engine.Describe(), approvalURL, approverDisabled, httpExplicit)
 
 	handler := func(direction string, raw []byte, msg *proxy.Message) *proxy.HandlerResult {
 		method := ""
@@ -698,9 +712,14 @@ func approvalRejectionResponse(toolName, ruleName string, riskScore int, approva
 // out via -http=none, the line is marked WARN so misconfiguration is caught
 // before the first failing tool call.
 //
+// httpExplicit distinguishes "default none" (operator didn't set -http at all)
+// from "explicit none" (operator passed -http=none). The two cases produce
+// different messages: default-none emits a soft info line describing opt-in,
+// explicit-none is silent.
+//
 // "require approval" is reserved for pause rules; block rules are enforced
 // without user interaction and are reported separately.
-func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisabled bool) {
+func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisabled bool, httpExplicit bool) {
 	pauseCount := len(summary.PauseRules)
 	blockCount := len(summary.BlockRules)
 
@@ -714,11 +733,21 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 
 	level := "INFO"
 	suffix := ""
-	// Only warn on the accidental case: pause rules loaded, no approver,
+	// Warn only on the accidental case: pause rules loaded, no approver,
 	// and operator didn't explicitly opt out.
-	if approvalURL == "" && !approverDisabled && pauseCount > 0 {
-		level = "WARN"
-		suffix = " — pause rules will fail (set -http=ADDR to enable approver, or -http=none to acknowledge)"
+	// Default "none" (httpExplicit=false) is NOT a misconfiguration — emit a
+	// soft info hint instead. Explicit -http=none stays silent.
+	if approvalURL == "" && pauseCount > 0 {
+		if !approverDisabled {
+			// approverDisabled=false here means neither default-none nor explicit-none;
+			// this branch should not normally be reached, but guard it anyway.
+			level = "WARN"
+			suffix = " — pause rules will fail (set -http=ADDR to enable approver, or -http=none to acknowledge)"
+		} else if !httpExplicit {
+			// Default none: emit a soft info hint, not a WARN.
+			suffix = " — approver off by default; pass -http <addr> to enable"
+		}
+		// Explicit -http=none: no suffix, no WARN.
 	}
 
 	pauseDesc := ""

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -149,9 +150,105 @@ func captureStderr(t *testing.T, fn func()) string {
 	return <-done
 }
 
+// TestStartupBannerDefaultNone: -http not set at all (httpExplicit=false).
+// With default rules containing pause_high_risk, the banner should emit INFO
+// (not WARN) with a soft hint about opt-in.
+func TestStartupBannerDefaultNone(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	// approverDisabled=true (default is "none"), httpExplicit=false
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", true, false) })
+
+	if strings.Contains(out, "[WARN]") {
+		t.Errorf("did not expect WARN for default-off approver, got: %s", out)
+	}
+	if !strings.Contains(out, "[INFO]") {
+		t.Errorf("expected INFO marker for default-off case, got: %s", out)
+	}
+	if !strings.Contains(out, "approver off by default") {
+		t.Errorf("expected 'approver off by default' hint, got: %s", out)
+	}
+	if !strings.Contains(out, "pass -http") {
+		t.Errorf("expected '-http' opt-in hint, got: %s", out)
+	}
+	if !strings.Contains(out, "pause_high_risk") {
+		t.Errorf("expected pause rule name listed, got: %s", out)
+	}
+	if !strings.Contains(out, `"event":"policy_banner"`) {
+		t.Errorf("expected machine-readable companion line, got: %s", out)
+	}
+}
+
+// TestStartupBannerExplicitNone: operator passed -http=none explicitly.
+// Should be completely silent (no suffix, no WARN, no hint).
+func TestStartupBannerExplicitNone(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	// approverDisabled=true, httpExplicit=true
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", true, true) })
+
+	if strings.Contains(out, "[WARN]") {
+		t.Errorf("did not expect WARN for explicit -http=none, got: %s", out)
+	}
+	if strings.Contains(out, "approver off by default") {
+		t.Errorf("did not expect default-off hint for explicit -http=none, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: disabled") {
+		t.Errorf("expected 'approver: disabled' for explicit -http=none, got: %s", out)
+	}
+}
+
+// TestStartupBannerExplicitAddr: operator passed -http 127.0.0.1:0 and the
+// listener is up. Banner should show INFO with the resolved URL.
+func TestStartupBannerExplicitAddr(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	// approverDisabled=false, httpExplicit=true, approvalURL set
+	out := captureStderr(t, func() {
+		emitStartupBanner(summary, "http://127.0.0.1:8081", false, true)
+	})
+
+	if !strings.Contains(out, "[INFO]") {
+		t.Errorf("expected INFO marker, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: http://127.0.0.1:8081") {
+		t.Errorf("expected approver URL in banner, got: %s", out)
+	}
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN when approver is set, got: %s", out)
+	}
+}
+
+func TestStartupBannerNoPauseRulesNoWarn(t *testing.T) {
+	// Pure-flag ruleset: no approver needed, so empty URL should not warn.
+	summary := policy.NewEngine([]policy.Rule{
+		{Name: "flag_all", Enabled: true, Action: "flag"},
+	}).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", false, false) })
+
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN for flag-only ruleset, got: %s", out)
+	}
+}
+
+func TestStartupBannerNoWarnWhenApproverExplicitlyDisabled(t *testing.T) {
+	summary := policy.NewEngine(policy.DefaultRules()).Describe()
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", true, true) })
+
+	if strings.Contains(out, "WARN") {
+		t.Errorf("did not expect WARN when approver explicitly disabled, got: %s", out)
+	}
+	if !strings.Contains(out, "approver: disabled") {
+		t.Errorf("expected 'approver: disabled' in banner, got: %s", out)
+	}
+}
+
+// TestStartupBannerWarnsWhenApproverMissing covers the edge case where
+// approverDisabled=false but approvalURL is also empty (i.e. no listener and
+// no explicit opt-out). This should not happen in normal operation (the default
+// is now "none" so approverDisabled will be true), but the WARN path must
+// remain reachable for safety.
 func TestStartupBannerWarnsWhenApproverMissing(t *testing.T) {
 	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "", false) })
+	// approverDisabled=false and approvalURL="" — the unusual "neither" case
+	out := captureStderr(t, func() { emitStartupBanner(summary, "", false, true) })
 
 	if !strings.Contains(out, "[WARN]") {
 		t.Errorf("expected WARN marker in banner, got: %s", out)
@@ -170,9 +267,11 @@ func TestStartupBannerWarnsWhenApproverMissing(t *testing.T) {
 	}
 }
 
+// TestStartupBannerInfoWhenApproverSet covers the normal opt-in case:
+// operator passed -http 127.0.0.1:8081 and the listener is up.
 func TestStartupBannerInfoWhenApproverSet(t *testing.T) {
 	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "http://127.0.0.1:8081", false) })
+	out := captureStderr(t, func() { emitStartupBanner(summary, "http://127.0.0.1:8081", false, true) })
 
 	if !strings.Contains(out, "[INFO]") {
 		t.Errorf("expected INFO marker, got: %s", out)
@@ -185,27 +284,39 @@ func TestStartupBannerInfoWhenApproverSet(t *testing.T) {
 	}
 }
 
-func TestStartupBannerNoPauseRulesNoWarn(t *testing.T) {
-	// Pure-flag ruleset: no approver needed, so empty URL should not warn.
-	summary := policy.NewEngine([]policy.Rule{
-		{Name: "flag_all", Enabled: true, Action: "flag"},
-	}).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "", false) })
-
-	if strings.Contains(out, "WARN") {
-		t.Errorf("did not expect WARN for flag-only ruleset, got: %s", out)
+// TestBindFailureDiagnostic verifies that the actionable error message on a
+// busy port names the address and suggests both remediation options.
+// This test exercises the message format; the os.Exit(1) is not exercised here
+// (that's integration-level). We construct the message the same way main.go
+// does and assert it contains the required substrings.
+func TestBindFailureDiagnostic(t *testing.T) {
+	// Grab a real busy port by binding it ourselves.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind listener for test setup: %v", err)
 	}
-}
+	defer ln.Close()
+	busyAddr := ln.Addr().String()
 
-func TestStartupBannerNoWarnWhenApproverExplicitlyDisabled(t *testing.T) {
-	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "", true) })
-
-	if strings.Contains(out, "WARN") {
-		t.Errorf("did not expect WARN when approver explicitly disabled, got: %s", out)
+	// Attempt to bind the same address — this must fail.
+	_, bindErr := net.Listen("tcp", busyAddr)
+	if bindErr == nil {
+		t.Skip("could not reproduce busy-port condition on this platform")
 	}
-	if !strings.Contains(out, "approver: disabled") {
-		t.Errorf("expected 'approver: disabled' in banner, got: %s", out)
+
+	// Build the message the same way main.go does.
+	msg := "mcp-proxy: cannot bind approval listener on " + busyAddr + ": " + bindErr.Error() + "\n" +
+		"  Fix: use -http 127.0.0.1:0 for a random free port, or -http=none to disable the listener.\n"
+
+	for _, want := range []string{
+		busyAddr,
+		"Fix:",
+		"-http 127.0.0.1:0",
+		"-http=none",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("bind-failure message missing %q:\n%s", want, msg)
+		}
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -179,7 +179,9 @@ func TestStartupBannerDefaultNone(t *testing.T) {
 }
 
 // TestStartupBannerExplicitNone: operator passed -http=none explicitly.
-// Should be completely silent (no suffix, no WARN, no hint).
+// The banner line and JSON companion still print; what's suppressed is the
+// trailing opt-in suffix and the WARN level — the operator made an informed
+// choice and doesn't need a nudge.
 func TestStartupBannerExplicitNone(t *testing.T) {
 	summary := policy.NewEngine(policy.DefaultRules()).Describe()
 	// approverDisabled=true, httpExplicit=true
@@ -193,6 +195,9 @@ func TestStartupBannerExplicitNone(t *testing.T) {
 	}
 	if !strings.Contains(out, "approver: disabled") {
 		t.Errorf("expected 'approver: disabled' for explicit -http=none, got: %s", out)
+	}
+	if !strings.Contains(out, `"event":"policy_banner"`) {
+		t.Errorf("expected machine-readable companion line to still print, got: %s", out)
 	}
 }
 
@@ -225,18 +230,6 @@ func TestStartupBannerNoPauseRulesNoWarn(t *testing.T) {
 
 	if strings.Contains(out, "WARN") {
 		t.Errorf("did not expect WARN for flag-only ruleset, got: %s", out)
-	}
-}
-
-func TestStartupBannerNoWarnWhenApproverExplicitlyDisabled(t *testing.T) {
-	summary := policy.NewEngine(policy.DefaultRules()).Describe()
-	out := captureStderr(t, func() { emitStartupBanner(summary, "", true, true) })
-
-	if strings.Contains(out, "WARN") {
-		t.Errorf("did not expect WARN when approver explicitly disabled, got: %s", out)
-	}
-	if !strings.Contains(out, "approver: disabled") {
-		t.Errorf("expected 'approver: disabled' in banner, got: %s", out)
 	}
 }
 
@@ -285,12 +278,13 @@ func TestStartupBannerInfoWhenApproverSet(t *testing.T) {
 }
 
 // TestBindFailureDiagnostic verifies that the actionable error message on a
-// busy port names the address and suggests both remediation options.
-// This test exercises the message format; the os.Exit(1) is not exercised here
-// (that's integration-level). We construct the message the same way main.go
-// does and assert it contains the required substrings.
+// busy port names the address and suggests both remediation options. It calls
+// the same formatBindFailure helper main.go uses, so the test fails if the
+// real output regresses (rather than asserting against a re-implemented copy).
+// The os.Exit(1) is not exercised here — that's integration-level.
 func TestBindFailureDiagnostic(t *testing.T) {
-	// Grab a real busy port by binding it ourselves.
+	// Reproduce a real bind failure so the err string in the message matches
+	// what an operator would actually see.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("could not bind listener for test setup: %v", err)
@@ -298,18 +292,16 @@ func TestBindFailureDiagnostic(t *testing.T) {
 	defer ln.Close()
 	busyAddr := ln.Addr().String()
 
-	// Attempt to bind the same address — this must fail.
 	_, bindErr := net.Listen("tcp", busyAddr)
 	if bindErr == nil {
 		t.Skip("could not reproduce busy-port condition on this platform")
 	}
 
-	// Build the message the same way main.go does.
-	msg := "mcp-proxy: cannot bind approval listener on " + busyAddr + ": " + bindErr.Error() + "\n" +
-		"  Fix: use -http 127.0.0.1:0 for a random free port, or -http=none to disable the listener.\n"
+	msg := formatBindFailure(busyAddr, bindErr)
 
 	for _, want := range []string{
 		busyAddr,
+		bindErr.Error(),
 		"Fix:",
 		"-http 127.0.0.1:0",
 		"-http=none",

--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -3,7 +3,7 @@ title: Approval Server
 description: HTTP endpoints that gate paused tool calls, how to approve or deny them, and how to auto-start an approver.
 ---
 
-When a policy rule pauses a tool call, the proxy blocks forwarding until something POSTs an approve or deny decision to its HTTP endpoint. **If no approver is listening, every paused call fails with JSON-RPC code `-32002` (message `tool call approval timed out after <duration>…`) after the configured `-approval-timeout`.**
+**Approvals are off by default.** To turn them on, pass `-http 127.0.0.1:<port>` to `mcp-proxy`. Without that flag the listener never starts, and any tool call that matches a `pause` rule fails immediately with JSON-RPC code `-32003` (`no approver configured`) instead of waiting for an approver that isn't there. With the listener up, a paused call blocks forwarding until something POSTs an approve or deny decision; if no approver responds within `-approval-timeout` (default 60s), the call fails with code `-32002` (`tool call approval timed out…`).
 
 The built-in defaults include a `pause_high_risk` rule (`min_risk_score: 50`). A call only pauses when its score actually reaches 50. Base by operation: read 0, write 20, execute 30, delete 40, unknown 10. Modifiers: +30 for sensitive keywords in the tool name (`auth`/`credential`/`password`/`token`/`secret`/`key`), +30 for SQL mutations in arguments missing `WHERE`, +20 for `config`/`setting` substrings, +15 for `send_*`/`post_*` prefixes. So `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), and `exec_sql` with an unparenthesised `DELETE` (60) all pause. But plain `update_config` (40), plain `delete_branch` (40), and sensitive-keyword *reads* like `get_token` (30) stay below the threshold — as do ordinary writes like `create_pull_request` (20) and `push_files` (20).
 
@@ -13,7 +13,7 @@ The HTTP server is **not** a web UI. There is no index page at `/` — requestin
 
 ## When the server runs
 
-The proxy starts the HTTP listener on startup if and only if the loaded policy contains at least one `pause` rule. With the built-in defaults, that condition is always true. You can confirm the server is up by looking for these lines on stderr:
+The proxy starts the HTTP listener on startup if and only if the operator passed `-http <addr>` (anything other than the default `none`). The listener does not depend on what rules are loaded — even with no `pause` rules the listener will still come up if `-http` is set. To run with the listener off, omit the flag or pass `-http=none` explicitly. You can confirm the server is up by looking for these lines on stderr:
 
 ```
 mcp-proxy: approvals at http://127.0.0.1:8081 (token: 5fce4e79...)
@@ -24,7 +24,7 @@ The first line is human-readable; the second is a stable JSON event designed for
 
 ## Pin a predictable port
 
-The default (`-http 127.0.0.1:0`) binds a random free port. That's fine when a co-located approver reads the stderr discovery event, but painful for everything else: launchd units, browser bookmarks, integration tests, anything that wants a hard-coded URL. Pin a port in your MCP client config:
+`-http 127.0.0.1:0` binds a random free port — fine when a co-located approver reads the stderr discovery event, but painful for everything else: launchd units, browser bookmarks, integration tests, anything that wants a hard-coded URL. Pin a port in your MCP client config:
 
 ```json
 {
@@ -97,7 +97,9 @@ On deny or timeout, the MCP client receives a JSON-RPC error (`code: -32002`) wi
 
 ## Opting out of approval
 
-If you don't want to run an approver, the alternative is to edit your policy so it never pauses. Two ways:
+The simplest opt-out is to **not pass `-http`** — the listener won't start, and any call matching a `pause` rule fails fast with code `-32003` (`no approver configured`). That's what happens by default.
+
+If you want paused calls to *succeed* without human review (i.e. treat the rule as a no-op rather than a fail-fast), edit the policy:
 
 **Option 1 — Disable the default rule.** Write a custom `-rules` YAML that omits `pause_high_risk`. Anything the default rule would have paused will now pass (and still be flagged if it matches other rules). This is a policy decision: high-risk writes now go through without human review.
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -5,8 +5,8 @@ description: How to route Claude Code MCP servers through the Agent Receipts pro
 
 Claude Code is a CLI-based agent that connects to MCP servers for tools like GitHub, databases, and file systems. The Agent Receipts proxy wraps any MCP server transparently — Claude Code doesn't know or care that the proxy is there.
 
-:::note[Approval server — when you need it]
-The default policy pauses calls scoring ≥50. Scores stack a base (write 20, execute 30, delete 40) with modifiers (+30 sensitive keyword, +30 SQL mutation without `WHERE`, +20 `config`/`setting`), so `create_token` (50), `update_auth_config` (70), and `delete_credential` (70) pause, but ordinary GitHub writes like `create_pull_request` (20) and `merge_pull_request` (10) do not. The configs below pin `-http 127.0.0.1:8081` so an approver has a stable URL when your server does expose tools that cross 50. If you're seeing `-32002` on tools that *shouldn't* pause, suspect client-side denial first — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
+:::note[Approval workflow — opt-in]
+The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) and `merge_pull_request` (10) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/). If you're seeing `-32002` on tools that *shouldn't* pause, suspect client-side denial first — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
 :::
 
 ## Prerequisites
@@ -44,7 +44,6 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
   "args": [
     "-name", "github",
     "-key", "$HOME/.agent-receipts/github-proxy.pem",
-    "-http", "127.0.0.1:8081",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -88,7 +87,6 @@ echo "server:  $(which github-mcp-server)"
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-http", "127.0.0.1:8081",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -137,7 +135,7 @@ Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low
 
 **Absolute paths required.** Claude Code launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
 
-**Pin `-http` when running an external approver.** The default policy's `pause_high_risk` rule catches anything scoring ≥50 — combinations like write + sensitive keyword (`create_token` = 50), delete + sensitive (`delete_credential` = 70), execute + SQL mutation without `WHERE` (60). Ordinary GitHub writes (`create_pull_request`, `push_files`) score below that, so most Claude Code sessions never pause. But if one does, the random-port default (`-http 127.0.0.1:0`) means external approvers can't find the endpoint without parsing stderr, and the paused call eventually fails with JSON-RPC code `-32002` (message `tool call approval timed out after <duration>…`; `error.data.status` is `timed_out` for a timeout, `denied` for a deny). Pin a port (`127.0.0.1:8081` above) and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Or drop `pause`/`block` rules from a custom `-rules` YAML if you don't want approvals at all.
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. If your server exposes tools that cross the risk-score threshold (e.g. `create_token` = 50, `update_auth_config` = 70), pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with JSON-RPC code `-32003` (`no approver configured`). To prevent pausing entirely, drop `pause`/`block` rules from a custom `-rules` YAML.
 
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -5,8 +5,8 @@ description: How to route Claude Desktop MCP servers through the Agent Receipts 
 
 Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Agent Receipts proxy wraps any MCP server transparently — Claude Desktop doesn't know or care that the proxy is there.
 
-:::note[Approval server — when you need it]
-The default policy pauses calls scoring ≥50. Scores stack a base (write 20, execute 30, delete 40) with modifiers (+30 sensitive keyword, +30 SQL mutation without `WHERE`, +20 `config`/`setting`), so `create_token` (50), `update_auth_config` (70), and `delete_credential` (70) pause, but ordinary GitHub writes like `create_pull_request` (20) do not. The config below pins `-http 127.0.0.1:8080` so an approver has a stable URL when your server does expose tools that cross 50. See [Approval Server](/mcp-proxy/approval-ui/).
+:::note[Approval workflow — opt-in]
+The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
 ## Prerequisites
@@ -60,7 +60,6 @@ Then substitute the three values into the `mcpServers` block below, and replace 
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-http", "127.0.0.1:8080",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {
@@ -71,7 +70,7 @@ Then substitute the three values into the `mcpServers` block below, and replace 
 }
 ```
 
-`-http 127.0.0.1:8080` pins the approval endpoint to a known port so an approver can target it. If the policy ever pauses a call and no approver responds, the client sees JSON-RPC code `-32002` (message `tool call approval timed out after <duration>…`) — see [Approval Server](/mcp-proxy/approval-ui/). If you also run Claude Code or Codex simultaneously, give each client a distinct port (e.g. `8080`, `8081`, `8082`).
+The approval listener is off by default. If the policy pauses a call (e.g. a high-risk tool your server exposes), it fails immediately with JSON-RPC code `-32003` (`no approver configured`). To enable approvals, add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
 
 Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — every tool call goes through it transparently.
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -5,8 +5,8 @@ description: How to route OpenAI Codex MCP servers through the Agent Receipts pr
 
 OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/config.toml`. The Agent Receipts proxy wraps any MCP server transparently — Codex doesn't know or care that the proxy is there.
 
-:::note[Approval server — when you need it]
-The default policy pauses calls scoring ≥50. Scores stack a base (write 20, execute 30, delete 40) with modifiers (+30 sensitive keyword, +30 SQL mutation without `WHERE`, +20 `config`/`setting`), so `create_token` (50), `update_auth_config` (70), and `delete_credential` (70) pause, but ordinary GitHub writes like `create_pull_request` (20) do not. The configs below pin `-http 127.0.0.1:8082` so an approver has a stable URL when your server does expose tools that cross 50. See [Approval Server](/mcp-proxy/approval-ui/).
+:::note[Approval workflow — opt-in]
+The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
 ## Prerequisites
@@ -43,7 +43,6 @@ codex mcp add github-audited \
   -- "$(which mcp-proxy)" \
     -name github \
     -key "$HOME/.agent-receipts/github-proxy.pem" \
-    -http 127.0.0.1:8082 \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
@@ -72,7 +71,6 @@ command = "/Users/YOU/go/bin/mcp-proxy"
 args = [
   "-name", "github",
   "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-  "-http", "127.0.0.1:8082",
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",
   "-operator-name", "OpenAI",
@@ -132,4 +130,4 @@ The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Th
 
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
 
-**Pin `-http` when running an external approver.** The default policy's `pause_high_risk` rule catches anything scoring ≥50 — combinations like write + sensitive keyword (`create_token` = 50), delete + sensitive (`delete_credential` = 70), execute + SQL mutation without `WHERE` (60). Ordinary GitHub writes (`create_pull_request`, `push_files`) score below that, so most Codex sessions never pause. But if one does, the random-port default (`-http 127.0.0.1:0`) means external approvers can't find the endpoint without parsing stderr, and the paused call eventually fails with JSON-RPC code `-32002` (message `tool call approval timed out after <duration>…`; `error.data.status` is `timed_out` for a timeout, `denied` for a deny). Pin a port (`127.0.0.1:8082` above) and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Or drop `pause`/`block` rules from a custom `-rules` YAML if you don't want approvals at all.
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. If your server exposes tools that cross the risk-score threshold (e.g. `create_token` = 50, `update_auth_config` = 70), pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with JSON-RPC code `-32003` (`no approver configured`). To prevent pausing entirely, drop `pause`/`block` rules from a custom `-rules` YAML.

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -21,7 +21,7 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 | `-operator-name` | (none) | Operator name, e.g. `Anthropic` |
 | `-principal` | `did:user:unknown` | Principal DID for receipts |
 | `-chain` | (auto UUID) | Chain ID for receipt chaining |
-| `-http` | `127.0.0.1:0` | HTTP address for the approval endpoint (default: random free port, logged to stderr). Pin a port (e.g. `127.0.0.1:8081`) whenever you're running an external approver that can't parse stderr to discover the URL. See [Approval Server](/mcp-proxy/approval-ui/). |
+| `-http` | `none` | HTTP address for the approval listener. Off by default — no listener starts unless you opt in. Pass `127.0.0.1:0` for a random free port or `127.0.0.1:<port>` to pin a port. See [Approval Server](/mcp-proxy/approval-ui/). |
 | `-approval-timeout` | `1m0s` | Maximum time to wait for HTTP approval before a paused call is auto-denied |
 
 ## Policy rules
@@ -117,13 +117,15 @@ The proxy ships with bundled mappings — currently [`github_taxonomy.json`](htt
 
 ## Approval workflow
 
+Approvals are **off by default** — the HTTP listener does not start unless you pass `-http <addr>`. A pause rule that fires without a listener fails fast with JSON-RPC code `-32003` (`no approver configured…`) so the failure is immediate and obvious rather than a silent 60-second timeout.
+
 The [Approval Server page](/mcp-proxy/approval-ui/) has the full treatment — endpoints, auth, running an approver, opting out. Quick reference:
 
 - Endpoints: `POST /api/tool-calls/{id}/approve` and `POST /api/tool-calls/{id}/deny`, both require `Authorization: Bearer <token>`.
 - The URL and token are printed on stderr at startup, plus a machine-readable JSON line (`{"event":"approval_endpoint",...}`).
 - No `/pending` or index route — hitting `GET /` returns 404.
-- The HTTP server only starts when the policy has at least one `pause` rule. With the built-in defaults, that's always true.
-- Default `-http` is a random port; pin one (`127.0.0.1:8081`) if you're running an external approver that can't parse the stderr discovery event.
+- The HTTP server only starts when you pass `-http <addr>` explicitly. Passing `none` (or omitting `-http`) keeps the listener off.
+- Pin a port (`127.0.0.1:8081`) if you're running an external approver that can't parse the stderr discovery event.
 - On deny or timeout the client receives a JSON-RPC error with `code: -32002` and a `data` object including `status`, `rule_name`, `risk_score`, `approval_id`, and `approval_url`.
 
 ## Data redaction
@@ -195,7 +197,9 @@ The approval server is not a web UI. `GET /` returns 404 by design. The only rou
 
 ### Multiple MCP clients running the proxy simultaneously
 
-Each `mcp-proxy` instance binds its own HTTP server for the approval workflow. Give each instance a distinct port with `-http` so an approver can route to the right one:
+By default, `mcp-proxy` starts no HTTP listener (`-http none`), so multiple concurrent sessions work without any port configuration — they simply don't collide.
+
+If you do opt in to the approval workflow, each instance that passes `-http <addr>` binds its own server. Give each a distinct port so an approver can route to the right one:
 
 ```bash
 # Claude Desktop
@@ -208,6 +212,6 @@ mcp-proxy -name github -http 127.0.0.1:8081 ... /path/to/server
 mcp-proxy -name github -http 127.0.0.1:8082 ... /path/to/server
 ```
 
-The random-port default (`127.0.0.1:0`) avoids collisions but leaves approvers without a stable URL — fine only when the approver parses stderr on startup.
+`127.0.0.1:0` picks a random free port automatically — fine when the approver parses the stderr discovery event at startup.
 
 Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log. By default both point at `$HOME/.agent-receipts/`, so all clients share one audit log unless you override them.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -53,15 +53,15 @@ The proxy intercepts stdin/stdout, logs every tool call, and forwards messages t
 
 For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), or [Codex](/mcp-proxy/codex/).
 
-## Approval server (when the policy pauses)
+## Approval server (opt-in)
 
-The default policy contains `pause_high_risk` (`min_risk_score: 50`). Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores 20, `merge_pull_request` scores 10, reads score 0 — so many deployments never trigger a pause. The scorer stacks a base (read 0, write 20, execute 30, delete 40, unknown 10) with modifiers: +30 for sensitive keywords in the tool name (`auth`/`credential`/`password`/`token`/`secret`/`key`), +30 for SQL mutations missing `WHERE`, +20 for `config`/`setting` substrings, +15 for `send_*`/`post_*` prefixes. Combinations that actually cross 50: write + sensitive (e.g. `create_token` = 50, `update_auth_config` = 70), delete + sensitive (e.g. `delete_credential` = 70), delete + config (`delete_config` = 60), execute + sensitive or execute + SQL-no-WHERE (60). Plain writes, plain deletes (40), `update_config` alone (40), and sensitive-keyword *reads* like `get_token` (30) do **not** pause.
+The default policy contains `pause_high_risk` (`min_risk_score: 50`), but the approval listener is **off by default**. A paused call without a listener configured fails immediately with JSON-RPC code `-32003` (`no approver configured…`) — a fast, obvious failure rather than a 60-second timeout.
 
-Plan for it if your MCP server exposes any combinations that cross 50. A paused call with no approver listening fails with JSON-RPC code `-32002` (message `tool call approval timed out after <duration>: tool=… rule=… risk=… approval_id=…`) after `-approval-timeout` elapses, while every other call continues to pass through.
+Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores 20, `merge_pull_request` scores 10, reads score 0. Combinations that actually cross 50: write + sensitive keyword (`create_token` = 50, `update_auth_config` = 70), delete + sensitive (`delete_credential` = 70), delete + config (`delete_config` = 60), execute + SQL-no-WHERE (60). Plain writes, plain deletes (40), `update_config` alone (40), and sensitive-keyword *reads* like `get_token` (30) do **not** pause.
 
-**If you want approvals:** pin a port with `-http 127.0.0.1:8081` and run an approver against it. The dedicated [Approval Server](/mcp-proxy/approval-ui/) page documents the real HTTP routes (`POST /api/tool-calls/{id}/approve` and `/deny` — there is no index page at `/`) and shows a minimal shell approver.
+**If you want human-in-the-loop approvals:** this section is for you. Pass `-http 127.0.0.1:<port>` to start the listener, then run an approver against it. The dedicated [Approval Server](/mcp-proxy/approval-ui/) page documents the HTTP routes (`POST /api/tool-calls/{id}/approve` and `/deny`) and shows a minimal shell approver.
 
-**If you don't want approvals at all:** load a custom `-rules` YAML with no `pause` or `block` rules — see [opting out](/mcp-proxy/approval-ui/#opting-out-of-approval).
+**If you don't want approvals at all:** omit `-http` (the default) and paused calls will fail fast. To prevent pausing entirely, load a custom `-rules` YAML with no `pause` or `block` rules — see [opting out](/mcp-proxy/approval-ui/#opting-out-of-approval).
 
 **Seeing `-32002` on a tool that shouldn't pause?** It's most likely client-side denial by the MCP client (e.g. Claude Code), not the proxy. See the [`-32002` troubleshooting entry](/mcp-proxy/configuration/#-32002-errors-on-tool-calls) for how to distinguish the two sources.
 
@@ -80,6 +80,6 @@ mcp-proxy -key private.pem npx -y @modelcontextprotocol/server-filesystem ~/Docu
 
 ## Next steps
 
-- [Approval Server](/mcp-proxy/approval-ui/) — required reading if the default policy is active
+- [Approval Server](/mcp-proxy/approval-ui/) — opt-in human-in-the-loop approval workflow
 - [Configuration](/mcp-proxy/configuration/) for CLI flags, policy rules, redaction, and encryption
 - [CLI Commands](/reference/cli-commands/) for querying and verifying the audit trail

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -7,10 +7,10 @@ The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP clien
 
 **Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
 
-:::note[The default policy can pause — plan for it if your server exposes sensitive tools]
-The built-in policy contains a `pause_high_risk` rule (`min_risk_score: 50`). Scores stack: base by operation (read 0, write 20, execute 30, delete 40, unknown 10), plus +30 for sensitive keywords in the tool name (`auth`/`credential`/`password`/`token`/`secret`/`key`), +30 for SQL mutations in arguments missing a `WHERE`, +20 for `config`/`setting` substrings, +15 for `send_*`/`post_*` prefixes. What actually crosses 50: `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), `exec_sql` with `DELETE …` and no WHERE (60). What doesn't: plain writes like `create_pull_request` (20), plain deletes like `delete_branch` (40), or sensitive-keyword reads like `get_token` (30). Calls at ≥50 hold until something POSTs an approve/deny; with no approver they fail with JSON-RPC code `-32002` (message `tool call approval timed out after <duration>…`) once `-approval-timeout` elapses.
+:::note[The default policy includes a `pause_high_risk` rule — approvals are opt-in]
+The built-in policy contains a `pause_high_risk` rule (`min_risk_score: 50`). The approval listener is **off by default**, so a paused call fails fast with a clear error (JSON-RPC code `-32003`, message `no approver configured…`) rather than timing out. To approve high-risk calls interactively instead, see [Approval Server](/mcp-proxy/approval-ui/).
 
-If your MCP server exposes tools that can cross 50, either pin `-http 127.0.0.1:8081` and run an approver (see [Approval Server](/mcp-proxy/approval-ui/)), or load a custom `-rules` YAML with no `pause`/`block` rules. Seeing `-32002` on tools that *shouldn't* pause (like `create_pull_request`) is usually client-side denial, not the proxy — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
+Scores that cross 50: `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), `exec_sql` with `DELETE …` and no `WHERE` (60). Scores that don't: plain writes like `create_pull_request` (20), plain deletes like `delete_branch` (40), sensitive-keyword reads like `get_token` (30). Seeing `-32002` on tools that *shouldn't* pause is usually client-side denial — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
 :::
 
 ## Features
@@ -61,13 +61,12 @@ mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 mcp-proxy \
   -name github \
   -key private.pem \
-  -http 127.0.0.1:8081 \
   -rules rules.yaml \
   -taxonomy taxonomy.json \
   github-mcp-server stdio
 ```
 
-Then run an approver that POSTs to `http://127.0.0.1:8081/api/tool-calls/{id}/approve` as paused calls come in — see [Approval Server](/mcp-proxy/approval-ui/).
+To enable the approval workflow, pass `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/).
 
 ## Claude Desktop integration
 
@@ -81,7 +80,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-        "-http", "127.0.0.1:8080",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -97,8 +95,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 
 > **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
 
-`-http 127.0.0.1:8080` pins the approval endpoint to a fixed port. If you run Claude Code and Codex alongside Claude Desktop, assign each one a distinct port (e.g. `8080` / `8081` / `8082`) so an approver can route to the right instance.
-
 ## Claude Code integration
 
 Claude Code uses `claude mcp add-json` to register servers. Use `--scope user` to make the proxy available across all projects:
@@ -109,7 +105,6 @@ claude mcp add-json github-audited --scope user '{
   "args": [
     "-name", "github",
     "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
-    "-http", "127.0.0.1:8081",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -130,7 +125,7 @@ claude mcp list
 See the [Claude Code integration guide](/mcp-proxy/claude-code/) for a full walkthrough including project-scoped setup and `.mcp.json` configuration.
 
 :::tip
-Running multiple MCP clients simultaneously? See [Troubleshooting: port conflicts](/mcp-proxy/configuration/#multiple-mcp-clients-running-the-proxy-simultaneously) in the configuration guide.
+Running multiple MCP clients simultaneously with the approval listener enabled? See [Troubleshooting: port conflicts](/mcp-proxy/configuration/#multiple-mcp-clients-running-the-proxy-simultaneously) in the configuration guide.
 :::
 
 ## What receipts look like

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -58,7 +58,6 @@ Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-r
       "args": [
         "-name", "atlassian",
         "-key", "/Users/YOU/.agent-receipts/atlassian-proxy.pem",
-        "-http", "127.0.0.1:8082",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -78,7 +77,6 @@ claude mcp add-json atlassian-audited --scope user '{
   "args": [
     "-name", "atlassian",
     "-key", "'"$HOME"'/.agent-receipts/atlassian-proxy.pem",
-    "-http", "127.0.0.1:8082",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -101,19 +99,6 @@ The proxy ships with bundled mappings for Atlassian's Jira and Confluence tools 
 
 The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy/configs) — open a PR to add or correct mappings.
 
-## Port assignment
-
-`mcp-remote` listens on `127.0.0.1` for the local end of the OAuth callback, and the proxy itself binds an approval port. If you run multiple audited remote servers alongside local ones, give each its own approval port:
-
-| Server          | `-http`            |
-| --------------- | ------------------ |
-| GitHub          | `127.0.0.1:8080`   |
-| Codex / Linear  | `127.0.0.1:8081`   |
-| Atlassian       | `127.0.0.1:8082`   |
-| Slack           | `127.0.0.1:8083`   |
-
-This keeps an external approval UI able to route by port. See [Approval Server](/mcp-proxy/approval-ui/) for the wider workflow.
-
 ## Caveats
 
 - **OAuth is invisible to the proxy.** `mcp-remote` owns the credential. The proxy can't include token identity in receipts and can't log auth refreshes. Tracked in [#227](https://github.com/agent-receipts/ar/issues/227).
@@ -126,7 +111,6 @@ This keeps an external approval UI able to route by port. See [Approval Server](
 
 ```bash
 $HOME/go/bin/mcp-proxy -name atlassian -key ~/.agent-receipts/atlassian-proxy.pem \
-  -http 127.0.0.1:8082 \
   npx --registry https://registry.npmjs.org -y mcp-remote https://mcp.atlassian.com/v1/mcp
 ```
 


### PR DESCRIPTION
## Summary

- Flip default of `-http` from `127.0.0.1:0` to `none`. The HTTP approval listener now only starts when the operator explicitly passes `-http <addr>`. Pause rules still load and evaluate; an unwired pause takes the existing `ApprovalNoApprover` fail-fast path (code `-32003`) instead of the 60-second timeout.
- Replace `log.Fatalf` on bind failure with an actionable error: names the busy address and offers both `-http 127.0.0.1:0` (random) and `-http=none` (disable) as remediations. Exits non-zero.
- Soften the startup banner: default-off is now an `[INFO]` hint ("approver off by default; pass -http <addr> to enable"), not a `[WARN]`. Explicit `-http=none` stays silent. The existing WARN path remains reachable for the unusual `approverDisabled=false && approvalURL=""` case.
- Reframe docs across `claude-code.mdx`, `claude-desktop.mdx`, `codex.mdx`, `remote-servers.mdx`, `overview.mdx`, `installation.mdx`, and `README.md` so setup snippets no longer pin `-http`. The Approval Server page and Configuration reference lead with "off by default" and document the opt-in path.

## Why

Closes #262. The port collision happens because (1) the listener auto-starts whenever any `pause` rule is enabled (always true given default rules) and (2) our docs pin `-http 127.0.0.1:8082`, so two concurrent sessions both try to bind that port and the second one `log.Fatalf`s. Making the listener opt-in eliminates the collision as a category — no listener, no port, no fight — without removing the feature for users who want it.

We considered removing the `pause` action entirely (~350 LOC, no current users, no UI ships) but kept it: the marketing story (approval workflow as a first-class capability), the option to wire a bundled UI later, and the testing cost of removal all argued for preservation.

#263 (OAuth token caching for remote MCP servers) is unrelated and stays scoped against #227 — out of scope here.

## Test plan

- [x] `go vet ./... && go test ./...` from `mcp-proxy/` — passes
- [x] `mcp-proxy -h` shows new `-http` default of `none` with opt-in guidance
- [x] Default-flag boot emits `[INFO]` banner with "approver off by default" hint, no `[WARN]`
- [x] `-http 127.0.0.1:<busy-port>` produces the actionable diagnostic and exits non-zero
- [x] `cd site && pnpm build` — clean, no broken internal links to `/mcp-proxy/approval-ui/`
- [ ] Two concurrent `mcp-proxy` sessions with default flags both connect (the original #262 repro)
- [ ] Pause path with `-http 127.0.0.1:0` still functions end-to-end (listener up, approve via curl, audit row populated)

The two unchecked items need real MCP-client wiring to exercise — left for reviewer / manual smoke. Unit tests cover the banner branches, the help text, and the bind-failure message format.