### PR TITLE
[Docs] Add doc.go files for pkg.go.dev documentation

### DIFF
--- a/mcp-proxy/doc.go
+++ b/mcp-proxy/doc.go
@@ -1,0 +1,4 @@
+// Package mcpproxy provides an MCP (Model Context Protocol) proxy server
+// that handles authentication, routing, and request transformation for
+// MCP-compatible agent tools.
+package mcpproxy

--- a/sdk/go/receipt/doc.go
+++ b/sdk/go/receipt/doc.go
@@ -1,0 +1,3 @@
+// Package receipt provides types and functions for creating, validating,
+// and verifying agent receipts - cryptographic attestations of agent actions.
+package receipt

--- a/sdk/go/store/doc.go
+++ b/sdk/go/store/doc.go
@@ -1,0 +1,3 @@
+// Package store provides storage backends for agent receipts,
+// including in-memory and persistent implementations.
+package store


### PR DESCRIPTION
## Summary

Adds `doc.go` files with package-level comments so pkg.go.dev shows proper documentation.

## Changes

- `mcp-proxy/doc.go` — package docs for mcp-proxy module
- `sdk/go/receipt/doc.go` — package docs for receipt module
- `sdk/go/store/doc.go` — package docs for store module

Closes agent-receipts/ar#73