### PR TITLE
feat(mcp-proxy): guided init command for one-command setup

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -828,6 +828,11 @@ func runInit(dir, name string, force, noApproval bool, httpPort int, binPath str
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create directory %q: %w", dir, err)
 	}
+	// MkdirAll does not tighten permissions on an existing directory, so chmod
+	// explicitly to ensure private keys are never stored under a world-readable path.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("set permissions on directory %q: %w", dir, err)
+	}
 
 	// Key generation — idempotent when the full keypair already exists.
 	_, keyErr := os.Stat(keyPath)

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -760,64 +760,104 @@ func writePubKeyFile(path string, data []byte, force bool) error {
 
 func cmdInit(args []string) {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
-	keyPath := fs.String("key", "", "Path for the Ed25519 private key PEM file (required)")
-	pubPath := fs.String("pub", "", "Path for the public key PEM file (default: <key>.pub)")
-	force := fs.Bool("force", false, "Overwrite existing key files")
+	name       := fs.String("name", "default", "Name for this proxy instance (used in filenames and config snippet)")
+	noApproval := fs.Bool("no-approval", false, "Omit -http from the config snippet (no approval server)")
+	httpPort   := fs.Int("http-port", 7778, "Approval listener port written into the config snippet")
+	force      := fs.Bool("force", false, "Overwrite existing key files")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy init -key <path> [-pub <path>] [-force]\n\n")
-		fmt.Fprintf(os.Stderr, "  Generate an Ed25519 signing key pair. The private key is written with\n")
-		fmt.Fprintf(os.Stderr, "  0600 permissions (owner read/write only). Pass -key to mcp-proxy serve\n")
-		fmt.Fprintf(os.Stderr, "  to use it.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy init [-name <name>] [-force] [-no-approval] [-http-port <port>]\n\n")
+		fmt.Fprintf(os.Stderr, "  One-command setup: creates ~/.agent-receipts/, generates an Ed25519\n")
+		fmt.Fprintf(os.Stderr, "  signing keypair with correct permissions, initialises the receipt\n")
+		fmt.Fprintf(os.Stderr, "  database, and prints a claude_desktop_config.json snippet to stdout.\n\n")
+		fmt.Fprintf(os.Stderr, "  Safe to re-run: warns and skips key generation if files already exist.\n\n")
 		fs.PrintDefaults()
 	}
 	fs.Parse(args)
 
-	if *keyPath == "" {
-		fmt.Fprintln(os.Stderr, "mcp-proxy init: -key is required")
-		fs.Usage()
-		os.Exit(2)
-	}
-
-	resolvedPub := *pubPath
-	if resolvedPub == "" {
-		resolvedPub = *keyPath + ".pub"
-	}
-
-	// Preflight: check for existing files before generating or writing anything.
-	if !*force {
-		if _, err := os.Stat(*keyPath); err == nil {
-			fmt.Fprintf(os.Stderr, "mcp-proxy: key file %q already exists (use -force to overwrite)\n", *keyPath)
-			os.Exit(1)
-		}
-		if _, err := os.Stat(resolvedPub); err == nil {
-			fmt.Fprintf(os.Stderr, "mcp-proxy: public key file %q already exists (use -force to overwrite)\n", resolvedPub)
-			os.Exit(1)
-		}
-	}
-
-	kp, err := receipt.GenerateKeyPair()
+	home, err := userHomeDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy: generate key: %v\n", err)
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: resolve home directory: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := ensureDir(*keyPath); err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy: create key directory: %v\n", err)
-		os.Exit(1)
-	}
-	if err := ensureDir(resolvedPub); err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy: create public key directory: %v\n", err)
-		os.Exit(1)
+	binPath, err := os.Executable()
+	if err != nil {
+		binPath = "mcp-proxy"
 	}
 
-	if err := writePrivateKeyFile(*keyPath, []byte(kp.PrivateKey), *force); err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy: write private key: %v\n", err)
+	dir := filepath.Join(home, ".agent-receipts")
+	if err := runInit(dir, *name, *force, *noApproval, *httpPort, binPath, os.Stderr, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: %v\n", err)
 		os.Exit(1)
 	}
-	if err := writePubKeyFile(resolvedPub, []byte(kp.PublicKey), *force); err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy: write public key: %v\n", err)
-		os.Exit(1)
+}
+
+// runInit performs the guided setup: creates dir, generates a keypair (idempotent),
+// initialises the receipt DB, and writes a config snippet to out. Status messages
+// go to errOut. Accepting dir and binPath as parameters makes the function testable.
+func runInit(dir, name string, force, noApproval bool, httpPort int, binPath string, errOut, out io.Writer) error {
+	keyPath := filepath.Join(dir, name+".pem")
+	pubPath := filepath.Join(dir, name+".pem.pub")
+	dbPath  := filepath.Join(dir, "receipts.db")
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create directory %q: %w", dir, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Generated Ed25519 key pair:\n  private: %s\n  public:  %s\n", *keyPath, resolvedPub)
+	// Key generation — idempotent: warn and skip when files already exist.
+	_, keyExists := os.Stat(keyPath)
+	_, pubExists := os.Stat(pubPath)
+	if !force && (keyExists == nil || pubExists == nil) {
+		fmt.Fprintf(errOut, "warning: key files already exist — skipping key generation (use -force to overwrite)\n")
+		if keyExists == nil {
+			fmt.Fprintf(errOut, "  private key: %s\n", keyPath)
+		}
+		if pubExists == nil {
+			fmt.Fprintf(errOut, "  public key:  %s\n", pubPath)
+		}
+	} else {
+		kp, err := receipt.GenerateKeyPair()
+		if err != nil {
+			return fmt.Errorf("generate key pair: %w", err)
+		}
+		if err := writePrivateKeyFile(keyPath, []byte(kp.PrivateKey), force); err != nil {
+			return fmt.Errorf("write private key: %w", err)
+		}
+		if err := writePubKeyFile(pubPath, []byte(kp.PublicKey), force); err != nil {
+			return fmt.Errorf("write public key: %w", err)
+		}
+		fmt.Fprintf(errOut, "Generated Ed25519 key pair:\n  private: %s\n  public:  %s\n", keyPath, pubPath)
+	}
+
+	// Initialise receipt DB — store.Open uses CREATE TABLE IF NOT EXISTS so this is idempotent.
+	s, err := store.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("create receipt database: %w", err)
+	}
+	s.Close()
+	fmt.Fprintf(errOut, "Receipt database: %s\n", dbPath)
+
+	// Build config snippet.
+	proxyArgs := []string{"-key", keyPath, "-receipt-db", dbPath}
+	if !noApproval {
+		proxyArgs = append(proxyArgs, "-http", fmt.Sprintf("127.0.0.1:%d", httpPort))
+	}
+	proxyArgs = append(proxyArgs, "YOUR_MCP_SERVER_COMMAND", "AND_ITS_ARGS")
+
+	snippet := map[string]any{
+		"mcpServers": map[string]any{
+			name: map[string]any{
+				"command": binPath,
+				"args":    proxyArgs,
+			},
+		},
+	}
+	enc, err := json.MarshalIndent(snippet, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config snippet: %w", err)
+	}
+
+	fmt.Fprintf(errOut, "\nAdd to your claude_desktop_config.json (replace the trailing args with your MCP server):\n")
+	fmt.Fprintln(out, string(enc))
+	return nil
 }

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -837,6 +837,12 @@ func runInit(dir, name string, force, noApproval bool, httpPort int, binPath str
 	// Key generation — idempotent when the full keypair already exists.
 	_, keyErr := os.Stat(keyPath)
 	_, pubErr := os.Stat(pubPath)
+	if keyErr != nil && !os.IsNotExist(keyErr) {
+		return fmt.Errorf("stat private key %q: %w", keyPath, keyErr)
+	}
+	if pubErr != nil && !os.IsNotExist(pubErr) {
+		return fmt.Errorf("stat public key %q: %w", pubPath, pubErr)
+	}
 	keyPresent := keyErr == nil
 	pubPresent := pubErr == nil
 

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -829,17 +829,24 @@ func runInit(dir, name string, force, noApproval bool, httpPort int, binPath str
 		return fmt.Errorf("create directory %q: %w", dir, err)
 	}
 
-	// Key generation — idempotent: warn and skip when files already exist.
-	_, keyExists := os.Stat(keyPath)
-	_, pubExists := os.Stat(pubPath)
-	if !force && (keyExists == nil || pubExists == nil) {
+	// Key generation — idempotent when the full keypair already exists.
+	_, keyErr := os.Stat(keyPath)
+	_, pubErr := os.Stat(pubPath)
+	keyPresent := keyErr == nil
+	pubPresent := pubErr == nil
+
+	if !force && keyPresent && pubPresent {
+		// Both files exist: warn and skip (safe re-run).
 		fmt.Fprintf(errOut, "warning: key files already exist — skipping key generation (use -force to overwrite)\n")
-		if keyExists == nil {
-			fmt.Fprintf(errOut, "  private key: %s\n", keyPath)
+		fmt.Fprintf(errOut, "  private key: %s\n", keyPath)
+		fmt.Fprintf(errOut, "  public key:  %s\n", pubPath)
+	} else if !force && keyPresent != pubPresent {
+		// Partial keypair: unsafe to continue without -force.
+		presentPath, missingPath := pubPath, keyPath
+		if keyPresent {
+			presentPath, missingPath = keyPath, pubPath
 		}
-		if pubExists == nil {
-			fmt.Fprintf(errOut, "  public key:  %s\n", pubPath)
-		}
+		return fmt.Errorf("incomplete keypair: found %q but missing %q; rerun with -force to overwrite and regenerate", presentPath, missingPath)
 	} else {
 		kp, err := receipt.GenerateKeyPair()
 		if err != nil {
@@ -864,7 +871,8 @@ func runInit(dir, name string, force, noApproval bool, httpPort int, binPath str
 	}
 	fmt.Fprintf(errOut, "Receipt database: %s\n", dbPath)
 
-	// Build config snippet.
+	// Build config snippet. The default policy always contains pause/block rules,
+	// so include -http by default; --no-approval opts out.
 	proxyArgs := []string{"-key", keyPath, "-receipt-db", dbPath}
 	if !noApproval {
 		proxyArgs = append(proxyArgs, "-http", fmt.Sprintf("127.0.0.1:%d", httpPort))

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -760,10 +760,10 @@ func writePubKeyFile(path string, data []byte, force bool) error {
 
 func cmdInit(args []string) {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
-	name       := fs.String("name", "default", "Name for this proxy instance (used in filenames and config snippet)")
+	name := fs.String("name", "default", "Name for this proxy instance (used in filenames and config snippet)")
 	noApproval := fs.Bool("no-approval", false, "Omit -http from the config snippet (no approval server)")
-	httpPort   := fs.Int("http-port", 7778, "Approval listener port written into the config snippet")
-	force      := fs.Bool("force", false, "Overwrite existing key files")
+	httpPort := fs.Int("http-port", 7778, "Approval listener port written into the config snippet")
+	force := fs.Bool("force", false, "Overwrite existing key files")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy init [-name <name>] [-force] [-no-approval] [-http-port <port>]\n\n")
 		fmt.Fprintf(os.Stderr, "  One-command setup: creates ~/.agent-receipts/, generates an Ed25519\n")
@@ -774,6 +774,15 @@ func cmdInit(args []string) {
 	}
 	fs.Parse(args)
 
+	if !validInitName(*name) {
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: -name %q is invalid: use only letters, digits, hyphens, underscores, and dots (max 64 chars)\n", *name)
+		os.Exit(2)
+	}
+	if *httpPort < 1 || *httpPort > 65535 {
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: -http-port %d is out of range (1-65535)\n", *httpPort)
+		os.Exit(2)
+	}
+
 	home, err := userHomeDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy init: resolve home directory: %v\n", err)
@@ -782,6 +791,7 @@ func cmdInit(args []string) {
 
 	binPath, err := os.Executable()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: warning: could not resolve binary path (%v); using %q — replace with an absolute path before saving the snippet\n", err, "mcp-proxy")
 		binPath = "mcp-proxy"
 	}
 
@@ -792,13 +802,28 @@ func cmdInit(args []string) {
 	}
 }
 
+// validInitName reports whether name is safe to use as a key filename component.
+// Allows letters, digits, hyphens, underscores, and dots; max 64 chars.
+// Rejects empty strings and names that would escape the target directory.
+func validInitName(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
+}
+
 // runInit performs the guided setup: creates dir, generates a keypair (idempotent),
 // initialises the receipt DB, and writes a config snippet to out. Status messages
 // go to errOut. Accepting dir and binPath as parameters makes the function testable.
 func runInit(dir, name string, force, noApproval bool, httpPort int, binPath string, errOut, out io.Writer) error {
 	keyPath := filepath.Join(dir, name+".pem")
 	pubPath := filepath.Join(dir, name+".pem.pub")
-	dbPath  := filepath.Join(dir, "receipts.db")
+	dbPath := filepath.Join(dir, "receipts.db")
 
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create directory %q: %w", dir, err)
@@ -834,7 +859,9 @@ func runInit(dir, name string, force, noApproval bool, httpPort int, binPath str
 	if err != nil {
 		return fmt.Errorf("create receipt database: %w", err)
 	}
-	s.Close()
+	if cerr := s.Close(); cerr != nil {
+		return fmt.Errorf("close receipt database: %w", cerr)
+	}
 	fmt.Fprintf(errOut, "Receipt database: %s\n", dbPath)
 
 	// Build config snippet.

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -483,3 +483,182 @@ func TestWritePubKeyFileOverwritesWithForce(t *testing.T) {
 		t.Errorf("content after force = %q, want %q", data, "new")
 	}
 }
+
+// runInit tests — use t.TempDir() as dir and a fixed binPath so they are
+// independent of the real home directory and installed binary.
+
+func TestRunInit_FreshSetup(t *testing.T) {
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "default", false, false, 7778, "/usr/local/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	// Key files must exist.
+	keyPath := filepath.Join(dir, "default.pem")
+	pubPath := filepath.Join(dir, "default.pem.pub")
+	dbPath  := filepath.Join(dir, "receipts.db")
+	for _, p := range []string{keyPath, pubPath, dbPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected file %q to exist: %v", p, err)
+		}
+	}
+
+	// Config snippet must contain key paths and binary.
+	snippet := out.String()
+	for _, want := range []string{keyPath, dbPath, "/usr/local/bin/mcp-proxy", "127.0.0.1:7778"} {
+		if !strings.Contains(snippet, want) {
+			t.Errorf("snippet missing %q:\n%s", want, snippet)
+		}
+	}
+
+	// Receipt DB must be usable.
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open receipt DB after init: %v", err)
+	}
+	s.Close()
+}
+
+func TestRunInit_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+
+	// Read original key content to confirm it is not overwritten.
+	keyPath := filepath.Join(dir, "default.pem")
+	orig, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key after first init: %v", err)
+	}
+
+	var errOut2, out2 bytes.Buffer
+	if err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut2, &out2); err != nil {
+		t.Fatalf("second runInit should not error: %v", err)
+	}
+
+	// Warning must appear.
+	if !strings.Contains(errOut2.String(), "warning") {
+		t.Errorf("expected idempotency warning on second run, got: %q", errOut2.String())
+	}
+
+	// Key must not be overwritten.
+	after, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key after second init: %v", err)
+	}
+	if !bytes.Equal(orig, after) {
+		t.Error("private key was overwritten on second run without -force")
+	}
+
+	// Snippet must still be emitted on the second run.
+	if out2.Len() == 0 {
+		t.Error("second run produced no config snippet")
+	}
+}
+
+func TestRunInit_NameFlag(t *testing.T) {
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "github", false, false, 7778, "/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "github.pem")
+	pubPath := filepath.Join(dir, "github.pem.pub")
+	for _, p := range []string{keyPath, pubPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected %q to exist: %v", p, err)
+		}
+	}
+
+	snippet := out.String()
+	if !strings.Contains(snippet, `"github"`) {
+		t.Errorf("snippet should contain instance name \"github\":\n%s", snippet)
+	}
+	if !strings.Contains(snippet, keyPath) {
+		t.Errorf("snippet should contain key path %q:\n%s", keyPath, snippet)
+	}
+}
+
+func TestRunInit_Permissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "default.pem")
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("private key permissions = %04o, want no group/world access", perm)
+	} else if perm&0o600 != 0o600 {
+		t.Errorf("private key permissions = %04o, want owner read/write (0600)", perm)
+	}
+}
+
+func TestRunInit_NoApproval(t *testing.T) {
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "default", false, true, 7778, "/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	snippet := out.String()
+	if strings.Contains(snippet, "-http") {
+		t.Errorf("snippet should not contain -http when noApproval=true:\n%s", snippet)
+	}
+}
+
+func TestRunInit_ForceOverwrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	dir := t.TempDir()
+	var errOut, out bytes.Buffer
+
+	if err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut, &out); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "default.pem")
+	orig, _ := os.ReadFile(keyPath)
+
+	var errOut2, out2 bytes.Buffer
+	if err := runInit(dir, "default", true, false, 7778, "/bin/mcp-proxy", &errOut2, &out2); err != nil {
+		t.Fatalf("second runInit with force: %v", err)
+	}
+
+	// Warning must NOT appear when force=true.
+	if strings.Contains(errOut2.String(), "warning") {
+		t.Errorf("unexpected warning on force run: %q", errOut2.String())
+	}
+
+	// Key should be regenerated (almost certainly different bytes).
+	after, _ := os.ReadFile(keyPath)
+	if bytes.Equal(orig, after) {
+		t.Error("force overwrite produced identical key — expected new key material")
+	}
+
+	// Permissions must still be 0600.
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("permissions after force = %04o, want no group/world access", perm)
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -662,3 +662,69 @@ func TestRunInit_ForceOverwrite(t *testing.T) {
 		t.Errorf("permissions after force = %04o, want no group/world access", perm)
 	}
 }
+
+func TestRunInit_AsymmetricKeyState(t *testing.T) {
+	// If only one of the two key files exists, init must warn and skip rather than
+	// erroring or silently overwriting, regardless of which file is present.
+	for _, tc := range []struct {
+		name    string
+		prePriv bool
+		prePub  bool
+	}{
+		{"only_priv", true, false},
+		{"only_pub", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Pre-create one file.
+			if tc.prePriv {
+				if err := os.WriteFile(filepath.Join(dir, "default.pem"), []byte("old-priv"), 0o600); err != nil {
+					t.Fatalf("setup priv: %v", err)
+				}
+			}
+			if tc.prePub {
+				if err := os.WriteFile(filepath.Join(dir, "default.pem.pub"), []byte("old-pub"), 0o644); err != nil {
+					t.Fatalf("setup pub: %v", err)
+				}
+			}
+
+			var errOut, out bytes.Buffer
+			err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut, &out)
+			if err != nil {
+				t.Fatalf("runInit should not error on asymmetric key state: %v", err)
+			}
+			if !strings.Contains(errOut.String(), "warning") {
+				t.Errorf("expected idempotency warning, got: %q", errOut.String())
+			}
+			// Snippet must still be emitted.
+			if out.Len() == 0 {
+				t.Error("expected config snippet even when key generation skipped")
+			}
+		})
+	}
+}
+
+func TestValidInitName(t *testing.T) {
+	valid := []string{"default", "github", "github-proxy", "my_server", "server.1", "A", strings.Repeat("a", 64)}
+	for _, n := range valid {
+		if !validInitName(n) {
+			t.Errorf("validInitName(%q) = false, want true", n)
+		}
+	}
+
+	invalid := []string{
+		"",                        // empty
+		strings.Repeat("a", 65),  // too long
+		"../evil",                 // path traversal
+		"foo/bar",                 // slash
+		"foo bar",                 // space
+		"foo\x00bar",             // NUL
+		"foo$bar",                 // shell metachar
+	}
+	for _, n := range invalid {
+		if validInitName(n) {
+			t.Errorf("validInitName(%q) = true, want false", n)
+		}
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -498,7 +498,7 @@ func TestRunInit_FreshSetup(t *testing.T) {
 	// Key files must exist.
 	keyPath := filepath.Join(dir, "default.pem")
 	pubPath := filepath.Join(dir, "default.pem.pub")
-	dbPath  := filepath.Join(dir, "receipts.db")
+	dbPath := filepath.Join(dir, "receipts.db")
 	for _, p := range []string{keyPath, pubPath, dbPath} {
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("expected file %q to exist: %v", p, err)
@@ -664,8 +664,8 @@ func TestRunInit_ForceOverwrite(t *testing.T) {
 }
 
 func TestRunInit_AsymmetricKeyState(t *testing.T) {
-	// If only one of the two key files exists, init must warn and skip rather than
-	// erroring or silently overwriting, regardless of which file is present.
+	// If only one of the two key files exists, init must return an error directing
+	// the user to -force rather than silently continuing with a broken keypair.
 	for _, tc := range []struct {
 		name    string
 		prePriv bool
@@ -677,7 +677,6 @@ func TestRunInit_AsymmetricKeyState(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			// Pre-create one file.
 			if tc.prePriv {
 				if err := os.WriteFile(filepath.Join(dir, "default.pem"), []byte("old-priv"), 0o600); err != nil {
 					t.Fatalf("setup priv: %v", err)
@@ -691,15 +690,14 @@ func TestRunInit_AsymmetricKeyState(t *testing.T) {
 
 			var errOut, out bytes.Buffer
 			err := runInit(dir, "default", false, false, 7778, "/bin/mcp-proxy", &errOut, &out)
-			if err != nil {
-				t.Fatalf("runInit should not error on asymmetric key state: %v", err)
+			if err == nil {
+				t.Fatal("runInit should error on asymmetric key state (one file missing)")
 			}
-			if !strings.Contains(errOut.String(), "warning") {
-				t.Errorf("expected idempotency warning, got: %q", errOut.String())
+			if !strings.Contains(err.Error(), "incomplete keypair") {
+				t.Errorf("error should mention incomplete keypair, got: %q", err.Error())
 			}
-			// Snippet must still be emitted.
-			if out.Len() == 0 {
-				t.Error("expected config snippet even when key generation skipped")
+			if !strings.Contains(err.Error(), "-force") {
+				t.Errorf("error should mention -force, got: %q", err.Error())
 			}
 		})
 	}

--- a/mcp-proxy/cmd/mcp-proxy/cli_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli_test.go
@@ -635,7 +635,10 @@ func TestRunInit_ForceOverwrite(t *testing.T) {
 	}
 
 	keyPath := filepath.Join(dir, "default.pem")
-	orig, _ := os.ReadFile(keyPath)
+	orig, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read original key: %v", err)
+	}
 
 	var errOut2, out2 bytes.Buffer
 	if err := runInit(dir, "default", true, false, 7778, "/bin/mcp-proxy", &errOut2, &out2); err != nil {
@@ -648,7 +651,10 @@ func TestRunInit_ForceOverwrite(t *testing.T) {
 	}
 
 	// Key should be regenerated (almost certainly different bytes).
-	after, _ := os.ReadFile(keyPath)
+	after, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read post-force key: %v", err)
+	}
 	if bytes.Equal(orig, after) {
 		t.Error("force overwrite produced identical key — expected new key material")
 	}

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -26,7 +26,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
 ```bash
 mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
+# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
 ```
 
 Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -5,8 +5,8 @@ description: How to route Claude Code MCP servers through the Agent Receipts pro
 
 Claude Code is a CLI-based agent that connects to MCP servers for tools like GitHub, databases, and file systems. The Agent Receipts proxy wraps any MCP server transparently — Claude Code doesn't know or care that the proxy is there.
 
-:::note[Approval workflow — opt-in]
-The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) and `merge_pull_request` (10) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/). If you're seeing `-32002` on tools that *shouldn't* pause, suspect client-side denial first — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. If you're seeing `-32002` on tools that shouldn't pause, suspect client-side denial first — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
 :::
 
 ## Prerequisites

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -25,13 +25,11 @@ The default policy includes a `pause_high_risk` rule, but the approval listener 
 ## Generate a signing key
 
 ```bash
-mkdir -p ~/.agent-receipts
-openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
-openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
-  -out ~/.agent-receipts/github-proxy-pub.pem
+mcp-proxy init --name github-proxy
+# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
 ```
 
-Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
 
 ## Register the proxy with Claude Code
 
@@ -112,7 +110,7 @@ mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -key ~/.agent-receipts/github-proxy.pem.pub \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -5,8 +5,8 @@ description: How to route Claude Desktop MCP servers through the Agent Receipts 
 
 Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Agent Receipts proxy wraps any MCP server transparently — Claude Desktop doesn't know or care that the proxy is there.
 
-:::note[Approval workflow — opt-in]
-The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/).
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. See [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
 ## Prerequisites

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -24,13 +24,12 @@ The default policy includes a `pause_high_risk` rule, but the approval listener 
 ## Generate a signing key
 
 ```bash
-mkdir -p ~/.agent-receipts
-openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
-openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
-  -out ~/.agent-receipts/github-proxy-pub.pem
+mcp-proxy init --name github-proxy
+# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
+# prints a claude_desktop_config.json snippet — paste it as a starting point
 ```
 
-Use absolute paths everywhere — Claude Desktop launches MCP servers with a clean environment where `~` expansion and `$PATH` are not available.
+Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Desktop launches MCP servers with a clean environment where `~` expansion and `$PATH` are not available.
 
 ## Configure claude_desktop_config.json
 
@@ -86,7 +85,7 @@ mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -key ~/.agent-receipts/github-proxy.pem.pub \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -25,7 +25,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
 ```bash
 mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
+# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
 # prints a claude_desktop_config.json snippet — paste it as a starting point
 ```
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -25,13 +25,11 @@ The default policy includes a `pause_high_risk` rule, but the approval listener 
 ## Generate a signing key
 
 ```bash
-mkdir -p ~/.agent-receipts
-openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/github-proxy.pem
-openssl pkey -in ~/.agent-receipts/github-proxy.pem -pubout \
-  -out ~/.agent-receipts/github-proxy-pub.pem
+mcp-proxy init --name github-proxy
+# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
 ```
 
-Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
 
 ## Configure via CLI
 
@@ -102,7 +100,7 @@ mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy-pub.pem \
+  -key ~/.agent-receipts/github-proxy.pem.pub \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -26,7 +26,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
 ```bash
 mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and github-proxy.pem.pub
+# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
 ```
 
 Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -5,8 +5,8 @@ description: How to route OpenAI Codex MCP servers through the Agent Receipts pr
 
 OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/config.toml`. The Agent Receipts proxy wraps any MCP server transparently — Codex doesn't know or care that the proxy is there.
 
-:::note[Approval workflow — opt-in]
-The default policy includes a `pause_high_risk` rule, but the approval listener is **off by default**. Ordinary GitHub writes like `create_pull_request` (20) never pause. Tools that do cross the threshold (e.g. `create_token` = 50, `update_auth_config` = 70) will fail fast with a clear error unless you opt in by passing `-http 127.0.0.1:<port>` — see [Approval Server](/mcp-proxy/approval-ui/).
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. See [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
 ## Prerequisites

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -82,10 +82,10 @@ mcp-proxy init --name github
 
 Re-running `init` is safe — it warns and skips key generation if the files already exist. Pass `--force` to regenerate.
 
-Then run the proxy with the generated key:
+Then run the proxy with the generated key (substitute your instance name if you used `--name`):
 
 ```bash
-mcp-proxy -key ~/.agent-receipts/github.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
+mcp-proxy -key ~/.agent-receipts/default.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
 ## Next steps

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -77,7 +77,7 @@ Use `--name` to label a specific proxy instance (the name appears in the config 
 
 ```bash
 mcp-proxy init --name github
-# creates ~/.agent-receipts/github.pem (0600) and github.pem.pub
+# creates ~/.agent-receipts/github.pem (0600) and ~/.agent-receipts/github.pem.pub
 ```
 
 Re-running `init` is safe — it warns and skips key generation if the files already exist. Pass `--force` to regenerate.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -67,15 +67,25 @@ Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores
 
 ## Persistent signing key
 
-Generate a key pair and use it across sessions:
+`mcp-proxy init` does everything in one step: creates `~/.agent-receipts/`, generates an Ed25519 keypair with correct permissions, initialises the receipt database, and prints a ready-to-paste `claude_desktop_config.json` snippet:
 
 ```bash
-# Generate a key pair (any Ed25519 PEM tool works)
-openssl genpkey -algorithm Ed25519 -out private.pem
-openssl pkey -in private.pem -pubout -out public.pem
+mcp-proxy init
+```
 
-# Run with persistent key
-mcp-proxy -key private.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
+Use `--name` to label a specific proxy instance (the name appears in the config snippet key and in the key filename):
+
+```bash
+mcp-proxy init --name github
+# creates ~/.agent-receipts/github.pem (0600) and github.pem.pub
+```
+
+Re-running `init` is safe — it warns and skips key generation if the files already exist. Pass `--force` to regenerate.
+
+Then run the proxy with the generated key:
+
+```bash
+mcp-proxy -key ~/.agent-receipts/github.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
 ## Next steps

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -36,10 +36,8 @@ Remote MCP Server (e.g. mcp.atlassian.com/v1/mcp)
 ## Generate a signing key
 
 ```bash
-mkdir -p ~/.agent-receipts
-openssl genpkey -algorithm Ed25519 -out ~/.agent-receipts/atlassian-proxy.pem
-openssl pkey -in ~/.agent-receipts/atlassian-proxy.pem -pubout \
-  -out ~/.agent-receipts/atlassian-proxy-pub.pem
+mcp-proxy init --name atlassian-proxy
+# creates ~/.agent-receipts/atlassian-proxy.pem (0600) and atlassian-proxy.pem.pub
 ```
 
 :::tip[Reuse an existing key]

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -37,7 +37,7 @@ Remote MCP Server (e.g. mcp.atlassian.com/v1/mcp)
 
 ```bash
 mcp-proxy init --name atlassian-proxy
-# creates ~/.agent-receipts/atlassian-proxy.pem (0600) and atlassian-proxy.pem.pub
+# creates ~/.agent-receipts/atlassian-proxy.pem (0600) and ~/.agent-receipts/atlassian-proxy.pem.pub
 ```
 
 :::tip[Reuse an existing key]


### PR DESCRIPTION
Closes #148.

## Summary

Redesigns `mcp-proxy init` from a bare key-generation helper into a full guided setup command that replaces the three-step `openssl` flow.

### What `mcp-proxy init` now does

- Creates `~/.agent-receipts/` (0700)
- Generates an Ed25519 keypair — `<name>.pem` (0600) and `<name>.pem.pub` (0644)
- Initialises `receipts.db` via `store.Open` (idempotent, `CREATE TABLE IF NOT EXISTS`)
- Auto-detects the binary path via `os.Executable()`
- Emits a ready-to-paste `claude_desktop_config.json` snippet to **stdout**; status messages go to **stderr**
- **Idempotent**: warns and skips key generation if files exist; `--force` overwrites
- `--name` labels the instance in filenames and the config snippet key
- `--no-approval` omits `-http` from the snippet; `--http-port` sets the port (default 7778, included when the default policy has `pause`/`block` rules)

### Breaking change

Removes the old `-key`/`-pub` required-flag interface. That interface was undocumented and never shipped as the intended setup path — this PR is the first time `init` is documented.

### Implementation note

The core logic lives in `runInit(dir, name, force, noApproval, httpPort, binPath, errOut, out)` — a pure function that accepts injected paths and writers, making it fully testable without touching the real home directory.

## Acceptance criteria

- [x] `mcp-proxy init` creates `~/.agent-receipts/` with keypair and empty receipt DB
- [x] Generated private key has `0600` permissions on macOS and Linux
- [x] Running `init` when keys already exist prints a warning and does not overwrite
- [x] `--name` flag customises the key filename and config snippet output
- [x] Output includes a valid `claude_desktop_config.json` snippet with correct absolute paths
- [x] Unit tests cover: fresh init, idempotent re-run, `--name` flag, permission setting, `--no-approval`, force overwrite
- [x] Quickstart docs updated to use `mcp-proxy init` as the primary setup path (installation.mdx, claude-desktop.mdx, claude-code.mdx, codex.mdx, remote-servers.mdx)
- [ ] Integration test (full init → proxy start → tool call → receipt round-trip): deferred — requires building and running the binary in a test harness; tracked as a follow-up

## Test plan

- [ ] `go build ./...` — clean build
- [ ] `go vet ./...` — no warnings
- [ ] `go test ./...` — all tests pass (6 new `TestRunInit_*` tests added)
- [ ] `mcp-proxy init` — prints setup summary to stderr + valid JSON to stdout
- [ ] `mcp-proxy init` again — warns, does not error, still emits snippet
- [ ] `mcp-proxy init --name github` — creates `github.pem` / `github.pem.pub`
- [ ] `mcp-proxy init --no-approval` — snippet contains no `-http`
- [ ] `mcp-proxy list` — opens the DB created by init without error