### PR TITLE
docs(sdk-py): fix create_receipt and sign_receipt calling conventions

### DIFF
--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -84,31 +84,34 @@ pip install agent-receipts
 
 ```python
 from agent_receipts import (
+    CreateReceiptInput,
     create_receipt,
     generate_key_pair,
-    sign_receipt,
     hash_receipt,
+    sign_receipt,
 )
 
 keys = generate_key_pair()
 
 unsigned = create_receipt(
-    issuer={"id": "did:agent:my-agent"},
-    principal={"id": "did:user:alice"},
-    action={
-        "type": "filesystem.file.read",
-        "risk_level": "low",
-        "target": {"system": "local", "resource": "/docs/report.md"},
-    },
-    outcome={"status": "success"},
-    chain={
-        "sequence": 1,
-        "previous_receipt_hash": None,
-        "chain_id": "chain_session-1",
-    },
+    CreateReceiptInput(
+        issuer={"id": "did:agent:my-agent"},
+        principal={"id": "did:user:alice"},
+        action={
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "target": {"system": "local", "resource": "/docs/report.md"},
+        },
+        outcome={"status": "success"},
+        chain={
+            "sequence": 1,
+            "previous_receipt_hash": None,
+            "chain_id": "chain_session-1",
+        },
+    )
 )
 
-receipt = sign_receipt(unsigned, keys.private_key)
+receipt = sign_receipt(unsigned, keys.private_key, "did:agent:my-agent#key-1")
 receipt_hash = hash_receipt(receipt)
 ```
 

--- a/site/src/content/docs/sdk-py/overview.mdx
+++ b/site/src/content/docs/sdk-py/overview.mdx
@@ -18,19 +18,26 @@ The Python SDK (`agent-receipts`) provides tools for creating, signing, and veri
 ## Quick example
 
 ```python
-from agent_receipts import create_receipt, sign_receipt
+from agent_receipts import CreateReceiptInput, create_receipt, sign_receipt
 
 receipt = create_receipt(
-    issuer={"id": "did:agent:my-agent"},
-    action={
-        "type": "filesystem.file.read",
-        "risk_level": "low",
-    },
-    principal={"id": "did:user:alice"},
-    outcome={"status": "success"},
+    CreateReceiptInput(
+        issuer={"id": "did:agent:my-agent"},
+        principal={"id": "did:user:alice"},
+        action={
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+        },
+        outcome={"status": "success"},
+        chain={
+            "sequence": 1,
+            "previous_receipt_hash": None,
+            "chain_id": "chain_session-1",
+        },
+    )
 )
 
-signed = sign_receipt(receipt, private_key)
+signed = sign_receipt(receipt, private_key, "did:agent:my-agent#key-1")
 ```
 
 See [Installation](/sdk-py/installation/) to get started.

--- a/site/src/content/docs/sdk-py/overview.mdx
+++ b/site/src/content/docs/sdk-py/overview.mdx
@@ -18,9 +18,16 @@ The Python SDK (`agent-receipts`) provides tools for creating, signing, and veri
 ## Quick example
 
 ```python
-from agent_receipts import CreateReceiptInput, create_receipt, sign_receipt
+from agent_receipts import (
+    CreateReceiptInput,
+    create_receipt,
+    generate_key_pair,
+    sign_receipt,
+)
 
-receipt = create_receipt(
+keys = generate_key_pair()
+
+unsigned = create_receipt(
     CreateReceiptInput(
         issuer={"id": "did:agent:my-agent"},
         principal={"id": "did:user:alice"},
@@ -37,7 +44,7 @@ receipt = create_receipt(
     )
 )
 
-signed = sign_receipt(receipt, private_key, "did:agent:my-agent#key-1")
+signed = sign_receipt(unsigned, keys.private_key, "did:agent:my-agent#key-1")
 ```
 
 See [Installation](/sdk-py/installation/) to get started.


### PR DESCRIPTION
## Summary

The Python examples on `getting-started/quick-start.mdx` and `sdk-py/overview.mdx` called `create_receipt` with loose kwargs and `sign_receipt` with two positional arguments. Both raise `TypeError` against the shipped API:

- `create_receipt` takes a single `CreateReceiptInput` argument, not loose kwargs (`sdk/py/src/agent_receipts/receipt/create.py:59`).
- `sign_receipt` requires `verification_method` as a third positional argument (`sdk/py/src/agent_receipts/receipt/signing.py:69-73`).
- `sdk-py/overview.mdx` example was also missing the required `chain` field.

Both corrected examples were executed against the real SDK to confirm they run end-to-end.

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [x] Both corrected examples executed against `agent-receipts` via `uv run python -c`, producing valid signed receipts
- [ ] CI green

Refs site action plan #291 (B3, B4, B6, B7).
