### PR TITLE
docs(sdk): correct stale taxonomy counts on SDK API references

### DIFF
--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -260,7 +260,7 @@ Classify a tool call to an action type and risk level using the provided mapping
 func AllActions() []ActionTypeEntry
 ```
 
-Return all 15 built-in action types (filesystem and system categories).
+Return all 18 built-in action types (filesystem, system, and data categories, plus unknown).
 
 #### `GetActionType`
 

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -403,7 +403,7 @@ class ClassificationResult:
 
 ```python
 FILESYSTEM_ACTIONS: list[ActionTypeEntry]  # 7 types
-SYSTEM_ACTIONS: list[ActionTypeEntry]      # 8 types
+SYSTEM_ACTIONS: list[ActionTypeEntry]      # 7 types
 ALL_ACTIONS: list[ActionTypeEntry]         # all + unknown
 UNKNOWN_ACTION: ActionTypeEntry
 ```

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -405,7 +405,7 @@ interface ClassificationResult {
 
 ```typescript
 const FILESYSTEM_ACTIONS: readonly ActionTypeEntry[]  // 7 types
-const SYSTEM_ACTIONS: readonly ActionTypeEntry[]       // 8 types
+const SYSTEM_ACTIONS: readonly ActionTypeEntry[]       // 7 types
 const ALL_ACTIONS: readonly ActionTypeEntry[]           // all + unknown
 const UNKNOWN_ACTION: ActionTypeEntry
 ```


### PR DESCRIPTION
## Summary

The three SDK API reference pages had count claims that drifted away from the shipped taxonomy. Verified against source: the canonical counts (consistent across `sdk/go/taxonomy/taxonomy.go`, `sdk/ts/src/taxonomy/actions.ts`, and `sdk/py/src/agent_receipts/taxonomy/actions.py`) are **FILESYSTEM 7, SYSTEM 7, DATA 3, UNKNOWN 1, ALL 18**.

### Fixes

| Page | Before | After |
|---|---|---|
| `sdk-go/api-reference.mdx:263` | *"Return all 15 built-in action types (filesystem and system categories)."* | *"Return all 18 built-in action types (filesystem, system, and data categories, plus unknown)."* |
| `sdk-ts/api-reference.mdx:408` | `SYSTEM_ACTIONS: readonly ActionTypeEntry[]  // 8 types` | `// 7 types` |
| `sdk-py/api-reference.mdx:406` | `SYSTEM_ACTIONS: list[ActionTypeEntry]      # 8 types` | `# 7 types` |

The Go count fix also corrected the parenthetical, which was missing the `data` category and `unknown` action — saying "18 built-in action types (filesystem and system categories)" would have been internally contradictory.

### Out of scope

`DATA_ACTIONS` is missing from the registry blocks on the TypeScript and Python pages. That's tracked as nits **N4** and **N6** in the action plan and belongs in the Track 3 per-page rewrites, not this mechanical PR.

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [x] Counts cross-checked against source files in all three SDKs
- [ ] CI green

Refs site action plan #291 (D33, D34, D35).
