### PR TITLE
docs(openclaw): add CLI reference and agent tools pages, expand overview

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -103,6 +103,8 @@ export default defineConfig({
           items: [
             { label: "Overview", slug: "openclaw/overview" },
             { label: "Installation", slug: "openclaw/installation" },
+            { label: "CLI Reference", slug: "openclaw/cli-reference" },
+            { label: "Agent Tools", slug: "openclaw/agent-tools" },
           ],
         },
         {

--- a/site/src/content/docs/openclaw/agent-tools.mdx
+++ b/site/src/content/docs/openclaw/agent-tools.mdx
@@ -1,0 +1,108 @@
+---
+title: Agent Tools
+description: Reference for the two Agent Receipts tools the OpenClaw agent can call — ar_query_receipts and ar_verify_chain.
+---
+
+The `@agnt-rcpt/openclaw` plugin registers two tools that the OpenClaw agent can call directly during a session:
+
+| Tool | Purpose |
+|------|---------|
+| `ar_query_receipts` | Query and summarise receipts from the current or past sessions |
+| `ar_verify_chain`   | Verify the cryptographic integrity of a receipt chain |
+
+These tools are not visible by default. See [Installation: Tool visibility](/openclaw/installation/#tool-visibility) for the `alsoAllow` config required to expose them to the agent.
+
+---
+
+## `ar_query_receipts`
+
+Returns a summary of receipts matching the given filters, including breakdowns by risk level, outcome status, and action type.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action_type` | string (optional) | Filter by action type, e.g. `filesystem.file.read` |
+| `risk_level`  | string (optional) | Filter by risk level: `low`, `medium`, `high`, `critical` |
+| `status`      | string (optional) | Filter by outcome: `success` or `failure` |
+| `limit`       | number (optional) | Maximum number of results to include |
+| `session_id`  | string (optional) | Restrict to a specific session; defaults to the current session |
+
+All parameters are optional. Called with no arguments the tool returns a summary of all receipts in the current session.
+
+### Example
+
+**Agent prompt:**
+
+> Query all high-risk actions from this session
+
+**Tool response:**
+
+```json
+{
+  "total_receipts": 12,
+  "results": [
+    { "action": "filesystem.file.delete", "risk": "high", "target": "delete_file", "status": "success", "sequence": 7 },
+    { "action": "system.command.execute", "risk": "high", "target": "run_command",  "status": "success", "sequence": 3 }
+  ]
+}
+```
+
+:::tip
+The agent can use `ar_query_receipts` to self-audit mid-session — for example, to confirm which files it has already written before deciding whether to proceed with a destructive operation.
+:::
+
+---
+
+## `ar_verify_chain`
+
+Verifies the cryptographic integrity of a receipt chain: checks every Ed25519 signature and every SHA-256 hash link between receipts.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `chain_id` | string | The chain to verify. Defaults to the current session's chain if omitted. |
+
+### Example — valid chain
+
+**Agent prompt:**
+
+> Verify the audit trail for this session
+
+**Tool response:**
+
+```
+Chain "chain_openclaw_main_sid-42" is valid: 12 receipts, all signatures and hash links verified.
+```
+
+### Example — broken chain
+
+If a receipt has been modified or removed after it was signed, the tool reports the first position where verification fails:
+
+```
+Chain "chain_openclaw_main_sid-42": BROKEN at position 7
+Tamper detected! The following receipts have issues:
+  [7] urn:receipt:...: invalid signature, hash link
+```
+
+:::caution[A broken chain means receipts at or after the reported position cannot be trusted]
+A valid chain guarantees that no receipt was altered, inserted, or deleted after it was written. If the chain is broken, treat all receipts from the reported position onward as potentially compromised and investigate before relying on them.
+:::
+
+---
+
+## Tool visibility
+
+Both tools require explicit opt-in. The default `"coding"` profile in OpenClaw does not expose plugin-registered tools. Add them to `alsoAllow` in your `openclaw.json`:
+
+```jsonc
+{
+  "tools": {
+    "profile": "coding",
+    "alsoAllow": ["ar_query_receipts", "ar_verify_chain"]
+  }
+}
+```
+
+See [Installation: Tool visibility](/openclaw/installation/#tool-visibility) for alternative configurations, including profile-level and plugin-level allowlisting.

--- a/site/src/content/docs/openclaw/cli-reference.mdx
+++ b/site/src/content/docs/openclaw/cli-reference.mdx
@@ -1,0 +1,181 @@
+---
+title: CLI Reference
+description: Command-line reference for the OpenClaw Agent Receipts plugin — query, verify, and export receipts outside of agent sessions.
+---
+
+The `@agnt-rcpt/openclaw` package ships a CLI for inspecting the receipt database outside of active agent sessions. Use it for post-session audits, automated compliance checks, or integration with external tools via JSON output and jq.
+
+```bash
+npx @agnt-rcpt/openclaw <subcommand> [flags]
+```
+
+## Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `receipts` | List and filter receipts |
+| `verify`   | Verify the integrity of a receipt chain |
+| `export`   | Export one receipt or a full chain |
+
+---
+
+## `receipts`
+
+Lists receipts from the local database, with optional filters.
+
+```bash
+npx @agnt-rcpt/openclaw receipts [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--risk` | string | Filter by risk level: `low`, `medium`, `high`, `critical` |
+| `--action` | string | Filter by action type (e.g. `system.command.execute`) |
+| `--status` | string | Filter by outcome: `success` or `failure` |
+| `--limit` | number | Maximum number of results to return |
+| `--db` | path | Path to the SQLite database (default: `~/.openclaw/agent-receipts/receipts.db`) |
+| `--json` | flag | Output raw JSON instead of the default tabular display |
+
+### Examples
+
+List all high-risk receipts:
+
+```bash
+npx @agnt-rcpt/openclaw receipts --risk high
+```
+
+List the last 20 receipts in JSON:
+
+```bash
+npx @agnt-rcpt/openclaw receipts --limit 20 --json
+```
+
+Filter by action type and output JSON for downstream processing:
+
+```bash
+npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
+```
+
+Use `jq` to find shell commands that reference `rm`:
+
+```bash
+npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
+  | jq '.receipts[] | select(.parameters_preview.command | strings | contains("rm"))'
+```
+
+:::note[`parameters_preview` is empty by default]
+The `parameters_preview` field is only populated when `parameterPreview` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-preview) page for configuration options.
+:::
+
+---
+
+## `verify`
+
+Verifies the cryptographic integrity of a receipt chain: checks every Ed25519 signature and every SHA-256 hash link between receipts.
+
+```bash
+npx @agnt-rcpt/openclaw verify [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--chain` | string | Chain ID to verify (required unless `--all` is given) |
+| `--all`   | flag   | Verify all chains in the database |
+| `--db`    | path   | Path to the SQLite database |
+
+### Examples
+
+Verify a specific chain:
+
+```bash
+npx @agnt-rcpt/openclaw verify --chain chain_openclaw_main_sid-42
+```
+
+Output when the chain is valid:
+
+```
+Chain "chain_openclaw_main_sid-42" is valid: 12 receipts, all signatures and hash links verified.
+```
+
+Output when tampering is detected:
+
+```
+Chain "chain_openclaw_main_sid-42": BROKEN at position 7
+Tamper detected! The following receipts have issues:
+  [7] urn:receipt:...: invalid signature, hash link
+```
+
+:::caution[Broken chains indicate tampering or corruption]
+A broken chain means one or more receipts have been modified, deleted, or inserted after the fact. The receipt at the reported position — and all receipts after it — cannot be trusted. Investigate before using the chain as evidence.
+:::
+
+Verify every chain in the database:
+
+```bash
+npx @agnt-rcpt/openclaw verify --all
+```
+
+---
+
+## `export`
+
+Exports receipts to a file or stdout, either as individual receipts or as a W3C Verifiable Presentation wrapping a full chain.
+
+```bash
+npx @agnt-rcpt/openclaw export [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--id`     | string | Export a single receipt by ID |
+| `--chain`  | string | Export all receipts in a chain |
+| `--format` | string | Output format: `json` (default) or `vp` (W3C Verifiable Presentation) |
+| `--db`     | path   | Path to the SQLite database |
+
+### `--id` vs `receipts`
+
+`export --id` fetches one receipt by its full URN and returns the complete signed credential object — including `@context`, `proof`, and all metadata fields. The `receipts` subcommand returns a collection view with summary fields only; it is designed for filtering and browsing, not for extracting individual credentials for verification.
+
+### Examples
+
+Export a single receipt as JSON:
+
+```bash
+npx @agnt-rcpt/openclaw export --id urn:receipt:abc123...
+```
+
+Export a full chain as JSON:
+
+```bash
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42
+```
+
+Export a chain as a W3C Verifiable Presentation:
+
+```bash
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42 --format vp
+```
+
+The `vp` format wraps the chain in a standard W3C VP envelope, making it suitable for submission to compliance systems or external verifiers:
+
+```json
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    { /* receipt 1 */ },
+    { /* receipt 2 */ },
+    { /* … */ }
+  ]
+}
+```
+
+:::tip
+Pipe `export --chain` output to `jq` for custom filtering or transformation before forwarding to external systems.
+:::

--- a/site/src/content/docs/openclaw/overview.mdx
+++ b/site/src/content/docs/openclaw/overview.mdx
@@ -40,7 +40,7 @@ OpenClaw agent makes a tool call
     |  - chain to previous receipt (SHA-256 hash link)
     |  - store in SQLite
     v
- Receipt written to ~/.openclaw/agent-receipts/receipts.db
+ Receipt written to SQLite (default: ~/.openclaw/agent-receipts/receipts.db; configurable via `dbPath`)
 ```
 
 The two lifecycle hooks — `before_tool_call` and `after_tool_call` — bookend every call. The `before` hook classifies the action; the `after` hook records the outcome, signs the credential, and persists it.

--- a/site/src/content/docs/openclaw/overview.mdx
+++ b/site/src/content/docs/openclaw/overview.mdx
@@ -1,19 +1,84 @@
 ---
 title: OpenClaw
-description: OpenClaw plugin for Agent Receipts.
+description: OpenClaw plugin for Agent Receipts — automatic cryptographically signed receipts for every tool call an OpenClaw agent makes.
 ---
 
 [OpenClaw](https://github.com/openclaw) is an open-source framework for managing and orchestrating AI agents, providing routing, session management, and access control for multi-agent workflows.
 
-The OpenClaw plugin integrates the Agent Receipt Protocol with OpenClaw, enabling automatic receipt generation for actions taken through OpenClaw-managed agents.
+The `@agnt-rcpt/openclaw` plugin integrates the Agent Receipt Protocol with OpenClaw, enabling automatic receipt generation for every tool call an OpenClaw-managed agent makes.
 
 **Repository:** [agent-receipts/openclaw](https://github.com/agent-receipts/openclaw)
 
 ## What it does
 
-- Intercepts agent actions routed through OpenClaw
-- Generates signed Agent Receipts for each action
-- Maintains hash-chained receipt sequences per session
-- Stores receipts locally with optional remote sync
+- Intercepts every tool call routed through OpenClaw via lifecycle hooks
+- Classifies each call using the bundled action taxonomy (filesystem, system, browser, and more)
+- Signs a W3C Verifiable Credential receipt with an Ed25519 key
+- Hash-chains receipts into a tamper-evident sequence per session
+- Stores receipts in a local SQLite database
+- Exposes two agent tools (`ar_query_receipts`, `ar_verify_chain`) so the agent can query and verify its own audit trail
 
 See [Installation](/openclaw/installation/) to get started.
+
+## How it works
+
+```
+OpenClaw agent makes a tool call
+    |
+    v
+ before_tool_call hook
+    |  - classify action type and risk level
+    |  - hash parameters
+    |
+    v
+ Tool executes
+    |
+    v
+ after_tool_call hook
+    |  - record outcome (success / failure)
+    |  - sign receipt (Ed25519)
+    |  - chain to previous receipt (SHA-256 hash link)
+    |  - store in SQLite
+    v
+ Receipt written to ~/.openclaw/agent-receipts/receipts.db
+```
+
+The two lifecycle hooks — `before_tool_call` and `after_tool_call` — bookend every call. The `before` hook classifies the action; the `after` hook records the outcome, signs the credential, and persists it.
+
+## What it looks like
+
+After a session, `ar_query_receipts` returns a summary with per-risk, per-status, and per-action breakdowns:
+
+```json
+{
+  "total_receipts": 5,
+  "total_chains": 1,
+  "by_risk": { "low": 4, "high": 1 },
+  "by_status": { "success": 4, "failure": 1 },
+  "by_action": {
+    "filesystem.file.read": 2,
+    "filesystem.file.create": 1,
+    "system.command.execute": 1,
+    "system.browser.navigate": 1
+  },
+  "results": [
+    { "id": "rec-…01", "timestamp": "2026-04-01T02:10:01Z", "action": "filesystem.file.read",    "risk": "low",  "target": "read_file",        "status": "success", "sequence": 1 },
+    { "id": "rec-…02", "timestamp": "2026-04-01T02:10:02Z", "action": "filesystem.file.read",    "risk": "low",  "target": "read_file",        "status": "failure", "sequence": 2 },
+    { "id": "rec-…03", "timestamp": "2026-04-01T02:10:03Z", "action": "system.command.execute",  "risk": "high", "target": "run_command",      "status": "success", "sequence": 3 },
+    { "id": "rec-…04", "timestamp": "2026-04-01T02:10:04Z", "action": "system.browser.navigate", "risk": "low",  "target": "browser_navigate", "status": "success", "sequence": 4 },
+    { "id": "rec-…05", "timestamp": "2026-04-01T02:10:05Z", "action": "filesystem.file.create",  "risk": "low",  "target": "write_file",       "status": "success", "sequence": 5 }
+  ]
+}
+```
+
+The same data is available from the CLI outside of agent sessions — see [CLI Reference](/openclaw/cli-reference/).
+
+## Use cases
+
+**Post-incident review** — after an agent produces an unexpected result, query its receipt chain to replay every tool call in order, see which step failed, and confirm what parameters were used.
+
+**Compliance** — export signed receipts as W3C Verifiable Presentations for record-keeping. Every receipt includes a cryptographic proof that it was produced by a specific key at a specific time, and that it has not been tampered with since.
+
+**Multi-agent trust** — in workflows where one agent invokes another, each agent maintains its own receipt chain. The hash links within each chain let a downstream verifier confirm that no receipt was inserted, removed, or modified after the fact.
+
+**Cost and activity tracking** — the action taxonomy and risk classifications in the receipts give a structured breakdown of what the agent actually did: how many reads vs. writes, how many high-risk calls, which tools were used most.


### PR DESCRIPTION
## Summary

- Expands `site/src/content/docs/openclaw/overview.mdx` with three new sections: **How it works** (hook flow diagram), **What it looks like** (JSON query result example), and **Use cases** (post-incident review, compliance, multi-agent trust, cost tracking)
- Adds `site/src/content/docs/openclaw/cli-reference.mdx` documenting all three CLI subcommands (`receipts`, `verify`, `export`) with flags, examples, the jq filtering pattern, and a note about `parameters_preview` requiring opt-in
- Adds `site/src/content/docs/openclaw/agent-tools.mdx` documenting `ar_query_receipts` and `ar_verify_chain` with parameters, example queries/responses for valid and broken chains, and a tool visibility reminder
- Updates `site/astro.config.mjs` to add CLI Reference and Agent Tools to the OpenClaw sidebar section

## Test plan

- [ ] `pnpm build` passes in `site/` with no broken link warnings for the new pages
- [ ] New pages appear in the sidebar under OpenClaw in the built site
- [ ] Cross-links (`/openclaw/installation/#parameter-preview`, `/openclaw/installation/#tool-visibility`, `/openclaw/cli-reference/`) resolve correctly
- [ ] All code blocks render correctly (JSON, bash, plain text terminal output)