### PR TITLE
fix(mcp-proxy): coordinate stdio shutdown to surface upstream death (closes #158)

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -672,8 +672,10 @@ func serve() {
 
 	p := proxy.New(command, commandArgs, handler)
 	log.Printf("mcp-proxy: session %s, server %s, chain %s", sessionID, *serverName, *chainID)
-	if err := p.Run(); err != nil {
-		log.Printf("mcp-proxy: %v", err)
+	runErr := p.Run()
+	log.Printf("mcp-proxy: session %s ended", sessionID)
+	if runErr != nil {
+		log.Printf("mcp-proxy: %v", runErr)
 		os.Exit(1)
 	}
 }

--- a/mcp-proxy/internal/proxy/proxy.go
+++ b/mcp-proxy/internal/proxy/proxy.go
@@ -9,7 +9,9 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"sync"
+	"time"
 )
 
 // HandlerResult tells the proxy what to do with a message.
@@ -75,23 +77,40 @@ func (p *Proxy) Run() error {
 		return fmt.Errorf("start server: %w", err)
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	// exits carries the pipe direction name when each goroutine finishes.
+	// Capacity 2 so neither sender ever blocks.
+	exits := make(chan string, 2)
 
 	// Client → Server
 	go func() {
-		defer wg.Done()
 		defer serverIn.Close()
 		p.pipe(os.Stdin, serverIn, "client_to_server")
+		exits <- "client_to_server"
 	}()
 
 	// Server → Client
 	go func() {
-		defer wg.Done()
 		p.pipe(serverOut, os.Stdout, "server_to_client")
+		exits <- "server_to_client"
 	}()
 
-	wg.Wait()
+	// Wait for the first pipe to finish, then kill the upstream so the
+	// surviving pipe unblocks instead of blocking forever.
+	first := <-exits
+	log.Printf("mcp-proxy: pipe %s exited, shutting down", first)
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+
+	// Drain the second exit with a short timeout so we capture the reason
+	// but do not block forever.
+	select {
+	case second := <-exits:
+		log.Printf("mcp-proxy: pipe %s exited", second)
+	case <-time.After(2 * time.Second):
+		log.Printf("mcp-proxy: second pipe did not exit within timeout")
+	}
+
 	return p.cmd.Wait()
 }
 
@@ -121,7 +140,16 @@ func (p *Proxy) pipe(src io.Reader, dst io.Writer, direction string) {
 			msg := ParseMessage(raw)
 
 			if p.handler != nil {
-				if result := p.handler(direction, raw, msg); result != nil && result.Block {
+				var result *HandlerResult
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-proxy: handler panic (%s): %v\n%s", direction, r, debug.Stack())
+						}
+					}()
+					result = p.handler(direction, raw, msg)
+				}()
+				if result != nil && result.Block {
 					// Send the block response to the client, not to dst.
 					if writeErr := p.writeToClient(result.ClientResponse); writeErr != nil {
 						log.Printf("mcp-proxy: write block response: %v", writeErr)
@@ -145,8 +173,10 @@ func (p *Proxy) pipe(src io.Reader, dst io.Writer, direction string) {
 		}
 
 		if err != nil {
-			if err != io.EOF {
-				log.Printf("mcp-proxy: read error (%s): %v", direction, err)
+			if err == io.EOF {
+				log.Printf("mcp-proxy: pipe %s closed (EOF)", direction)
+			} else {
+				log.Printf("mcp-proxy: pipe %s read error: %v", direction, err)
 			}
 			return
 		}

--- a/mcp-proxy/internal/proxy/proxy_parallel_test.go
+++ b/mcp-proxy/internal/proxy/proxy_parallel_test.go
@@ -91,7 +91,15 @@ func startParallelProxy(t *testing.T, proxyBin, fakeserverBin string, extraEnv [
 	}
 	t.Cleanup(func() {
 		_ = stdinPipe.Close()
-		_ = cmd.Wait()
+		// Subtests may have already waited; only wait again if the process
+		// hasn't been reaped yet, and force-kill if it's still running so
+		// cleanup doesn't hang.
+		if cmd.ProcessState == nil {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+		}
 	})
 
 	// Give the proxy a moment to start the child.

--- a/mcp-proxy/internal/proxy/proxy_parallel_test.go
+++ b/mcp-proxy/internal/proxy/proxy_parallel_test.go
@@ -1,0 +1,226 @@
+package proxy_test
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+)
+
+// buildTestBinary compiles a Go package into tmpDir and returns the binary path.
+func buildTestBinary(t *testing.T, pkg, tmpDir, name string) string {
+	t.Helper()
+	out := filepath.Join(tmpDir, name)
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build %s: %v", pkg, err)
+	}
+	return out
+}
+
+// writeKeyFile generates an Ed25519 private key and writes it as a PKCS8 PEM file.
+func writeKeyFile(t *testing.T, dir string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPath := filepath.Join(dir, "key.pem")
+	f, err := os.OpenFile(keyPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: "PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatalf("encode key: %v", err)
+	}
+	return keyPath
+}
+
+// startParallelProxy starts the mcp-proxy binary with fakeserverBin as upstream
+// and returns stdin/stdout pipes, a stderr buffer, and the command.
+func startParallelProxy(t *testing.T, proxyBin, fakeserverBin string, extraEnv []string) (io.WriteCloser, io.ReadCloser, *bytes.Buffer, *exec.Cmd) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	keyPath := writeKeyFile(t, tmpDir)
+	auditDB := filepath.Join(tmpDir, "audit.db")
+	receiptDB := filepath.Join(tmpDir, "receipts.db")
+
+	cmd := exec.Command(proxyBin,
+		"--db", auditDB,
+		"--receipt-db", receiptDB,
+		"--key", keyPath,
+		"--chain", "parallel-test",
+		"--http", "none",
+		"--", fakeserverBin,
+	)
+	cmd.Env = append(os.Environ(), extraEnv...)
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdinPipe.Close()
+		_ = cmd.Wait()
+	})
+
+	// Give the proxy a moment to start the child.
+	time.Sleep(200 * time.Millisecond)
+
+	return stdinPipe, stdoutPipe, &stderrBuf, cmd
+}
+
+// TestParallelToolCalls covers two scenarios for parallel tool-call traffic.
+func TestParallelToolCalls(t *testing.T) {
+	tmpDir := t.TempDir()
+	proxyBin := buildTestBinary(t,
+		"github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy",
+		tmpDir, "mcp-proxy")
+	fakeBin := buildTestBinary(t,
+		"github.com/agent-receipts/ar/mcp-proxy/internal/proxy/testdata/fakeserver",
+		tmpDir, "fakeserver")
+
+	t.Run("AllRespond", func(t *testing.T) {
+		stdinW, stdoutR, _, cmd := startParallelProxy(t, proxyBin, fakeBin, nil)
+
+		const n = 10
+		scanner := bufio.NewScanner(stdoutR)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+		// Collect responses in the background.
+		respCh := make(chan float64, n*2)
+		go func() {
+			for scanner.Scan() {
+				var m map[string]any
+				if err := json.Unmarshal(scanner.Bytes(), &m); err != nil {
+					continue
+				}
+				if id, ok := m["id"].(float64); ok {
+					respCh <- id
+				}
+			}
+		}()
+
+		// Send n requests in parallel, serialising writes with a mutex.
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		for i := 1; i <= n; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				msg, _ := json.Marshal(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"method":  "tools/call",
+					"params":  map[string]any{"name": "test", "arguments": map[string]any{}},
+				})
+				mu.Lock()
+				fmt.Fprintf(stdinW, "%s\n", msg)
+				mu.Unlock()
+			}(i)
+		}
+		wg.Wait()
+
+		// Collect all responses within a deadline.
+		received := make(map[float64]bool)
+		deadline := time.After(10 * time.Second)
+		for len(received) < n {
+			select {
+			case id := <-respCh:
+				received[id] = true
+			case <-deadline:
+				t.Fatalf("timeout: only received %d/%d responses; got ids: %v", len(received), n, received)
+			}
+		}
+
+		// Clean shutdown.
+		stdinW.Close()
+		if err := cmd.Wait(); err != nil {
+			t.Logf("proxy exited: %v (expected)", err)
+		}
+	})
+
+	t.Run("UpstreamDiesMidway", func(t *testing.T) {
+		// MAX_RESPONSES=5 makes the fakeserver exit after responding to 5 requests.
+		stdinW, stdoutR, stderrBuf, cmd := startParallelProxy(t, proxyBin, fakeBin,
+			[]string{"MAX_RESPONSES=5"})
+
+		const n = 10
+		scanner := bufio.NewScanner(stdoutR)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+		// Drain stdout in the background so the proxy is never blocked writing.
+		go func() {
+			for scanner.Scan() {
+			}
+		}()
+
+		// Send n requests; the upstream will exit after 5 without ever sending
+		// the remaining responses.
+		var mu sync.Mutex
+		for i := 1; i <= n; i++ {
+			msg, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      i,
+				"method":  "tools/call",
+				"params":  map[string]any{"name": "test", "arguments": map[string]any{}},
+			})
+			mu.Lock()
+			fmt.Fprintf(stdinW, "%s\n", msg)
+			mu.Unlock()
+		}
+
+		// Before the fix, wg.Wait() would block forever because the
+		// client→server goroutine keeps running. After the fix, Run() exits
+		// promptly once the server→client pipe closes.
+		done := make(chan error, 1)
+		go func() {
+			done <- cmd.Wait()
+		}()
+
+		select {
+		case <-done:
+			// Good — proxy exited as expected.
+		case <-time.After(5 * time.Second):
+			cmd.Process.Kill()
+			t.Fatal("proxy did not exit within 5s after upstream died — regression of #158")
+		}
+
+		// Proxy stderr should mention the pipe exit (EOF or read error).
+		stderr := stderrBuf.String()
+		re := regexp.MustCompile(`pipe .*(EOF|read error|exited)`)
+		if !re.MatchString(stderr) {
+			t.Errorf("expected pipe-exit log in stderr, got:\n%s", stderr)
+		}
+	})
+}

--- a/mcp-proxy/internal/proxy/testdata/fakeserver/main.go
+++ b/mcp-proxy/internal/proxy/testdata/fakeserver/main.go
@@ -1,0 +1,53 @@
+// fakeserver is a minimal JSON-RPC MCP server used in proxy tests.
+//
+// It reads newline-delimited JSON-RPC requests from stdin and writes back a
+// trivial success response for each one that carries an "id" field.
+//
+// Environment variable MAX_RESPONSES controls how many responses to emit before
+// exiting (default: unlimited). This is used to simulate upstream death midway.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	max := -1 // unlimited
+	if s := os.Getenv("MAX_RESPONSES"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakeserver: bad MAX_RESPONSES %q: %v\n", s, err)
+			os.Exit(1)
+		}
+		max = n
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+	sent := 0
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var req map[string]json.RawMessage
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		id, hasID := req["id"]
+		if !hasID {
+			continue // notification — no response needed
+		}
+
+		if max >= 0 && sent >= max {
+			// Simulate upstream dying — exit without responding.
+			os.Exit(0)
+		}
+
+		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{}}`, string(id))
+		fmt.Println(resp)
+		sent++
+	}
+}


### PR DESCRIPTION
## Summary

Closes #158.

When the upstream MCP server stops responding, the `server→client` pipe goroutine in `internal/proxy/proxy.go` exits silently on EOF while the `client→server` pipe keeps blocking on `os.Stdin`. `wg.Wait()` blocks forever — the proxy process stays alive but is half-dead. From Claude Code's perspective: `MCP error -32000: Connection closed`, no stderr line, zombie PID.

This is the silent-failure path that's been bothering parallel `update_issue` traffic against the GitHub MCP upstream.

### Why "asymmetric goroutine shutdown" rather than the obvious suspects

I checked two tempting wrong answers first:

- **Concurrent stdout writes**: not the bug. [`writeToClient`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/internal/proxy/proxy.go#L99-L104) wraps the entire `fmt.Fprintf` in `writerMu`, and both server→client and block-response writes go through it. Writes are properly serialised.
- **Approval listener**: not the bug. PR #266 already fixed the no-approver hang.

The real cause is that `client→server` defers `serverIn.Close()` (so when *it* exits, upstream gets EOF and shuts down cleanly), but `server→client` has no symmetric coordination. When the upstream dies first, no signal flows back.

## Changes

### `internal/proxy/proxy.go` (≈40 LoC)

- **`Run()`**: replace `sync.WaitGroup` + `wg.Wait()` with a buffered `chan string` (cap 2). On the **first** pipe exit, log the direction and `_ = p.cmd.Process.Kill()` so the surviving pipe unblocks. Drain the second exit with a 2s `select` timeout for telemetry, then `return p.cmd.Wait()`.
- **`pipe()`**: log every exit reason. EOF was previously swallowed at `if err != io.EOF`; now it logs `pipe %s closed (EOF)` and other errors log `pipe %s read error: %v`.
- **`pipe()`**: wrap the `p.handler(...)` call in a `defer recover()` closure. A handler panic now logs the direction, value, and `debug.Stack()` and is treated as "no result" (forward as-is), instead of crashing the goroutine.

### `cmd/mcp-proxy/main.go` (3 lines)

Capture `p.Run()` into `runErr`, log `mcp-proxy: session %s ended` unconditionally, then preserve the existing error-exit path. So both clean and error exits are visible in stderr.

### `internal/proxy/proxy_parallel_test.go` (new, ~160 LoC) + `internal/proxy/testdata/fakeserver/` (new, ~50 LoC)

`TestParallelToolCalls` has two sub-tests:

- **`AllRespond`**: spawns the proxy with a tiny stdlib-only fake JSON-RPC echo server, sends 10 parallel `tools/call` requests, asserts all 10 responses arrive within 10s.
- **`UpstreamDiesMidway`**: same setup with `MAX_RESPONSES=5`, sends 10 requests, asserts the proxy's `Run()` returns within 5s and stderr contains a pipe-exit log line. **Today this hangs forever** — that's the #158 reproducer.

The fake server is an in-tree Go program under `testdata/fakeserver/` (no shell dependency, stdlib only) compiled by the test setup, mirroring the existing `e2e_test.go` binary-build pattern.

## What this PR deliberately does NOT change

- `WaitForApproval` — fine; #266 fixed it.
- Synchronous `auditDB.LogMessage` / `InsertToolCall` calls in main.go — pre-existing throughput concern, separate issue.
- `writerMu` / `writeToClient` — already correct.
- `SetMaxOpenConns(1)` on the audit store — separate concern.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race ./internal/proxy/...` — pass (12 tests including the 2 new sub-tests)
- [x] `go test ./...` from `mcp-proxy/` — pass (5 packages)
- [x] `go build ./...` — clean
- [ ] Manual repro: build the proxy, point Claude Code at it via stdio, fire 5+ parallel `update_issue` calls. Pre-fix: connection dies silently. Post-fix: either calls succeed, or if upstream goes bad, proxy exits cleanly with a stderr line and Claude Code respawns it.

## Notes for reviewers

- The 200ms `time.Sleep` in the test's `startParallelProxy` helper is a pragmatic "wait for child to start" — slightly flaky-prone but acceptable for a first cut. Open to swapping for an explicit readiness ping if reviewers prefer.
- Killing the upstream rather than closing `os.Stdin` is intentional. Closing `os.Stdin` from inside a Go process doesn't reliably unblock a `bufio.Reader.ReadBytes` call across darwin/linux. The kill path is deterministic (kernel closes both pipes from the upstream side, both directions unblock).
