### PR TITLE
feat(spec): add parameters_disclosure to Action

### DIFF
--- a/spec/examples/parameters-disclosure-receipt.json
+++ b/spec/examples/parameters-disclosure-receipt.json
@@ -28,32 +28,29 @@
     },
     "action": {
       "id": "act_7f3a1b2c-d4e5-46f7-a8b9-c0d1e2f3a4b5",
-      "type": "communication.email.send",
+      "type": "system.command.execute",
       "risk_level": "high",
       "target": {
-        "system": "mail.google.com",
-        "resource": "email:compose"
+        "system": "localhost",
+        "resource": "shell:bash"
       },
       "parameters_hash": "sha256:a3f1c2d4e5b6a7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1d6",
       "parameters_disclosure": {
-        "to": "team@example.com",
-        "subject": "Q3 report"
+        "command": "echo \"build complete\""
       },
       "timestamp": "2026-04-28T10:00:00Z"
     },
     "intent": {
-      "prompt_preview": "Send the Q3 report to the team",
+      "prompt_preview": "Run the build completion notification command",
       "prompt_preview_truncated": false
     },
     "outcome": {
       "status": "success",
-      "reversible": true,
-      "reversal_method": "gmail:undo_send",
-      "reversal_window_seconds": 30
+      "reversible": false
     },
     "authorization": {
       "scopes": [
-        "email:send"
+        "shell:execute"
       ],
       "granted_at": "2026-04-28T09:30:00Z",
       "expires_at": "2026-04-28T10:30:00Z"

--- a/spec/examples/parameters-disclosure-receipt.json
+++ b/spec/examples/parameters-disclosure-receipt.json
@@ -1,0 +1,74 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.1",
+  "issuer": {
+    "id": "did:agent:claude-cowork-instance-abc123",
+    "type": "AIAgent",
+    "name": "Claude Cowork",
+    "operator": {
+      "id": "did:org:anthropic",
+      "name": "Anthropic"
+    },
+    "model": "claude-sonnet-4-6",
+    "session_id": "session_xyz789"
+  },
+  "issuanceDate": "2026-04-28T10:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:otto-abc",
+      "type": "HumanPrincipal"
+    },
+    "action": {
+      "id": "act_7f3a1b2c-d4e5-46f7-a8b9-c0d1e2f3a4b5",
+      "type": "communication.email.send",
+      "risk_level": "high",
+      "target": {
+        "system": "mail.google.com",
+        "resource": "email:compose"
+      },
+      "parameters_hash": "sha256:a3f1c2d4e5b6a7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1d6",
+      "parameters_disclosure": {
+        "to": "team@example.com",
+        "subject": "Q3 report"
+      },
+      "timestamp": "2026-04-28T10:00:00Z"
+    },
+    "intent": {
+      "prompt_preview": "Send the Q3 report to the team",
+      "prompt_preview_truncated": false
+    },
+    "outcome": {
+      "status": "success",
+      "reversible": true,
+      "reversal_method": "gmail:undo_send",
+      "reversal_window_seconds": 30
+    },
+    "authorization": {
+      "scopes": [
+        "email:send"
+      ],
+      "granted_at": "2026-04-28T09:30:00Z",
+      "expires_at": "2026-04-28T10:30:00Z"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_session_xyz789"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-28T10:00:01Z",
+    "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
+  }
+}

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -162,7 +162,7 @@
         "parameters_disclosure": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "Operator-controlled flat map of parameter field name → stringified value. Only fields the operator allowlists via the `parameterDisclosure` config (per ADR-0012) are ever included. The parameters_hash still covers the full parameter set; the disclosure is additive metadata for human/auditor display. The envelope-based encrypted form is reserved for a future schema version per ADR-0012."
+          "description": "Operator-controlled flat map of parameter field name → stringified value. Only fields the operator allowlists via the `parameterDisclosure` config (per ADR-0012) are ever included; operators MUST NOT disclose fields that may contain secrets, PII, or other sensitive payload data — `parameters_hash` is the privacy-preserving default, and this field is additive metadata for human/auditor display only. The envelope-based encrypted form (per ADR-0012 Phase B) is reserved for a future schema version."
         },
         "timestamp": {
           "type": "string",

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -159,6 +159,11 @@
           "$ref": "#/$defs/sha256Hash",
           "description": "SHA-256 hash of the action parameters (RFC 8785 canonical JSON)."
         },
+        "parameters_disclosure": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Operator-controlled flat map of parameter field name → stringified value. Only fields explicitly listed in the taxonomy preview_fields config are ever included. The parameters_hash still covers the full parameter set; the disclosure is additive metadata for human/auditor display. The envelope-based encrypted form is reserved for a future schema version per ADR-0012."
+        },
         "timestamp": {
           "type": "string",
           "format": "date-time",

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -162,7 +162,7 @@
         "parameters_disclosure": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "Operator-controlled flat map of parameter field name → stringified value. Only fields explicitly listed in the taxonomy preview_fields config are ever included. The parameters_hash still covers the full parameter set; the disclosure is additive metadata for human/auditor display. The envelope-based encrypted form is reserved for a future schema version per ADR-0012."
+          "description": "Operator-controlled flat map of parameter field name → stringified value. Only fields the operator allowlists via the `parameterDisclosure` config (per ADR-0012) are ever included. The parameters_hash still covers the full parameter set; the disclosure is additive metadata for human/auditor display. The envelope-based encrypted form is reserved for a future schema version per ADR-0012."
         },
         "timestamp": {
           "type": "string",


### PR DESCRIPTION
Closes #254. Per [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md).

**Merge order: 1 of 4** — must merge before #283 (TS rename), #255 (Go), #256 (Py).

## Summary

- Add an optional `parameters_disclosure` field to the `Action` definition in `spec/schema/agent-receipt.schema.json`. Flat string→string map. The `parameters_hash` still covers the full parameter set; the disclosure is additive metadata for human/auditor display. The envelope-based encrypted form is reserved for a future schema version per ADR-0012.
- Add `spec/examples/parameters-disclosure-receipt.json` exercising the field.

## Scope

- No SDK code touched.
- No `cross-sdk-tests/` fixtures touched (deferred to a follow-up PR after all four SDKs land).
- Field is additive and optional — pre-existing receipts and examples stay valid.

## Test plan

- [ ] Schema validates as draft 2020-12 JSON Schema
- [ ] All existing examples in `spec/examples/` still validate against the updated schema (field is optional)
- [ ] New `parameters-disclosure-receipt.json` validates against the updated schema