### PR TITLE
docs: bump receipt schema version 0.1.0 → 0.2.0 across site

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -26,7 +26,7 @@ An Agent Receipt is a JSON object conforming to W3C VC Data Model 2.0:
 - `@context`: ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 - `id`: urn:receipt:<uuid>
 - `type`: ["VerifiableCredential", "AgentReceipt"]
-- `version`: "0.1.0"
+- `version`: "0.2.0"
 - `issuer`: { id, type?, name?, operator?, model?, session_id? }
 - `issuanceDate`: ISO 8601 datetime
 - `credentialSubject`: { principal, action, intent?, outcome, authorization?, delegation?, chain }
@@ -58,7 +58,7 @@ An Agent Receipt is a JSON object conforming to W3C VC Data Model 2.0:
   "@context": ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"],
   "id": "urn:receipt:660e8400-e29b-41d4-a716-446655440001",
   "type": ["VerifiableCredential", "AgentReceipt"],
-  "version": "0.1.0",
+  "version": "0.2.0",
   "issuer": { "id": "did:agent:my-agent" },
   "issuanceDate": "2026-03-31T14:31:00Z",
   "credentialSubject": {

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -216,7 +216,7 @@ type ChainVerification struct {
 ### Constants
 
 ```go
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 type RiskLevel string
 const (

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -255,8 +255,8 @@ OutcomeStatus = Literal["success", "failure", "pending"]
 
 CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
-RECEIPT_VERSION: str        # "0.1.0"
-VERSION: str                # "0.2.3"
+RECEIPT_VERSION: str        # "0.2.0" (receipt schema)
+VERSION: str                # "0.5.0" (package version)
 ```
 
 ---

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -256,8 +256,8 @@ type OutcomeStatus = "success" | "failure" | "pending"
 
 const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 const CREDENTIAL_TYPE: readonly ["VerifiableCredential", "AgentReceipt"]
-const RECEIPT_VERSION: "0.1.0"
-const VERSION: "0.1.0"
+const RECEIPT_VERSION: "0.2.0"  // receipt schema
+const VERSION: "0.6.0"          // package version
 ```
 
 ---

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -50,7 +50,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
   ],
   "id": "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
   "type": ["VerifiableCredential", "AgentReceipt"],
-  "version": "0.1.0",
+  "version": "0.2.0",
 
   "issuer": {
     "id": "did:agent:claude-cowork-instance-abc123",
@@ -135,7 +135,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `@context` | Yes | JSON-LD context. Must include the W3C VC v2 and Agent Receipt context URIs in order. |
 | `id` | Yes | Globally unique identifier. Must be `urn:receipt:<uuid>`. |
 | `type` | Yes | Must be `["VerifiableCredential", "AgentReceipt"]`. |
-| `version` | Yes | Spec version. Must be `"0.1.0"` for this version. |
+| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, or `"0.2.1"`. Verifiers MUST accept all three. |
 | `issuer` | Yes | The agent or platform that issued the receipt. |
 | `issuanceDate` | Yes | ISO 8601 datetime when the receipt was issued. May differ from `action.timestamp`. |
 | `credentialSubject` | Yes | The receipt payload. |

--- a/site/src/content/docs/specification/overview.mdx
+++ b/site/src/content/docs/specification/overview.mdx
@@ -5,7 +5,7 @@ description: Design principles and core concepts of the Agent Receipt Protocol.
 
 import { Badge } from "@astrojs/starlight/components";
 
-<Badge text="v0.1.0" variant="note" /> <Badge text="Draft" variant="caution" />
+<Badge text="v0.2.0" variant="note" /> <Badge text="Draft" variant="caution" />
 
 The Agent Receipt Protocol defines a standard format for cryptographically signed records of AI agent actions. This page covers the design principles and core concepts. For the full specification, see the [spec source on GitHub](https://github.com/agent-receipts/spec).
 


### PR DESCRIPTION
## Summary

The receipt schema `VERSION` constant moved from `0.1.0` to `0.2.0` in all three SDKs (`sdk/go/receipt/types.go:19`, `sdk/ts/src/receipt/types.ts:19`, `sdk/py/src/agent_receipts/receipt/types.py:24`) and the spec schema (`spec/schema/agent-receipt.schema.json` now enumerates `"0.1.0"`, `"0.2.0"`, `"0.2.1"` with verifiers required to accept all three).

The site still referenced `"0.1.0"` in nine places, all updated to match shipped SDK output.

### Changes

| File | Change |
|---|---|
| `specification/overview.mdx` | Version badge `v0.1.0` → `v0.2.0` |
| `specification/agent-receipt-schema.mdx` | JSON example version + schema table description (rewrote per spec enum) |
| `sdk-go/api-reference.mdx` | `Version` constant value |
| `sdk-py/api-reference.mdx` | `RECEIPT_VERSION` constant value |
| `sdk-ts/api-reference.mdx` | `RECEIPT_VERSION` constant value |
| `public/llms-full.txt` | Schema overview + JSON example |

The schema-table description was rewritten from *"Must be `\"0.1.0\"` for this version"* to *"Must be `\"0.1.0\"`, `\"0.2.0\"`, or `\"0.2.1\"`. Verifiers MUST accept all three"* — matches the actual schema enum and verifier-MUST language. The original phrasing was already misleading.

### Papercut

While editing the SDK constant blocks, also corrected two stale package-version comments that had drifted independently of the schema bump:

- `sdk-ts/api-reference.mdx`: `VERSION "0.1.0"` → `"0.6.0"` (matches `sdk/ts/package.json`)
- `sdk-py/api-reference.mdx`: `VERSION "0.2.3"` → `"0.5.0"` (matches `sdk/py/pyproject.toml`)

Annotated inline as `// receipt schema` vs `// package version` so the two constants don't get conflated again.

## Test plan

- [x] `pnpm build` in `site/` passes locally
- [x] `grep -rn "0\.1\.0" site/src/content/docs/ site/public/llms-full.txt` returns only the intentional verifier-acceptance list in the schema-table description
- [x] Cross-checked against canonical sources: `sdk/{go,ts,py}/.../receipt/types.*` and `spec/schema/agent-receipt.schema.json`
- [ ] CI green

Refs site action plan #291 (CC-10).
