### PR TITLE
feat(mcp-proxy): enforce restrictive file permissions on signing keys

### DIFF
--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -89,9 +89,40 @@ Add to `claude_desktop_config.json`:
 mcp-proxy -version
 ```
 
+### Persistent signing key
+
+By default, mcp-proxy generates an ephemeral key pair on each startup. To use a
+persistent key whose receipts can be verified offline, generate one with `init`:
+
+```sh
+mcp-proxy init -key ~/.agent-receipts/signing.pem
+# writes ~/.agent-receipts/signing.pem     (0600 — owner read/write only)
+# writes ~/.agent-receipts/signing.pem.pub (0644 — public, shareable)
+```
+
+Pass the key to the proxy:
+
+```sh
+mcp-proxy --key ~/.agent-receipts/signing.pem node /path/to/mcp-server.js
+```
+
+Enable strict permission enforcement to make loose file permissions a fatal error:
+
+```sh
+mcp-proxy --key ~/.agent-receipts/signing.pem --strict-permissions node /path/to/mcp-server.js
+```
+
+If you generated a key with another tool (e.g. `openssl genpkey`), restrict
+access manually before use:
+
+```sh
+chmod 600 private.pem
+```
+
 ### CLI subcommands
 
 ```sh
+mcp-proxy init -key <path>              # Generate a persistent Ed25519 key pair
 mcp-proxy list                          # Latest 50 receipts, newest first
 mcp-proxy list --risk high              # Filter by risk
 mcp-proxy inspect <receipt-id>          # Show receipt details

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -667,32 +668,76 @@ func truncate(s string, max int) string {
 }
 
 // writePrivateKeyFile writes data to path with 0600 permissions. When force is
-// false the call fails if the file already exists. When force is true the
-// existing file is removed first so that O_EXCL creates a fresh inode — this
-// ensures the kernel sets the permissions atomically without a chmod race.
-func writePrivateKeyFile(path string, data []byte, force bool) (retErr error) {
+// false the call fails atomically if the file already exists (O_EXCL). When
+// force is true the key is written to a temp file first then renamed into place
+// so the previous key remains intact if the write fails.
+func writePrivateKeyFile(path string, data []byte, force bool) error {
 	if force {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove existing key file %q: %w", path, err)
+		// Write-then-rename: old key survives intact until the new one is safely on disk.
+		dir := filepath.Dir(path)
+		tmp, err := os.CreateTemp(dir, ".key-*.tmp")
+		if err != nil {
+			return fmt.Errorf("create temp key file in %q: %w", dir, err)
 		}
+		tmpName := tmp.Name()
+		if _, werr := tmp.Write(data); werr != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			return fmt.Errorf("write temp key file: %w", werr)
+		}
+		if cerr := tmp.Close(); cerr != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("close temp key file: %w", cerr)
+		}
+		if rerr := os.Rename(tmpName, path); rerr != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("rename key file to %q: %w", path, rerr)
+		}
+		return nil
 	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		if !force && os.IsExist(err) {
+		if os.IsExist(err) {
 			return fmt.Errorf("key file %q already exists (use -force to overwrite)", path)
 		}
 		return fmt.Errorf("create key file %q: %w", path, err)
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("close key file %q: %w", path, cerr)
+	if _, werr := f.Write(data); werr != nil {
+		f.Close()
+		os.Remove(path)
+		return fmt.Errorf("write key file %q: %w", path, werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		os.Remove(path)
+		return fmt.Errorf("close key file %q: %w", path, cerr)
+	}
+	return nil
+}
+
+// writePubKeyFile writes data to path with 0644 permissions. When force is false
+// the call fails if the file already exists. When force is true the existing file
+// is removed first so a fresh inode is created with the correct 0644 mode.
+func writePubKeyFile(path string, data []byte, force bool) error {
+	if force {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing public key %q: %w", path, err)
 		}
-		if retErr != nil {
-			os.Remove(path) // best-effort: remove partial file on any failure
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("public key file %q already exists (use -force to overwrite)", path)
 		}
-	}()
-	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("write key file %q: %w", path, err)
+		return fmt.Errorf("create public key file %q: %w", path, err)
+	}
+	if _, werr := f.Write(data); werr != nil {
+		f.Close()
+		os.Remove(path)
+		return fmt.Errorf("write public key file %q: %w", path, werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		os.Remove(path)
+		return fmt.Errorf("close public key file %q: %w", path, cerr)
 	}
 	return nil
 }
@@ -753,7 +798,7 @@ func cmdInit(args []string) {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write private key: %v\n", err)
 		os.Exit(1)
 	}
-	if err := os.WriteFile(resolvedPub, []byte(kp.PublicKey), 0o644); err != nil {
+	if err := writePubKeyFile(resolvedPub, []byte(kp.PublicKey), *force); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write public key: %v\n", err)
 		os.Exit(1)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -687,6 +687,9 @@ func writePrivateKeyFile(path string, data []byte, force bool) (retErr error) {
 		if cerr := f.Close(); cerr != nil && retErr == nil {
 			retErr = fmt.Errorf("close key file %q: %w", path, cerr)
 		}
+		if retErr != nil {
+			os.Remove(path) // best-effort: remove partial file on any failure
+		}
 	}()
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("write key file %q: %w", path, err)
@@ -719,17 +722,29 @@ func cmdInit(args []string) {
 		resolvedPub = *keyPath + ".pub"
 	}
 
+	// Preflight: check for existing files before generating or writing anything.
+	if !*force {
+		if _, err := os.Stat(*keyPath); err == nil {
+			fmt.Fprintf(os.Stderr, "mcp-proxy: key file %q already exists (use -force to overwrite)\n", *keyPath)
+			os.Exit(1)
+		}
+		if _, err := os.Stat(resolvedPub); err == nil {
+			fmt.Fprintf(os.Stderr, "mcp-proxy: public key file %q already exists (use -force to overwrite)\n", resolvedPub)
+			os.Exit(1)
+		}
+	}
+
 	kp, err := receipt.GenerateKeyPair()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: generate key: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := ensureDBDir(*keyPath); err != nil {
+	if err := ensureDir(*keyPath); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: create key directory: %v\n", err)
 		os.Exit(1)
 	}
-	if err := ensureDBDir(resolvedPub); err != nil {
+	if err := ensureDir(resolvedPub); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: create public key directory: %v\n", err)
 		os.Exit(1)
 	}
@@ -737,13 +752,6 @@ func cmdInit(args []string) {
 	if err := writePrivateKeyFile(*keyPath, []byte(kp.PrivateKey), *force); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write private key: %v\n", err)
 		os.Exit(1)
-	}
-
-	if !*force {
-		if _, err := os.Stat(resolvedPub); err == nil {
-			fmt.Fprintf(os.Stderr, "mcp-proxy: public key file %q already exists (use -force to overwrite)\n", resolvedPub)
-			os.Exit(1)
-		}
 	}
 	if err := os.WriteFile(resolvedPub, []byte(kp.PublicKey), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write public key: %v\n", err)

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -670,7 +670,7 @@ func truncate(s string, max int) string {
 // false the call fails if the file already exists. When force is true the
 // existing file is removed first so that O_EXCL creates a fresh inode — this
 // ensures the kernel sets the permissions atomically without a chmod race.
-func writePrivateKeyFile(path string, data []byte, force bool) error {
+func writePrivateKeyFile(path string, data []byte, force bool) (retErr error) {
 	if force {
 		os.Remove(path) // best-effort; ignore error so O_EXCL below handles the fresh-create
 	}
@@ -681,9 +681,13 @@ func writePrivateKeyFile(path string, data []byte, force bool) error {
 		}
 		return err
 	}
-	defer f.Close()
-	_, err = f.Write(data)
-	return err
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+	_, retErr = f.Write(data)
+	return retErr
 }
 
 func cmdInit(args []string) {

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -672,22 +672,26 @@ func truncate(s string, max int) string {
 // ensures the kernel sets the permissions atomically without a chmod race.
 func writePrivateKeyFile(path string, data []byte, force bool) (retErr error) {
 	if force {
-		os.Remove(path) // best-effort; ignore error so O_EXCL below handles the fresh-create
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing key file %q: %w", path, err)
+		}
 	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		if !force && os.IsExist(err) {
 			return fmt.Errorf("key file %q already exists (use -force to overwrite)", path)
 		}
-		return err
+		return fmt.Errorf("create key file %q: %w", path, err)
 	}
 	defer func() {
 		if cerr := f.Close(); cerr != nil && retErr == nil {
-			retErr = cerr
+			retErr = fmt.Errorf("close key file %q: %w", path, cerr)
 		}
 	}()
-	_, retErr = f.Write(data)
-	return retErr
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write key file %q: %w", path, err)
+	}
+	return nil
 }
 
 func cmdInit(args []string) {
@@ -725,12 +729,22 @@ func cmdInit(args []string) {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: create key directory: %v\n", err)
 		os.Exit(1)
 	}
+	if err := ensureDBDir(resolvedPub); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy: create public key directory: %v\n", err)
+		os.Exit(1)
+	}
 
 	if err := writePrivateKeyFile(*keyPath, []byte(kp.PrivateKey), *force); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write private key: %v\n", err)
 		os.Exit(1)
 	}
 
+	if !*force {
+		if _, err := os.Stat(resolvedPub); err == nil {
+			fmt.Fprintf(os.Stderr, "mcp-proxy: public key file %q already exists (use -force to overwrite)\n", resolvedPub)
+			os.Exit(1)
+		}
+	}
 	if err := os.WriteFile(resolvedPub, []byte(kp.PublicKey), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy: write public key: %v\n", err)
 		os.Exit(1)

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -665,3 +665,72 @@ func truncate(s string, max int) string {
 	}
 	return s[:max-3] + "..."
 }
+
+// writePrivateKeyFile writes data to path with 0600 permissions. When force is
+// false the call fails if the file already exists. When force is true the
+// existing file is removed first so that O_EXCL creates a fresh inode — this
+// ensures the kernel sets the permissions atomically without a chmod race.
+func writePrivateKeyFile(path string, data []byte, force bool) error {
+	if force {
+		os.Remove(path) // best-effort; ignore error so O_EXCL below handles the fresh-create
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if !force && os.IsExist(err) {
+			return fmt.Errorf("key file %q already exists (use -force to overwrite)", path)
+		}
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+func cmdInit(args []string) {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	keyPath := fs.String("key", "", "Path for the Ed25519 private key PEM file (required)")
+	pubPath := fs.String("pub", "", "Path for the public key PEM file (default: <key>.pub)")
+	force := fs.Bool("force", false, "Overwrite existing key files")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy init -key <path> [-pub <path>] [-force]\n\n")
+		fmt.Fprintf(os.Stderr, "  Generate an Ed25519 signing key pair. The private key is written with\n")
+		fmt.Fprintf(os.Stderr, "  0600 permissions (owner read/write only). Pass -key to mcp-proxy serve\n")
+		fmt.Fprintf(os.Stderr, "  to use it.\n\n")
+		fs.PrintDefaults()
+	}
+	fs.Parse(args)
+
+	if *keyPath == "" {
+		fmt.Fprintln(os.Stderr, "mcp-proxy init: -key is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	resolvedPub := *pubPath
+	if resolvedPub == "" {
+		resolvedPub = *keyPath + ".pub"
+	}
+
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy: generate key: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := ensureDBDir(*keyPath); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy: create key directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writePrivateKeyFile(*keyPath, []byte(kp.PrivateKey), *force); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy: write private key: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(resolvedPub, []byte(kp.PublicKey), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy: write public key: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "Generated Ed25519 key pair:\n  private: %s\n  public:  %s\n", *keyPath, resolvedPub)
+}

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -681,13 +682,18 @@ func writePrivateKeyFile(path string, data []byte, force bool) error {
 		}
 		tmpName := tmp.Name()
 		if _, werr := tmp.Write(data); werr != nil {
-			tmp.Close()
+			cerr := tmp.Close()
 			os.Remove(tmpName)
-			return fmt.Errorf("write temp key file: %w", werr)
+			return fmt.Errorf("write temp key file: %w", errors.Join(werr, cerr))
 		}
 		if cerr := tmp.Close(); cerr != nil {
 			os.Remove(tmpName)
 			return fmt.Errorf("close temp key file: %w", cerr)
+		}
+		// Explicit chmod guarantees 0600 regardless of process umask.
+		if chErr := os.Chmod(tmpName, 0o600); chErr != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("set permissions on key file %q: %w", path, chErr)
 		}
 		if rerr := os.Rename(tmpName, path); rerr != nil {
 			os.Remove(tmpName)
@@ -703,13 +709,18 @@ func writePrivateKeyFile(path string, data []byte, force bool) error {
 		return fmt.Errorf("create key file %q: %w", path, err)
 	}
 	if _, werr := f.Write(data); werr != nil {
-		f.Close()
+		cerr := f.Close()
 		os.Remove(path)
-		return fmt.Errorf("write key file %q: %w", path, werr)
+		return fmt.Errorf("write key file %q: %w", path, errors.Join(werr, cerr))
 	}
 	if cerr := f.Close(); cerr != nil {
 		os.Remove(path)
 		return fmt.Errorf("close key file %q: %w", path, cerr)
+	}
+	// Explicit chmod guarantees 0600 regardless of process umask.
+	if chErr := os.Chmod(path, 0o600); chErr != nil {
+		os.Remove(path)
+		return fmt.Errorf("set permissions on key file %q: %w", path, chErr)
 	}
 	return nil
 }
@@ -731,13 +742,18 @@ func writePubKeyFile(path string, data []byte, force bool) error {
 		return fmt.Errorf("create public key file %q: %w", path, err)
 	}
 	if _, werr := f.Write(data); werr != nil {
-		f.Close()
+		cerr := f.Close()
 		os.Remove(path)
-		return fmt.Errorf("write public key file %q: %w", path, werr)
+		return fmt.Errorf("write public key file %q: %w", path, errors.Join(werr, cerr))
 	}
 	if cerr := f.Close(); cerr != nil {
 		os.Remove(path)
 		return fmt.Errorf("close public key file %q: %w", path, cerr)
+	}
+	// Explicit chmod guarantees 0644 regardless of process umask.
+	if chErr := os.Chmod(path, 0o644); chErr != nil {
+		os.Remove(path)
+		return fmt.Errorf("set permissions on public key file %q: %w", path, chErr)
 	}
 	return nil
 }

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -395,7 +395,7 @@ func TestWritePrivateKeyFileOverwritesWithForce(t *testing.T) {
 }
 
 func TestWritePrivateKeyFileFailsWhenParentDirectoryMissing(t *testing.T) {
-	// cmdInit calls ensureDBDir before writePrivateKeyFile; this test confirms
+	// cmdInit calls ensureDir before writePrivateKeyFile; this test confirms
 	// writePrivateKeyFile itself returns an error if the directory is absent.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "key.pem")
@@ -403,5 +403,83 @@ func TestWritePrivateKeyFileFailsWhenParentDirectoryMissing(t *testing.T) {
 	err := writePrivateKeyFile(path, []byte("pem"), false)
 	if err == nil {
 		t.Fatal("expected error when parent directory does not exist")
+	}
+}
+
+func TestWritePubKeyFileCreatesWithCorrectPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem.pub")
+
+	if err := writePubKeyFile(path, []byte("pub-data"), false); err != nil {
+		t.Fatalf("writePubKeyFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o444 != 0o444 {
+		t.Errorf("permissions = %04o, want owner+group+world read (0644)", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "pub-data" {
+		t.Errorf("content = %q, want %q", data, "pub-data")
+	}
+}
+
+func TestWritePubKeyFileFailsIfExistsWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem.pub")
+
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	err := writePubKeyFile(path, []byte("new"), false)
+	if err == nil {
+		t.Fatal("expected error when file exists and force=false, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got %q", err.Error())
+	}
+}
+
+func TestWritePubKeyFileOverwritesWithForce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem.pub")
+
+	// Existing file with restrictive permissions — force should fix them to 0644.
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := writePubKeyFile(path, []byte("new"), true); err != nil {
+		t.Fatalf("writePubKeyFile with force: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o444 != 0o444 {
+		t.Errorf("permissions after force overwrite = %04o, want at least 0444", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("content after force = %q, want %q", data, "new")
 	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -326,8 +326,10 @@ func TestWritePrivateKeyFileCreatesWithCorrectPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("permissions = %04o, want 0600", perm)
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("permissions = %04o, want no group/world access", perm)
+	} else if perm&0o600 != 0o600 {
+		t.Errorf("permissions = %04o, want owner read/write", perm)
 	}
 
 	data, err := os.ReadFile(path)
@@ -377,19 +379,24 @@ func TestWritePrivateKeyFileOverwritesWithForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("permissions after force overwrite = %04o, want 0600", perm)
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("permissions after force overwrite = %04o, want no group/world access", perm)
+	} else if perm&0o600 != 0o600 {
+		t.Errorf("permissions after force overwrite = %04o, want owner read/write", perm)
 	}
 
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
 	if string(data) != "new" {
 		t.Errorf("content after force = %q, want %q", data, "new")
 	}
 }
 
-func TestWritePrivateKeyFileCreatesParentViaEnsureDBDir(t *testing.T) {
+func TestWritePrivateKeyFileFailsWhenParentDirectoryMissing(t *testing.T) {
 	// cmdInit calls ensureDBDir before writePrivateKeyFile; this test confirms
-	// writePrivateKeyFile itself fails gracefully if the directory is absent.
+	// writePrivateKeyFile itself returns an error if the directory is absent.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "key.pem")
 

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -306,4 +309,92 @@ func TestRunFollowLoopHonoursFilters(t *testing.T) {
 		t.Fatalf("follow loop returned error: %v", err)
 	}
 	t.Fatalf("chain-a receipt never appeared in follow output: %q", w.String())
+}
+
+func TestWritePrivateKeyFileCreatesWithCorrectPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+
+	if err := writePrivateKeyFile(path, []byte("pem-data"), false); err != nil {
+		t.Fatalf("writePrivateKeyFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("permissions = %04o, want 0600", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "pem-data" {
+		t.Errorf("content = %q, want %q", data, "pem-data")
+	}
+}
+
+func TestWritePrivateKeyFileFailsIfExistsWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+
+	// Create the file first.
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	err := writePrivateKeyFile(path, []byte("new"), false)
+	if err == nil {
+		t.Fatal("expected error when file exists and force=false, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got %q", err.Error())
+	}
+}
+
+func TestWritePrivateKeyFileOverwritesWithForce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+
+	// Create an existing file with loose permissions to simulate the bad case.
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := writePrivateKeyFile(path, []byte("new"), true); err != nil {
+		t.Fatalf("writePrivateKeyFile with force: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("permissions after force overwrite = %04o, want 0600", perm)
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) != "new" {
+		t.Errorf("content after force = %q, want %q", data, "new")
+	}
+}
+
+func TestWritePrivateKeyFileCreatesParentViaEnsureDBDir(t *testing.T) {
+	// cmdInit calls ensureDBDir before writePrivateKeyFile; this test confirms
+	// writePrivateKeyFile itself fails gracefully if the directory is absent.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "key.pem")
+
+	err := writePrivateKeyFile(path, []byte("pem"), false)
+	if err == nil {
+		t.Fatal("expected error when parent directory does not exist")
+	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -69,6 +70,9 @@ func main() {
 		case "doctor":
 			cmdDoctor(os.Args[2:])
 			return
+		case "init":
+			cmdInit(os.Args[2:])
+			return
 		case "serve":
 			os.Args = append(os.Args[:1], os.Args[2:]...)
 			// Fall through to serve.
@@ -80,27 +84,28 @@ func main() {
 
 func serve() {
 	var (
-		dbPath          = flag.String("db", defaultDBPath("audit.db"), "SQLite audit database path")
-		receiptDB       = flag.String("receipt-db", defaultDBPath("receipts.db"), "SQLite receipt store path")
-		keyPath         = flag.String("key", "", "Ed25519 private key (PEM file)")
-		taxonomyPath    = flag.String("taxonomy", "", "Taxonomy mappings (JSON file). Merged with bundled taxonomies; user mappings win on conflict.")
-		bundledTaxonomy = flag.Bool("bundled-taxonomies", true, "Include bundled taxonomies (e.g. GitHub, Atlassian). Set to false to use only -taxonomy.")
-		rulesPath       = flag.String("rules", "", "Policy rules (YAML file)")
-		serverName      = flag.String("name", "", "Server name for audit trail")
-		issuerDID       = flag.String("issuer", "did:agent:mcp-proxy", "Issuer DID")
-		issuerName      = flag.String("issuer-name", "", "Issuer name (e.g. Claude Code, Codex)")
-		issuerModel     = flag.String("issuer-model", "", "AI model identifier (e.g. claude-sonnet-4-6)")
-		operatorID      = flag.String("operator-id", "", "Operator DID (organisation running the agent)")
-		operatorName    = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
-		principalDID    = flag.String("principal", "did:user:unknown", "Principal DID")
-		chainID         = flag.String("chain", "", "Chain ID (auto-generated if empty)")
-		httpAddr        = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
-		approvalWait    = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
+		dbPath            = flag.String("db", defaultDBPath("audit.db"), "SQLite audit database path")
+		receiptDB         = flag.String("receipt-db", defaultDBPath("receipts.db"), "SQLite receipt store path")
+		keyPath           = flag.String("key", "", "Ed25519 private key (PEM file)")
+		taxonomyPath      = flag.String("taxonomy", "", "Taxonomy mappings (JSON file). Merged with bundled taxonomies; user mappings win on conflict.")
+		bundledTaxonomy   = flag.Bool("bundled-taxonomies", true, "Include bundled taxonomies (e.g. GitHub, Atlassian). Set to false to use only -taxonomy.")
+		rulesPath         = flag.String("rules", "", "Policy rules (YAML file)")
+		serverName        = flag.String("name", "", "Server name for audit trail")
+		issuerDID         = flag.String("issuer", "did:agent:mcp-proxy", "Issuer DID")
+		issuerName        = flag.String("issuer-name", "", "Issuer name (e.g. Claude Code, Codex)")
+		issuerModel       = flag.String("issuer-model", "", "AI model identifier (e.g. claude-sonnet-4-6)")
+		operatorID        = flag.String("operator-id", "", "Operator DID (organisation running the agent)")
+		operatorName      = flag.String("operator-name", "", "Operator name (e.g. Anthropic)")
+		principalDID      = flag.String("principal", "did:user:unknown", "Principal DID")
+		chainID           = flag.String("chain", "", "Chain ID (auto-generated if empty)")
+		httpAddr          = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
+		approvalWait      = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
+		strictPermissions = flag.Bool("strict-permissions", false, "Fatal error if the private key file has permissions wider than 0600 (group/world-accessible)")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
 		fmt.Fprintf(os.Stderr, "  Wraps an MCP server with audit, receipts, and policy enforcement.\n\n")
-		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing, doctor\n\n")
+		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing, doctor, init\n\n")
 		fmt.Fprintf(os.Stderr, "  -version\n\tPrint version and exit\n")
 		flag.PrintDefaults()
 	}
@@ -165,6 +170,12 @@ func serve() {
 	// Load or generate key pair.
 	var kp receipt.KeyPair
 	if *keyPath != "" {
+		if warn := checkKeyFilePermissions(*keyPath); warn != "" {
+			if *strictPermissions {
+				log.Fatalf("mcp-proxy: insecure key permissions: %s", warn)
+			}
+			log.Printf("[WARN] mcp-proxy: %s", warn)
+		}
 		privPEM, err := os.ReadFile(*keyPath)
 		if err != nil {
 			log.Fatalf("mcp-proxy: read key: %v", err)
@@ -879,6 +890,23 @@ func ensureDBDir(path string) error {
 		return fmt.Errorf("create database directory %q: %w", dir, err)
 	}
 	return nil
+}
+
+// checkKeyFilePermissions returns a non-empty warning string if the file at
+// path is readable or writable by users other than the owner (mode & 0o077 != 0).
+// Returns "" on Windows or when the file cannot be stat'd.
+func checkKeyFilePermissions(path string) string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Sprintf("key file %q has permissions %04o — run: chmod 600 %q", path, perm, path)
+	}
+	return ""
 }
 
 func generateToken(n int) string {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -903,23 +903,6 @@ func ensureDBDir(path string) error {
 	return nil
 }
 
-// checkKeyFilePermissions returns a non-empty warning string if the file at
-// path is readable or writable by users other than the owner (mode & 0o077 != 0).
-// Returns "" on Windows or when the file cannot be stat'd.
-func checkKeyFilePermissions(path string) string {
-	if runtime.GOOS == "windows" {
-		return ""
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return ""
-	}
-	if perm := info.Mode().Perm(); perm&0o077 != 0 {
-		return fmt.Sprintf("key file %q has permissions %04o — run: chmod 600 %q", path, perm, path)
-	}
-	return ""
-}
-
 // checkOpenFilePermissions is like checkKeyFilePermissions but operates on an
 // already-open file descriptor, eliminating the TOCTOU race between stat and
 // read. Returns "" on Windows or when f.Stat() fails.

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -170,13 +171,18 @@ func serve() {
 	// Load or generate key pair.
 	var kp receipt.KeyPair
 	if *keyPath != "" {
-		if warn := checkKeyFilePermissions(*keyPath); warn != "" {
+		f, err := os.Open(*keyPath)
+		if err != nil {
+			log.Fatalf("mcp-proxy: read key: %v", err)
+		}
+		defer f.Close()
+		if warn := checkOpenFilePermissions(f); warn != "" {
 			if *strictPermissions {
 				log.Fatalf("mcp-proxy: insecure key permissions: %s", warn)
 			}
 			log.Printf("[WARN] mcp-proxy: %s", warn)
 		}
-		privPEM, err := os.ReadFile(*keyPath)
+		privPEM, err := io.ReadAll(f)
 		if err != nil {
 			log.Fatalf("mcp-proxy: read key: %v", err)
 		}
@@ -879,15 +885,20 @@ func defaultDBPath(name string) string {
 	return filepath.Join(home, ".agent-receipts", name)
 }
 
-// ensureDBDir creates the parent directory of path with 0o700 permissions.
-// SQLite can create the database file itself but not the directory holding it.
-func ensureDBDir(path string) error {
+// ensureDir creates the parent directory of path at 0o700 permissions.
+func ensureDir(path string) error {
 	dir := filepath.Dir(path)
 	if dir == "" || dir == "." {
 		return nil
 	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create database directory %q: %w", dir, err)
+	return os.MkdirAll(dir, 0o700)
+}
+
+// ensureDBDir creates the parent directory of path with 0o700 permissions.
+// SQLite can create the database file itself but not the directory holding it.
+func ensureDBDir(path string) error {
+	if err := ensureDir(path); err != nil {
+		return fmt.Errorf("create database directory %q: %w", filepath.Dir(path), err)
 	}
 	return nil
 }
@@ -905,6 +916,23 @@ func checkKeyFilePermissions(path string) string {
 	}
 	if perm := info.Mode().Perm(); perm&0o077 != 0 {
 		return fmt.Sprintf("key file %q has permissions %04o — run: chmod 600 %q", path, perm, path)
+	}
+	return ""
+}
+
+// checkOpenFilePermissions is like checkKeyFilePermissions but operates on an
+// already-open file descriptor, eliminating the TOCTOU race between stat and
+// read. Returns "" on Windows or when f.Stat() fails.
+func checkOpenFilePermissions(f *os.File) string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Sprintf("key file %q has permissions %04o — run: chmod 600 %q", f.Name(), perm, f.Name())
 	}
 	return ""
 }

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -500,3 +500,70 @@ func TestCheckKeyFilePermissionsNonexistentNoWarning(t *testing.T) {
 		t.Errorf("expected no warning for unstat-able path, got %q", got)
 	}
 }
+
+func TestCheckOpenFilePermissions0600OK(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o600)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if got := checkOpenFilePermissions(f); got != "" {
+		t.Errorf("expected no warning for 0600, got %q", got)
+	}
+}
+
+func TestCheckOpenFilePermissions0400OK(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o400)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if got := checkOpenFilePermissions(f); got != "" {
+		t.Errorf("expected no warning for 0400, got %q", got)
+	}
+}
+
+func TestCheckOpenFilePermissions0644Warns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o644)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	got := checkOpenFilePermissions(f)
+	if got == "" {
+		t.Fatalf("expected warning for 0644, got empty string")
+	}
+	if !strings.Contains(got, path) {
+		t.Errorf("warning should contain path, got %q", got)
+	}
+	if !strings.Contains(got, "chmod 600") {
+		t.Errorf("warning should mention chmod 600, got %q", got)
+	}
+}
+
+func TestCheckOpenFilePermissions0666Warns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o666)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if got := checkOpenFilePermissions(f); got == "" {
+		t.Errorf("expected warning for 0666, got empty string")
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -443,64 +443,6 @@ func writeFileWithPerm(t *testing.T, dir string, perm os.FileMode) string {
 	return path
 }
 
-func TestCheckKeyFilePermissions0600OK(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits not enforced on Windows")
-	}
-	path := writeFileWithPerm(t, t.TempDir(), 0o600)
-	if got := checkKeyFilePermissions(path); got != "" {
-		t.Errorf("expected no warning for 0600, got %q", got)
-	}
-}
-
-func TestCheckKeyFilePermissions0400OK(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits not enforced on Windows")
-	}
-	path := writeFileWithPerm(t, t.TempDir(), 0o400)
-	if got := checkKeyFilePermissions(path); got != "" {
-		t.Errorf("expected no warning for 0400, got %q", got)
-	}
-}
-
-func TestCheckKeyFilePermissions0644Warns(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits not enforced on Windows")
-	}
-	path := writeFileWithPerm(t, t.TempDir(), 0o644)
-	got := checkKeyFilePermissions(path)
-	if got == "" {
-		t.Fatalf("expected warning for 0644, got empty string")
-	}
-	if !strings.Contains(got, path) {
-		t.Errorf("warning should contain path, got %q", got)
-	}
-	if !strings.Contains(got, "chmod 600") {
-		t.Errorf("warning should mention chmod 600, got %q", got)
-	}
-}
-
-func TestCheckKeyFilePermissions0666Warns(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits not enforced on Windows")
-	}
-	path := writeFileWithPerm(t, t.TempDir(), 0o666)
-	if got := checkKeyFilePermissions(path); got == "" {
-		t.Errorf("expected warning for 0666, got empty string")
-	}
-}
-
-func TestCheckKeyFilePermissionsNonexistentNoWarning(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits not enforced on Windows")
-	}
-	// Non-existent path under a temp dir: stat will fail and the error surfaces at ReadFile.
-	path := filepath.Join(t.TempDir(), "does-not-exist.pem")
-	if got := checkKeyFilePermissions(path); got != "" {
-		t.Errorf("expected no warning for unstat-able path, got %q", got)
-	}
-}
-
 func TestCheckOpenFilePermissions0600OK(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits not enforced on Windows")

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -430,3 +430,72 @@ func TestDiagnoseConfigUnreachableApproverIsUnhealthy(t *testing.T) {
 		t.Errorf("approver reach = %q, want unreachable", report.ApproverReach)
 	}
 }
+
+func writeFileWithPerm(t *testing.T, dir string, perm os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	return path
+}
+
+func TestCheckKeyFilePermissions0600OK(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o600)
+	if got := checkKeyFilePermissions(path); got != "" {
+		t.Errorf("expected no warning for 0600, got %q", got)
+	}
+}
+
+func TestCheckKeyFilePermissions0400OK(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o400)
+	if got := checkKeyFilePermissions(path); got != "" {
+		t.Errorf("expected no warning for 0400, got %q", got)
+	}
+}
+
+func TestCheckKeyFilePermissions0644Warns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o644)
+	got := checkKeyFilePermissions(path)
+	if got == "" {
+		t.Fatalf("expected warning for 0644, got empty string")
+	}
+	if !strings.Contains(got, path) {
+		t.Errorf("warning should contain path, got %q", got)
+	}
+	if !strings.Contains(got, "chmod 600") {
+		t.Errorf("warning should mention chmod 600, got %q", got)
+	}
+}
+
+func TestCheckKeyFilePermissions0666Warns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	path := writeFileWithPerm(t, t.TempDir(), 0o666)
+	if got := checkKeyFilePermissions(path); got == "" {
+		t.Errorf("expected warning for 0666, got empty string")
+	}
+}
+
+func TestCheckKeyFilePermissionsNonexistentNoWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	// Non-existent path: stat will fail and the error surfaces at ReadFile.
+	if got := checkKeyFilePermissions("/nonexistent/path/key.pem"); got != "" {
+		t.Errorf("expected no warning for unstat-able path, got %q", got)
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -494,8 +494,9 @@ func TestCheckKeyFilePermissionsNonexistentNoWarning(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits not enforced on Windows")
 	}
-	// Non-existent path: stat will fail and the error surfaces at ReadFile.
-	if got := checkKeyFilePermissions("/nonexistent/path/key.pem"); got != "" {
+	// Non-existent path under a temp dir: stat will fail and the error surfaces at ReadFile.
+	path := filepath.Join(t.TempDir(), "does-not-exist.pem")
+	if got := checkKeyFilePermissions(path); got != "" {
 		t.Errorf("expected no warning for unstat-able path, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #156.

The private signing key is the root of trust for the entire receipt chain, yet keys generated with external tools (e.g. `openssl genpkey`) are often written as 0644 by default, making them world-readable. This PR adds a three-layer defence:

- **`mcp-proxy init`** — new subcommand that generates an Ed25519 key pair and writes the private key with 0600 permissions using `O_CREATE|O_EXCL`, so the kernel sets the mode atomically (no chmod race). The public key lands alongside as `<key>.pub` (0644). Accepts `-pub` to override the public-key path and `-force` to overwrite an existing key.

- **Startup permission check** — when `-key` is supplied to `serve`, `checkKeyFilePermissions` stats the file before reading it. If group or world bits are set (`mode & 0o077 != 0`), a `[WARN]` is logged with the offending mode and a `chmod 600` remediation hint.

- **`--strict-permissions` flag** — promotes the warning to a fatal error, suitable for security-conscious deployments and CI pipelines.

## What changed

| File | Change |
|------|--------|
| `cmd/mcp-proxy/main.go` | `case "init":` dispatch; `--strict-permissions` flag; `checkKeyFilePermissions` helper; permission check in `serve()` before `os.ReadFile` |
| `cmd/mcp-proxy/cli.go` | `writePrivateKeyFile` helper; `cmdInit` function |
| `cmd/mcp-proxy/main_test.go` | 5 tests: 0600/0400 → ok, 0644/0666 → warn with path + `chmod 600`, non-existent → no warn |
| `cmd/mcp-proxy/cli_test.go` | 4 tests: creates with 0600, rejects existing without `-force`, corrects 0644→0600 on force overwrite, fails when parent dir absent |
| `README.md` | "Persistent signing key" section; `mcp-proxy init` in CLI reference |

## Test plan

- [ ] `go build ./...` — compiles cleanly
- [ ] `go vet ./...` — no issues
- [ ] `go test ./cmd/mcp-proxy/...` — all 54 tests pass including the 9 new ones
- [ ] `mcp-proxy init -key /tmp/test.pem` → file created at 0600
- [ ] `mcp-proxy init -key /tmp/test.pem` (repeat without `-force`) → error "already exists"
- [ ] `chmod 644 /tmp/test.pem && mcp-proxy --key /tmp/test.pem echo hello` → `[WARN]` in stderr
- [ ] Same with `--strict-permissions` → fatal exit