### PR TITLE
fix(sdk-py): surface hash_receipt errors in ChainVerification.error

### DIFF
--- a/sdk/py/src/agent_receipts/receipt/chain.py
+++ b/sdk/py/src/agent_receipts/receipt/chain.py
@@ -97,18 +97,36 @@ def verify_chain(
 
         signature_valid = verify_receipt(receipt, public_key)
 
-        if previous is None:
-            hash_link_valid = chain.previous_receipt_hash is None
-        else:
-            previous_hash = hash_receipt(previous)
-            hash_link_valid = chain.previous_receipt_hash == previous_hash
-
         current_sequence = chain.sequence
         if previous is None:
             sequence_valid = current_sequence >= 1
         else:
             prev_sequence = previous.credentialSubject.chain.sequence
             sequence_valid = current_sequence == prev_sequence + 1
+
+        if previous is None:
+            hash_link_valid = chain.previous_receipt_hash is None
+        else:
+            try:
+                previous_hash = hash_receipt(previous)
+            except (TypeError, ValueError) as exc:
+                results.append(
+                    ReceiptVerification(
+                        index=i,
+                        receipt_id=receipt.id,
+                        signature_valid=signature_valid,
+                        hash_link_valid=False,
+                        sequence_valid=sequence_valid,
+                    )
+                )
+                return ChainVerification(
+                    valid=False,
+                    length=len(receipts),
+                    receipts=results,
+                    broken_at=i,
+                    error=f"hash compute failed at index {i - 1}: {exc}",
+                )
+            hash_link_valid = chain.previous_receipt_hash == previous_hash
 
         verification = ReceiptVerification(
             index=i,
@@ -191,10 +209,17 @@ def verify_chain(
         return cv
 
     if expected_final_hash is not None:
-        last_hash = hash_receipt(receipts[-1])
+        last_index = len(receipts) - 1
+        try:
+            last_hash = hash_receipt(receipts[-1])
+        except (TypeError, ValueError) as exc:
+            cv.valid = False
+            cv.broken_at = last_index
+            cv.error = f"hash compute failed at index {last_index}: {exc}"
+            return cv
         if last_hash != expected_final_hash:
             cv.valid = False
-            cv.broken_at = len(receipts) - 1
+            cv.broken_at = last_index
             cv.error = "final receipt hash does not match expected value"
             return cv
 

--- a/sdk/py/tests/receipt/test_chain.py
+++ b/sdk/py/tests/receipt/test_chain.py
@@ -472,10 +472,12 @@ class TestAdr0008ChainBehaviours:
     def test_hash_failure_in_loop_populates_error(self) -> None:
         """hash_receipt raising on a previous receipt surfaces as a structured error.
 
-        Patch hash_receipt to raise ValueError on the second call (when the
-        loop computes hash_receipt(previous) for receipt[1]).  verify_receipt
-        is unaffected because it does not call hash_receipt — this isolates the
-        try/except at the per-receipt hash-link check in verify_chain.
+        Patch hash_receipt to raise ValueError on every call. The first
+        patched invocation occurs when the loop computes hash_receipt(previous)
+        for receipt[1], which exercises the try/except at the per-receipt
+        hash-link check.  verify_receipt is unaffected because it does not call
+        hash_receipt — this isolates the try/except at the per-receipt
+        hash-link check in verify_chain.
         """
         kp = generate_key_pair()
         chain = _build_chain(2, kp.private_key)
@@ -491,6 +493,41 @@ class TestAdr0008ChainBehaviours:
         assert result.error.startswith("hash compute failed at index 0:")
         assert len(result.receipts) == 2
         assert result.receipts[1].hash_link_valid is False
+
+    def test_hash_failure_in_expected_final_hash_populates_error(self) -> None:
+        """hash_receipt raising on the final receipt surfaces via expected_final_hash.
+
+        Patches hash_receipt to raise only when called on the last receipt's id,
+        so the per-receipt loop succeeds (hash_receipt(previous) is called for
+        earlier indices and returns normally) and the expected_final_hash branch
+        triggers the new try/except.
+        """
+        kp = generate_key_pair()
+        chain = _build_chain(2, kp.private_key)
+        real_final_hash = hash_receipt(chain[-1])
+
+        target_id = chain[-1].id
+        real_hash_receipt = hash_receipt
+
+        def selective_raise(r: object) -> str:
+            if getattr(r, "id", None) == target_id:
+                raise ValueError("injected hash failure on final receipt")
+            return real_hash_receipt(r)  # type: ignore[arg-type]
+
+        with patch(
+            "agent_receipts.receipt.chain.hash_receipt",
+            side_effect=selective_raise,
+        ):
+            result = verify_chain(
+                chain,
+                kp.public_key,
+                expected_final_hash=real_final_hash,
+            )
+
+        assert result.valid is False
+        assert result.broken_at == 1
+        assert result.error.startswith("hash compute failed at index 1:")
+        assert "injected hash failure" in result.error
 
     def test_response_bodies_absent_entry_emits_note(self) -> None:
         """When response_hash is present but receipt id is not in the map, emit note."""

--- a/sdk/py/tests/receipt/test_chain.py
+++ b/sdk/py/tests/receipt/test_chain.py
@@ -1,5 +1,7 @@
 """Tests for chain verification."""
 
+from unittest.mock import patch
+
 from agent_receipts.receipt.chain import verify_chain
 from agent_receipts.receipt.create import (
     ActionInput,
@@ -464,6 +466,31 @@ class TestAdr0008ChainBehaviours:
         )
         assert not result.valid
         assert "response_hash mismatch" in result.error
+
+    # --- hash compute errors ---
+
+    def test_hash_failure_in_loop_populates_error(self) -> None:
+        """hash_receipt raising on a previous receipt surfaces as a structured error.
+
+        Patch hash_receipt to raise ValueError on the second call (when the
+        loop computes hash_receipt(previous) for receipt[1]).  verify_receipt
+        is unaffected because it does not call hash_receipt — this isolates the
+        try/except at the per-receipt hash-link check in verify_chain.
+        """
+        kp = generate_key_pair()
+        chain = _build_chain(2, kp.private_key)
+
+        with patch(
+            "agent_receipts.receipt.chain.hash_receipt",
+            side_effect=ValueError("injected hash failure"),
+        ):
+            result = verify_chain(chain, kp.public_key)
+
+        assert result.valid is False
+        assert result.broken_at == 1
+        assert result.error.startswith("hash compute failed at index 0:")
+        assert len(result.receipts) == 2
+        assert result.receipts[1].hash_link_valid is False
 
     def test_response_bodies_absent_entry_emits_note(self) -> None:
         """When response_hash is present but receipt id is not in the map, emit note."""


### PR DESCRIPTION
## Summary

- Wrap `hash_receipt` calls in `verify_chain` so canonicalization failures populate `ChainVerification.error` (with index and reason) instead of escaping the function.
- Split `expected_final_hash` into separate hash-error and mismatch branches.
- Adds a pytest case that patches `hash_receipt` to raise and asserts the structured error is surfaced correctly.

Python counterpart to #173 / #269 (Go SDK fix).

Closes #271

## Test plan

- [x] `uv run pytest` passes including the new case
- [x] `uv run ruff check .` clean
- [x] `uv run pyright src` clean