### PR TITLE
fix(sdk-go): surface hash errors in VerifyChain

### DIFF
--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -7,7 +7,7 @@ import (
 
 // hashReceipt is overridable in tests so the error-return path of HashReceipt
 // (unreachable in production with the current strictly-typed AgentReceipt) can
-// be exercised. Production code always resolves to receipt.HashReceipt.
+// be exercised. In production, this variable is left pointing at HashReceipt.
 var hashReceipt = HashReceipt
 
 // ReceiptVerification holds the verification result for a single receipt in a chain.
@@ -128,12 +128,13 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		} else {
 			prevHash, err := hashReceipt(receipts[i-1])
 			if err != nil {
+				seqValid := chain.Sequence == receipts[i-1].CredentialSubject.Chain.Sequence+1
 				results = append(results, ReceiptVerification{
 					Index:          i,
 					ReceiptID:      r.ID,
 					SignatureValid: sigValid,
 					HashLinkValid:  false,
-					SequenceValid:  false,
+					SequenceValid:  seqValid,
 				})
 				return ChainVerification{
 					Valid:    false,

--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 )
 
+// hashReceipt is overridable in tests so the error-return path of HashReceipt
+// (unreachable in production with the current strictly-typed AgentReceipt) can
+// be exercised. Production code always resolves to receipt.HashReceipt.
+var hashReceipt = HashReceipt
+
 // ReceiptVerification holds the verification result for a single receipt in a chain.
 type ReceiptVerification struct {
 	Index          int    `json:"index"`
@@ -121,12 +126,24 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		if i == 0 {
 			hashValid = chain.PreviousReceiptHash == nil
 		} else {
-			prevHash, err := HashReceipt(receipts[i-1])
+			prevHash, err := hashReceipt(receipts[i-1])
 			if err != nil {
-				hashValid = false
-			} else {
-				hashValid = chain.PreviousReceiptHash != nil && *chain.PreviousReceiptHash == prevHash
+				results = append(results, ReceiptVerification{
+					Index:          i,
+					ReceiptID:      r.ID,
+					SignatureValid: sigValid,
+					HashLinkValid:  false,
+					SequenceValid:  false,
+				})
+				return ChainVerification{
+					Valid:    false,
+					Length:   len(receipts),
+					Receipts: results,
+					BrokenAt: i,
+					Error:    "hash compute failed at index " + strconv.Itoa(i-1) + ": " + err.Error(),
+				}
 			}
+			hashValid = chain.PreviousReceiptHash != nil && *chain.PreviousReceiptHash == prevHash
 		}
 
 		seqValid := true
@@ -224,10 +241,15 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 			cv.BrokenAt = len(receipts) - 1
 			cv.Error = "expected chain length does not match: expected " + strconv.Itoa(*opt.ExpectedLength) + ", got " + strconv.Itoa(len(receipts))
 		} else if opt.ExpectedFinalHash != "" {
-			lastHash, err := HashReceipt(receipts[len(receipts)-1])
-			if err != nil || lastHash != opt.ExpectedFinalHash {
+			last := len(receipts) - 1
+			lastHash, err := hashReceipt(receipts[last])
+			if err != nil {
 				cv.Valid = false
-				cv.BrokenAt = len(receipts) - 1
+				cv.BrokenAt = last
+				cv.Error = "hash compute failed at index " + strconv.Itoa(last) + ": " + err.Error()
+			} else if lastHash != opt.ExpectedFinalHash {
+				cv.Valid = false
+				cv.BrokenAt = last
 				cv.Error = "final receipt hash does not match expected value"
 			}
 		}

--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -2,6 +2,8 @@ package receipt
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 )
 
@@ -106,6 +108,35 @@ func TestVerifyChainDetectsBrokenHashLink(t *testing.T) {
 	// Broken at 2 (hash link) but also signature will fail because we modified the receipt.
 	if result.BrokenAt != 2 {
 		t.Errorf("expected broken at 2, got %d", result.BrokenAt)
+	}
+}
+
+func TestVerifyChainSurfacesHashError(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChain(t, kp, 3)
+
+	targetID := chain[0].ID
+	orig := hashReceipt
+	hashReceipt = func(r AgentReceipt) (string, error) {
+		if r.ID == targetID {
+			return "", errors.New("synthetic canonicalize failure")
+		}
+		return orig(r)
+	}
+	t.Cleanup(func() { hashReceipt = orig })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false when HashReceipt errors")
+	}
+	if result.BrokenAt != 1 {
+		t.Errorf("expected BrokenAt=1, got %d", result.BrokenAt)
+	}
+	if !strings.Contains(result.Error, "hash compute failed at index 0") {
+		t.Errorf("expected error to contain 'hash compute failed at index 0', got: %s", result.Error)
+	}
+	if !strings.Contains(result.Error, "synthetic canonicalize failure") {
+		t.Errorf("expected error to contain 'synthetic canonicalize failure', got: %s", result.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #173

- `VerifyChain` was silently converting `HashReceipt` errors into `HashLinkValid: false`, making tampering indistinguishable from canonicalization failure.
- The fix mirrors the existing signature-error pattern: on hash-compute failure, `ChainVerification.Error` is populated with the failing index and reason, and the function returns early.
- A package-private `hashReceipt` var is introduced as a test seam (the failure path is unreachable in production with valid `AgentReceipt` inputs).

## Test plan

- [ ] `TestVerifyChainSurfacesHashError` overrides `hashReceipt` with a synthetic error and asserts `ChainVerification.Error` contains the failing index and underlying reason.
- [ ] All existing chain verification tests continue to pass unchanged.
- [ ] `go vet ./...` clean.