### PR TITLE
fix(sdk-py): surface verify_receipt errors in ChainVerification.error

### DIFF
--- a/sdk/py/src/agent_receipts/receipt/chain.py
+++ b/sdk/py/src/agent_receipts/receipt/chain.py
@@ -91,11 +91,19 @@ def verify_chain(
     results: list[ReceiptVerification] = []
     broken_at = -1
     previous: AgentReceipt | None = None
+    signature_compute_error: str | None = None
 
     for i, receipt in enumerate(receipts):
         chain = receipt.credentialSubject.chain
 
-        signature_valid = verify_receipt(receipt, public_key)
+        try:
+            signature_valid = verify_receipt(receipt, public_key)
+        except (TypeError, ValueError) as exc:
+            signature_valid = False
+            if signature_compute_error is None:
+                signature_compute_error = (
+                    f"signature compute failed at index {i}: {exc}"
+                )
 
         current_sequence = chain.sequence
         if previous is None:
@@ -143,6 +151,19 @@ def verify_chain(
             broken_at = i
 
         previous = receipt
+
+    # Signature-compute exception takes precedence over later structural checks:
+    # if a receipt could not be canonicalised for verification, the chain is
+    # already structurally broken and downstream checks (terminal placement,
+    # response_hash, expected_length, ...) are not meaningful.
+    if signature_compute_error is not None:
+        return ChainVerification(
+            valid=False,
+            length=len(receipts),
+            receipts=results,
+            broken_at=broken_at,
+            error=signature_compute_error,
+        )
 
     # Receipt-after-terminal integrity check (unconditional — spec §7.3.2).
     for i, receipt in enumerate(receipts[:-1]):

--- a/sdk/py/tests/receipt/test_chain.py
+++ b/sdk/py/tests/receipt/test_chain.py
@@ -529,6 +529,35 @@ class TestAdr0008ChainBehaviours:
         assert result.error.startswith("hash compute failed at index 1:")
         assert "injected hash failure" in result.error
 
+    def test_signature_failure_in_loop_populates_error(self) -> None:
+        """verify_receipt raising surfaces as a structured error.
+
+        Patches verify_receipt to raise ValueError on every call. The
+        try/except mirrors the False-return path: signature_valid is set to
+        False and the loop continues, so every receipt still gets a per-receipt
+        entry. ChainVerification.error captures the first failure (index 0).
+        """
+        kp = generate_key_pair()
+        chain = _build_chain(2, kp.private_key)
+
+        with patch(
+            "agent_receipts.receipt.chain.verify_receipt",
+            side_effect=ValueError("injected verify failure"),
+        ):
+            result = verify_chain(chain, kp.public_key)
+
+        assert result.valid is False
+        assert result.broken_at == 0
+        assert result.error.startswith("signature compute failed at index 0:")
+        assert "injected verify failure" in result.error
+        # Loop continued: both receipts have entries with signature_valid=False,
+        # and non-signature checks (hash_link, sequence) still ran for each.
+        assert len(result.receipts) == 2
+        assert result.receipts[0].signature_valid is False
+        assert result.receipts[1].signature_valid is False
+        assert result.receipts[0].hash_link_valid is True
+        assert result.receipts[1].hash_link_valid is True
+
     def test_response_bodies_absent_entry_emits_note(self) -> None:
         """When response_hash is present but receipt id is not in the map, emit note."""
         unsigned = create_receipt(


### PR DESCRIPTION
## Summary

- Wraps the `verify_receipt` call site in `verify_chain` (sdk/py/src/agent_receipts/receipt/chain.py) in `try/except (TypeError, ValueError)` so canonicalisation failures are surfaced via `ChainVerification.error` instead of escaping the function.
- The exception path mirrors the False-return path: `signature_valid` is set to False and the loop continues, so every receipt still gets a per-receipt entry with `hash_link` and `sequence` checks intact. The first captured signature-compute error takes precedence over later structural checks (terminal placement, response_hash, expected_length, …) since a chain that cannot be canonicalised is already structurally broken.
- Python analogue of the TS fix in #277. The asymmetry with the `hash_receipt` early-return added in #271 is intentional: hash-compute failure breaks chain linkage and propagates forward, signature-compute failure is per-receipt independent.

Closes #278

## Test plan

- [x] `uv run pytest` (200/200 pass)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright src` strict (0 errors)
- [x] New test `test_signature_failure_in_loop_populates_error` patches `verify_receipt` to raise `ValueError` and asserts: `verify_chain` does not raise; `ChainVerification.error` starts with `"signature compute failed at index 0:"` and includes the reason; both per-receipt entries are populated with `signature_valid=False` and `hash_link_valid=True` (proving the loop continued and non-signature checks still ran).