### PR TITLE
docs(mcp-proxy): update troubleshooting + add CHANGELOG

### DIFF
--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to mcp-proxy are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file starts at 0.6.2; earlier releases are recorded only in git history.
+A repo-wide effort to auto-generate changelogs from Conventional Commits is
+tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
+
+## [0.6.2] - 2026-04-29
+
+### Changed
+
+- Default of `-http` flag flipped from `127.0.0.1:0` to `none`; the approval
+  HTTP listener is now opt-in. Pause rules still load and evaluate; an unwired
+  pause fails fast with JSON-RPC code `-32003` ("no approver configured")
+  instead of waiting 60s for a timeout. See
+  [#266](https://github.com/agent-receipts/ar/pull/266) and
+  [#262](https://github.com/agent-receipts/ar/issues/262).
+
+- Startup banner softened. The default-off case (operator did not pass `-http`)
+  now emits an `[INFO]` line with a soft "approver off by default; pass -http
+  `<addr>` to enable" hint, instead of a `[WARN]`. Explicit `-http=none` is
+  treated as an informed opt-out (no hint, no warn). The `[WARN]` path remains
+  for the unusual misconfiguration case.
+
+### Fixed
+
+- Bind failure on `-http <addr>` no longer `log.Fatalf`s with a cryptic
+  `bind: address already in use`. Now prints an actionable error naming the
+  address and offering both `-http 127.0.0.1:0` (random port) and `-http=none`
+  (disable) as remediations, then exits non-zero. Closes
+  [#262](https://github.com/agent-receipts/ar/issues/262).
+
+[0.6.2]: https://github.com/agent-receipts/ar/compare/mcp-proxy/v0.6.1...mcp-proxy/v0.6.2

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -159,8 +159,8 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 **Three different things produce these error codes.** Distinguish them before reaching for a fix, because they need different remedies and only two of them involve the proxy:
 
 1. **Client-side denial** — the MCP client (e.g. Claude Code) rejected the tool use before it reached the proxy. The call never hits the audit DB.
-2. **Proxy: no approver configured** (`-32003`) — the call reached the proxy, matched a `pause` rule, but the approval HTTP listener is not running (operator did not pass `-http <addr>`). The proxy fails fast rather than waiting out the timeout. The call appears in the audit DB with `policy_action = 'rejected'`, `approved_by` NULL, and `approval_wait_us` near zero. This is the common case when running the default configuration.
-3. **Proxy: approval timeout** (`-32002`) — the call reached the proxy, matched a `pause` rule, an approver listener is wired up (`-http <addr>` was passed), but no approver POSTed a decision before `-approval-timeout` elapsed. The audit DB row signature is the same as case 2 (`policy_action = 'rejected'`, `approved_by` NULL), distinguishable by `approval_wait_us` close to the configured `-approval-timeout` (default 60s = 60000000μs).
+2. **Proxy: no approver configured** (`-32003`) — the call reached the proxy, matched a `pause` rule, but the approval HTTP listener is not running (operator did not pass `-http <addr>`). The proxy fails fast rather than waiting out the timeout. The call appears in the audit DB with `policy_action = 'rejected'`, `approved_by` NULL, and `approval_wait_us` NULL or near zero. This is the common case when running the default configuration. The JSON-RPC error response carries `data.status = "no_approver"`.
+3. **Proxy: approval denied or timed out** (`-32002`) — the call reached the proxy, matched a `pause` rule, and an approver listener was wired up (`-http <addr>` was passed). The approver either explicitly denied the call, or no approver POSTed a decision before `-approval-timeout` elapsed. The audit DB row signature is the same as case 2 (`policy_action = 'rejected'`, `approved_by` NULL). The JSON-RPC error response disambiguates via `data.status`: `"denied"` for an explicit deny, `"timed_out"` for a timeout. A timeout will have `approval_wait_us` close to `-approval-timeout` (default 60s = 60000000μs); a fast deny may have a small `approval_wait_us` indistinguishable from case 2.
 
 **Diagnose — which one is it?**
 
@@ -168,16 +168,16 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 # Did the failing call reach the proxy at all?
 # Substitute the tool name you saw fail.
 sqlite3 ~/.agent-receipts/audit.db \
-  "SELECT tool_name, policy_action, risk_score, approved_by, approval_wait_us, created_at
+  "SELECT tool_name, policy_action, risk_score, approved_by, approval_wait_us, requested_at
    FROM tool_calls
    WHERE tool_name = 'create_pull_request'
-     AND created_at > datetime('now', '-1 hour')
+     AND requested_at > datetime('now', '-1 hour')
    ORDER BY id DESC LIMIT 10;"
 ```
 
 - **No rows at all** → client-side denial (case 1). The proxy never saw it. See [ar#157](https://github.com/agent-receipts/ar/issues/157) for the ongoing work to make these visible.
 - **Rows with `policy_action = 'pass'`** → the proxy forwarded it; the error came from somewhere downstream (the MCP server, the remote API). Check the proxy's stderr log and the server's own logs.
-- **Rows with `policy_action = 'rejected'` and `approved_by` NULL** → proxy pause rejection (case 2 or 3). The JSON-RPC error code the client received tells them apart: `-32003` means no approver was wired up; `-32002` means an approver was wired but timed out. If you no longer have the error response, the `approval_wait_us` column is a good proxy: near zero is case 2 (no approver, fail-fast), near `-approval-timeout` is case 3 (timeout).
+- **Rows with `policy_action = 'rejected'` and `approved_by` NULL** → proxy pause rejection (case 2 or 3). Distinguish via the JSON-RPC error response when you have it: code `-32003` is case 2; code `-32002` is case 3, and its `data.status` field (`"denied"` vs `"timed_out"`) tells you which sub-case. If the error response is gone, `approval_wait_us` only reliably identifies the timeout sub-case (it'll be close to `-approval-timeout`); a small or NULL value can be either case 2 (no approver, fail-fast) or a fast deny under case 3 — they're indistinguishable from the audit DB alone.
 
 **If the error is `-32003` (no approver configured):**
 
@@ -188,9 +188,9 @@ The proxy is pausing high-risk calls but has no approval listener running. Eithe
 ps aux | grep mcp-proxy | grep -v grep
 ```
 
-**If the error is `-32002` (approval timeout):**
+**If the error is `-32002` (approval denied or timed out):**
 
-An approver listener is running but no decision arrived in time. Check that your approver can reach the endpoint and that `-approval-timeout` is long enough.
+An approver listener is running and either denied the call or didn't respond in time. Check `data.status` in the JSON-RPC error: `"denied"` means the approver said no — that's the workflow working as intended, no proxy fix needed. `"timed_out"` means no decision arrived; verify your approver can reach the endpoint and that `-approval-timeout` is long enough.
 
 ```bash
 # Confirm the -http address and timeout flags.

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -154,12 +154,13 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 
 ## Troubleshooting
 
-### `-32002` errors on tool calls
+### Tool call errors (`-32002` / `-32003`)
 
-**Two different things produce this error code.** Distinguish them before reaching for a fix, because they need different remedies and only one of them involves the proxy:
+**Three different things produce these error codes.** Distinguish them before reaching for a fix, because they need different remedies and only two of them involve the proxy:
 
 1. **Client-side denial** — the MCP client (e.g. Claude Code) rejected the tool use before it reached the proxy. The call never hits the audit DB.
-2. **Proxy approval timeout** — the call reached the proxy, matched a `pause` rule, and timed out because no approver POSTed a decision. The call appears in the audit DB with `policy_action = 'pause'` and `approved_by` NULL.
+2. **Proxy: no approver configured** (`-32003`) — the call reached the proxy, matched a `pause` rule, but the approval HTTP listener is not running (operator did not pass `-http <addr>`). The proxy fails fast rather than waiting out the timeout. The call appears in the audit DB with `policy_action = 'rejected'`, `approved_by` NULL, and `approval_wait_us` near zero. This is the common case when running the default configuration.
+3. **Proxy: approval timeout** (`-32002`) — the call reached the proxy, matched a `pause` rule, an approver listener is wired up (`-http <addr>` was passed), but no approver POSTed a decision before `-approval-timeout` elapsed. The audit DB row signature is the same as case 2 (`policy_action = 'rejected'`, `approved_by` NULL), distinguishable by `approval_wait_us` close to the configured `-approval-timeout` (default 60s = 60000000μs).
 
 **Diagnose — which one is it?**
 
@@ -167,21 +168,32 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 # Did the failing call reach the proxy at all?
 # Substitute the tool name you saw fail.
 sqlite3 ~/.agent-receipts/audit.db \
-  "SELECT tool_name, policy_action, risk_score, approved_by, created_at
+  "SELECT tool_name, policy_action, risk_score, approved_by, approval_wait_us, created_at
    FROM tool_calls
    WHERE tool_name = 'create_pull_request'
      AND created_at > datetime('now', '-1 hour')
    ORDER BY id DESC LIMIT 10;"
 ```
 
-- **No rows at all** → client-side denial. The proxy never saw it. See [ar#157](https://github.com/agent-receipts/ar/issues/157) for the ongoing work to make these visible.
-- **Rows with `policy_action = 'pass'`** → the proxy forwarded it; the `-32002` came from somewhere downstream (the MCP server, the remote API). Check the proxy's stderr log and the server's own logs.
-- **Rows with `policy_action = 'pause'` and `approved_by` NULL** → proxy approval timeout. Continue below.
+- **No rows at all** → client-side denial (case 1). The proxy never saw it. See [ar#157](https://github.com/agent-receipts/ar/issues/157) for the ongoing work to make these visible.
+- **Rows with `policy_action = 'pass'`** → the proxy forwarded it; the error came from somewhere downstream (the MCP server, the remote API). Check the proxy's stderr log and the server's own logs.
+- **Rows with `policy_action = 'rejected'` and `approved_by` NULL** → proxy pause rejection (case 2 or 3). The JSON-RPC error code the client received tells them apart: `-32003` means no approver was wired up; `-32002` means an approver was wired but timed out. If you no longer have the error response, the `approval_wait_us` column is a good proxy: near zero is case 2 (no approver, fail-fast), near `-approval-timeout` is case 3 (timeout).
 
-**If it's a proxy approval timeout:**
+**If the error is `-32003` (no approver configured):**
+
+The proxy is pausing high-risk calls but has no approval listener running. Either start an approver by passing `-http <addr>` when launching the proxy, or relax the policy so the tool is not paused. See [Approval Server](/mcp-proxy/approval-ui/) for both paths.
 
 ```bash
-# Confirm -http is pinned so your approver can reach the endpoint.
+# Check which process flags are in effect.
+ps aux | grep mcp-proxy | grep -v grep
+```
+
+**If the error is `-32002` (approval timeout):**
+
+An approver listener is running but no decision arrived in time. Check that your approver can reach the endpoint and that `-approval-timeout` is long enough.
+
+```bash
+# Confirm the -http address and timeout flags.
 ps aux | grep mcp-proxy | grep -v grep
 
 # Check overall breakdown.
@@ -189,7 +201,7 @@ sqlite3 ~/.agent-receipts/audit.db \
   "SELECT policy_action, COUNT(*) FROM tool_calls GROUP BY policy_action;"
 ```
 
-The remedy is to run an approver, or to relax the policy. See [Approval Server](/mcp-proxy/approval-ui/) for both paths. The scorer stacks a base (read 0, write 20, execute 30, delete 40, unknown 10) with modifiers — sensitive keywords in the tool name (+30), SQL mutations without `WHERE` (+30), `config`/`setting` substrings (+20), `send_*`/`post_*` prefixes (+15) — so what actually crosses 50 is combinations: `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), `delete_config` (60), `exec_sql` with a `DELETE` and no `WHERE` (60). Ordinary writes like `create_pull_request` (20), unknown-prefix calls like `merge_pull_request` (10), plain deletes like `delete_branch` (40), `update_config` with no sensitive keyword (40), and sensitive-keyword *reads* like `get_token` (30) all stay below the threshold — if one of those is failing, you're in path #1, not #2.
+The scorer stacks a base (read 0, write 20, execute 30, delete 40, unknown 10) with modifiers — sensitive keywords in the tool name (+30), SQL mutations without `WHERE` (+30), `config`/`setting` substrings (+20), `send_*`/`post_*` prefixes (+15) — so what actually crosses 50 is combinations: `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), `delete_config` (60), `exec_sql` with a `DELETE` and no `WHERE` (60). Ordinary writes like `create_pull_request` (20), unknown-prefix calls like `merge_pull_request` (10), plain deletes like `delete_branch` (40), `update_config` with no sensitive keyword (40), and sensitive-keyword *reads* like `get_token` (30) all stay below the threshold — if one of those is failing, you're in path #1, not #2 or #3.
 
 ### 404 at `http://127.0.0.1:8081/`
 


### PR DESCRIPTION
## Summary

Follow-up to [#266](https://github.com/agent-receipts/ar/pull/266) (released as `mcp-proxy/v0.6.2`).

- Rewrites the troubleshooting section in `configuration.mdx` for the new opt-in default. With the listener off by default, `-32003` ("no approver configured") is the new common proxy-side failure mode and gets its own remediation block. The old "always `-32002`" framing is replaced with a three-case taxonomy (client-side denial / `-32003` / `-32002`).
- Fixes a pre-existing inaccuracy in the audit-DB diagnostic: rejected pause calls write `policy_action = 'rejected'`, not `'pause'` ([main.go:427](mcp-proxy/cmd/mcp-proxy/main.go:427)). The doc previously instructed readers to look for `policy_action = 'pause'` rows, which would never appear for a rejected call.
- Adds `approval_wait_us` to the diagnostic `SELECT` so users can distinguish `-32003` (≈0μs wait) from `-32002` (≈ `-approval-timeout` wait) post-hoc, without the error response.
- Adds `mcp-proxy/CHANGELOG.md`, mirroring [`sdk/ts/CHANGELOG.md`](sdk/ts/CHANGELOG.md). First entry documents v0.6.2. The "starts at X; earlier in git history" disclaimer matches the TS pattern and references [#253](https://github.com/agent-receipts/ar/issues/253) for the eventual auto-generation work.

## Test plan

- [x] `cd site && pnpm build` — clean, no broken internal links
- [x] CHANGELOG renders in GitHub's default Markdown viewer
- [x] Troubleshooting flow walks correctly from a `-32003` error to the right remediation block