### PR TITLE
fix(sdk-py): bump VERSION to 0.5.0 to match pyproject.toml

### DIFF
--- a/sdk/py/src/agent_receipts/_version.py
+++ b/sdk/py/src/agent_receipts/_version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.2"
+VERSION = "0.5.0"


### PR DESCRIPTION
## Summary

Resolves version drift between `pyproject.toml` (0.5.0) and runtime constant `_version.py` (0.2.2).

The runtime constant now correctly exports as 0.5.0, matching the package version reported by `pip show` and the canonical version in the documentation.

## Test coverage

All 200 Python SDK tests pass. Verified runtime export:
```
import agent_receipts
print(agent_receipts.VERSION)  # → "0.5.0" ✓
```

Fixes #316