### PR TITLE
feat(sdk-py): add parameters_disclosure to Action

### DIFF
--- a/sdk/py/src/agent_receipts/receipt/create.py
+++ b/sdk/py/src/agent_receipts/receipt/create.py
@@ -37,6 +37,7 @@ class ActionInput(BaseModel):
     risk_level: str
     target: Any = None  # noqa: ANN401
     parameters_hash: str | None = None
+    parameters_disclosure: dict[str, str] | None = None
     trusted_timestamp: str | None = None
 
 
@@ -75,6 +76,8 @@ def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
         action_data["target"] = input.action.target
     if input.action.parameters_hash is not None:
         action_data["parameters_hash"] = input.action.parameters_hash
+    if input.action.parameters_disclosure is not None:
+        action_data["parameters_disclosure"] = input.action.parameters_disclosure
     if input.action.trusted_timestamp is not None:
         action_data["trusted_timestamp"] = input.action.trusted_timestamp
 

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -69,7 +69,16 @@ class Action(BaseModel):
     risk_level: RiskLevel
     target: ActionTarget | None = None
     parameters_hash: str | None = None
-    parameters_disclosure: dict[str, str] | None = None
+    parameters_disclosure: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Operator-controlled disclosure metadata for intentionally "
+            "revealed parameter values (per ADR-0012). Operators MUST NOT "
+            "include secrets, PII, or other sensitive payload data — "
+            "parameters_hash is the privacy-preserving default. Included "
+            "in the canonical hash when present."
+        ),
+    )
     timestamp: str
     trusted_timestamp: str | None = None
 

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -69,6 +69,7 @@ class Action(BaseModel):
     risk_level: RiskLevel
     target: ActionTarget | None = None
     parameters_hash: str | None = None
+    parameters_disclosure: dict[str, str] | None = None
     timestamp: str
     trusted_timestamp: str | None = None
 

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -1,9 +1,11 @@
 """Tests for receipt types and constants."""
 
+from agent_receipts.receipt.hash import hash_receipt
 from agent_receipts.receipt.types import (
     CONTEXT,
     CREDENTIAL_TYPE,
     VERSION,
+    AgentReceipt,
 )
 from tests.conftest import make_receipt, make_unsigned
 
@@ -59,3 +61,58 @@ class TestUnsignedAgentReceipt:
         unsigned = make_unsigned(1, None)
         assert unsigned.credentialSubject.chain.sequence == 1
         assert unsigned.credentialSubject.chain.previous_receipt_hash is None
+
+
+class TestParametersDisclosure:
+    """Round-trip tests for the optional Action.parameters_disclosure field."""
+
+    def test_default_is_none(self) -> None:
+        receipt = make_receipt()
+        assert receipt.credentialSubject.action.parameters_disclosure is None
+
+    def test_round_trip_serialise_deserialise(self) -> None:
+        receipt = make_receipt()
+        receipt.credentialSubject.action.parameters_disclosure = {
+            "path": "/tmp/foo.txt",
+            "mode": "r",
+        }
+
+        dumped = receipt.model_dump(by_alias=True)
+        action_dict = dumped["credentialSubject"]["action"]
+        assert action_dict["parameters_disclosure"] == {
+            "path": "/tmp/foo.txt",
+            "mode": "r",
+        }
+
+        restored = AgentReceipt.model_validate(dumped)
+        assert restored.credentialSubject.action.parameters_disclosure == {
+            "path": "/tmp/foo.txt",
+            "mode": "r",
+        }
+
+    def test_included_in_canonical_hash_when_present(self) -> None:
+        """Setting parameters_disclosure must change the canonical hash."""
+        baseline = make_receipt()
+        baseline_hash = hash_receipt(baseline)
+
+        with_disclosure = make_receipt()
+        with_disclosure.credentialSubject.action.parameters_disclosure = {
+            "path": "/tmp/foo.txt",
+        }
+        disclosure_hash = hash_receipt(with_disclosure)
+
+        assert baseline_hash != disclosure_hash
+
+    def test_omitted_from_canonical_hash_when_none(self) -> None:
+        """When parameters_disclosure is None, hash matches a receipt without it."""
+        r1 = make_receipt()
+        r2 = make_receipt()
+        r2.credentialSubject.action.parameters_disclosure = None
+        assert hash_receipt(r1) == hash_receipt(r2)
+
+    def test_canonical_hash_is_deterministic(self) -> None:
+        r1 = make_receipt()
+        r1.credentialSubject.action.parameters_disclosure = {"a": "1", "b": "2"}
+        r2 = make_receipt()
+        r2.credentialSubject.action.parameters_disclosure = {"a": "1", "b": "2"}
+        assert hash_receipt(r1) == hash_receipt(r2)

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -104,15 +104,19 @@ class TestParametersDisclosure:
         assert baseline_hash != disclosure_hash
 
     def test_omitted_from_canonical_hash_when_none(self) -> None:
-        """When parameters_disclosure is None, hash matches a receipt without it."""
-        r1 = make_receipt()
-        r2 = make_receipt()
-        r2.credentialSubject.action.parameters_disclosure = None
-        assert hash_receipt(r1) == hash_receipt(r2)
+        """Explicit null and omitted parameters_disclosure hash identically."""
+        with_null = make_receipt().model_dump(by_alias=True)
+        with_null["credentialSubject"]["action"]["parameters_disclosure"] = None
+
+        omitted = make_receipt().model_dump(by_alias=True)
+        omitted["credentialSubject"]["action"].pop("parameters_disclosure", None)
+
+        assert hash_receipt(with_null) == hash_receipt(omitted)
 
     def test_canonical_hash_is_deterministic(self) -> None:
+        """Different insertion order produces identical canonical hash."""
         r1 = make_receipt()
         r1.credentialSubject.action.parameters_disclosure = {"a": "1", "b": "2"}
         r2 = make_receipt()
-        r2.credentialSubject.action.parameters_disclosure = {"a": "1", "b": "2"}
+        r2.credentialSubject.action.parameters_disclosure = {"b": "2", "a": "1"}
         assert hash_receipt(r1) == hash_receipt(r2)


### PR DESCRIPTION
Closes #256. Per [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md).

**Merge order: 4 of 4** — depends on #286 (spec), #285 (TS rename), and the Go PR.

## Summary

Adds an optional `parameters_disclosure: dict[str, str] | None = None` field to the `Action` Pydantic model in `sdk/py/src/agent_receipts/receipt/types.py`. The Python SDK has not shipped a prior name, so this is a clean addition.

The encrypted envelope shape from ADR-0012 is deferred to a follow-up; this change covers the simple string-map form only.

## Tests

`sdk/py/tests/receipt/test_types.py` adds five round-trip tests under `TestParametersDisclosure`:

- Default is `None`.
- Round-trip serialise/deserialise preserves entries.
- Field included in canonical hash when present.
- Field omitted from canonical hash when `None` (existing receipts canonicalize identically).
- Hash is deterministic across equivalent inputs.

## Verification

- [x] `uv run pytest` — 194 passed
- [x] `uv run ruff check` — clean

## Scope

- No spec, TS, or Go code touched.
- No `cross-sdk-tests/` fixtures touched (deferred to a follow-up PR after all four SDKs land).