### PR TITLE
sdk/ts + openclaw: rename parameters_preview → parameters_disclosure

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,6 +9,25 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.6.0] - 2026-04-28
+
+### Changed
+
+- **BREAKING:** Renamed `parameters_preview` → `parameters_disclosure` on the
+  `Action` interface and its Zod schema. Per
+  [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md),
+  "preview" misdescribed a permanent, signed field — receipts are durable, so
+  any value placed there is a deliberate disclosure rather than a transient
+  preview. The shape is unchanged (`Record<string, string>`); only the field
+  name moved. No deprecation alias is provided: pre-1.0 adoption is low and
+  the rename is intentionally a clean break. Tracking issue:
+  [#283](https://github.com/agent-receipts/ar/issues/283).
+
+  Migration: rename every read/write of `action.parameters_preview` to
+  `action.parameters_disclosure`. Previously written receipts that carry the
+  old key under `.passthrough()` will still load, but new receipts MUST use
+  the new key to round-trip through this SDK's typed surface.
+
 ## [0.5.0] - 2026-04-27
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",

--- a/sdk/ts/src/receipt/create.test.ts
+++ b/sdk/ts/src/receipt/create.test.ts
@@ -112,17 +112,17 @@ describe("createReceipt", () => {
 		expect(action.parameters_hash).toBe("sha256:abc123");
 	});
 
-	it("passes through parameters_preview", () => {
+	it("passes through parameters_disclosure", () => {
 		const input = makeInput({
 			action: {
 				type: "filesystem.file.create",
 				risk_level: "medium",
-				parameters_preview: { path: "/tmp/test.txt", mode: "write" },
+				parameters_disclosure: { path: "/tmp/test.txt", mode: "write" },
 			},
 		});
 		const receipt = createReceipt(input);
 
-		expect(receipt.credentialSubject.action.parameters_preview).toEqual({
+		expect(receipt.credentialSubject.action.parameters_disclosure).toEqual({
 			path: "/tmp/test.txt",
 			mode: "write",
 		});

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -63,7 +63,7 @@ const actionSchema = z
 		risk_level: riskLevelSchema,
 		target: actionTargetSchema.optional(),
 		parameters_hash: z.string().optional(),
-		parameters_preview: z.record(z.string()).optional(),
+		parameters_disclosure: z.record(z.string()).optional(),
 		timestamp: z.string(),
 		trusted_timestamp: z.string().optional(),
 	})

--- a/sdk/ts/src/receipt/types.test.ts
+++ b/sdk/ts/src/receipt/types.test.ts
@@ -78,7 +78,10 @@ describe("receipt types", () => {
 					risk_level: "high",
 					target: { system: "mail.google.com", resource: "email:compose" },
 					parameters_hash: "sha256:abc123",
-					parameters_preview: { to: "team@example.com", subject: "Q3 Report" },
+					parameters_disclosure: {
+						to: "team@example.com",
+						subject: "Q3 Report",
+					},
 					timestamp: "2026-03-29T14:30:00Z",
 				},
 				intent: {

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -64,7 +64,7 @@ export interface Action {
 	target?: ActionTarget;
 	parameters_hash?: string;
 	/**
-	 * Operator-controlled, additive preview of parameter values for audit display.
+	 * Operator-controlled, additive disclosure of parameter values for audit display.
 	 * SAFETY: callers MUST restrict keys to an explicit operator-managed allowlist.
 	 * Never populate from raw arguments — receipts are signed and durable, and any
 	 * value placed here is permanent. The SDK does not auto-populate or validate
@@ -72,8 +72,13 @@ export interface Action {
 	 * support is tracked in
 	 * {@link https://github.com/agent-receipts/ar/issues/258 | #258}.
 	 * `parameters_hash` remains the cryptographic commitment to the full payload.
+	 *
+	 * Renamed from `parameters_preview` in 0.6.0 per
+	 * {@link https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md | ADR-0012}
+	 * — "preview" misdescribed a permanent, signed field. No deprecation alias
+	 * is provided; pre-1.0 callers must update field names.
 	 */
-	parameters_preview?: Record<string, string>;
+	parameters_disclosure?: Record<string, string>;
 	timestamp: string;
 	trusted_timestamp?: string;
 }

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -117,7 +117,7 @@ With `"high"` enabled, a `system.command.execute` receipt includes:
 }
 ```
 
-The hash always covers the full original parameters regardless of disclosure config. Only the **first** matching field from the taxonomy's `disclosure_fields` list is included in `parameters_disclosure`, and non-string values are JSON-stringified. Disclosed values are stored verbatim — do not list fields that may contain secrets.
+The hash always covers the full original parameters regardless of disclosure config. Only the **first** matching field from the taxonomy's `preview_fields` list is included in `parameters_disclosure`, and non-string values are JSON-stringified. Disclosed values are stored verbatim — do not list fields that may contain secrets.
 
 > The config key was named `parameterPreview` and the receipt field
 > `parameters_preview` before the 0.6.0 SDK release. Per

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -70,7 +70,7 @@ All configuration is optional. Defaults are shown below:
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
           // "taxonomyPath": "/path/to/custom-taxonomy.json",  // optional — overrides bundled taxonomy
-          "parameterPreview": false       // false | true | "high" | string[]
+          "parameterDisclosure": false    // false | true | "high" | string[]
         }
       }
     }
@@ -78,9 +78,9 @@ All configuration is optional. Defaults are shown below:
 }
 ```
 
-## Parameter preview
+## Parameter disclosure
 
-By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterDisclosure` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
 
 ```jsonc
 {
@@ -88,7 +88,7 @@ By default, action parameters are hashed but not stored in plaintext. Enable `pa
     "entries": {
       "openclaw-agent-receipts": {
         "config": {
-          "parameterPreview": "high"
+          "parameterDisclosure": "high"
         }
       }
     }
@@ -101,9 +101,9 @@ Options:
 | Value | Behavior |
 |-------|----------|
 | `false` | Hashes only — no plaintext (default) |
-| `true` | Preview enabled for all action types |
-| `"high"` | Preview enabled for `high` and `critical` risk actions only |
-| `["system.command.execute"]` | Preview enabled for specific action types |
+| `true` | Disclosure enabled for all action types |
+| `"high"` | Disclosure enabled for `high` and `critical` risk actions only |
+| `["system.command.execute"]` | Disclosure enabled for specific action types |
 
 With `"high"` enabled, a `system.command.execute` receipt includes:
 
@@ -111,13 +111,20 @@ With `"high"` enabled, a `system.command.execute` receipt includes:
 {
   // ...other receipt fields
   "parameters_hash": "sha256:9c84a8c9...",
-  "parameters_preview": {
+  "parameters_disclosure": {
     "command": "echo \"Testing agent-receipts plugin fix\""
   }
 }
 ```
 
-The hash always covers the full original parameters regardless of preview config. Only the **first** matching field from the taxonomy's `preview_fields` list is included in `parameters_preview`, and non-string values are JSON-stringified. Previewed values are stored verbatim — do not list fields that may contain secrets.
+The hash always covers the full original parameters regardless of disclosure config. Only the **first** matching field from the taxonomy's `disclosure_fields` list is included in `parameters_disclosure`, and non-string values are JSON-stringified. Disclosed values are stored verbatim — do not list fields that may contain secrets.
+
+> The config key was named `parameterPreview` and the receipt field
+> `parameters_preview` before the 0.6.0 SDK release. Per
+> [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md),
+> "preview" misdescribed a permanent, signed field, so both renamed to
+> `parameterDisclosure` / `parameters_disclosure` in lockstep. There is no
+> deprecation alias — update your `openclaw.json`.
 
 ## Verify the install
 


### PR DESCRIPTION
Closes #283 (in part — TS SDK + OpenClaw docs portion).

Per [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md), the field name `parameters_preview` misdescribed a permanent, signed value: receipts are durable, so anything written there is a deliberate disclosure rather than a transient preview. This PR renames the field on the TypeScript surface and updates the OpenClaw plugin docs in lockstep. The receipt shape is unchanged (`Record<string, string>`); only the key moved. The encrypted-envelope half of ADR-0012 is a future follow-up.

**Merge order: 2 of 4** — depends on #254 (spec rename), unblocks #255 (Go SDK) and #256 (Python SDK).

## Changes

### TypeScript SDK (`sdk/ts/`)

- `src/receipt/types.ts` — `Action.parameters_preview` → `parameters_disclosure`; JSDoc rewritten and an ADR-0012 migration note appended.
- `src/receipt/schema.ts` — Zod field renamed in the action schema.
- `src/receipt/types.test.ts` — full-receipt fixture uses the new key.
- `src/receipt/create.test.ts` — pass-through test renamed and updated.
- `package.json` — version bumped 0.5.0 → 0.6.0 (breaking rename; pre-1.0 protocol stays at 0.1.0).
- `CHANGELOG.md` — new [0.6.0] entry under \"Changed\" with a BREAKING marker and migration note.

### OpenClaw plugin docs (`site/src/content/docs/openclaw/`)

- `installation.mdx` — config key `parameterPreview` → `parameterDisclosure`; example output uses `parameters_disclosure`; surrounding prose updated; appended a backwards-incompat note pointing at ADR-0012.

> The OpenClaw plugin source lives in a sibling repo (`agent-receipts/openclaw`), not in this repo, so the runtime config-key rename for the plugin itself will need a matching PR there. This PR covers only what lives in `agent-receipts/ar`.

### Out of scope

- `cross-sdk-tests/` fixtures — separate follow-up.
- `spec/` schemas — handled in #254.
- Go and Python SDKs — handled in #255 and #256.

## Breaking change

`@agnt-rcpt/sdk-ts@0.6.0` removes `parameters_preview` from the typed surface. There is no deprecation alias — adoption is low pre-1.0 and the rename is intentionally a clean break. Receipts previously serialized with `parameters_preview` still round-trip through the schema's `.passthrough()` path, but they will not appear under the typed `Action.parameters_disclosure` key. New code must write the new field name to be visible through the typed API.

## Test plan

- [x] `pnpm test` in `sdk/ts/` — all 187 tests pass (12 files).
- [x] grep `parameters_preview` in `sdk/ts/` shows only the intentional migration references (CHANGELOG + JSDoc).
- [x] grep `parameterPreview` in `site/src/content/docs/openclaw/` — only the historical reference in the migration note.
- [ ] Confirm cross-SDK fixtures still verify after the spec-side PR (#254) lands; this PR doesn't touch fixtures and the receipt shape is unchanged.
- [ ] Coordinate with #255 (Go) and #256 (Python) so all three SDKs ship the rename in lockstep.