### PR TITLE
chore(sdk-ts): update CHANGELOG for v0.6.0

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,24 +9,51 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
-## [0.6.0] - 2026-04-28
+## [0.6.0] - 2026-05-01
 
-### Changed
+### Breaking Changes
 
-- **BREAKING:** Renamed `parameters_preview` → `parameters_disclosure` on the
-  `Action` interface and its Zod schema. Per
+- **Renamed `parameters_preview` → `parameters_disclosure`** on the `Action`
+  interface and its Zod schema. Per
   [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md),
   "preview" misdescribed a permanent, signed field — receipts are durable, so
   any value placed there is a deliberate disclosure rather than a transient
   preview. The shape is unchanged (`Record<string, string>`); only the field
-  name moved. No deprecation alias is provided: pre-1.0 adoption is low and
-  the rename is intentionally a clean break. Tracking issue:
+  name moved. **No deprecation alias is provided. Update all call sites
+  before upgrading.** Pre-1.0 adoption is low and the rename is intentionally
+  a clean break. Tracking issue:
   [#283](https://github.com/agent-receipts/ar/issues/283).
 
   Migration: rename every read/write of `action.parameters_preview` to
   `action.parameters_disclosure`. Previously written receipts that carry the
   old key under `.passthrough()` will still load, but new receipts MUST use
   the new key to round-trip through this SDK's typed surface.
+
+### Features
+
+- Add `parameters_disclosure` to the `Action` schema in the protocol spec
+  (commits `2fd1837`, `5ef9d9a`, `e43cd06`).
+
+### Bug Fixes
+
+- Surface `verifyReceipt` errors in `ChainVerification.error` instead of
+  swallowing them ([#294](https://github.com/agent-receipts/ar/pull/294)).
+- Surface `hashReceipt` errors in `ChainVerification.error`
+  ([#270](https://github.com/agent-receipts/ar/issues/270), commits `6a97840`,
+  `bf030de`).
+- Validate receipt schema on load from store, preserve unknown fields, tighten
+  validator types, preserve `Error.cause`, and render the root path on parse
+  failures ([#170](https://github.com/agent-receipts/ar/issues/170), commits
+  `2db99c6`, `b273e50`, `01f5745`).
+- Spec: align `proofValue` encoding to base64url throughout, tighten the
+  schema pattern, fix inline placeholders, and use 86-char base64url
+  placeholder values in all examples (commits `fa0db6b`, `79f7301`,
+  `0839e81`).
+
+### Tests
+
+- Add `parameters_disclosure` cross-language test vector in
+  `cross-sdk-tests/` (commit `60bbe51`).
 
 ## [0.5.0] - 2026-04-27
 


### PR DESCRIPTION
Prepares the CHANGELOG for the upcoming `@agnt-rcpt/sdk-ts` v0.6.0 release. This PR is changelog-only — no code changes — and must merge before `scripts/release.sh sdk-ts 0.6.0` can run from `main`.

## Summary

The existing `[0.6.0]` section only documented the `parameters_preview` → `parameters_disclosure` rename. This update expands it to cover every commit on `sdk/ts/`, `spec/`, and `cross-sdk-tests/` since `sdk-ts-v0.5.0`, grouped by conventional-commit prefix, and re-dates the section to **2026-05-01**.

## Highlights

**Breaking change (no deprecation alias)**

- `parameters_preview` is renamed to `parameters_disclosure` on the `Action` interface and Zod schema, per [ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md). Update all call sites before upgrading. Tracking: [#283](https://github.com/agent-receipts/ar/issues/283).

**Bug fixes bundled in 0.6.0**

- Surface `verifyReceipt` errors in `ChainVerification.error` ([#294](https://github.com/agent-receipts/ar/pull/294)).
- Surface `hashReceipt` errors in `ChainVerification.error` ([#270](https://github.com/agent-receipts/ar/issues/270)).
- Validate receipt schema on store load, preserve unknown fields, tighten validator types, preserve `Error.cause`, render the root path on parse failures ([#170](https://github.com/agent-receipts/ar/issues/170)).
- Spec `proofValue` aligned to base64url throughout (schema pattern, inline placeholders, 86-char example values).

**Spec / tests**

- `parameters_disclosure` added to the `Action` schema in the spec.
- New cross-language test vector for `parameters_disclosure` in `cross-sdk-tests/`.

## Test plan

- [x] `pnpm install --frozen-lockfile && pnpm test && pnpm build && pnpm lint` clean in `sdk/ts/` (193/193 vitest tests pass; lint shows only a pre-existing biome schema-version info)
- [ ] CI green on this changelog-only diff
- [ ] After merge, run `scripts/release.sh sdk-ts 0.6.0` from `main` to tag and create the GitHub release