### PR TITLE
chore(mcp-proxy): bump sdk/go to v0.6.0 and add CHANGELOG for v0.7.0

### DIFF
--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -9,6 +9,49 @@ This file starts at 0.6.2; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.7.0] - 2026-05-01
+
+### Features
+
+- **Guided `init` command** (`mcp-proxy init`) walks the operator through
+  one-command setup: generates an Ed25519 signing key, writes a starter
+  `config.yaml`, and prints the shell snippet to wire it into the MCP client
+  config. Key files are written with restrictive permissions (0600) from the
+  first write. Detailed `os.Stat` error handling and `ReadFile` error paths
+  are covered by tests (commits `d463126`, `64b9f5a`, `46bcd93`, `60e7280`,
+  `578ef68`).
+
+- **Restrictive file permissions on signing keys**
+  ([#156](https://github.com/agent-receipts/ar/issues/156)): `writePrivateKeyFile`
+  now creates key files with mode `0600` and rejects existing files whose
+  permissions are too open. `Close` errors on write failure are propagated
+  rather than silently discarded (commits `3ab4912`, `0927c90`, `8148748`,
+  `d323ca9`, `5a1b94e`, `b7725d8`).
+
+- **Expanded secret redaction and `audit-secrets` scan**: the secret redaction
+  pattern set is broadened to cover additional token formats; a CI
+  `audit-secrets` scan is added to catch regressions (commits `de790cb`,
+  `000ae5b`, `89ce066`, `e825d22`).
+
+### Bug Fixes
+
+- Coordinate stdio shutdown to surface upstream server death: the proxy now
+  detects when the upstream MCP server exits and propagates the termination
+  signal cleanly instead of hanging
+  ([#158](https://github.com/agent-receipts/ar/issues/158), commit `9a0fd20`).
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.5.0` to `v0.6.0`,
+  picking up `ParametersDisclosure` on `Action` and the `VerifyChain`
+  hash-error surfacing fix.
+
+### Tests
+
+- Guard parallel-test cleanup against double `cmd.Wait` (commit `af58f46`).
+
+[0.7.0]: https://github.com/agent-receipts/ar/compare/mcp-proxy/v0.6.2...mcp-proxy/v0.7.0
+
 ## [0.6.2] - 2026-04-29
 
 ### Changed

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/mcp-proxy
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.5.0
+	github.com/agent-receipts/ar/sdk/go v0.6.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.5.0 h1:N5tvD3t4gqyv3OTUrwDV1LaAS0ObrdjfAygj/A8gm8Y=
-github.com/agent-receipts/ar/sdk/go v0.5.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/sdk/go v0.6.0 h1:zSpXnUOJFWRBikQmT1brOaEVv68eiFsLQSp+ZPAgHxw=
+github.com/agent-receipts/ar/sdk/go v0.6.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Prepares mcp-proxy for the v0.7.0 release. Must merge before `scripts/release.sh mcp-proxy 0.7.0` runs from `main`.

## Changes

- `mcp-proxy/go.mod` + `go.sum`: `sdk/go v0.5.0` → `v0.6.0`
- `mcp-proxy/CHANGELOG.md`: prepend `[0.7.0]` section

## Highlights

**Features**
- **`mcp-proxy init`** — guided one-command setup: generates an Ed25519 signing key (0600), writes a starter `config.yaml`, prints the shell snippet for MCP client wiring.
- **Restrictive key file permissions** ([#156](https://github.com/agent-receipts/ar/issues/156)) — `writePrivateKeyFile` creates at `0600`, rejects over-permissive existing files, propagates `Close` errors.
- **Expanded secret redaction + `audit-secrets` CI scan** — broader token pattern coverage with a regression-catching scan.

**Bug fixes**
- Coordinate stdio shutdown to surface upstream server death cleanly ([#158](https://github.com/agent-receipts/ar/issues/158)).

**Dependencies**
- `sdk/go v0.6.0` picks up `ParametersDisclosure` on `Action` and the `VerifyChain` hash-error fix.

## Test plan

- [x] `go vet ./mcp-proxy/... && go test ./mcp-proxy/...` — all 5 packages pass
- [ ] CI green on this diff (mcp-proxy CI also re-runs sdk/go tests via go.work)
- [ ] After merge: `bash scripts/release.sh mcp-proxy 0.7.0` from `main`