### PR TITLE
test(cross-sdk-tests): add parameters_disclosure vector

### DIFF
--- a/cross-sdk-tests/canonicalization_vectors.json
+++ b/cross-sdk-tests/canonicalization_vectors.json
@@ -54,6 +54,14 @@
       "canonical": "{\"\ud83c\udf89\":2,\"\ue000\":1}"
     },
     {
+      "name": "parameters_disclosure_multikey_sort",
+      "rule": "rule1_key_sort",
+      "description": "Pins the canonical form of an action.parameters_disclosure map (ADR-0012 Phase A) with two keys. The field is a plain string\u2192string map and flows through the same canonicaliser as every other map, so this is a key-sort vector rather than a parameters_disclosure-specific rule. Input has insertion order user\u2192command; canonical output sorts to command\u2192user.",
+      "input": { "user": "ci", "command": "echo build" },
+      "canonical": "{\"command\":\"echo build\",\"user\":\"ci\"}",
+      "expectedHash": "sha256:c998221c9390ec1796069faaf6c8890b70ad6693bb3b01c4d01e7a84edcf5d24"
+    },
+    {
       "name": "number_zero",
       "rule": "rule4_numbers",
       "description": "Positive zero.",
@@ -296,6 +304,40 @@
       "expectedHash": "SAME_AS_receipt_all_optional_absent"
     },
     {
+      "name": "receipt_parameters_disclosure_null_becomes_absent",
+      "rule": "rule2_null_optional_absent",
+      "preNormalizationInput": true,
+      "description": "INTENTIONALLY SCHEMA-INVALID caller input. action.parameters_disclosure is set to null, which the 0.2.1 schema (and ADR-0012 Phase A) forbids. The post-sweep canonicaliser MUST normalise null-valued optional fields to absent before hashing; the resulting canonical bytes MUST be identical to receipt_all_optional_absent. Mirrors receipt_optional_null_becomes_absent for the parameters_disclosure field specifically (regression test for ADR-0012 rollout).",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000001",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "parameters_disclosure": null,
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "expectedHash": "SAME_AS_receipt_all_optional_absent"
+    },
+    {
       "name": "receipt_required_null_preserved",
       "rule": "rule2_null_required_preserved",
       "description": "previous_receipt_hash is required-nullable; when null it MUST appear as \"previous_receipt_hash\":null in the canonical bytes. This vector is identical to receipt_all_optional_absent — included separately to document the required-nullable rule explicitly and pin a regression test against an SDK that accidentally drops it.",
@@ -425,6 +467,7 @@
             "risk_level": "low",
             "target": { "system": "local", "resource": "/tmp/x.txt" },
             "parameters_hash": "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+            "parameters_disclosure": { "command": "echo build", "user": "ci" },
             "timestamp": "2026-04-22T00:00:00Z"
           },
           "intent": {
@@ -458,7 +501,7 @@
           }
         }
       },
-      "expectedHash": "sha256:ff630bef13c63602c44c12ae7650305abb7a16cdc3e6db61ad2e620862d1b66a"
+      "expectedHash": "sha256:9e43a72dab99b0104bfdd05cebe473281fdc84153a30841d2ea044ab991c1e29"
     },
     {
       "name": "receipt_signature_preservation_legacy_0_2_0",
@@ -475,6 +518,6 @@
     "Fields marked mustContainSubstring assert a substring appears in the canonical output — useful when the full canonical is verbose but one specific byte sequence is the thing being tested (e.g., that Go does not HTML-escape < and >).",
     "Vectors marked preNormalizationInput: true carry schema-invalid caller input on purpose — they test the SDK's pre-serialization null→absent sweep. Do NOT attempt to schema-validate these `receipt` payloads; canonicalise and hash them and assert the invariant.",
     "The number vectors rely on language-native IEEE 754 double-precision arithmetic. Each SDK should construct the test value from its numeric literal exactly as written in the input field; some JSON parsers may not round-trip -0 through JSON.parse, so implementations should hard-code -0 when the vector name is number_negative_zero rather than parsing it from this file.",
-    "Legacy 0.2.0 vectors in cross-sdk-tests/v020_vectors.json stay as-is (signature-preservation proof); new vectors added in this file use schemaVersion 0.2.1."
+    "The legacy 0.2.0 terminalChain in cross-sdk-tests/v020_vectors.json stays as-is (signature-preservation proof). New vectors added to v020_vectors.json (e.g. parametersDisclosureReceipt) and to this file use schemaVersion 0.2.1."
   ]
 }

--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -46,10 +46,11 @@ type signingSection struct {
 
 // v020Vectors holds ADR-0008 cross-SDK test vectors.
 type v020Vectors struct {
-	Version      string               `json:"version"`
-	Keys         keysSection          `json:"keys"`
-	ResponseHash responseHashSection  `json:"responseHash"`
-	TerminalChain terminalChainSection `json:"terminalChain"`
+	Version                     string                             `json:"version"`
+	Keys                        keysSection                        `json:"keys"`
+	ResponseHash                responseHashSection                `json:"responseHash"`
+	TerminalChain               terminalChainSection               `json:"terminalChain"`
+	ParametersDisclosureReceipt parametersDisclosureReceiptSection `json:"parametersDisclosureReceipt"`
 }
 
 type responseHashSection struct {
@@ -59,9 +60,19 @@ type responseHashSection struct {
 }
 
 type terminalChainSection struct {
-	Receipts                           []json.RawMessage `json:"receipts"`
-	ExpectedValid                      bool              `json:"expectedValid"`
-	ExpectedValidWithRequireTerminal   bool              `json:"expectedValidWithRequireTerminal"`
+	Receipts                         []json.RawMessage `json:"receipts"`
+	ExpectedValid                    bool              `json:"expectedValid"`
+	ExpectedValidWithRequireTerminal bool              `json:"expectedValidWithRequireTerminal"`
+}
+
+// parametersDisclosureReceiptSection holds a single 0.2.1 signed receipt with
+// parameters_disclosure populated. All three SDKs MUST canonicalise, hash, and
+// verify it identically (per ADR-0012 Phase A).
+type parametersDisclosureReceiptSection struct {
+	Description         string          `json:"description"`
+	Receipt             json.RawMessage `json:"receipt"`
+	ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+	ExpectedValid       bool            `json:"expectedValid"`
 }
 
 func main() {
@@ -246,6 +257,18 @@ func generateV020Vectors(keys keysSection) error {
 		receiptJSONs[i] = json.RawMessage(b)
 	}
 
+	// Single-receipt parameters_disclosure vector (ADR-0012 Phase A, schema 0.2.1).
+	// Built standalone (not part of the legacy 0.2.0 chain), signed with the same
+	// shared key, deterministic via fixed timestamps and UUID overrides.
+	pdReceipt, pdHash, err := generateParametersDisclosureReceipt(keys)
+	if err != nil {
+		return fmt.Errorf("generate parameters_disclosure receipt: %w", err)
+	}
+	pdReceiptJSON, err := json.Marshal(pdReceipt)
+	if err != nil {
+		return fmt.Errorf("marshal parameters_disclosure receipt: %w", err)
+	}
+
 	v020 := v020Vectors{
 		Version: "0.2.0",
 		Keys:    keys,
@@ -259,6 +282,12 @@ func generateV020Vectors(keys keysSection) error {
 			ExpectedValid:                    true,
 			ExpectedValidWithRequireTerminal: true,
 		},
+		ParametersDisclosureReceipt: parametersDisclosureReceiptSection{
+			Description:         "Single 0.2.1 signed receipt with action.parameters_disclosure populated. All three SDKs MUST verify the signature and reproduce expectedReceiptHash byte-for-byte (ADR-0012 Phase A; ADR-0009 canonicalisation).",
+			Receipt:             json.RawMessage(pdReceiptJSON),
+			ExpectedReceiptHash: pdHash,
+			ExpectedValid:       true,
+		},
 	}
 
 	out, err := json.MarshalIndent(v020, "", "  ")
@@ -266,4 +295,55 @@ func generateV020Vectors(keys keysSection) error {
 		return fmt.Errorf("marshal v020 vectors: %w", err)
 	}
 	return os.WriteFile("v020_vectors.json", append(out, '\n'), 0644)
+}
+
+// generateParametersDisclosureReceipt builds a deterministic single-receipt
+// vector (schema 0.2.1) with action.parameters_disclosure populated, signs it
+// with the shared private key, and returns the signed receipt and its hash.
+//
+// The receipt deliberately uses a fresh chain (chain_pd_test, sequence 1) so it
+// cannot be confused with the legacy 0.2.0 terminalChain — that chain stays
+// frozen as the signature-preservation oracle.
+func generateParametersDisclosureReceipt(keys keysSection) (receipt.AgentReceipt, string, error) {
+	const fixedTimestamp = "2026-04-22T00:00:00Z"
+
+	r := receipt.Create(receipt.CreateInput{
+		Issuer:    receipt.Issuer{ID: "did:agent:test"},
+		Principal: receipt.Principal{ID: "did:user:test"},
+		Action: receipt.Action{
+			Type:      "filesystem.file.read",
+			RiskLevel: receipt.RiskLow,
+			ParametersDisclosure: map[string]string{
+				"command": "echo build",
+				"user":    "ci",
+			},
+		},
+		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain:   receipt.Chain{Sequence: 1, PreviousReceiptHash: nil, ChainID: "chain_pd_test"},
+	})
+	r.Version = "0.2.1"
+	r.ID = "urn:receipt:v021-pd-1"
+	r.IssuanceDate = fixedTimestamp
+	r.CredentialSubject.Action.ID = "act_v021_pd_1"
+	r.CredentialSubject.Action.Timestamp = fixedTimestamp
+
+	signed, err := receipt.Sign(r, keys.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("sign: %w", err)
+	}
+	signed.Proof.Created = fixedTimestamp
+
+	valid, err := receipt.Verify(signed, keys.PublicKey)
+	if err != nil {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("verify: %w", err)
+	}
+	if !valid {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("generated parameters_disclosure receipt failed verification")
+	}
+
+	hash, err := receipt.HashReceipt(signed)
+	if err != nil {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("hash: %w", err)
+	}
+	return signed, hash, nil
 }

--- a/cross-sdk-tests/v020_vectors.json
+++ b/cross-sdk-tests/v020_vectors.json
@@ -150,5 +150,56 @@
     ],
     "expectedValid": true,
     "expectedValidWithRequireTerminal": true
+  },
+  "parametersDisclosureReceipt": {
+    "description": "Single 0.2.1 signed receipt with action.parameters_disclosure populated. All three SDKs MUST verify the signature and reproduce expectedReceiptHash byte-for-byte (ADR-0012 Phase A; ADR-0009 canonicalisation).",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v1"
+      ],
+      "id": "urn:receipt:v021-pd-1",
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.2.1",
+      "issuer": {
+        "id": "did:agent:test"
+      },
+      "issuanceDate": "2026-04-22T00:00:00Z",
+      "credentialSubject": {
+        "principal": {
+          "id": "did:user:test"
+        },
+        "action": {
+          "id": "act_v021_pd_1",
+          "type": "filesystem.file.read",
+          "risk_level": "low",
+          "parameters_disclosure": {
+            "command": "echo build",
+            "user": "ci"
+          },
+          "timestamp": "2026-04-22T00:00:00Z"
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "chain": {
+          "sequence": 1,
+          "previous_receipt_hash": null,
+          "chain_id": "chain_pd_test"
+        }
+      },
+      "proof": {
+        "type": "Ed25519Signature2020",
+        "created": "2026-04-22T00:00:00Z",
+        "verificationMethod": "did:agent:test#key-1",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u9pZz8W-4gWMZlS2p6NqLHQY2Mm7uKg1xNz649yJdyUmbigNAXgBbAnl7b0j0klrPJzpQN-7KwLHI23Xes-7BBw"
+      }
+    },
+    "expectedReceiptHash": "sha256:c8a0e84e7ce000c6aa68df1ce5571872d2c0356a01707100afac0d30fc13560b",
+    "expectedValid": true
   }
 }

--- a/sdk/go/receipt/canonicalization_vectors_test.go
+++ b/sdk/go/receipt/canonicalization_vectors_test.go
@@ -61,6 +61,11 @@ type v020VectorFile struct {
 	TerminalChain struct {
 		Receipts []json.RawMessage `json:"receipts"`
 	} `json:"terminalChain"`
+	ParametersDisclosureReceipt struct {
+		Receipt             json.RawMessage `json:"receipt"`
+		ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+		ExpectedValid       bool            `json:"expectedValid"`
+	} `json:"parametersDisclosureReceipt"`
 }
 
 const vectorsPath = "../../../cross-sdk-tests/canonicalization_vectors.json"
@@ -243,5 +248,43 @@ func TestSignaturePreservationLegacy_0_2_0(t *testing.T) {
 		if !valid {
 			t.Errorf("receipt[%d] (%s): signature no longer verifies after canonicaliser sweep", i, signed.ID)
 		}
+	}
+}
+
+// TestParametersDisclosureReceipt verifies the cross-SDK parameters_disclosure
+// receipt vector: the signature must verify and HashReceipt must reproduce
+// expectedReceiptHash byte-for-byte (ADR-0012 Phase A).
+func TestParametersDisclosureReceipt(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(filepath.Dir("."), v020VectorsPath))
+	if err != nil {
+		t.Fatalf("read v020_vectors.json: %v", err)
+	}
+	var vf v020VectorFile
+	if err := json.Unmarshal(data, &vf); err != nil {
+		t.Fatalf("parse v020_vectors.json: %v", err)
+	}
+	if len(vf.ParametersDisclosureReceipt.Receipt) == 0 {
+		t.Fatal("v020_vectors.json: parametersDisclosureReceipt.receipt is empty")
+	}
+
+	var signed AgentReceipt
+	if err := json.Unmarshal(vf.ParametersDisclosureReceipt.Receipt, &signed); err != nil {
+		t.Fatalf("unmarshal parameters_disclosure receipt: %v", err)
+	}
+
+	valid, err := Verify(signed, vf.Keys.PublicKey)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !valid {
+		t.Fatal("parameters_disclosure receipt failed signature verification")
+	}
+
+	gotHash, err := HashReceipt(signed)
+	if err != nil {
+		t.Fatalf("HashReceipt: %v", err)
+	}
+	if gotHash != vf.ParametersDisclosureReceipt.ExpectedReceiptHash {
+		t.Errorf("HashReceipt\n  got:  %s\n  want: %s", gotHash, vf.ParametersDisclosureReceipt.ExpectedReceiptHash)
 	}
 }

--- a/sdk/py/tests/test_cross_language_go.py
+++ b/sdk/py/tests/test_cross_language_go.py
@@ -125,3 +125,17 @@ class TestV020Vectors:
         vectors = _load_v020_vectors()
         receipts = [AgentReceipt(**r) for r in vectors["terminalChain"]["receipts"]]
         assert receipts[-1].credentialSubject.chain.terminal is True
+
+    def test_parameters_disclosure_receipt_verifies(self) -> None:
+        """Go-signed parameters_disclosure receipt verifies (ADR-0012 Phase A)."""
+        vectors = _load_v020_vectors()
+        public_key = vectors["keys"]["publicKey"]
+        receipt = AgentReceipt(**vectors["parametersDisclosureReceipt"]["receipt"])
+        assert verify_receipt(receipt, public_key) is True
+
+    def test_parameters_disclosure_receipt_hash_matches_go(self) -> None:
+        """Python hash_receipt matches the Go-computed expectedReceiptHash."""
+        vectors = _load_v020_vectors()
+        section = vectors["parametersDisclosureReceipt"]
+        receipt = AgentReceipt(**section["receipt"])
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]

--- a/sdk/ts/src/receipt/cross-language.test.ts
+++ b/sdk/ts/src/receipt/cross-language.test.ts
@@ -40,6 +40,12 @@ interface V020Vectors {
 		expectedValid: boolean;
 		expectedValidWithRequireTerminal: boolean;
 	};
+	parametersDisclosureReceipt: {
+		description: string;
+		receipt: AgentReceipt;
+		expectedReceiptHash: string;
+		expectedValid: boolean;
+	};
 }
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
@@ -152,5 +158,19 @@ describe("cross-language: v0.2.0 vectors", () => {
 		const v = loadV020Vectors();
 		const last = v.terminalChain.receipts.at(-1);
 		expect(last?.credentialSubject.chain.terminal).toBe(true);
+	});
+
+	it("Go-signed parameters_disclosure receipt verifies in TypeScript", () => {
+		const v = loadV020Vectors();
+		expect(
+			verifyReceipt(v.parametersDisclosureReceipt.receipt, v.keys.publicKey),
+		).toBe(true);
+	});
+
+	it("parameters_disclosure receipt hash matches Go", () => {
+		const v = loadV020Vectors();
+		expect(hashReceipt(v.parametersDisclosureReceipt.receipt)).toBe(
+			v.parametersDisclosureReceipt.expectedReceiptHash,
+		);
 	});
 });


### PR DESCRIPTION
Closes #290.

## Summary

ADR-0012 Phase A `parameters_disclosure` shipped across spec (#286), TS (#285), Go (#287), and Py (#288) without a cross-language test vector — each SDK landed independently, with the fixture regen explicitly deferred to this PR. This adds three layers of cross-SDK proof so all three SDKs canonicalise, hash, and (where applicable) verify byte-identically when the field is present.

## Changes

**`cross-sdk-tests/canonicalization_vectors.json`**
- New `parameters_disclosure_multikey_sort` canonicalization vector — pins canonical key sort for a 2-key map.
- `receipt_all_optional_present` extended with `parameters_disclosure` (its description already promised "every currently-defined optional field"); `expectedHash` recomputed.
- New `receipt_parameters_disclosure_null_becomes_absent` receipt-hash vector — exercises ADR-0009 Rule 2 specifically for this field, asserts `SAME_AS_receipt_all_optional_absent`.
- `notes_for_implementers` clarified to reflect the now-mixed-version v020 file.

**`cross-sdk-tests/v020_vectors.json`**
- New top-level `parametersDisclosureReceipt` section: a single signed 0.2.1 receipt with `action.parameters_disclosure` populated, an `expectedReceiptHash`, and `expectedValid: true`.
- The legacy 0.2.0 `terminalChain` is **untouched** — `receipt_signature_preservation_legacy_0_2_0` still passes (verified locally).

**`cross-sdk-tests/cmd/generate-vectors/main.go`**
- New `generateParametersDisclosureReceipt` helper produces the section deterministically (Ed25519 + fixed timestamps + UUID overrides). Re-running yields zero diff.

**SDK consumers** — each adds focused tests for the new section:
- Go: `TestParametersDisclosureReceipt` in `sdk/go/receipt/canonicalization_vectors_test.go`.
- TS: two new `it(...)` blocks in `sdk/ts/src/receipt/cross-language.test.ts`.
- Py: `test_parameters_disclosure_receipt_verifies` and `test_parameters_disclosure_receipt_hash_matches_go` in `sdk/py/tests/test_cross_language_go.py`.

## Note on file naming

`v020_vectors.json` carries its top-level `"version": "0.2.0"` (anchoring the legacy chain) but now also holds a 0.2.1 receipt in the new section. This is consistent with the file's evolution into a multi-version cross-SDK oracle and is documented in `notes_for_implementers`.

## Test plan

- [x] `cd cross-sdk-tests && go run ./cmd/generate-vectors` succeeds and is deterministic on re-run (zero diff)
- [x] `cd sdk/go && go test ./...` and `go test -tags=integration ./...` pass
- [x] `cd sdk/ts && pnpm test` — 191 tests pass
- [x] `cd sdk/py && uv run pytest` — 199 tests pass
- [x] `cd cross-sdk-tests && go test ./...` — clean
- [x] `go vet ./...`, `gofmt -l`, `ruff check`, `pyright src`, `biome check` — all clean
- [x] Confirmed `terminalChain` receipts in `v020_vectors.json` byte-identical to pre-PR; signature-preservation invariant still passes