### PR TITLE
fix(sdk-ts): surface verifyReceipt errors in ChainVerification.error

### DIFF
--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -161,6 +161,47 @@ describe("verifyChain", () => {
 		}
 	});
 
+	it("preserves verifyReceipt error through the receipt-after-terminal early return", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const terminalChain = buildTerminalChain(2, privateKey);
+		const terminalReceipt = terminalChain.at(-1);
+		const terminalHash =
+			terminalReceipt != null ? hashReceipt(terminalReceipt) : "";
+		const extra = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:test" },
+			action: { type: "filesystem.file.read", risk_level: "low" },
+			outcome: { status: "success" },
+			chain: {
+				sequence: 3,
+				previous_receipt_hash: terminalHash,
+				chain_id: "chain_test",
+			},
+		});
+		const extraSigned = signReceipt(extra, privateKey, "did:agent:test#key-1");
+		const chain = [...terminalChain, extraSigned];
+		const targetId = chain[0]?.id;
+
+		const original = signingModule.verifyReceipt;
+		const spy = vi
+			.spyOn(signingModule, "verifyReceipt")
+			.mockImplementation((r, key) => {
+				if (r.id === targetId) {
+					throw new Error("synthetic canonicalize failure");
+				}
+				return original(r, key);
+			});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(/^signature compute failed at index 0:/);
+			expect(result.error).toContain("synthetic canonicalize failure");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	it("detects a broken sequence", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -4,6 +4,7 @@ import { verifyChain } from "./chain.js";
 import { createReceipt } from "./create.js";
 import * as hashModule from "./hash.js";
 import { canonicalize, hashReceipt, sha256 } from "./hash.js";
+import * as signingModule from "./signing.js";
 import { generateKeyPair, signReceipt } from "./signing.js";
 
 function buildChain(count: number, privateKey: string) {
@@ -129,6 +130,32 @@ describe("verifyChain", () => {
 			expect(result.error).toMatch(/^hash compute failed at index 0:/);
 			expect(result.error).toContain("synthetic canonicalize failure");
 			expect(result.receipts[1]?.hashLinkValid).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("surfaces verifyReceipt errors via the error field", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const chain = buildChain(2, privateKey);
+		const targetId = chain[0]?.id;
+
+		const original = signingModule.verifyReceipt;
+		const spy = vi
+			.spyOn(signingModule, "verifyReceipt")
+			.mockImplementation((r, key) => {
+				if (r.id === targetId) {
+					throw new Error("synthetic canonicalize failure");
+				}
+				return original(r, key);
+			});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(/^signature compute failed at index 0:/);
+			expect(result.error).toContain("synthetic canonicalize failure");
+			expect(result.receipts[0]?.signatureValid).toBe(false);
 		} finally {
 			spy.mockRestore();
 		}

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -105,13 +105,23 @@ export function verifyChain(
 	const results: ReceiptVerification[] = [];
 	let brokenAt = -1;
 	let previous: AgentReceipt | undefined;
+	let signatureError: string | undefined;
 
 	for (let i = 0; i < receipts.length; i++) {
 		const receipt = receipts[i];
 		if (!receipt) continue;
 		const chain = receipt.credentialSubject.chain;
 
-		const signatureValid = verifyReceipt(receipt, publicKey);
+		let signatureValid: boolean;
+		try {
+			signatureValid = verifyReceipt(receipt, publicKey);
+		} catch (e) {
+			signatureValid = false;
+			if (signatureError === undefined) {
+				const reason = e instanceof Error ? e.message : String(e);
+				signatureError = `signature compute failed at index ${i}: ${reason}`;
+			}
+		}
 
 		let hashLinkValid: boolean;
 		if (previous === undefined) {
@@ -199,6 +209,9 @@ export function verifyChain(
 		receipts: results,
 		brokenAt,
 	};
+	if (signatureError !== undefined) {
+		cv.error = signatureError;
+	}
 
 	// Response-hash verification (spec §4.3.2).
 	// When a body is supplied: recompute and fail on mismatch.

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -199,6 +199,7 @@ export function verifyChain(
 				receipts: results,
 				brokenAt,
 				responseHashNote: undefined,
+				error: signatureError,
 			};
 		}
 	}


### PR DESCRIPTION
## Summary

- Wrap the `verifyReceipt` call in `verifyChain` so canonicalization failures populate `ChainVerification.error` (with index and reason) instead of escaping the function.
- The per-receipt entry retains `signatureValid: false`, so callers still get a structured result for the failing index.
- Adds a vitest case using `vi.spyOn` against the signing module to force `verifyReceipt` to throw and asserts the structured error.

Signature-side analogue of #272 (hashReceipt). Wording (`signature compute failed at index N: <reason>`) mirrors the hashReceipt fix for cross-SDK consistency. Continues the loop instead of returning early — a signature throw on one receipt does not make subsequent chain checks unknowable, unlike a hash failure that breaks chain linkage.

Closes #277

## Test plan

- [x] `pnpm test` passes (192 tests, 1 new)
- [x] `pnpm build` clean
- [x] `pnpm exec biome check src` clean