### PR TITLE
chore(hooks): filter test-before-push to actual git push commands

### DIFF
--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -1,10 +1,49 @@
 #!/usr/bin/env bash
-# Run tests before git push.
-# Detects which components have committed changes relative to the upstream
-# branch and runs their tests.
-# Exit 0: tests passed. Exit 2: tests failed.
+# Run tests before `git push` to catch regressions in changed components.
+#
+# Wired as PreToolUse:Bash in .claude/settings.json. Claude Code's hook
+# `matcher` field is a regex on tool names — there is no built-in way to
+# restrict by command content, so this hook fires on every Bash invocation
+# and filters here. Without that filter, every `ls` / `git status` would
+# re-trigger the full test matrix.
+#
+# Stdin protocol: Claude Code passes a JSON object containing
+# `.tool_input.command`. We parse it, exit 0 immediately for any command
+# that isn't a `git push`, and only fall through to the test runners for
+# real pushes. Robust to missing `jq` (uses sed fallback) and to non-JSON
+# input (treats empty COMMAND as not-a-push, exits 0).
+#
+# Exits:
+#   0  not a `git push`, or all relevant tests passed
+#   2  one or more component test suites failed; do not push
 
 set -euo pipefail
+
+# --- Filter: only run for `git push` -----------------------------------------
+
+extract_command() {
+  local input="${1:-}"
+  [ -z "$input" ] && return 0
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null
+  else
+    printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
+  fi
+}
+
+TOOL_INPUT="$(cat 2>/dev/null || true)"
+COMMAND="$(extract_command "$TOOL_INPUT")"
+
+# Match `git push` either at the start of the command or after whitespace.
+# This covers env-var prefixes (`FOO=bar git push`) and shell-list operators
+# (`&& git push`, `; git push`, `|| git push`) since each is followed by a
+# space in normal shell usage. Avoids false positives like `echo "git push"`.
+case "$COMMAND" in
+  "git push"*|*" git push"*) ;;
+  *) exit 0 ;;
+esac
+
+# --- Run tests for changed components ----------------------------------------
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 FAILED=0

--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -25,7 +25,9 @@ extract_command() {
   local input="${1:-}"
   [ -z "$input" ] && return 0
   if command -v jq >/dev/null 2>&1; then
-    printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null
+    # `|| true` so `set -e` doesn't kill the script on malformed JSON;
+    # an empty result falls through to "not a git push" and exits 0.
+    printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true
   else
     printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
   fi
@@ -34,12 +36,14 @@ extract_command() {
 TOOL_INPUT="$(cat 2>/dev/null || true)"
 COMMAND="$(extract_command "$TOOL_INPUT")"
 
-# Match `git push` either at the start of the command or after whitespace.
-# This covers env-var prefixes (`FOO=bar git push`) and shell-list operators
+# Match `git push` only when `push` is the end of the command or followed by
+# whitespace, so `git push --force` matches but `git pushup` does not.
+# Covers env-var prefixes (`FOO=bar git push`) and shell-list operators
 # (`&& git push`, `; git push`, `|| git push`) since each is followed by a
-# space in normal shell usage. Avoids false positives like `echo "git push"`.
+# space in normal shell usage. Avoids false positives like `echo "git push"`
+# (no leading whitespace boundary) and `git pushup` (no trailing boundary).
 case "$COMMAND" in
-  "git push"*|*" git push"*) ;;
+  "git push"|"git push "*|*" git push"|*" git push "*) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,6 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(git push*)",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

The `PreToolUse:Bash` hook in `.claude/settings.json` was firing on **every** Bash invocation rather than only on `git push`. The `if: "Bash(git push*)"` field in the config was an attempt to scope the hook by command pattern, but Claude Code hook configs only support a regex matcher on tool names — there is no built-in command-content filter, so the field was silently ignored.

The result: every `ls`, `git status`, or `pnpm install` re-ran the full repo test matrix, which fails loudly in any worktree missing `pnpm` / `uv` deps and blocks subsequent work. This bit four parallel agents during the `parameters_disclosure` rollout (#285/#286/#287/#288).

## Fix

- **`.claude/hooks/test-before-push.sh`** — read the JSON tool-input payload on stdin and exit `0` immediately for any command that isn't a `git push`. Robust to missing `jq` (sed fallback) and to non-JSON input. Header comment documents the design choice so the next reader doesn't try to "fix" the broad matcher.
- **`.claude/settings.json`** — drop the misleading `if` field. Matcher stays as `"Bash"`; filtering is in the script.

The test-running logic itself is unchanged. When a real `git push` fires, the hook still detects changed components and runs their tests.

## Test plan

- [x] Run a non-push Bash command (e.g. `echo`, `ls`, `git status`) — hook exits `0`, no test matrix runs.
- [ ] Run `git push` from a clean worktree with deps installed — hook detects changed paths and runs the relevant test runner(s).
- [ ] Run `git push` from a worktree with failing tests — hook exits non-zero and blocks the push.
- [x] `shellcheck` clean.

## Notes

- Filter patterns: `"git push"*` (start of command) and `*" git push"*` (after whitespace, covering env-var prefixes, `&& git push`, `; git push`, `|| git push`). Doesn't match `echo "git push"` or `git pushup` (false positives are bounded; false negatives like `;git push` without a space are rare in practice).
- This does not introduce or replace any git pre-push hook (e.g. lefthook); the behaviour is scoped to Claude Code's hook system only.