### PR TITLE
docs(sdk-ts): bump Node.js requirement to 22.11+

### DIFF
--- a/site/src/content/docs/sdk-ts/installation.mdx
+++ b/site/src/content/docs/sdk-ts/installation.mdx
@@ -17,7 +17,7 @@ pnpm add @agnt-rcpt/sdk-ts
 
 ## Requirements
 
-- Node.js 18+
+- Node.js 22.11+
 - TypeScript 5.0+ (recommended)
 
 ## Next steps


### PR DESCRIPTION
## Summary

The sdk-ts installation page advertised Node.js 18+, but `sdk/ts/package.json` declares `engines.node ">=22.11.0"`. Align the docs with the engines field so npm/pnpm install warnings match what users see at install time.

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [ ] CI green

Refs site action plan #291 (B13).
