### PR TITLE
docs: roll out ADR-0012 parameterDisclosure rename across site

### DIFF
--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -153,11 +153,11 @@ The `receipts` command produces a human-readable summary table for auditing.
 
 ---
 
-## parameterPreview: operator-controlled privacy
+## parameterDisclosure: operator-controlled privacy
 
 By default, the plugin stores only the parameters hash. You cannot reconstruct what arguments were passed to `exec`. This is deliberate — agents frequently receive secrets, tokens, or sensitive data in their tool call parameters.
 
-If you need more forensic detail, set `parameterPreview` in `openclaw.json`:
+If you need more forensic detail, set `parameterDisclosure` in `openclaw.json`:
 
 ```jsonc
 {
@@ -165,7 +165,7 @@ If you need more forensic detail, set `parameterPreview` in `openclaw.json`:
     "entries": {
       "openclaw-agent-receipts": {
         "config": {
-          "parameterPreview": "high"
+          "parameterDisclosure": "high"
         }
       }
     }
@@ -173,7 +173,7 @@ If you need more forensic detail, set `parameterPreview` in `openclaw.json`:
 }
 ```
 
-With `parameterPreview: "high"`, high-risk and critical actions include a `parameters_preview` field alongside the hash:
+With `parameterDisclosure: "high"`, high-risk and critical actions include a `parameters_disclosure` field alongside the hash:
 
 ```json
 {
@@ -181,7 +181,7 @@ With `parameterPreview: "high"`, high-risk and critical actions include a `param
     "type": "system.command.execute",
     "risk_level": "high",
     "parameters_hash": "sha256:9c84a8c9e89a07ff323b0ad52972f148b7f2f5240817f2d9f9892ca514b4522c",
-    "parameters_preview": {
+    "parameters_disclosure": {
       "command": "echo \"Testing agent-receipts plugin fix\""
     }
   }
@@ -223,7 +223,7 @@ Two things the plugin cannot provide that the MCP Proxy can:
 
 **Intent field.** The MCP Proxy sits between the client and server and has access to the full JSON-RPC request, including the reasoning context that prompted the call. The plugin intercepts at the tool boundary — it sees the call, not what caused it. The `intent` field in the receipt schema is populated by the proxy, not the plugin.
 
-**Proxy-side argument retention.** The proxy still records `action.parameters_hash` in receipts by default, but it can additionally retain a redacted or encrypted copy of the full arguments in its audit database, depending on configuration. The plugin's privacy-preserving default is hash-only. Even with `parameterPreview: true`, what's stored is a best-effort plaintext representation, not the full canonical arguments object.
+**Proxy-side argument retention.** The proxy still records `action.parameters_hash` in receipts by default, but it can additionally retain a redacted or encrypted copy of the full arguments in its audit database, depending on configuration. The plugin's privacy-preserving default is hash-only. Even with `parameterDisclosure: true`, what's stored is a best-effort plaintext representation, not the full canonical arguments object.
 
 The tradeoff: the plugin requires no changes to your agent implementation, no wrapping of your MCP servers, and no proxy process in your stack. You get receipts for every tool call across every tool your agent uses. The depth of each receipt is narrower.
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -129,7 +129,7 @@ Every Agent Receipt captures:
 - **Outcome** — success, failure, or pending — and whether the action is reversible
 - **Chain position** — a hash link to the previous receipt, forming a tamper-evident sequence
 
-Parameters are hashed, not stored in plaintext. The human principal controls what is disclosed. Sensitive data never appears in receipts.
+Parameters are hashed, not stored in plaintext. The operator controls what is disclosed. Sensitive data never appears in receipts.
 
 ## Design principles
 

--- a/site/src/content/docs/openclaw/cli-reference.mdx
+++ b/site/src/content/docs/openclaw/cli-reference.mdx
@@ -62,11 +62,11 @@ Use `jq` to find shell commands that reference `rm`:
 
 ```bash
 npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
-  | jq '.receipts[] | select(.parameters_preview.command | strings | contains("rm"))'
+  | jq '.receipts[] | select(.parameters_disclosure.command | strings | contains("rm"))'
 ```
 
-:::note[`parameters_preview` is empty by default]
-The `parameters_preview` field is only populated when `parameterPreview` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-preview) page for configuration options.
+:::note[`parameters_disclosure` is empty by default]
+The `parameters_disclosure` field is only populated when `parameterDisclosure` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-disclosure) page for configuration options.
 :::
 
 ---

--- a/site/src/content/docs/openclaw/cli-reference.mdx
+++ b/site/src/content/docs/openclaw/cli-reference.mdx
@@ -65,8 +65,8 @@ npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
   | jq '.receipts[] | select(.parameters_disclosure.command | strings | contains("rm"))'
 ```
 
-:::note[`parameters_disclosure` is empty by default]
-The `parameters_disclosure` field is only populated when `parameterDisclosure` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-disclosure) page for configuration options.
+:::note[`parameters_disclosure` is omitted by default]
+The `parameters_disclosure` field is only included when `parameterDisclosure` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-disclosure) page for configuration options.
 :::
 
 ---

--- a/site/src/content/docs/openclaw/cli-reference.mdx
+++ b/site/src/content/docs/openclaw/cli-reference.mdx
@@ -58,15 +58,15 @@ Filter by action type and output JSON for downstream processing:
 npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
 ```
 
-Use `jq` to find shell commands that reference `rm`:
+Use `jq` to filter shell commands by risk level:
 
 ```bash
 npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
-  | jq '.receipts[] | select(.parameters_disclosure.command | strings | contains("rm"))'
+  | jq '.receipts[] | select(.risk == "high")'
 ```
 
-:::note[`parameters_disclosure` is omitted by default]
-The `parameters_disclosure` field is only included when `parameterDisclosure` is enabled in the plugin config. By default, only the parameter hash is stored. See the [Installation](/openclaw/installation/#parameter-disclosure) page for configuration options.
+:::note[Filtering on disclosed parameter content]
+The CLI's `--json` projection includes `id`, `action`, `risk`, `target`, `status`, `sequence`, `chain_id`, and `timestamp` — not `parameters_disclosure`. To inspect disclosed parameter content for a specific receipt, use `inspect <id>` for the full receipt body (`parameters_disclosure` is only present when `parameterDisclosure` is enabled in the plugin config — see the [Installation](/openclaw/installation/#parameter-disclosure) page). Extending the `--json` projection to include `parameters_disclosure` is tracked in [#315](https://github.com/agent-receipts/ar/issues/315).
 :::
 
 ---

--- a/site/src/content/docs/specification/overview.mdx
+++ b/site/src/content/docs/specification/overview.mdx
@@ -11,7 +11,7 @@ The Agent Receipt Protocol defines a standard format for cryptographically signe
 
 ## Design principles
 
-1. **Privacy-preserving by default.** Parameters are hashed, not stored in plaintext. The human principal controls what is disclosed. Sensitive data never appears in receipts — only hashes and user-controlled previews.
+1. **Privacy-preserving by default.** Parameters are hashed, not stored in plaintext. The operator controls what is disclosed. Sensitive data never appears in receipts — only hashes and operator-controlled disclosures.
 
 2. **Built on existing standards.** W3C Verifiable Credentials Data Model 2.0 for structure. Ed25519 for signing. SHA-256 for hashing. RFC 3161 for trusted timestamps. No novel cryptographic primitives.
 


### PR DESCRIPTION
## Summary

[ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md) renamed the config key `parameterPreview` → `parameterDisclosure` and the receipt field `parameters_preview` → `parameters_disclosure`. The renames already shipped in `sdk/py` and `openclaw/installation.mdx` but the rest of the site still referenced the deprecated names.

ADR-0012 also commits to **operator-controlled** (not user-controlled) disclosure config — independent of the not-yet-shipped encrypted envelope architecture. Two prose statements that implied user control were corrected to match the canonical position.

### Changes

| File | Change |
|---|---|
| `openclaw/cli-reference.mdx` | jq filter field name; note prose; broken anchor `/openclaw/installation/#parameter-preview` → `/openclaw/installation/#parameter-disclosure` (matches existing `## Parameter disclosure` heading on the installation page) |
| `blog/openclaw-plugin-deep-dive.mdx` | Rename `parameterPreview` → `parameterDisclosure` and `parameters_preview` → `parameters_disclosure` throughout (heading, prose, JSON example) |
| `specification/overview.mdx` | `"human principal controls what is disclosed"` / `"user-controlled previews"` → `"operator controls"` / `"operator-controlled disclosures"` |
| `index.mdx` | Same prose framing update on the homepage |

### Out of scope

The blog post still describes the plaintext-in-body disclosure model (where `parameters_disclosure` is a `dict[str, str]`). ADR-0012 supersedes that with an encrypted envelope, but envelope implementation is still **Status: Proposed (Phase A)** — the field is currently a plaintext map in shipped code. Rewriting the blog to describe ciphertext today would misrepresent shipped behavior. Track 3 should revisit once the envelope architecture ships.

The intentional deprecation note in `openclaw/installation.mdx:122-123` retains both old and new names — that's the canonical migration callout and stays as-is.

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [x] `grep -rn "parameterPreview\|parameters_preview\|#parameter-preview" site/` returns only the deprecation note in `openclaw/installation.mdx`
- [x] Anchor target verified: `openclaw/installation.mdx` line 81 has `## Parameter disclosure` which Starlight slugifies to `parameter-disclosure`
- [ ] CI green

Refs site action plan #291 (B14, CC-8, CC-11).
