### PR TITLE
fix(sdk-ts): validate receipt schema on load from store (#170)

### DIFF
--- a/docs/adr/0011-zod-for-runtime-validation.md
+++ b/docs/adr/0011-zod-for-runtime-validation.md
@@ -1,0 +1,60 @@
+# ADR-0011: Zod for runtime schema validation
+
+## Status
+
+Accepted
+
+## Context
+
+`parseReceiptJson` in the TypeScript SDK deserialised stored receipts with a
+bare `JSON.parse(json) as AgentReceipt` cast. The cast is compile-time only —
+a corrupt or partially-written SQLite row returns as a ghost-typed `AgentReceipt`
+with missing or wrong-typed fields, which then flows silently into chain
+verification, signature verification, and queries.
+
+For an audit-trail library this is a correctness gap, not a cosmetic one.
+The Python SDK validates via Pydantic `model_validate`; the Go SDK relies on
+`json.Unmarshal` against a typed struct. The TypeScript SDK had no equivalent.
+
+Issue #170 asked for runtime validation at the store-load boundary. Three
+options were evaluated:
+
+1. **Hand-written validator** — covers the need but is maintenance-heavy: every
+   field added to the spec requires a parallel update in the validator, and
+   there is no type-level guarantee that the two stay in sync.
+
+2. **ajv + JSON Schema** — the spec ships JSON schemas, so this would be
+   authoritative. However, ajv is a significantly larger dependency, JSON Schema
+   and TypeScript types have different evolution cadences, and keeping both in
+   sync would require additional tooling.
+
+3. **Zod** — schemas are written in TypeScript alongside the types, `z.infer`
+   ensures structural alignment at compile time, and the library is the de-facto
+   standard for runtime validation in the TypeScript ecosystem (>30M weekly
+   downloads, actively maintained).
+
+## Decision
+
+Adopt Zod for runtime validation at the store-load boundary. A Zod schema
+mirroring every interface in `src/receipt/types.ts` is defined in
+`src/receipt/schema.ts` and called inside `parseReceiptJson` after
+`JSON.parse`. Schema objects are not strict (no `.strict()`) so unknown extra
+fields introduced by newer SDK versions do not break older stores. The existing
+`AgentReceipt` interface is kept unchanged; the schema type is structurally
+compatible but separate.
+
+This is the SDK's first runtime dependency.
+
+## Consequences
+
+- Corrupt or schema-invalid rows in the store now surface a clear, field-pathed
+  error at load time rather than propagating ghost-typed values downstream.
+- Zod adds approximately 50 KB to the installed package (tree-shaking applies
+  for bundled consumers).
+- Setting a precedent for a runtime dependency: future additions must clear the
+  same bar (well-maintained, widely adopted, supply-chain vetted).
+- Validation in `createReceipt`, `signReceipt`, and `verifyReceipt` is
+  explicitly deferred; the same schema can be reused at those sites if issue
+  #170 scope is expanded later.
+- If cross-SDK schema consistency becomes a priority (ajv + canonical JSON
+  Schema), a future ADR may supersede this one.

--- a/docs/adr/0011-zod-for-runtime-validation.md
+++ b/docs/adr/0011-zod-for-runtime-validation.md
@@ -38,10 +38,14 @@ options were evaluated:
 Adopt Zod for runtime validation at the store-load boundary. A Zod schema
 mirroring every interface in `src/receipt/types.ts` is defined in
 `src/receipt/schema.ts` and called inside `parseReceiptJson` after
-`JSON.parse`. Schema objects are not strict (no `.strict()`) so unknown extra
-fields introduced by newer SDK versions do not break older stores. The existing
-`AgentReceipt` interface is kept unchanged; the schema type is structurally
-compatible but separate.
+`JSON.parse`. Every object schema uses `.passthrough()` so unknown extra fields
+written by a newer SDK survive the load — required for forward-compatibility,
+since the default `z.object` strips unknown keys, which would silently
+invalidate the RFC 8785 canonical hash on signed receipts and break signature
+verification on receipts authored by newer SDK versions. The root schema is
+typed as `z.ZodType<AgentReceipt>` so `.parse()` returns `AgentReceipt`
+directly, with no type assertion at the validation boundary. The existing
+`AgentReceipt` interface is kept unchanged.
 
 This is the SDK's first runtime dependency.
 

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -54,6 +54,9 @@
 		]
 	},
 	"packageManager": "pnpm@10.33.0",
+	"dependencies": {
+		"zod": "^3.25.76"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.9",
 		"@types/node": "^25.5.0",

--- a/sdk/ts/pnpm-lock.yaml
+++ b/sdk/ts/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.9
@@ -577,6 +581,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@biomejs/biome@2.4.13':
@@ -977,3 +984,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  zod@3.25.76: {}

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -1,11 +1,13 @@
 /**
  * Zod runtime schemas mirroring the interfaces in types.ts.
  *
- * Used to validate receipts loaded from the store. Schemas intentionally do
- * not use .strict() — the spec evolves, and unknown extra fields must not
- * cause existing stores to fail on load when a newer SDK wrote the receipt.
+ * Every object uses .passthrough() so unknown extra fields written by a newer
+ * SDK are preserved on load — required for forward-compatibility of canonical
+ * JSON / signature verification, since stripping unknown keys would break the
+ * RFC 8785 hash on receipts written by future SDK versions.
  */
 import { z } from "zod";
+import type { AgentReceipt } from "./types.js";
 
 // --- Risk levels ---
 
@@ -17,123 +19,149 @@ const outcomeStatusSchema = z.enum(["success", "failure", "pending"]);
 
 // --- Issuer ---
 
-const operatorSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-});
+const operatorSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+	})
+	.passthrough();
 
-const issuerSchema = z.object({
-	id: z.string(),
-	type: z.string().optional(),
-	name: z.string().optional(),
-	operator: operatorSchema.optional(),
-	model: z.string().optional(),
-	session_id: z.string().optional(),
-});
+const issuerSchema = z
+	.object({
+		id: z.string(),
+		type: z.string().optional(),
+		name: z.string().optional(),
+		operator: operatorSchema.optional(),
+		model: z.string().optional(),
+		session_id: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Principal ---
 
-const principalSchema = z.object({
-	id: z.string(),
-	type: z.string().optional(),
-});
+const principalSchema = z
+	.object({
+		id: z.string(),
+		type: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Action ---
 
-const actionTargetSchema = z.object({
-	system: z.string(),
-	resource: z.string().optional(),
-});
+const actionTargetSchema = z
+	.object({
+		system: z.string(),
+		resource: z.string().optional(),
+	})
+	.passthrough();
 
-const actionSchema = z.object({
-	id: z.string(),
-	type: z.string(),
-	tool_name: z.string().optional(),
-	risk_level: riskLevelSchema,
-	target: actionTargetSchema.optional(),
-	parameters_hash: z.string().optional(),
-	parameters_preview: z.record(z.string()).optional(),
-	timestamp: z.string(),
-	trusted_timestamp: z.string().optional(),
-});
+const actionSchema = z
+	.object({
+		id: z.string(),
+		type: z.string(),
+		tool_name: z.string().optional(),
+		risk_level: riskLevelSchema,
+		target: actionTargetSchema.optional(),
+		parameters_hash: z.string().optional(),
+		parameters_preview: z.record(z.string()).optional(),
+		timestamp: z.string(),
+		trusted_timestamp: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Intent ---
 
-const intentSchema = z.object({
-	conversation_hash: z.string().optional(),
-	prompt_preview: z.string().optional(),
-	prompt_preview_truncated: z.boolean().optional(),
-	reasoning_hash: z.string().optional(),
-});
+const intentSchema = z
+	.object({
+		conversation_hash: z.string().optional(),
+		prompt_preview: z.string().optional(),
+		prompt_preview_truncated: z.boolean().optional(),
+		reasoning_hash: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Outcome ---
 
-const stateChangeSchema = z.object({
-	before_hash: z.string(),
-	after_hash: z.string(),
-});
+const stateChangeSchema = z
+	.object({
+		before_hash: z.string(),
+		after_hash: z.string(),
+	})
+	.passthrough();
 
-const outcomeSchema = z.object({
-	status: outcomeStatusSchema,
-	error: z.string().optional(),
-	reversible: z.boolean().optional(),
-	reversal_method: z.string().optional(),
-	reversal_window_seconds: z.number().optional(),
-	state_change: stateChangeSchema.optional(),
-	response_hash: z.string().optional(),
-});
+const outcomeSchema = z
+	.object({
+		status: outcomeStatusSchema,
+		error: z.string().optional(),
+		reversible: z.boolean().optional(),
+		reversal_method: z.string().optional(),
+		reversal_window_seconds: z.number().optional(),
+		state_change: stateChangeSchema.optional(),
+		response_hash: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Authorization ---
 
-const authorizationSchema = z.object({
-	scopes: z.array(z.string()),
-	granted_at: z.string(),
-	expires_at: z.string().optional(),
-	grant_ref: z.string().optional(),
-});
+const authorizationSchema = z
+	.object({
+		scopes: z.array(z.string()),
+		granted_at: z.string(),
+		expires_at: z.string().optional(),
+		grant_ref: z.string().optional(),
+	})
+	.passthrough();
 
 // --- Chain ---
 
-const chainSchema = z.object({
-	sequence: z.number(),
-	previous_receipt_hash: z.string().nullable(),
-	chain_id: z.string(),
-	// When present, MUST be true. Explicit false is not valid per the spec.
-	terminal: z.literal(true).optional(),
-});
+const chainSchema = z
+	.object({
+		sequence: z.number(),
+		previous_receipt_hash: z.string().nullable(),
+		chain_id: z.string(),
+		// When present, MUST be true. Explicit false is not valid per the spec.
+		terminal: z.literal(true).optional(),
+	})
+	.passthrough();
 
 // --- Credential Subject ---
 
-const credentialSubjectSchema = z.object({
-	principal: principalSchema,
-	action: actionSchema,
-	intent: intentSchema.optional(),
-	outcome: outcomeSchema,
-	authorization: authorizationSchema.optional(),
-	chain: chainSchema,
-});
+const credentialSubjectSchema = z
+	.object({
+		principal: principalSchema,
+		action: actionSchema,
+		intent: intentSchema.optional(),
+		outcome: outcomeSchema,
+		authorization: authorizationSchema.optional(),
+		chain: chainSchema,
+	})
+	.passthrough();
 
 // --- Proof ---
 
-const proofSchema = z.object({
-	type: z.string(),
-	created: z.string().optional(),
-	verificationMethod: z.string().optional(),
-	proofPurpose: z.string().optional(),
-	proofValue: z.string(),
-});
+const proofSchema = z
+	.object({
+		type: z.string(),
+		created: z.string().optional(),
+		verificationMethod: z.string().optional(),
+		proofPurpose: z.string().optional(),
+		proofValue: z.string(),
+	})
+	.passthrough();
 
 // --- Agent Receipt ---
 
-export const agentReceiptSchema = z.object({
-	"@context": z.array(z.string()),
-	id: z.string(),
-	type: z.array(z.string()),
-	version: z.string(),
-	issuer: issuerSchema,
-	issuanceDate: z.string(),
-	credentialSubject: credentialSubjectSchema,
-	proof: proofSchema,
-});
-
-export type AgentReceiptSchema = z.infer<typeof agentReceiptSchema>;
+// Annotated as ZodType<AgentReceipt> so .parse() returns AgentReceipt directly
+// at the call site, avoiding an `as` cast at the validation boundary.
+export const agentReceiptSchema: z.ZodType<AgentReceipt> = z
+	.object({
+		"@context": z.array(z.string()),
+		id: z.string(),
+		type: z.array(z.string()),
+		version: z.string(),
+		issuer: issuerSchema,
+		issuanceDate: z.string(),
+		credentialSubject: credentialSubjectSchema,
+		proof: proofSchema,
+	})
+	.passthrough();

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -1,0 +1,139 @@
+/**
+ * Zod runtime schemas mirroring the interfaces in types.ts.
+ *
+ * Used to validate receipts loaded from the store. Schemas intentionally do
+ * not use .strict() — the spec evolves, and unknown extra fields must not
+ * cause existing stores to fail on load when a newer SDK wrote the receipt.
+ */
+import { z } from "zod";
+
+// --- Risk levels ---
+
+const riskLevelSchema = z.enum(["low", "medium", "high", "critical"]);
+
+// --- Outcome status ---
+
+const outcomeStatusSchema = z.enum(["success", "failure", "pending"]);
+
+// --- Issuer ---
+
+const operatorSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+});
+
+const issuerSchema = z.object({
+	id: z.string(),
+	type: z.string().optional(),
+	name: z.string().optional(),
+	operator: operatorSchema.optional(),
+	model: z.string().optional(),
+	session_id: z.string().optional(),
+});
+
+// --- Principal ---
+
+const principalSchema = z.object({
+	id: z.string(),
+	type: z.string().optional(),
+});
+
+// --- Action ---
+
+const actionTargetSchema = z.object({
+	system: z.string(),
+	resource: z.string().optional(),
+});
+
+const actionSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	tool_name: z.string().optional(),
+	risk_level: riskLevelSchema,
+	target: actionTargetSchema.optional(),
+	parameters_hash: z.string().optional(),
+	parameters_preview: z.record(z.string()).optional(),
+	timestamp: z.string(),
+	trusted_timestamp: z.string().optional(),
+});
+
+// --- Intent ---
+
+const intentSchema = z.object({
+	conversation_hash: z.string().optional(),
+	prompt_preview: z.string().optional(),
+	prompt_preview_truncated: z.boolean().optional(),
+	reasoning_hash: z.string().optional(),
+});
+
+// --- Outcome ---
+
+const stateChangeSchema = z.object({
+	before_hash: z.string(),
+	after_hash: z.string(),
+});
+
+const outcomeSchema = z.object({
+	status: outcomeStatusSchema,
+	error: z.string().optional(),
+	reversible: z.boolean().optional(),
+	reversal_method: z.string().optional(),
+	reversal_window_seconds: z.number().optional(),
+	state_change: stateChangeSchema.optional(),
+	response_hash: z.string().optional(),
+});
+
+// --- Authorization ---
+
+const authorizationSchema = z.object({
+	scopes: z.array(z.string()),
+	granted_at: z.string(),
+	expires_at: z.string().optional(),
+	grant_ref: z.string().optional(),
+});
+
+// --- Chain ---
+
+const chainSchema = z.object({
+	sequence: z.number(),
+	previous_receipt_hash: z.string().nullable(),
+	chain_id: z.string(),
+	// When present, MUST be true. Explicit false is not valid per the spec.
+	terminal: z.literal(true).optional(),
+});
+
+// --- Credential Subject ---
+
+const credentialSubjectSchema = z.object({
+	principal: principalSchema,
+	action: actionSchema,
+	intent: intentSchema.optional(),
+	outcome: outcomeSchema,
+	authorization: authorizationSchema.optional(),
+	chain: chainSchema,
+});
+
+// --- Proof ---
+
+const proofSchema = z.object({
+	type: z.string(),
+	created: z.string().optional(),
+	verificationMethod: z.string().optional(),
+	proofPurpose: z.string().optional(),
+	proofValue: z.string(),
+});
+
+// --- Agent Receipt ---
+
+export const agentReceiptSchema = z.object({
+	"@context": z.array(z.string()),
+	id: z.string(),
+	type: z.array(z.string()),
+	version: z.string(),
+	issuer: issuerSchema,
+	issuanceDate: z.string(),
+	credentialSubject: credentialSubjectSchema,
+	proof: proofSchema,
+});
+
+export type AgentReceiptSchema = z.infer<typeof agentReceiptSchema>;

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -205,6 +205,57 @@ describe("ReceiptStore", () => {
 			);
 		});
 
+		it("getById: preserves the original error as Error.cause", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:cause-json" });
+			store.insert(receipt, "sha256:cj1");
+			corruptJson("urn:receipt:cause-json", "not-json{{");
+
+			let caught: unknown;
+			try {
+				store.getById("urn:receipt:cause-json");
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(Error);
+			expect((caught as Error).cause).toBeInstanceOf(SyntaxError);
+		});
+
+		it("getById: preserves ZodError as Error.cause on schema failure", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:cause-zod" });
+			store.insert(receipt, "sha256:cz1");
+			const corrupt = JSON.parse(JSON.stringify(receipt)) as Record<
+				string,
+				unknown
+			>;
+			(corrupt.credentialSubject as Record<string, unknown>) = {};
+			corruptJson("urn:receipt:cause-zod", JSON.stringify(corrupt));
+
+			let caught: unknown;
+			try {
+				store.getById("urn:receipt:cause-zod");
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(Error);
+			// ZodError extends Error and carries .issues
+			const cause = (caught as Error).cause as
+				| { issues?: unknown[] }
+				| undefined;
+			expect(cause).toBeDefined();
+			expect(Array.isArray(cause?.issues)).toBe(true);
+		});
+
+		it("getById: renders (root) for root-shape failures", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:root-shape" });
+			store.insert(receipt, "sha256:rs1");
+			// Replace the row with a JSON primitive so the schema fails at the root.
+			corruptJson("urn:receipt:root-shape", "42");
+
+			expect(() => store.getById("urn:receipt:root-shape")).toThrowError(
+				/\(root\):/,
+			);
+		});
+
 		it("getById: throws with field path on missing required field", () => {
 			const receipt = makeReceipt({ id: "urn:receipt:corrupt-2" });
 			store.insert(receipt, "sha256:c2");

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -179,6 +179,104 @@ describe("ReceiptStore", () => {
 		});
 	});
 
+	describe("corrupt receipt validation", () => {
+		/**
+		 * Helper to directly update the receipt_json for a stored row, bypassing
+		 * the ReceiptStore API. Reaches into the private `db` field so we can
+		 * inject corrupt payloads without needing a file-backed database.
+		 */
+		function corruptJson(id: string, payload: string): void {
+			(store as unknown as { db: DatabaseSync }).db
+				.prepare("UPDATE receipts SET receipt_json = ? WHERE id = ?")
+				.run(payload, id);
+		}
+
+		it("getById: throws on non-JSON garbage", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:corrupt-1" });
+			store.insert(receipt, "sha256:c1");
+			corruptJson("urn:receipt:corrupt-1", "not-json{{");
+
+			expect(() => store.getById("urn:receipt:corrupt-1")).toThrowError(
+				/Corrupt receipt in store \(id=urn:receipt:corrupt-1\)/,
+			);
+		});
+
+		it("getById: throws with field path on missing required field", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:corrupt-2" });
+			store.insert(receipt, "sha256:c2");
+			// Remove chain_id from credentialSubject.chain
+			const corrupt = JSON.parse(JSON.stringify(receipt)) as Record<
+				string,
+				unknown
+			>;
+			const cs = corrupt.credentialSubject as Record<string, unknown>;
+			const chain = cs.chain as Record<string, unknown>;
+			delete chain.chain_id;
+			corruptJson("urn:receipt:corrupt-2", JSON.stringify(corrupt));
+
+			expect(() => store.getById("urn:receipt:corrupt-2")).toThrowError(
+				/credentialSubject\.chain\.chain_id/,
+			);
+		});
+
+		it("getById: throws with field path on invalid enum value", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:corrupt-3" });
+			store.insert(receipt, "sha256:c3");
+			const corrupt = JSON.parse(JSON.stringify(receipt)) as Record<
+				string,
+				unknown
+			>;
+			const cs = corrupt.credentialSubject as Record<string, unknown>;
+			const action = cs.action as Record<string, unknown>;
+			action.risk_level = "extreme";
+			corruptJson("urn:receipt:corrupt-3", JSON.stringify(corrupt));
+
+			expect(() => store.getById("urn:receipt:corrupt-3")).toThrowError(
+				/credentialSubject\.action\.risk_level/,
+			);
+		});
+
+		it("getById: throws when chain.terminal is false (spec invariant)", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:corrupt-4" });
+			store.insert(receipt, "sha256:c4");
+			const corrupt = JSON.parse(JSON.stringify(receipt)) as Record<
+				string,
+				unknown
+			>;
+			const cs = corrupt.credentialSubject as Record<string, unknown>;
+			const chain = cs.chain as Record<string, unknown>;
+			chain.terminal = false;
+			corruptJson("urn:receipt:corrupt-4", JSON.stringify(corrupt));
+
+			expect(() => store.getById("urn:receipt:corrupt-4")).toThrowError(
+				/Corrupt receipt in store \(id=urn:receipt:corrupt-4\)/,
+			);
+		});
+
+		it("getChain: throws with chain context on corrupt row", () => {
+			const receipt = makeReceipt({
+				id: "urn:receipt:corrupt-chain-1",
+				chainId: "chain_corrupt",
+			});
+			store.insert(receipt, "sha256:cc1");
+			corruptJson("urn:receipt:corrupt-chain-1", "!!!bad json");
+
+			expect(() => store.getChain("chain_corrupt")).toThrowError(
+				/Corrupt receipt in store \(chain=chain_corrupt\)/,
+			);
+		});
+
+		it("query: throws with query context on corrupt row", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:corrupt-query-1" });
+			store.insert(receipt, "sha256:cq1");
+			corruptJson("urn:receipt:corrupt-query-1", "!!!bad json");
+
+			expect(() => store.query({})).toThrowError(
+				/Corrupt receipt in store \(query\)/,
+			);
+		});
+	});
+
 	describe("tool_name", () => {
 		it("persists tool_name from receipt action", () => {
 			const receipt = makeReceipt({});

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -182,11 +182,15 @@ describe("ReceiptStore", () => {
 	describe("corrupt receipt validation", () => {
 		/**
 		 * Helper to directly update the receipt_json for a stored row, bypassing
-		 * the ReceiptStore API. Reaches into the private `db` field so we can
-		 * inject corrupt payloads without needing a file-backed database.
+		 * the ReceiptStore API. Uses @ts-expect-error so a future rename of the
+		 * private db field surfaces here at compile time.
 		 */
+		function rawDb(): DatabaseSync {
+			// @ts-expect-error reaches into the private db field for test injection
+			return store.db;
+		}
 		function corruptJson(id: string, payload: string): void {
-			(store as unknown as { db: DatabaseSync }).db
+			rawDb()
 				.prepare("UPDATE receipts SET receipt_json = ? WHERE id = ?")
 				.run(payload, id);
 		}
@@ -274,6 +278,34 @@ describe("ReceiptStore", () => {
 			expect(() => store.query({})).toThrowError(
 				/Corrupt receipt in store \(query\)/,
 			);
+		});
+
+		// Guards the forward-compat property documented in ADR-0011 and
+		// schema.ts: receipts written by a newer SDK with extra unknown fields
+		// must round-trip through the store unchanged. Stripping those fields
+		// would silently invalidate the RFC 8785 hash on signed receipts.
+		it("preserves unknown extra fields written by a newer SDK", () => {
+			const receipt = makeReceipt({ id: "urn:receipt:forward-compat" });
+			store.insert(receipt, "sha256:fc1");
+
+			const extended = JSON.parse(JSON.stringify(receipt)) as Record<
+				string,
+				unknown
+			>;
+			extended.future_top_level = "added in a later spec version";
+			const cs = extended.credentialSubject as Record<string, unknown>;
+			const action = cs.action as Record<string, unknown>;
+			action.future_action_field = { nested: 42 };
+			corruptJson("urn:receipt:forward-compat", JSON.stringify(extended));
+
+			const loaded = store.getById("urn:receipt:forward-compat") as Record<
+				string,
+				unknown
+			>;
+			expect(loaded.future_top_level).toBe("added in a later spec version");
+			const loadedAction = (loaded.credentialSubject as Record<string, unknown>)
+				.action as Record<string, unknown>;
+			expect(loadedAction.future_action_field).toEqual({ nested: 42 });
 		});
 	});
 

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -1,4 +1,6 @@
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { ZodError } from "zod";
+import { agentReceiptSchema } from "../receipt/schema.js";
 import type {
 	AgentReceipt,
 	OutcomeStatus,
@@ -66,10 +68,22 @@ const DEFAULT_QUERY_LIMIT = 10000;
  * Parse a receipt JSON string from the store, with error context.
  */
 function parseReceiptJson(json: string, context: string): AgentReceipt {
+	let parsed: unknown;
 	try {
-		return JSON.parse(json) as AgentReceipt;
+		parsed = JSON.parse(json);
 	} catch (cause) {
 		throw new Error(`Corrupt receipt in store (${context}): ${cause}`);
+	}
+	try {
+		return agentReceiptSchema.parse(parsed) as AgentReceipt;
+	} catch (cause) {
+		if (cause instanceof ZodError) {
+			const fields = cause.issues
+				.map((i) => `${i.path.join(".")}: ${i.message}`)
+				.join("; ");
+			throw new Error(`Corrupt receipt in store (${context}): ${fields}`);
+		}
+		throw cause;
 	}
 }
 

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -72,16 +72,23 @@ function parseReceiptJson(json: string, context: string): AgentReceipt {
 	try {
 		parsed = JSON.parse(json);
 	} catch (cause) {
-		throw new Error(`Corrupt receipt in store (${context}): ${cause}`);
+		throw new Error(`Corrupt receipt in store (${context}): ${cause}`, {
+			cause,
+		});
 	}
 	try {
 		return agentReceiptSchema.parse(parsed);
 	} catch (cause) {
 		if (cause instanceof ZodError) {
 			const fields = cause.issues
-				.map((i) => `${i.path.join(".")}: ${i.message}`)
+				.map((i) => {
+					const path = i.path.length === 0 ? "(root)" : i.path.join(".");
+					return `${path}: ${i.message}`;
+				})
 				.join("; ");
-			throw new Error(`Corrupt receipt in store (${context}): ${fields}`);
+			throw new Error(`Corrupt receipt in store (${context}): ${fields}`, {
+				cause,
+			});
 		}
 		throw cause;
 	}

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -75,7 +75,7 @@ function parseReceiptJson(json: string, context: string): AgentReceipt {
 		throw new Error(`Corrupt receipt in store (${context}): ${cause}`);
 	}
 	try {
-		return agentReceiptSchema.parse(parsed) as AgentReceipt;
+		return agentReceiptSchema.parse(parsed);
 	} catch (cause) {
 		if (cause instanceof ZodError) {
 			const fields = cause.issues


### PR DESCRIPTION
Closes #170.

## Summary

- `parseReceiptJson` now validates every receipt loaded from SQLite against a Zod schema mirroring the `AgentReceipt` interface, instead of relying on a compile-time-only `as AgentReceipt` cast that silently passed corrupt rows through to chain/signature verification.
- Errors keep the existing `Corrupt receipt in store (<context>)` shape and now include the offending field path (e.g. `credentialSubject.chain.chain_id: Required`).
- Brings TS on-load validation past Go's level (typed `json.Unmarshal`) toward Python's Pydantic level. Scope is store-load only; create/sign/verify validation is explicitly deferred per the issue.

## New runtime dependency: `zod`

This is the SDK's first runtime dependency. Rationale captured in [ADR-0011](docs/adr/0011-zod-for-runtime-validation.md):

- **Hand-written validator** — drifts from `types.ts`, no compile-time guarantee they stay in sync.
- **ajv + JSON Schema** — heavier dep; JSON Schema and TS types have different evolution cadences.
- **Zod** — schemas live next to TS types; `z.infer` aligns the two at compile time; ecosystem standard.

Adds ~50 KB to install size; tree-shaking applies for bundled consumers.

## Notable design choices

- Schemas are **not** `.strict()` — unknown extra fields written by a newer SDK do not break older readers.
- `chain.terminal` is `z.literal(true).optional()` so a stored `false` value (spec-invalid per [types.ts:124-126](sdk/ts/src/receipt/types.ts:124)) is rejected at load time.
- `version` stays `z.string()` (not an enum) so older receipts still load.
- The existing `AgentReceipt` interface is unchanged; the schema's inferred type is structurally compatible but separate, to avoid churning callers.

## Files

- `sdk/ts/package.json` — add `zod` to `dependencies`.
- `sdk/ts/src/receipt/schema.ts` — new Zod schema mirroring `types.ts`.
- `sdk/ts/src/store/store.ts` — `parseReceiptJson` now runs `agentReceiptSchema.parse` after `JSON.parse` and re-throws `ZodError` with field paths in the existing message format.
- `sdk/ts/src/store/store.test.ts` — 6 new tests across all three caller paths.
- `docs/adr/0011-zod-for-runtime-validation.md` — new ADR.

## Test plan

- [x] `pnpm test` — 183 tests pass (was 177; +6 new).
- [x] `pnpm build` — `tsc` clean.
- [x] `pnpm exec biome check src` — clean.
- [x] New tests cover: non-JSON garbage, missing required field, invalid enum, `chain.terminal: false`, plus per-caller coverage for `getById`, `getChain`, and `query`.