### PR TITLE
fix(sdk-ts): surface hashReceipt errors in ChainVerification.error

### DIFF
--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeUnsigned } from "../test-utils/receipts.js";
 import { verifyChain } from "./chain.js";
 import { createReceipt } from "./create.js";
+import * as hashModule from "./hash.js";
 import { canonicalize, hashReceipt, sha256 } from "./hash.js";
 import { generateKeyPair, signReceipt } from "./signing.js";
 
@@ -111,23 +112,26 @@ describe("verifyChain", () => {
 	it("surfaces hashReceipt errors via the error field", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 		const chain = buildChain(2, privateKey);
+		const targetId = chain[0]?.id;
 
-		// Inject a non-finite number into a canonicalized field. RFC 8785 §3.2.2.3
-		// (and hashReceipt -> canonicalize) rejects NaN. chain_id is typed string,
-		// so cast through unknown to bypass at runtime.
-		const first = chain[0];
-		if (first) {
-			(
-				first.credentialSubject.chain as unknown as { chain_id: number }
-			).chain_id = Number.NaN;
+		const original = hashModule.hashReceipt;
+		const spy = vi.spyOn(hashModule, "hashReceipt").mockImplementation((r) => {
+			if (r.id === targetId) {
+				throw new Error("synthetic canonicalize failure");
+			}
+			return original(r);
+		});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.brokenAt).toBe(1);
+			expect(result.error).toMatch(/^hash compute failed at index 0:/);
+			expect(result.error).toContain("synthetic canonicalize failure");
+			expect(result.receipts[1]?.hashLinkValid).toBe(false);
+		} finally {
+			spy.mockRestore();
 		}
-
-		const result = verifyChain(chain, publicKey);
-
-		expect(result.valid).toBe(false);
-		expect(result.brokenAt).toBe(1);
-		expect(result.error).toMatch(/^hash compute failed at index 0:/);
-		expect(result.receipts[1]?.hashLinkValid).toBe(false);
 	});
 
 	it("detects a broken sequence", () => {

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -108,6 +108,28 @@ describe("verifyChain", () => {
 		expect(result.receipts[1]?.hashLinkValid).toBe(false);
 	});
 
+	it("surfaces hashReceipt errors via the error field", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const chain = buildChain(2, privateKey);
+
+		// Inject a non-finite number into a canonicalized field. RFC 8785 §3.2.2.3
+		// (and hashReceipt -> canonicalize) rejects NaN. chain_id is typed string,
+		// so cast through unknown to bypass at runtime.
+		const first = chain[0];
+		if (first) {
+			(
+				first.credentialSubject.chain as unknown as { chain_id: number }
+			).chain_id = Number.NaN;
+		}
+
+		const result = verifyChain(chain, publicKey);
+
+		expect(result.valid).toBe(false);
+		expect(result.brokenAt).toBe(1);
+		expect(result.error).toMatch(/^hash compute failed at index 0:/);
+		expect(result.receipts[1]?.hashLinkValid).toBe(false);
+	});
+
 	it("detects a broken sequence", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -111,13 +111,43 @@ export function verifyChain(
 		if (!receipt) continue;
 		const chain = receipt.credentialSubject.chain;
 
-		const signatureValid = verifyReceipt(receipt, publicKey);
+		let signatureValid: boolean;
+		try {
+			signatureValid = verifyReceipt(receipt, publicKey);
+		} catch {
+			signatureValid = false;
+		}
 
 		let hashLinkValid: boolean;
 		if (previous === undefined) {
 			hashLinkValid = chain.previous_receipt_hash === null;
 		} else {
-			const previousHash = hashReceipt(previous);
+			let previousHash: string;
+			try {
+				previousHash = hashReceipt(previous);
+			} catch (e) {
+				const reason = e instanceof Error ? e.message : String(e);
+				const prevSeq = previous.credentialSubject.chain.sequence;
+				const curSeq = chain.sequence;
+				const seqValid =
+					Number.isSafeInteger(curSeq) &&
+					Number.isSafeInteger(prevSeq) &&
+					curSeq === prevSeq + 1;
+				results.push({
+					index: i,
+					receiptId: receipt.id,
+					signatureValid,
+					hashLinkValid: false,
+					sequenceValid: seqValid,
+				});
+				return {
+					valid: false,
+					length: receipts.length,
+					receipts: results,
+					brokenAt: i,
+					error: `hash compute failed at index ${i - 1}: ${reason}`,
+				};
+			}
 			hashLinkValid = chain.previous_receipt_hash === previousHash;
 		}
 
@@ -219,14 +249,31 @@ export function verifyChain(
 
 	if (options?.expectedFinalHash !== undefined) {
 		const lastReceipt = receipts[receipts.length - 1];
-		if (
-			!lastReceipt ||
-			hashReceipt(lastReceipt) !== options.expectedFinalHash
-		) {
+		if (!lastReceipt) {
 			return {
 				...cv,
 				valid: false,
 				brokenAt: receipts.length - 1,
+			};
+		}
+		let lastHash: string;
+		try {
+			lastHash = hashReceipt(lastReceipt);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			return {
+				...cv,
+				valid: false,
+				brokenAt: receipts.length - 1,
+				error: `hash compute failed at index ${receipts.length - 1}: ${reason}`,
+			};
+		}
+		if (lastHash !== options.expectedFinalHash) {
+			return {
+				...cv,
+				valid: false,
+				brokenAt: receipts.length - 1,
+				error: "final receipt hash does not match expected value",
 			};
 		}
 	}

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -111,12 +111,7 @@ export function verifyChain(
 		if (!receipt) continue;
 		const chain = receipt.credentialSubject.chain;
 
-		let signatureValid: boolean;
-		try {
-			signatureValid = verifyReceipt(receipt, publicKey);
-		} catch {
-			signatureValid = false;
-		}
+		const signatureValid = verifyReceipt(receipt, publicKey);
 
 		let hashLinkValid: boolean;
 		if (previous === undefined) {


### PR DESCRIPTION
## Summary

- Wrap `hashReceipt` calls in `verifyChain` so canonicalization failures populate `ChainVerification.error` (with index and reason) instead of escaping the function.
- Split `expectedFinalHash` into separate hash-error and mismatch branches, so the two failure modes are distinguishable.
- Adds a vitest case that uses `vi.spyOn` to force `hashReceipt` to throw and asserts the structured error.

TypeScript counterpart to #173 / #269 (Go SDK fix). Mirrors the minimal-scope approach taken in #273 for sdk/py.

Closes #270

## Test plan

- [x] \`pnpm test\` passes including the new case (177 tests)
- [x] \`pnpm build\` clean
- [x] \`pnpm exec biome check src\` clean