### PR TITLE
docs(spec): correct proofValue encoding to u-prefixed base64url

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -81,7 +81,7 @@ An Agent Receipt is a JSON object conforming to W3C VC Data Model 2.0:
     "created": "2026-03-31T14:31:01Z",
     "verificationMethod": "did:agent:my-agent#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z..."
+    "proofValue": "u..."
   }
 }
 ```
@@ -119,7 +119,7 @@ Implementations may escalate but must not downgrade risk levels.
 
 1. Serialize receipt as RFC 8785 canonical JSON with proof field removed
 2. Issuer signs with Ed25519 private key
-3. Signature encoded as z-prefixed base58btc in proof.proofValue
+3. Signature encoded as u-prefixed base64url (no padding) in proof.proofValue
 4. Each receipt's previous_receipt_hash links to SHA-256 of previous receipt's canonical form
 5. Chain verified by checking signatures and hash links in sequence order
 

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -123,7 +123,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
     "created": "2026-03-31T14:30:01Z",
     "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z..."
+    "proofValue": "u..."
   }
 }
 ```
@@ -232,7 +232,7 @@ Present when this chain was spawned by delegation from another agent. All fields
 | `created` | Yes | ISO 8601 datetime when the proof was created. |
 | `verificationMethod` | Yes | DID URL of the signing key. |
 | `proofPurpose` | Yes | Must be `"assertionMethod"`. |
-| `proofValue` | Yes | Multibase-encoded (`z`-prefixed base58btc) Ed25519 signature. |
+| `proofValue` | Yes | Multibase-encoded (`u`-prefixed base64url, no padding) Ed25519 signature. |
 
 ## JSON Schema
 

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -76,7 +76,7 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
   <line x1="246" y1="30" x2="274" y2="30" stroke="#7c93f5" stroke-width="1" marker-end="url(#s-arrow)"/>
   <rect x="282" y="10" width="100" height="40" rx="4" fill="#181a24" stroke="#7c93f5" stroke-width="1"/>
   <text x="332" y="27" text-anchor="middle" fill="#e0e0e6" font-family="'SF Mono', monospace" font-size="9">Ed25519 sign</text>
-  <text x="332" y="40" text-anchor="middle" fill="#8b8fa3" font-family="'SF Mono', monospace" font-size="8">z-base58btc</text>
+  <text x="332" y="40" text-anchor="middle" fill="#8b8fa3" font-family="'SF Mono', monospace" font-size="8">u-base64url</text>
   <line x1="382" y1="30" x2="410" y2="30" stroke="#7c93f5" stroke-width="1" marker-end="url(#s-arrow)"/>
   <rect x="418" y="10" width="172" height="40" rx="4" fill="#181a24" stroke="#a5d6a7" stroke-width="1"/>
   <text x="504" y="34" text-anchor="middle" fill="#a5d6a7" font-family="'SF Mono', monospace" font-size="10">Signed Receipt</text>
@@ -86,7 +86,7 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 1. Start with the receipt fields (everything except `proof`)
 2. Serialize to **RFC 8785** canonical JSON — deterministic byte ordering
 3. Sign the canonical bytes with the issuer's **Ed25519** private key
-4. Encode the signature as **z-prefixed base58btc** and attach as `proof.proofValue`
+4. Encode the signature as **u-prefixed base64url** (no padding) and attach as `proof.proofValue`
 
 The same canonical bytes are also SHA-256 hashed to produce the link for the *next* receipt in the chain.
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -27,7 +27,7 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
   <line x1="248" y1="41" x2="278" y2="41" stroke="#7c93f5" stroke-width="1" marker-end="url(#sign-arrow)"/>
   <rect x="286" y="24" width="100" height="34" rx="4" fill="#181a24" stroke="#7c93f5" stroke-width="1"/>
   <text x="336" y="38" text-anchor="middle" fill="#e0e0e6" font-family="'SF Mono', monospace" font-size="9">Ed25519 sign</text>
-  <text x="336" y="50" text-anchor="middle" fill="#8b8fa3" font-family="'SF Mono', monospace" font-size="8">z-base58btc</text>
+  <text x="336" y="50" text-anchor="middle" fill="#8b8fa3" font-family="'SF Mono', monospace" font-size="8">u-base64url</text>
   <line x1="386" y1="41" x2="416" y2="41" stroke="#7c93f5" stroke-width="1" marker-end="url(#sign-arrow)"/>
   <rect x="424" y="24" width="166" height="34" rx="4" fill="#181a24" stroke="#a5d6a7" stroke-width="1"/>
   <text x="507" y="45" text-anchor="middle" fill="#a5d6a7" font-family="'SF Mono', monospace" font-size="10">Signed Receipt</text>
@@ -52,7 +52,7 @@ For hashing and signing, receipts must be serialized using the **JSON Canonicali
 
 ## Signing
 
-The issuer signs the canonical receipt (proof field excluded) with its Ed25519 private key. The signature is encoded as a multibase string (`z`-prefixed base58btc) and placed in `proof.proofValue`.
+The issuer signs the canonical receipt (proof field excluded) with its Ed25519 private key. The signature is encoded as a multibase string (`u`-prefixed base64url, no padding) and placed in `proof.proofValue`.
 
 ## Chain integrity verification
 


### PR DESCRIPTION
## Summary

Three specification pages on the site described `proofValue` as multibase **`z`-prefixed base58btc**, but `spec/spec/agent-receipt-spec-v0.1.md` (lines 303, 440, 517, 585) and the shipped SDK implementations encode it as **`u`-prefixed base64url, no padding** — an intentional deviation from the W3C Data Integrity default for runtime simplicity.

This fix aligns three site pages with the spec, plus a hand-curated LLM-consumable summary that had the same bug.

### Changes

- `specification/receipt-chain-verification.mdx` — SVG label (line 30) and prose (line 55)
- `specification/agent-receipt-schema.mdx` — JSON example (line 126) and proof table row (line 235)
- `specification/how-it-works.mdx` — SVG label (line 79) and signing-step prose (line 89)
- `public/llms-full.txt` *(papercut, same bug)* — JSON example (line 84) and chain-verification step (line 122)

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [x] `grep -rn "base58btc\|z-prefixed\|z-base58" site/` returns no matches
- [ ] CI green

Refs site action plan #291 (B8, B9, B11).
