### PR TITLE
feat(mcp-proxy): expand secret redaction patterns and add audit-secrets scan

### DIFF
--- a/mcp-proxy/README.md
+++ b/mcp-proxy/README.md
@@ -172,6 +172,72 @@ Paused calls auto-deny after 60 seconds (fail-safe).
 
 Set `BEACON_ENCRYPTION_KEY` to enable AES-256-GCM encryption at rest for sensitive audit data.
 
+## Secret redaction
+
+The proxy redacts secrets before writing to the audit database in two passes:
+1. **JSON-key pass** — any value whose JSON key matches a sensitive name (e.g. `password`, `token`, `api_key`) is replaced with `[REDACTED]`.
+2. **Pattern pass** — 12 built-in regular expressions catch common token formats regardless of key name.
+
+Built-in patterns:
+
+| Name | Matches |
+|------|---------|
+| `github-pat-classic` | `ghp_…` GitHub personal access tokens |
+| `github-pat-finegrained` | `github_pat_…` fine-grained PATs |
+| `github-oauth` | `gho_…` OAuth tokens |
+| `github-app-installation` | `ghs_…` GitHub App installation tokens |
+| `github-user-to-server` | `ghu_…` user-to-server tokens |
+| `github-installation-legacy` | `v1.<40+ hex chars>` legacy installation tokens |
+| `openai-anthropic-key` | `sk-…` OpenAI/Anthropic secret keys |
+| `aws-access-key` | `AKIA…` AWS access key IDs |
+| `bearer-token` | `Bearer <token>` HTTP Authorization headers |
+| `slack-token` | `xoxb-/xoxp-/xoxr-/xoxa-/xoxs-` Slack tokens |
+| `pem-private-key` | PEM `-----BEGIN … PRIVATE KEY-----` blocks |
+| `url-param-token` | `?token=…`, `?access_token=…`, `?key=…` etc. (key name preserved) |
+
+### Custom patterns
+
+Add organisation-specific patterns with a YAML file:
+
+```yaml
+# custom_redact.yaml
+patterns:
+  - name: slack-webhook
+    pattern: 'https://hooks\.slack\.com/services/[A-Z0-9/]+'
+  - name: stripe-live
+    pattern: 'sk_live_[A-Za-z0-9]{24,}'
+```
+
+Pass it at startup:
+
+```sh
+mcp-proxy -redact-patterns custom_redact.yaml -- npx -y @modelcontextprotocol/server-filesystem /
+```
+
+An example file is at `configs/example_redact_patterns.yaml`.
+
+### Auditing existing databases
+
+The `audit-secrets` subcommand scans an existing audit database for values that match any built-in or custom pattern — useful after upgrading the proxy or adding new patterns:
+
+```sh
+mcp-proxy audit-secrets -db ~/.agent-receipts/audit.db
+mcp-proxy audit-secrets -db ~/.agent-receipts/audit.db -redact-patterns custom_redact.yaml
+```
+
+If the database is encrypted, set `BEACON_ENCRYPTION_KEY` before running.
+
+**Exit codes:** `0` = no matches found; `1` = one or more matches found; `2` = error.
+
+The scanner runs two passes per row:
+
+1. **Regex pass** — checks the value against all built-in and custom named patterns. Output line: `<table> col=<column> row=<id> pattern=<name>`.
+2. **JSON-key pass** — parses the value as JSON and reports any value stored under a sensitive key (e.g. `password`, `token`, `api_key`) that is non-empty and not already `[REDACTED]`. Catches leaks that do not match any regex pattern. Output line: `<table> col=<column> row=<id> json-key=<path>`.
+
+If decryption fails for a row (invalid ciphertext), it is reported as `<table> col=<column> row=<id> decrypt-error` and counts as a hit — operators must investigate.
+
+If hits are reported, the raw token values are already in the database. Because the audit log is append-only, the recommended action is to **rotate the secret** and consider the old value compromised. You can then drop or redact the affected rows manually if needed.
+
 ## License
 
 Apache 2.0

--- a/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
+++ b/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
@@ -25,7 +25,7 @@ func runAuditSecrets(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	s, err := audit.Open(*db)
+	s, err := audit.OpenReadOnly(*db)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error opening audit store: %v\n", err)
 		return 2

--- a/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
+++ b/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+)
+
+func cmdAuditSecrets(args []string) {
+	os.Exit(runAuditSecrets(args, os.Stdout, os.Stderr))
+}
+
+// runAuditSecrets scans the audit database for unredacted secrets using
+// all built-in patterns and optional custom patterns loaded from a YAML file.
+// It returns 0 if no matches are found, 1 if any are found, and 2 on error.
+func runAuditSecrets(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("audit-secrets", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	db := fs.String("db", defaultDBPath("audit.db"), "Audit database path")
+	customPath := fs.String("redact-patterns", "", "Path to YAML file with custom redaction patterns to also scan for")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	s, err := audit.Open(*db)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error opening audit store: %v\n", err)
+		return 2
+	}
+	defer s.Close()
+
+	// Collect all named patterns: built-ins + custom.
+	named := make([]audit.NamedPattern, len(audit.BuiltinPatterns))
+	copy(named, audit.BuiltinPatterns)
+
+	if *customPath != "" {
+		custom, err := audit.LoadPatterns(*customPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error loading custom patterns: %v\n", err)
+			return 2
+		}
+		named = append(named, custom...)
+	}
+
+	// Optional decryption: if the DB was encrypted we must decrypt before scanning.
+	var enc *audit.Encryptor
+	if key := os.Getenv("BEACON_ENCRYPTION_KEY"); key != "" {
+		salt, err := s.EncryptionSalt()
+		if err != nil {
+			fmt.Fprintf(stderr, "Error reading encryption salt: %v\n", err)
+			return 2
+		}
+		var encErr error
+		enc, encErr = audit.NewEncryptor(key, salt)
+		if encErr != nil {
+			fmt.Fprintf(stderr, "Error initialising decryptor: %v\n", encErr)
+			return 2
+		}
+	}
+
+	hits := 0
+	scanErr := s.ScanRedactionTargets(func(table, column string, rowID int64, value string) error {
+		plaintext, decErr := enc.Decrypt(value)
+		if decErr != nil {
+			// Count as a hit — operators must investigate. Do not include the
+			// error message or ciphertext (they might leak information).
+			fmt.Fprintf(stdout, "%s col=%s row=%d decrypt-error\n", table, column, rowID)
+			hits++
+			return nil
+		}
+		for _, p := range named {
+			if p.Re.MatchString(plaintext) {
+				fmt.Fprintf(stdout, "%s col=%s row=%d pattern=%s\n", table, column, rowID, p.Name)
+				hits++
+			}
+		}
+		for _, path := range audit.ScanJSONLeaks(plaintext) {
+			fmt.Fprintf(stdout, "%s col=%s row=%d json-key=%s\n", table, column, rowID, path)
+			hits++
+		}
+		return nil
+	})
+	if scanErr != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", scanErr)
+		return 2
+	}
+
+	if hits > 0 {
+		return 1
+	}
+	return 0
+}

--- a/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
+++ b/mcp-proxy/cmd/mcp-proxy/audit_secrets.go
@@ -33,8 +33,7 @@ func runAuditSecrets(args []string, stdout, stderr io.Writer) int {
 	defer s.Close()
 
 	// Collect all named patterns: built-ins + custom.
-	named := make([]audit.NamedPattern, len(audit.BuiltinPatterns))
-	copy(named, audit.BuiltinPatterns)
+	named := audit.BuiltinPatterns()
 
 	if *customPath != "" {
 		custom, err := audit.LoadPatterns(*customPath)
@@ -48,9 +47,13 @@ func runAuditSecrets(args []string, stdout, stderr io.Writer) int {
 	// Optional decryption: if the DB was encrypted we must decrypt before scanning.
 	var enc *audit.Encryptor
 	if key := os.Getenv("BEACON_ENCRYPTION_KEY"); key != "" {
-		salt, err := s.EncryptionSalt()
+		salt, present, err := s.EncryptionSaltIfPresent()
 		if err != nil {
 			fmt.Fprintf(stderr, "Error reading encryption salt: %v\n", err)
+			return 2
+		}
+		if !present {
+			fmt.Fprintf(stderr, "Error: BEACON_ENCRYPTION_KEY is set but no encryption salt is recorded in the DB (was the DB ever encrypted?)\n")
 			return 2
 		}
 		var encErr error
@@ -63,6 +66,13 @@ func runAuditSecrets(args []string, stdout, stderr io.Writer) int {
 
 	hits := 0
 	scanErr := s.ScanRedactionTargets(func(table, column string, rowID int64, value string) error {
+		// If no key is configured but the row is ciphertext, report it: the
+		// scanner cannot inspect the plaintext, so operators must investigate.
+		if enc == nil && len(value) >= len("enc:") && value[:4] == "enc:" {
+			fmt.Fprintf(stdout, "%s col=%s row=%d encrypted-no-key\n", table, column, rowID)
+			hits++
+			return nil
+		}
 		plaintext, decErr := enc.Decrypt(value)
 		if decErr != nil {
 			// Count as a hit — operators must investigate. Do not include the

--- a/mcp-proxy/cmd/mcp-proxy/audit_secrets_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/audit_secrets_test.go
@@ -166,6 +166,11 @@ func TestRunAuditSecretsDecryptError(t *testing.T) {
 	if err := s.CreateSession("sess-dec", "test-server", "test-command"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
+	// Persist the encryption salt so Fix 3 (EncryptionSaltIfPresent) does not
+	// abort with exit 2 before the scanner reaches the invalid ciphertext row.
+	if _, err := s.EncryptionSalt(); err != nil {
+		t.Fatalf("seed encryption salt: %v", err)
+	}
 	// Seed a row with the enc: prefix but invalid base64/ciphertext.
 	if _, err := s.LogMessage("sess-dec", "client_to_server", "", "tools/call", "enc:not-base64-!!!"); err != nil {
 		t.Fatalf("log message: %v", err)
@@ -182,6 +187,81 @@ func TestRunAuditSecretsDecryptError(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "decrypt-error") {
 		t.Errorf("expected 'decrypt-error' in stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunAuditSecretsEncryptedNoKey asserts that a row with an "enc:" prefix is
+// reported as encrypted-no-key when BEACON_ENCRYPTION_KEY is not set (Fix 2).
+func TestRunAuditSecretsEncryptedNoKey(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-encnokey", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// Seed a row that looks like ciphertext (enc: prefix).
+	if _, err := s.LogMessage("sess-encnokey", "client_to_server", "", "tools/call", "enc:somebase64data=="); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	s.Close()
+
+	// Ensure no key is set.
+	t.Setenv("BEACON_ENCRYPTION_KEY", "")
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit 1 for encrypted-no-key, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "encrypted-no-key") {
+		t.Errorf("expected 'encrypted-no-key' in stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunAuditSecretsKeyButNoSalt asserts that when BEACON_ENCRYPTION_KEY is set
+// but the DB has no encryption salt, the scanner exits 2 with a descriptive error
+// and does NOT write a salt to the DB (Fix 3).
+func TestRunAuditSecretsKeyButNoSalt(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	// Open a fresh DB; do NOT call EncryptionSalt() so no salt is persisted.
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-nosalt", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	s.Close()
+
+	t.Setenv("BEACON_ENCRYPTION_KEY", "some-passphrase")
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("expected exit 2 for key-but-no-salt, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "encryption salt") {
+		t.Errorf("expected 'encryption salt' in stderr, got:\n%s", stderr.String())
+	}
+
+	// Verify the DB was NOT mutated: no encryption_salt row must exist.
+	s2, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer s2.Close()
+	_, present, err := s2.EncryptionSaltIfPresent()
+	if err != nil {
+		t.Fatalf("EncryptionSaltIfPresent: %v", err)
+	}
+	if present {
+		t.Error("scanner must not write encryption_salt to DB; salt was found after scan")
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/audit_secrets_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/audit_secrets_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+)
+
+// TestRunAuditSecretsDBOpenError asserts exit 2 and non-empty stderr when the
+// DB path is unopenable (Fix 1: open DB inline instead of via openAuditStore).
+func TestRunAuditSecretsDBOpenError(t *testing.T) {
+	var stdout, stderr strings.Builder
+	// /dev/null/x.db is guaranteed to be unopenable on macOS/Linux.
+	code := runAuditSecrets([]string{"-db", "/dev/null/x.db"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("expected exit 2 for bad DB path, got %d; stderr=%q", code, stderr.String())
+	}
+	if stderr.String() == "" {
+		t.Error("expected non-empty stderr for bad DB path")
+	}
+}
+
+func TestRunAuditSecretsCleanDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-1", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.LogMessage("sess-1", "client_to_server", "", "tools/list", `{"jsonrpc":"2.0","method":"tools/list"}`); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	s.Close()
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("expected exit 0 for clean DB, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("expected no output for clean DB, got %q", stdout.String())
+	}
+}
+
+func TestRunAuditSecretsWithTokens(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	ghsToken := "ghs_" + strings.Repeat("b", 36)
+	ghpFineToken := "github_pat_" + strings.Repeat("c", 82)
+	urlToken := "ghp_" + strings.Repeat("d", 36)
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-2", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// Seed a raw message containing a ghs_ token.
+	if _, err := s.LogMessage("sess-2", "client_to_server", "", "tools/call", `{"secret":"`+ghsToken+`"}`); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	// Seed a raw message containing a URL-param token.
+	if _, err := s.LogMessage("sess-2", "client_to_server", "", "tools/call", `{"url":"https://api.example.com?token=`+urlToken+`"}`); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	// Seed a clean message.
+	if _, err := s.LogMessage("sess-2", "server_to_client", "", "", `{"result":"ok"}`); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	// Seed a tool_calls row with a github_pat_ (finegrained) token in arguments.
+	if _, err := s.InsertToolCall(audit.ToolCallRecord{
+		SessionID:     "sess-2",
+		ToolName:      "create_file",
+		Arguments:     `{"token":"` + ghpFineToken + `"}`,
+		OperationType: "write",
+		PolicyAction:  "pass",
+		RequestedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("insert tool call: %v", err)
+	}
+	s.Close()
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit 1 for DB with tokens, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	out := stdout.String()
+	// Must report the ghs_ hit.
+	if !strings.Contains(out, "github-app-installation") {
+		t.Errorf("expected github-app-installation in output, got:\n%s", out)
+	}
+	// Must report the github_pat_ finegrained hit.
+	if !strings.Contains(out, "github-pat-finegrained") {
+		t.Errorf("expected github-pat-finegrained in output, got:\n%s", out)
+	}
+	// Must report the URL param token hit.
+	if !strings.Contains(out, "url-param-token") {
+		t.Errorf("expected url-param-token in output, got:\n%s", out)
+	}
+	// Output must NOT contain any of the raw token values.
+	for _, tok := range []string{ghsToken, ghpFineToken, urlToken} {
+		if strings.Contains(out, tok) {
+			t.Errorf("output should not contain raw token %q, got:\n%s", tok, out)
+		}
+	}
+}
+
+func TestRunAuditSecretsCustomPattern(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+	yamlPath := filepath.Join(dir, "patterns.yaml")
+
+	if err := os.WriteFile(yamlPath, []byte(`
+patterns:
+  - name: internal-secret
+    pattern: 'INT-SECRET-[A-Z0-9]+'
+`), 0600); err != nil {
+		t.Fatalf("write patterns: %v", err)
+	}
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-3", "test", "cmd"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.LogMessage("sess-3", "client_to_server", "", "", `{"note":"INT-SECRET-ABC123"}`); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	s.Close()
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath, "-redact-patterns", yamlPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit 1 for custom pattern hit, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "internal-secret") {
+		t.Errorf("expected internal-secret in output, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunAuditSecretsDecryptError asserts that a row with an invalid ciphertext
+// (enc: prefix but garbage payload) is reported as a decrypt-error hit (exit 1)
+// and does not abort the scan (Fix 2).
+func TestRunAuditSecretsDecryptError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-dec", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// Seed a row with the enc: prefix but invalid base64/ciphertext.
+	if _, err := s.LogMessage("sess-dec", "client_to_server", "", "tools/call", "enc:not-base64-!!!"); err != nil {
+		t.Fatalf("log message: %v", err)
+	}
+	s.Close()
+
+	// Set a valid-looking key so the Encryptor is initialised and Decrypt is attempted.
+	t.Setenv("BEACON_ENCRYPTION_KEY", "test-passphrase-for-decrypt-error-test")
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit 1 for decrypt error, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "decrypt-error") {
+		t.Errorf("expected 'decrypt-error' in stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunAuditSecretsJSONKeyLeak asserts that a row containing a sensitive JSON
+// key with a non-redacted value is reported even when no regex pattern matches
+// (Fix 4).
+func TestRunAuditSecretsJSONKeyLeak(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "audit.db")
+
+	s, err := audit.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := s.CreateSession("sess-json", "test-server", "test-command"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// "hunter2" does not match any built-in regex pattern.
+	if _, err := s.InsertToolCall(audit.ToolCallRecord{
+		SessionID:     "sess-json",
+		ToolName:      "do_thing",
+		Arguments:     `{"password":"hunter2"}`,
+		OperationType: "write",
+		PolicyAction:  "pass",
+		RequestedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("insert tool call: %v", err)
+	}
+	s.Close()
+
+	var stdout, stderr strings.Builder
+	code := runAuditSecrets([]string{"-db", dbPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit 1 for JSON key leak, got %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "json-key=password") {
+		t.Errorf("expected 'json-key=password' in stdout, got:\n%s", stdout.String())
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -74,6 +75,9 @@ func main() {
 		case "init":
 			cmdInit(os.Args[2:])
 			return
+		case "audit-secrets":
+			cmdAuditSecrets(os.Args[2:])
+			return
 		case "serve":
 			os.Args = append(os.Args[:1], os.Args[2:]...)
 			// Fall through to serve.
@@ -90,8 +94,9 @@ func serve() {
 		keyPath           = flag.String("key", "", "Ed25519 private key (PEM file)")
 		taxonomyPath      = flag.String("taxonomy", "", "Taxonomy mappings (JSON file). Merged with bundled taxonomies; user mappings win on conflict.")
 		bundledTaxonomy   = flag.Bool("bundled-taxonomies", true, "Include bundled taxonomies (e.g. GitHub, Atlassian). Set to false to use only -taxonomy.")
-		rulesPath         = flag.String("rules", "", "Policy rules (YAML file)")
-		serverName        = flag.String("name", "", "Server name for audit trail")
+		rulesPath            = flag.String("rules", "", "Policy rules (YAML file)")
+		redactPatternsPath   = flag.String("redact-patterns", "", "Path to YAML file with custom redaction patterns")
+		serverName           = flag.String("name", "", "Server name for audit trail")
 		issuerDID         = flag.String("issuer", "did:agent:mcp-proxy", "Issuer DID")
 		issuerName        = flag.String("issuer-name", "", "Issuer name (e.g. Claude Code, Codex)")
 		issuerModel       = flag.String("issuer-model", "", "AI model identifier (e.g. claude-sonnet-4-6)")
@@ -106,7 +111,7 @@ func serve() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
 		fmt.Fprintf(os.Stderr, "  Wraps an MCP server with audit, receipts, and policy enforcement.\n\n")
-		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing, doctor, init\n\n")
+		fmt.Fprintf(os.Stderr, "Subcommands: serve, list, inspect, verify, export, stats, timing, doctor, init, audit-secrets\n\n")
 		fmt.Fprintf(os.Stderr, "  -version\n\tPrint version and exit\n")
 		flag.PrintDefaults()
 	}
@@ -226,6 +231,19 @@ func serve() {
 	}
 	engine := policy.NewEngine(rules)
 
+	// Build redactor (built-ins + optional custom patterns).
+	var customPatterns []*regexp.Regexp
+	if *redactPatternsPath != "" {
+		np, err := audit.LoadPatterns(*redactPatternsPath)
+		if err != nil {
+			log.Fatalf("mcp-proxy: load redact patterns: %v", err)
+		}
+		for _, p := range np {
+			customPatterns = append(customPatterns, p.Re)
+		}
+	}
+	redactor := audit.NewRedactor(customPatterns)
+
 	// Encryption.
 	var encryptor *audit.Encryptor
 	if key := os.Getenv("BEACON_ENCRYPTION_KEY"); key != "" {
@@ -325,7 +343,7 @@ func serve() {
 			}
 			rawStr = truncated + "...[truncated]"
 		}
-		redactedRaw := audit.Redact(rawStr)
+		redactedRaw := redactor.Redact(rawStr)
 		skipAudit := false
 		if encryptor != nil {
 			enc, encErr := encryptor.Encrypt(redactedRaw)
@@ -364,7 +382,7 @@ func serve() {
 				policyEvalUs := time.Since(evalStart).Microseconds()
 
 				argJSON, _ := json.Marshal(params.Arguments)
-				redactedArgs := audit.Redact(string(argJSON))
+				redactedArgs := redactor.Redact(string(argJSON))
 				if encryptor != nil {
 					enc, encErr := encryptor.Encrypt(redactedArgs)
 					if encErr != nil {
@@ -525,13 +543,13 @@ func serve() {
 					errorStr = string(msg.Error)
 				}
 
-				redactedResult := audit.Redact(resultStr)
+				redactedResult := redactor.Redact(resultStr)
 				// Keep pre-encryption copy for response_hash computation.
 				receiptResponseBody := json.RawMessage(nil)
 				if redactedResult != "" && json.Valid([]byte(redactedResult)) {
 					receiptResponseBody = json.RawMessage(redactedResult)
 				}
-				redactedError := audit.Redact(errorStr)
+				redactedError := redactor.Redact(errorStr)
 				if encryptor != nil {
 					if enc, encErr := encryptor.Encrypt(redactedResult); encErr != nil {
 						log.Printf("mcp-proxy: encrypt result: %v", encErr)

--- a/mcp-proxy/configs/example_redact_patterns.yaml
+++ b/mcp-proxy/configs/example_redact_patterns.yaml
@@ -1,0 +1,7 @@
+# Example custom redaction patterns for mcp-proxy.
+# Pass to the proxy via: -redact-patterns configs/example_redact_patterns.yaml
+patterns:
+  - name: slack-webhook
+    pattern: 'https://hooks\.slack\.com/services/[A-Z0-9/]+'
+  - name: stripe-live
+    pattern: 'sk_live_[A-Za-z0-9]{24,}'

--- a/mcp-proxy/internal/audit/redact.go
+++ b/mcp-proxy/internal/audit/redact.go
@@ -48,10 +48,10 @@ type NamedPattern struct {
 	Re   *regexp.Regexp
 }
 
-// BuiltinPatterns is the ordered set of named patterns applied by the default
-// Redactor. The list is package-level so the audit-secrets subcommand can
-// iterate it for scanning.
-var BuiltinPatterns = []NamedPattern{
+// builtinPatterns is the ordered set of named patterns applied by the default
+// Redactor. The slice is unexported to prevent callers from mutating it and
+// silently weakening redaction; use BuiltinPatterns() to obtain a safe copy.
+var builtinPatterns = []NamedPattern{
 	{
 		Name: "github-pat-classic",
 		Re:   regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`),
@@ -97,9 +97,20 @@ var BuiltinPatterns = []NamedPattern{
 		Re:   regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----`),
 	},
 	{
+		// Exclude `[` and `]` from the value class so that already-redacted
+		// placeholders like `[REDACTED]` are not re-matched (idempotent scans).
+		// Real OAuth/API tokens never contain unencoded `[` or `]`.
 		Name: "url-param-token",
-		Re:   regexp.MustCompile(`(?i)([?&](?:access_token|token|api[_-]?key|apikey|key|auth)=)[^&\s"'<>]+`),
+		Re:   regexp.MustCompile(`(?i)([?&](?:access_token|token|api[_-]?key|apikey|key|auth)=)[^&\s"'<>\[\]]+`),
 	},
+}
+
+// BuiltinPatterns returns a copy of the built-in named redaction patterns.
+// The returned slice is safe to mutate without affecting the package state.
+func BuiltinPatterns() []NamedPattern {
+	out := make([]NamedPattern, len(builtinPatterns))
+	copy(out, builtinPatterns)
+	return out
 }
 
 // Redactor applies JSON-key redaction and pattern-based redaction. Custom
@@ -130,7 +141,7 @@ func (r *Redactor) Redact(raw string) string {
 	}
 
 	// 2. Built-in patterns.
-	for _, p := range BuiltinPatterns {
+	for _, p := range builtinPatterns {
 		if p.Name == "url-param-token" {
 			// Preserve the key name; replace only the value.
 			raw = p.Re.ReplaceAllString(raw, "${1}[REDACTED]")

--- a/mcp-proxy/internal/audit/redact.go
+++ b/mcp-proxy/internal/audit/redact.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -41,22 +42,85 @@ var sensitiveKeys = map[string]bool{
 	"pin":               true,
 }
 
-// Pattern-based redaction for common secret formats.
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`),             // GitHub PAT
-	regexp.MustCompile(`gho_[A-Za-z0-9]{36,}`),             // GitHub OAuth
-	regexp.MustCompile(`sk-[A-Za-z0-9\-]{20,}`),            // OpenAI/Anthropic
-	regexp.MustCompile(`AKIA[A-Z0-9]{16}`),                 // AWS access key
-	regexp.MustCompile(`Bearer\s+[A-Za-z0-9._\-/+=]{20,}`), // Bearer tokens
-	regexp.MustCompile(`xox[bpras]-[A-Za-z0-9\-]+`),        // Slack tokens
-	// PEM private keys: match the entire block from BEGIN to END.
-	regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----`),
+// NamedPattern is a compiled regular expression with a stable name.
+type NamedPattern struct {
+	Name string
+	Re   *regexp.Regexp
 }
 
-// Redact removes sensitive data from a JSON string.
-// First applies JSON-aware key redaction, then pattern-based fallback.
-func Redact(raw string) string {
-	// Try JSON-aware redaction.
+// BuiltinPatterns is the ordered set of named patterns applied by the default
+// Redactor. The list is package-level so the audit-secrets subcommand can
+// iterate it for scanning.
+var BuiltinPatterns = []NamedPattern{
+	{
+		Name: "github-pat-classic",
+		Re:   regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`),
+	},
+	{
+		Name: "github-pat-finegrained",
+		Re:   regexp.MustCompile(`github_pat_[A-Za-z0-9_]{82}`),
+	},
+	{
+		Name: "github-oauth",
+		Re:   regexp.MustCompile(`gho_[A-Za-z0-9]{36,}`),
+	},
+	{
+		Name: "github-app-installation",
+		Re:   regexp.MustCompile(`ghs_[A-Za-z0-9]{36,}`),
+	},
+	{
+		Name: "github-user-to-server",
+		Re:   regexp.MustCompile(`ghu_[A-Za-z0-9]{36,}`),
+	},
+	{
+		Name: "github-installation-legacy",
+		Re:   regexp.MustCompile(`v1\.[a-f0-9]{40,}`),
+	},
+	{
+		Name: "openai-anthropic-key",
+		Re:   regexp.MustCompile(`sk-[A-Za-z0-9\-]{20,}`),
+	},
+	{
+		Name: "aws-access-key",
+		Re:   regexp.MustCompile(`AKIA[A-Z0-9]{16}`),
+	},
+	{
+		Name: "bearer-token",
+		Re:   regexp.MustCompile(`Bearer\s+[A-Za-z0-9._\-/+=]{20,}`),
+	},
+	{
+		Name: "slack-token",
+		Re:   regexp.MustCompile(`xox[bpras]-[A-Za-z0-9\-]+`),
+	},
+	{
+		Name: "pem-private-key",
+		Re:   regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----`),
+	},
+	{
+		Name: "url-param-token",
+		Re:   regexp.MustCompile(`(?i)([?&](?:access_token|token|api[_-]?key|apikey|key|auth)=)[^&\s"'<>]+`),
+	},
+}
+
+// Redactor applies JSON-key redaction and pattern-based redaction. Custom
+// patterns are appended after the built-ins.
+type Redactor struct {
+	custom []*regexp.Regexp
+}
+
+// NewRedactor creates a Redactor with optional extra patterns appended after
+// the built-ins.
+func NewRedactor(custom []*regexp.Regexp) *Redactor {
+	return &Redactor{custom: custom}
+}
+
+// Redact removes sensitive data from raw. It applies three passes:
+//  1. JSON-aware key redaction (sensitiveKeys).
+//  2. Built-in NamedPatterns (BuiltinPatterns). The url-param-token pattern
+//     uses a capture-group replacement to preserve the key name.
+//  3. Custom patterns supplied at construction time.
+func (r *Redactor) Redact(raw string) string {
+	// 1. JSON-aware key redaction.
 	var parsed any
 	if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
 		redacted := redactValue(parsed)
@@ -65,13 +129,30 @@ func Redact(raw string) string {
 		}
 	}
 
-	// Pattern-based redaction as second pass.
-	for _, pat := range secretPatterns {
-		raw = pat.ReplaceAllString(raw, redacted)
+	// 2. Built-in patterns.
+	for _, p := range BuiltinPatterns {
+		if p.Name == "url-param-token" {
+			// Preserve the key name; replace only the value.
+			raw = p.Re.ReplaceAllString(raw, "${1}[REDACTED]")
+		} else {
+			raw = p.Re.ReplaceAllString(raw, "[REDACTED]")
+		}
+	}
+
+	// 3. Custom patterns.
+	for _, re := range r.custom {
+		raw = re.ReplaceAllString(raw, "[REDACTED]")
 	}
 
 	return raw
 }
+
+// defaultRedactor is used by the package-level Redact shim.
+var defaultRedactor = NewRedactor(nil)
+
+// Redact is a package-level shim that calls the default Redactor.
+// Callers that need custom patterns should construct a *Redactor via NewRedactor.
+func Redact(raw string) string { return defaultRedactor.Redact(raw) }
 
 func redactValue(v any) any {
 	switch val := v.(type) {
@@ -93,5 +174,42 @@ func redactValue(v any) any {
 		return out
 	default:
 		return v
+	}
+}
+
+// ScanJSONLeaks returns the JSON paths of values stored under sensitive keys
+// whose value is non-empty and not equal to "[REDACTED]". Returns nil if raw is
+// not valid JSON. Used by the audit-secrets scanner to detect leaks the JSON-key
+// redaction pass should have caught but didn't.
+func ScanJSONLeaks(raw string) []string {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return nil
+	}
+	var leaks []string
+	walkSensitive(v, "", &leaks)
+	return leaks
+}
+
+func walkSensitive(v any, path string, leaks *[]string) {
+	switch val := v.(type) {
+	case map[string]any:
+		for k, child := range val {
+			childPath := path + "." + k
+			if path == "" {
+				childPath = k
+			}
+			if sensitiveKeys[strings.ToLower(k)] {
+				if s, ok := child.(string); ok && s != "" && s != redacted {
+					*leaks = append(*leaks, childPath)
+				}
+				continue // do not recurse into a sensitive subtree
+			}
+			walkSensitive(child, childPath, leaks)
+		}
+	case []any:
+		for i, child := range val {
+			walkSensitive(child, fmt.Sprintf("%s[%d]", path, i), leaks)
+		}
 	}
 }

--- a/mcp-proxy/internal/audit/redact.go
+++ b/mcp-proxy/internal/audit/redact.go
@@ -106,10 +106,16 @@ var builtinPatterns = []NamedPattern{
 }
 
 // BuiltinPatterns returns a copy of the built-in named redaction patterns.
-// The returned slice is safe to mutate without affecting the package state.
+// The returned slice and its regexps are safe to mutate without affecting
+// the package state — each Re is freshly recompiled from its source.
 func BuiltinPatterns() []NamedPattern {
 	out := make([]NamedPattern, len(builtinPatterns))
-	copy(out, builtinPatterns)
+	for i, p := range builtinPatterns {
+		out[i] = NamedPattern{
+			Name: p.Name,
+			Re:   regexp.MustCompile(p.Re.String()),
+		}
+	}
 	return out
 }
 

--- a/mcp-proxy/internal/audit/redact.go
+++ b/mcp-proxy/internal/audit/redact.go
@@ -144,15 +144,15 @@ func (r *Redactor) Redact(raw string) string {
 	for _, p := range builtinPatterns {
 		if p.Name == "url-param-token" {
 			// Preserve the key name; replace only the value.
-			raw = p.Re.ReplaceAllString(raw, "${1}[REDACTED]")
+			raw = p.Re.ReplaceAllString(raw, "${1}"+redacted)
 		} else {
-			raw = p.Re.ReplaceAllString(raw, "[REDACTED]")
+			raw = p.Re.ReplaceAllString(raw, redacted)
 		}
 	}
 
 	// 3. Custom patterns.
 	for _, re := range r.custom {
-		raw = re.ReplaceAllString(raw, "[REDACTED]")
+		raw = re.ReplaceAllString(raw, redacted)
 	}
 
 	return raw

--- a/mcp-proxy/internal/audit/redact_config.go
+++ b/mcp-proxy/internal/audit/redact_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -36,6 +37,9 @@ func LoadPatterns(path string) ([]NamedPattern, error) {
 	for i, p := range pf.Patterns {
 		if p.Name == "" {
 			return nil, fmt.Errorf("pattern %d: name is required", i)
+		}
+		if strings.TrimSpace(p.Pattern) == "" {
+			return nil, fmt.Errorf("pattern %q: pattern is required", p.Name)
 		}
 		re, err := regexp.Compile(p.Pattern)
 		if err != nil {

--- a/mcp-proxy/internal/audit/redact_config.go
+++ b/mcp-proxy/internal/audit/redact_config.go
@@ -1,0 +1,47 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+type patternFile struct {
+	Patterns []patternEntry `yaml:"patterns"`
+}
+
+type patternEntry struct {
+	Name    string `yaml:"name"`
+	Pattern string `yaml:"pattern"`
+}
+
+// LoadPatterns reads a YAML file of custom redaction patterns and returns
+// compiled NamedPatterns. The file format is:
+//
+//	patterns:
+//	  - name: my-secret
+//	    pattern: 'MY_SECRET_[A-Z0-9]+'
+func LoadPatterns(path string) ([]NamedPattern, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var pf patternFile
+	if err := yaml.Unmarshal(data, &pf); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	out := make([]NamedPattern, 0, len(pf.Patterns))
+	for i, p := range pf.Patterns {
+		if p.Name == "" {
+			return nil, fmt.Errorf("pattern %d: name is required", i)
+		}
+		re, err := regexp.Compile(p.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("pattern %q: invalid regex: %w", p.Name, err)
+		}
+		out = append(out, NamedPattern{Name: p.Name, Re: re})
+	}
+	return out, nil
+}

--- a/mcp-proxy/internal/audit/redact_config_test.go
+++ b/mcp-proxy/internal/audit/redact_config_test.go
@@ -1,0 +1,100 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPatternsValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "patterns.yaml")
+	if err := os.WriteFile(path, []byte(`
+patterns:
+  - name: my-secret
+    pattern: 'MY_SECRET_[A-Z0-9]+'
+  - name: internal-id
+    pattern: 'INT-[0-9]+'
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := LoadPatterns(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patterns) != 2 {
+		t.Fatalf("expected 2 patterns, got %d", len(patterns))
+	}
+	if patterns[0].Name != "my-secret" {
+		t.Errorf("expected name %q, got %q", "my-secret", patterns[0].Name)
+	}
+	if patterns[1].Name != "internal-id" {
+		t.Errorf("expected name %q, got %q", "internal-id", patterns[1].Name)
+	}
+	// Patterns must compile and match.
+	if !patterns[0].Re.MatchString("MY_SECRET_ABC123") {
+		t.Error("pattern my-secret did not match expected input")
+	}
+	if !patterns[1].Re.MatchString("INT-42") {
+		t.Error("pattern internal-id did not match expected input")
+	}
+}
+
+func TestLoadPatternsMissingName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "patterns.yaml")
+	if err := os.WriteFile(path, []byte(`
+patterns:
+  - name: ok
+    pattern: 'OK-[0-9]+'
+  - pattern: 'NO_NAME_[A-Z]+'
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadPatterns(path)
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+}
+
+func TestLoadPatternsInvalidRegex(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "patterns.yaml")
+	if err := os.WriteFile(path, []byte(`
+patterns:
+  - name: bad-regex
+    pattern: '['
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadPatterns(path)
+	if err == nil {
+		t.Fatal("expected error for invalid regex, got nil")
+	}
+}
+
+func TestLoadPatternsMissingFile(t *testing.T) {
+	_, err := LoadPatterns("/nonexistent/path/patterns.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestLoadPatternsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.yaml")
+	if err := os.WriteFile(path, []byte(``), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := LoadPatterns(path)
+	if err != nil {
+		t.Fatalf("unexpected error for empty file: %v", err)
+	}
+	if len(patterns) != 0 {
+		t.Errorf("expected 0 patterns, got %d", len(patterns))
+	}
+}

--- a/mcp-proxy/internal/audit/redact_config_test.go
+++ b/mcp-proxy/internal/audit/redact_config_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -96,5 +97,45 @@ func TestLoadPatternsEmptyFile(t *testing.T) {
 	}
 	if len(patterns) != 0 {
 		t.Errorf("expected 0 patterns, got %d", len(patterns))
+	}
+}
+
+func TestLoadPatternsEmptyPattern(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "patterns.yaml")
+	if err := os.WriteFile(path, []byte(`
+patterns:
+  - name: empty-pattern
+    pattern: ""
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadPatterns(path)
+	if err == nil {
+		t.Fatal("expected error for empty pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "pattern is required") {
+		t.Errorf("expected error to mention 'pattern is required', got: %v", err)
+	}
+}
+
+func TestLoadPatternsWhitespacePattern(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "patterns.yaml")
+	if err := os.WriteFile(path, []byte(`
+patterns:
+  - name: whitespace-pattern
+    pattern: "   "
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadPatterns(path)
+	if err == nil {
+		t.Fatal("expected error for whitespace-only pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "pattern is required") {
+		t.Errorf("expected error to mention 'pattern is required', got: %v", err)
 	}
 }

--- a/mcp-proxy/internal/audit/redact_test.go
+++ b/mcp-proxy/internal/audit/redact_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -67,4 +68,229 @@ func TestRedactPEMBlock(t *testing.T) {
 	if !strings.Contains(got, "some text") {
 		t.Error("surrounding text should be preserved")
 	}
+}
+
+func TestRedactTokenFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "github-pat-classic",
+			in:   "ghp_" + strings.Repeat("a", 36),
+		},
+		{
+			name: "github-pat-finegrained",
+			in:   "github_pat_" + strings.Repeat("a", 82),
+		},
+		{
+			name: "github-oauth",
+			in:   "gho_" + strings.Repeat("a", 36),
+		},
+		{
+			name: "github-app-installation",
+			in:   "ghs_" + strings.Repeat("a", 36),
+		},
+		{
+			name: "github-user-to-server",
+			in:   "ghu_" + strings.Repeat("a", 36),
+		},
+		{
+			name: "github-installation-legacy",
+			in:   "v1." + strings.Repeat("a", 40),
+		},
+		{
+			name: "openai-anthropic-key",
+			in:   "sk-" + strings.Repeat("a", 20),
+		},
+		{
+			name: "aws-access-key",
+			in:   "AKIA" + strings.Repeat("A", 16),
+		},
+		{
+			name: "bearer-token",
+			in:   "Bearer " + strings.Repeat("a", 20),
+		},
+		{
+			name: "slack-token",
+			in:   "xoxb-abc123-def456",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Redact(tc.in)
+			if strings.Contains(out, tc.in) {
+				t.Errorf("token not redacted: output %q still contains full input token", out)
+			}
+			if !strings.Contains(out, "[REDACTED]") {
+				t.Errorf("expected [REDACTED] in output, got %q", out)
+			}
+		})
+	}
+}
+
+// TestRedactLegacyVersionNotRedacted verifies that semver strings like "v1.0.0"
+// are not matched by the github-installation-legacy pattern, which requires 40+
+// lowercase hex chars after "v1.".
+func TestRedactLegacyVersionNotRedacted(t *testing.T) {
+	input := "v1.0.0"
+	got := Redact(input)
+	if got != input {
+		t.Errorf("semver v1.0.0 should not be redacted, got %q", got)
+	}
+}
+
+func TestRedactLocations(t *testing.T) {
+	token := "ghp_" + strings.Repeat("a", 36)
+
+	t.Run("header-style", func(t *testing.T) {
+		in := "Authorization: Bearer " + token
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in header: %q", out)
+		}
+	})
+
+	t.Run("url-param-GET", func(t *testing.T) {
+		in := "GET /repos?token=" + token + " HTTP/1.1"
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in URL param: %q", out)
+		}
+		if !strings.Contains(out, "token=") {
+			t.Errorf("key name 'token=' should be preserved: %q", out)
+		}
+	})
+
+	t.Run("url-param-access_token", func(t *testing.T) {
+		in := "https://api.example.com/x?access_token=" + token
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in access_token: %q", out)
+		}
+		if !strings.Contains(out, "access_token=") {
+			t.Errorf("key 'access_token=' should be preserved: %q", out)
+		}
+	})
+
+	t.Run("json-nested-sensitive-key", func(t *testing.T) {
+		in := `{"auth":{"token":"` + token + `"}}`
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted under sensitive JSON key: %q", out)
+		}
+	})
+
+	t.Run("json-nested-non-sensitive-key", func(t *testing.T) {
+		in := `{"data":{"note":"my key is ` + token + `"}}`
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted via regex under non-sensitive key: %q", out)
+		}
+	})
+
+	t.Run("plain-error-string", func(t *testing.T) {
+		in := "request failed with token " + token
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in plain error string: %q", out)
+		}
+	})
+}
+
+func TestRedactorCustomPatterns(t *testing.T) {
+	re := regexp.MustCompile(`SECRET-[A-Z0-9]+`)
+	r := NewRedactor([]*regexp.Regexp{re})
+	out := r.Redact("here is SECRET-ABC123 in text")
+	if strings.Contains(out, "SECRET-ABC123") {
+		t.Errorf("custom pattern not applied: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in output, got %q", out)
+	}
+}
+
+func TestRedactorURLParamPreservesKey(t *testing.T) {
+	token := "ghp_" + strings.Repeat("a", 36)
+	out := Redact("?token=" + token + "&other=keep")
+	if strings.Contains(out, token) {
+		t.Errorf("token value not redacted: %q", out)
+	}
+	if !strings.Contains(out, "token=") {
+		t.Errorf("key 'token=' should be preserved: %q", out)
+	}
+	if !strings.Contains(out, "other=keep") {
+		t.Errorf("unrelated param 'other=keep' should be preserved: %q", out)
+	}
+}
+
+func TestRedactURLParamCaseInsensitive(t *testing.T) {
+	token := "ghp_" + strings.Repeat("z", 36)
+
+	t.Run("mixed-case-Token", func(t *testing.T) {
+		in := "https://api.example.com/x?Token=" + token
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in mixed-case param: %q", out)
+		}
+		if !strings.Contains(out, "Token=") {
+			t.Errorf("key 'Token=' should be preserved: %q", out)
+		}
+	})
+
+	t.Run("upper-case-API_KEY", func(t *testing.T) {
+		in := "https://api.example.com/x?API_KEY=" + token
+		out := Redact(in)
+		if strings.Contains(out, token) {
+			t.Errorf("token not redacted in upper-case API_KEY param: %q", out)
+		}
+		if !strings.Contains(out, "API_KEY=") {
+			t.Errorf("key 'API_KEY=' should be preserved: %q", out)
+		}
+	})
+}
+
+func TestScanJSONLeaks(t *testing.T) {
+	t.Run("non-json returns nil", func(t *testing.T) {
+		got := ScanJSONLeaks("not json at all")
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("clean json returns empty", func(t *testing.T) {
+		got := ScanJSONLeaks(`{"username":"alice","data":"safe"}`)
+		if len(got) != 0 {
+			t.Errorf("expected no leaks, got %v", got)
+		}
+	})
+
+	t.Run("password hunter2 detected", func(t *testing.T) {
+		got := ScanJSONLeaks(`{"password":"hunter2"}`)
+		if len(got) != 1 || got[0] != "password" {
+			t.Errorf("expected [password], got %v", got)
+		}
+	})
+
+	t.Run("nested token detected", func(t *testing.T) {
+		got := ScanJSONLeaks(`{"a":{"token":"x"}}`)
+		if len(got) != 1 || got[0] != "a.token" {
+			t.Errorf("expected [a.token], got %v", got)
+		}
+	})
+
+	t.Run("already redacted not reported", func(t *testing.T) {
+		got := ScanJSONLeaks(`{"password":"[REDACTED]"}`)
+		if len(got) != 0 {
+			t.Errorf("expected no leaks for already-redacted, got %v", got)
+		}
+	})
+
+	t.Run("sensitive key with non-string value", func(t *testing.T) {
+		got := ScanJSONLeaks(`{"password":null}`)
+		if len(got) != 0 {
+			t.Errorf("expected no leaks for null value, got %v", got)
+		}
+	})
 }

--- a/mcp-proxy/internal/audit/redact_test.go
+++ b/mcp-proxy/internal/audit/redact_test.go
@@ -251,6 +251,30 @@ func TestRedactURLParamCaseInsensitive(t *testing.T) {
 	})
 }
 
+// TestRedactURLParamSkipsAlreadyRedacted verifies that an already-redacted URL
+// parameter is not double-redacted, and that the scanner (BuiltinPatterns) does
+// not flag it as a hit.
+func TestRedactURLParamSkipsAlreadyRedacted(t *testing.T) {
+	input := "?token=[REDACTED]&other=keep"
+
+	// Redactor must leave the placeholder untouched.
+	out := Redact(input)
+	if out != input {
+		t.Errorf("Redact mutated already-redacted placeholder: got %q, want %q", out, input)
+	}
+
+	// Scanner (BuiltinPatterns) must not flag the already-redacted value.
+	patterns := BuiltinPatterns()
+	for _, p := range patterns {
+		if p.Name != "url-param-token" {
+			continue
+		}
+		if p.Re.MatchString(input) {
+			t.Errorf("url-param-token scanner regex incorrectly matches already-redacted input %q", input)
+		}
+	}
+}
+
 func TestScanJSONLeaks(t *testing.T) {
 	t.Run("non-json returns nil", func(t *testing.T) {
 		got := ScanJSONLeaks("not json at all")

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -163,13 +163,15 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 			return nil, fmt.Errorf("open database: %w", err)
 		}
 	}
-	// Use a file: URI with mode=ro so SQLite opens the file in
-	// SQLITE_OPEN_READONLY mode. The SQLITE_OPEN_URI flag (set by
-	// modernc.org/sqlite) allows SQLite itself to parse the URI and
-	// honour the mode parameter, enforcing read-only at the driver level.
-	// url.URL{Opaque: dbPath} produces "file:/path?mode=ro" without
-	// percent-encoding the path separators.
-	dsn := (&url.URL{Scheme: "file", Opaque: dbPath, RawQuery: "mode=ro"}).String()
+	// Build a file: URI with mode=ro. Use Path so reserved characters in
+	// dbPath (spaces, ?, #, etc.) are percent-encoded correctly. Keep
+	// :memory: as an Opaque value because Path would prepend a slash.
+	var dsn string
+	if dbPath == ":memory:" {
+		dsn = (&url.URL{Scheme: "file", Opaque: dbPath, RawQuery: "mode=ro"}).String()
+	} else {
+		dsn = (&url.URL{Scheme: "file", Path: filepath.ToSlash(dbPath), RawQuery: "mode=ro"}).String()
+	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -148,6 +149,42 @@ func Open(dbPath string) (*Store, error) {
 		"ALTER TABLE tool_calls ADD COLUMN receipt_sign_us INTEGER",
 	} {
 		db.Exec(col) // Ignore "duplicate column" errors.
+	}
+	return &Store{db: db}, nil
+}
+
+// OpenReadOnly opens an existing audit database in read-only mode.
+// It does not run migrations, set PRAGMAs, or create the file. Used by
+// forensic tooling such as audit-secrets that must not mutate the store.
+// Returns an error if the file does not exist or cannot be opened read-only.
+func OpenReadOnly(dbPath string) (*Store, error) {
+	if dbPath != ":memory:" {
+		if _, err := os.Stat(dbPath); err != nil {
+			return nil, fmt.Errorf("open database: %w", err)
+		}
+	}
+	// Use a file: URI with mode=ro so SQLite opens the file in
+	// SQLITE_OPEN_READONLY mode. The SQLITE_OPEN_URI flag (set by
+	// modernc.org/sqlite) allows SQLite itself to parse the URI and
+	// honour the mode parameter, enforcing read-only at the driver level.
+	// url.URL{Opaque: dbPath} produces "file:/path?mode=ro" without
+	// percent-encoding the path separators.
+	dsn := (&url.URL{Scheme: "file", Opaque: dbPath, RawQuery: "mode=ro"}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	// Verify the schema exists by probing for the messages table; gives
+	// a clearer error than a query failure later.
+	var name string
+	err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'").Scan(&name)
+	if err != nil {
+		db.Close()
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("audit database has no messages table (was it ever used?)")
+		}
+		return nil, fmt.Errorf("probe schema: %w", err)
 	}
 	return &Store{db: db}, nil
 }

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -288,6 +288,28 @@ func (s *Store) EncryptionSalt() ([]byte, error) {
 	return salt, nil
 }
 
+// EncryptionSaltIfPresent returns the persisted encryption salt, or (nil, false, nil)
+// if no salt has been set. Unlike EncryptionSalt, it never writes to the database.
+// Used by read-only scanners that must not mutate the audit store.
+func (s *Store) EncryptionSaltIfPresent() ([]byte, bool, error) {
+	var encoded string
+	err := s.db.QueryRow("SELECT value FROM metadata WHERE key = 'encryption_salt'").Scan(&encoded)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("query encryption salt: %w", err)
+	}
+	salt, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode encryption salt: %w", err)
+	}
+	if len(salt) != 16 {
+		return nil, false, fmt.Errorf("invalid encryption salt length: got %d, want 16", len(salt))
+	}
+	return salt, true, nil
+}
+
 // ToolTiming holds per-tool aggregate timing data.
 type ToolTiming struct {
 	ToolName      string `json:"tool_name"`
@@ -589,8 +611,15 @@ func (s *Store) ScanRedactionTargets(fn func(table, column string, rowID int64, 
 		return fmt.Errorf("scan messages: %w", err)
 	}
 
-	// tool_calls: arguments, result, error (all nullable)
-	tcRows, err := s.db.Query("SELECT id, arguments, result, error FROM tool_calls")
+	// tool_calls: arguments, result, error (all nullable); skip rows where all
+	// three columns are NULL or empty to avoid loading noise.
+	tcRows, err := s.db.Query(`
+		SELECT id, arguments, result, error
+		FROM tool_calls
+		WHERE (arguments IS NOT NULL AND arguments != '')
+		   OR (result IS NOT NULL AND result != '')
+		   OR (error IS NOT NULL AND error != '')
+	`)
 	if err != nil {
 		return fmt.Errorf("scan tool_calls: %w", err)
 	}

--- a/mcp-proxy/internal/audit/store.go
+++ b/mcp-proxy/internal/audit/store.go
@@ -563,6 +563,66 @@ func floatToInt64(f *float64) *int64 {
 	return &v
 }
 
+// ScanRedactionTargets calls fn for every (table, column, rowID, value) where
+// value is non-empty in messages.raw and tool_calls.{arguments,result,error}.
+// Used by the audit-secrets subcommand to detect unredacted secrets at rest.
+// NULL and empty-string values are skipped. Any error returned by fn stops
+// iteration and is propagated to the caller.
+func (s *Store) ScanRedactionTargets(fn func(table, column string, rowID int64, value string) error) error {
+	// messages.raw
+	rows, err := s.db.Query("SELECT id, raw FROM messages WHERE raw IS NOT NULL AND raw != ''")
+	if err != nil {
+		return fmt.Errorf("scan messages: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var raw string
+		if err := rows.Scan(&id, &raw); err != nil {
+			return fmt.Errorf("scan messages row: %w", err)
+		}
+		if err := fn("messages", "raw", id, raw); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scan messages: %w", err)
+	}
+
+	// tool_calls: arguments, result, error (all nullable)
+	tcRows, err := s.db.Query("SELECT id, arguments, result, error FROM tool_calls")
+	if err != nil {
+		return fmt.Errorf("scan tool_calls: %w", err)
+	}
+	defer tcRows.Close()
+	for tcRows.Next() {
+		var id int64
+		var args, result, errCol sql.NullString
+		if err := tcRows.Scan(&id, &args, &result, &errCol); err != nil {
+			return fmt.Errorf("scan tool_calls row: %w", err)
+		}
+		for _, cv := range []struct {
+			col string
+			val sql.NullString
+		}{
+			{"arguments", args},
+			{"result", result},
+			{"error", errCol},
+		} {
+			if cv.val.Valid && cv.val.String != "" {
+				if err := fn("tool_calls", cv.col, id, cv.val.String); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if err := tcRows.Err(); err != nil {
+		return fmt.Errorf("scan tool_calls: %w", err)
+	}
+
+	return nil
+}
+
 // Close closes the database.
 func (s *Store) Close() error {
 	return s.db.Close()

--- a/mcp-proxy/internal/audit/store_test.go
+++ b/mcp-proxy/internal/audit/store_test.go
@@ -397,3 +397,21 @@ func TestOpenReadOnlyDoesNotMutate(t *testing.T) {
 		t.Errorf("file mtime changed: before=%v after=%v", mtimeBefore, statAfter.ModTime())
 	}
 }
+
+func TestOpenReadOnlyPathWithSpaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "dir with spaces")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "audit.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.Close()
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly with spaces: %v", err)
+	}
+	ro.Close()
+}

--- a/mcp-proxy/internal/audit/store_test.go
+++ b/mcp-proxy/internal/audit/store_test.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -325,5 +327,73 @@ func TestTimingStats(t *testing.T) {
 	}
 	if st3.Total != 3 {
 		t.Errorf("session total: want 3, got %d", st3.Total)
+	}
+}
+
+func TestOpenReadOnlyMissingFile(t *testing.T) {
+	_, err := OpenReadOnly(filepath.Join(t.TempDir(), "nonexistent.db"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestOpenReadOnlyRejectsWrites(t *testing.T) {
+	// Create a real DB first.
+	path := filepath.Join(t.TempDir(), "audit.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateSession("sess1", "srv", "cmd"); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Reopen read-only and verify a write fails.
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer ro.Close()
+	if err := ro.CreateSession("sess2", "srv", "cmd"); err == nil {
+		t.Error("expected write to fail on read-only store")
+	}
+}
+
+func TestOpenReadOnlyDoesNotMutate(t *testing.T) {
+	// Create + populate a DB.
+	path := filepath.Join(t.TempDir(), "audit.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateSession("sess1", "srv", "cmd"); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	statBefore, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtimeBefore := statBefore.ModTime()
+
+	// Open read-only and run a scan-like read.
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ro.ScanRedactionTargets(func(table, column string, rowID int64, value string) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	ro.Close()
+
+	statAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !statAfter.ModTime().Equal(mtimeBefore) {
+		t.Errorf("file mtime changed: before=%v after=%v", mtimeBefore, statAfter.ModTime())
 	}
 }


### PR DESCRIPTION
Closes #150.

## Summary

- Adds patterns for fine-grained PATs (`github_pat_`), `ghs_`, `ghu_`, legacy `v1.<hex>` installation tokens, and URL-parameter tokens (`?token=`, `?access_token=`, `?api_key=`, `?auth=`, mixed case). The URL-param replacement preserves the key name so debugging context survives.
- Introduces a `Redactor` struct + `NewRedactor(custom []*regexp.Regexp)` so callers can layer custom patterns on top of the built-ins without mutating package state. The package-level `Redact(raw)` shim is preserved so existing call sites are untouched.
- Adds `LoadPatterns` (YAML) and a `-redact-patterns` flag on `serve`. Example file at `mcp-proxy/configs/example_redact_patterns.yaml`.
- Adds `mcp-proxy audit-secrets` subcommand that scans `messages.raw` and `tool_calls.{arguments,result,error}` for unredacted secrets the live redactor missed. Runs both the regex pattern set **and** a JSON-key pass, mirroring the live redactor's two-pass logic. Honours `BEACON_ENCRYPTION_KEY` for encrypted DBs; decrypt failures are reported as hits and the scan continues. Exit 0 = clean, 1 = hits, 2 = operational error. Output never echoes the matched secret.
- Tests cover each token format × each location (header, URL param, JSON body, plain error string, multi-line PEM), case-insensitive URL params, custom patterns, `ScanJSONLeaks`, and the `audit-secrets` exit-code paths including the encrypted-DB decrypt-error path.

## Notes / deviations from the issue

- The proposed `-key-file` flag is replaced by the existing `BEACON_ENCRYPTION_KEY` env var (the proxy already uses this for encryption-at-rest). Documented in the README.
- The high-entropy catch-all detector mentioned in the issue is intentionally out of scope here — false-positive risk on commit hashes / UUIDs / opaque IDs warrants a separate discussion. Will file a follow-up issue if useful.
- `audit-secrets` does not open the receipt store — receipts contain hashes, not bodies, so there is nothing leak-scannable there. Only the audit DB needs scanning.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` (all 5 mcp-proxy packages green)
- [x] Smoke: `mcp-proxy audit-secrets -db <empty>.db` → exit 0
- [ ] Reviewer: try `mcp-proxy serve -redact-patterns configs/example_redact_patterns.yaml ...`, send a tool call with a Slack token, confirm the stored row shows `[REDACTED]`
- [ ] Reviewer: seed an audit DB with a known leaked token, run `mcp-proxy audit-secrets -db <path>`, confirm the row is reported and exit code is 1