### PR TITLE
daemon: ship `agent-receipts verify` and 0644 public-key publishing

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -85,14 +85,27 @@ itself is `0660`. Phase 1 unprivileged installs use the per-user defaults
 (`$TMPDIR` on macOS, `$XDG_RUNTIME_DIR` on Linux when set).
 
 On every startup the daemon publishes the matching SPKI public key to
-`--public-key` (default `<KeyPath>.pub`) with mode `0644`, so independent
-verifiers — `agent-receipts verify`, audit scripts, CI checks — can load it
-without access to the private key path. If the file already exists with the
-same contents the publish is a no-op; if the contents differ the daemon
-refuses to start (a mismatch means either the signing key was rotated /
-restored from backup, or the published file was tampered with — operator
-must remove the stale file deliberately). The daemon also refuses if the
-path is a symlink, FIFO, device, etc.
+`--public-key` (default `<KeyPath>.pub`, tracking any `--key` override) with
+mode `0644`, so independent verifiers — `agent-receipts verify`, audit
+scripts, CI checks — can load it without access to the private key path. If
+the file already exists with the same contents the publish is a no-op; if
+the contents differ the daemon refuses to start (a mismatch means either
+the signing key was rotated / restored from backup, or the published file
+was tampered with — operator must remove the stale file deliberately). The
+daemon also refuses if the path is a symlink, FIFO, device, etc.
+
+The published key file is `0644`, but its parent directory is created at
+`0750` to match the receipt-store directory's access policy — non-owners
+must be in the daemon user's group to traverse it and reach the public key.
+Per-user installs (the MVP path: `~/.agent-receipts/`) are unaffected since
+the operator who runs the verify CLI owns the directory. System installs
+(`/etc/agentreceipts/`, `/var/lib/agentreceipts/`) are expected to give the
+daemon a dedicated `agentreceipts` user and the read-side an
+`agentreceipts-read` group whose members traverse the directory; that
+ownership/grouping is a packaging concern (Homebrew / launchd / systemd) and
+not something the daemon assigns at runtime. If the directory already exists
+the daemon does not modify its mode, so operator-managed permissions are
+preserved.
 
 ## Read interface: `agent-receipts verify`
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -11,9 +11,10 @@ rationale and [issue #236](https://github.com/agent-receipts/ar/issues/236)
 for the work breakdown.
 
 This is **Phase 1** of the daemon roll-out — the foundation slice. It ships
-the standalone daemon binary, peer-cred capture, chain-tail resumption, and
-the file-backed `KeySource`. Emitter refactor for mcp-proxy / OpenClaw / SDK
-ships in later phases.
+the standalone daemon binary, peer-cred capture, chain-tail resumption, the
+file-backed `KeySource`, and the `agent-receipts verify` read CLI (which
+works whether the daemon is up or down). Emitter refactor for mcp-proxy /
+OpenClaw / SDK ships in later phases.
 
 ## Build
 
@@ -69,6 +70,7 @@ agent-receipts-daemon \
 | `--key` | `AGENTRECEIPTS_KEY` | `~/.agent-receipts/signing.key` |
 | `--chain-id` | `AGENTRECEIPTS_CHAIN_ID` | `default` |
 | `--issuer-id` | `AGENTRECEIPTS_ISSUER_ID` | `did:agent-receipts-daemon:local` |
+| `--public-key` | `AGENTRECEIPTS_PUBLIC_KEY` | `<--key>.pub` |
 | `--verification-method` | `AGENTRECEIPTS_VERIFICATION_METHOD` | `did:agent-receipts-daemon:local#k1` |
 
 The signing key file must be a PKCS#8-encoded Ed25519 private key (the format
@@ -81,6 +83,43 @@ non-regular file at this path.
 The socket directory is created with mode `0750` if missing; the socket
 itself is `0660`. Phase 1 unprivileged installs use the per-user defaults
 (`$TMPDIR` on macOS, `$XDG_RUNTIME_DIR` on Linux when set).
+
+On every startup the daemon publishes the matching SPKI public key to
+`--public-key` (default `<KeyPath>.pub`) with mode `0644`, so independent
+verifiers — `agent-receipts verify`, audit scripts, CI checks — can load it
+without access to the private key path. If the file already exists with the
+same contents the publish is a no-op; if the contents differ the daemon
+refuses to start (a mismatch means either the signing key was rotated /
+restored from backup, or the published file was tampered with — operator
+must remove the stale file deliberately). The daemon also refuses if the
+path is a symlink, FIFO, device, etc.
+
+## Read interface: `agent-receipts verify`
+
+```sh
+agent-receipts verify --chain-id default
+# or, with explicit paths:
+agent-receipts verify \
+  --db /var/lib/agentreceipts/receipts.db \
+  --public-key /etc/agentreceipts/signing.key.pub \
+  --chain-id default
+```
+
+Defaults match the daemon's: a verify run without flags works after
+`agent-receipts-daemon` has run at least once with the same per-user paths.
+
+`verify` opens the SQLite store **read-only** via `sdk/go/store.OpenReadOnly`
+so it is safe to run while the daemon is the active writer, and it does not
+require the daemon socket to be reachable. Independent verifiability is not
+gated on daemon availability (issue #236, Section 4).
+
+Exit codes are stable for scripting:
+
+| Code | Meaning |
+|---|---|
+| `0` | Chain verified |
+| `1` | Chain failed verification (output lists per-receipt status) |
+| `2` | Usage error (bad flags, missing key file, unreadable DB) |
 
 ## Wire protocol
 
@@ -144,8 +183,9 @@ The following are deliberate Phase 1 choices, all callable out for follow-up:
 ## Layout
 
 ```
-daemon.go                                  # Run() entrypoint and Config
-cmd/agent-receipts-daemon/main.go          # CLI: flag/env parsing, signal handling
+daemon.go                                  # Run() entrypoint and Config; publishes the public key on startup
+cmd/agent-receipts-daemon/main.go          # daemon CLI: flag/env parsing, signal handling
+cmd/agent-receipts/main.go                 # read CLI: thin shim over internal/verifycli
 internal/
   chain/state.go                           # in-memory (seq, prev_hash) owner; sole writer
   keysource/keysource.go                   # KeySource interface (ADR-0015 shape)
@@ -153,5 +193,6 @@ internal/
   socket/listener.go                       # Unix-domain socket + length-prefix framing
   socket/peercred_{linux,darwin,other}.go  # OS-specific peer-credential capture
   pipeline/build.go                        # frame + peer -> AgentReceipt -> sign -> store
-integration_test.go                        # tags: integration. End-to-end concurrency + peer-cred fixture.
+  verifycli/verify.go                      # `agent-receipts verify` subcommand
+integration_test.go                        # tags: integration. End-to-end concurrency, peer-cred, and verify-CLI fixtures.
 ```

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -17,10 +17,12 @@ import (
 )
 
 func main() {
+	keyPath := envOrDefault("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
 	cfg := daemon.Config{
 		SocketPath:           envOrDefault("AGENTRECEIPTS_SOCKET", daemon.DefaultSocketPath()),
 		DBPath:               envOrDefault("AGENTRECEIPTS_DB", daemon.DefaultDBPath()),
-		KeyPath:              envOrDefault("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath()),
+		KeyPath:              keyPath,
+		PublicKeyPath:        envOrDefault("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath)),
 		ChainID:              envOrDefault("AGENTRECEIPTS_CHAIN_ID", "default"),
 		IssuerID:             envOrDefault("AGENTRECEIPTS_ISSUER_ID", "did:agent-receipts-daemon:local"),
 		VerificationMethodID: envOrDefault("AGENTRECEIPTS_VERIFICATION_METHOD", "did:agent-receipts-daemon:local#k1"),
@@ -29,6 +31,7 @@ func main() {
 	flag.StringVar(&cfg.SocketPath, "socket", cfg.SocketPath, "Unix-domain socket path (env: AGENTRECEIPTS_SOCKET)")
 	flag.StringVar(&cfg.DBPath, "db", cfg.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	flag.StringVar(&cfg.KeyPath, "key", cfg.KeyPath, "Ed25519 PEM private key path, mode 0600 (env: AGENTRECEIPTS_KEY)")
+	flag.StringVar(&cfg.PublicKeyPath, "public-key", cfg.PublicKeyPath, "Path to publish the SPKI public key as PEM, mode 0644 (env: AGENTRECEIPTS_PUBLIC_KEY)")
 	flag.StringVar(&cfg.ChainID, "chain-id", cfg.ChainID, "Chain id to write under (env: AGENTRECEIPTS_CHAIN_ID)")
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -17,12 +17,16 @@ import (
 )
 
 func main() {
-	keyPath := envOrDefault("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
 	cfg := daemon.Config{
-		SocketPath:           envOrDefault("AGENTRECEIPTS_SOCKET", daemon.DefaultSocketPath()),
-		DBPath:               envOrDefault("AGENTRECEIPTS_DB", daemon.DefaultDBPath()),
-		KeyPath:              keyPath,
-		PublicKeyPath:        envOrDefault("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath)),
+		SocketPath: envOrDefault("AGENTRECEIPTS_SOCKET", daemon.DefaultSocketPath()),
+		DBPath:     envOrDefault("AGENTRECEIPTS_DB", daemon.DefaultDBPath()),
+		KeyPath:    envOrDefault("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath()),
+		// PublicKeyPath defaults to <KeyPath>.pub. Resolve the default AFTER
+		// flag.Parse so a user-supplied --key (which overrides KeyPath) is
+		// what we derive against — pre-filling here against the env/default
+		// KeyPath would silently ignore the operator's --key choice.
+		// AGENTRECEIPTS_PUBLIC_KEY (if set) wins over the derived default.
+		PublicKeyPath:        os.Getenv("AGENTRECEIPTS_PUBLIC_KEY"),
 		ChainID:              envOrDefault("AGENTRECEIPTS_CHAIN_ID", "default"),
 		IssuerID:             envOrDefault("AGENTRECEIPTS_ISSUER_ID", "did:agent-receipts-daemon:local"),
 		VerificationMethodID: envOrDefault("AGENTRECEIPTS_VERIFICATION_METHOD", "did:agent-receipts-daemon:local#k1"),
@@ -31,11 +35,19 @@ func main() {
 	flag.StringVar(&cfg.SocketPath, "socket", cfg.SocketPath, "Unix-domain socket path (env: AGENTRECEIPTS_SOCKET)")
 	flag.StringVar(&cfg.DBPath, "db", cfg.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	flag.StringVar(&cfg.KeyPath, "key", cfg.KeyPath, "Ed25519 PEM private key path, mode 0600 (env: AGENTRECEIPTS_KEY)")
-	flag.StringVar(&cfg.PublicKeyPath, "public-key", cfg.PublicKeyPath, "Path to publish the SPKI public key as PEM, mode 0644 (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	flag.StringVar(&cfg.PublicKeyPath, "public-key", cfg.PublicKeyPath, "Path to publish the SPKI public key as PEM, mode 0644 (default: <--key>.pub) (env: AGENTRECEIPTS_PUBLIC_KEY)")
 	flag.StringVar(&cfg.ChainID, "chain-id", cfg.ChainID, "Chain id to write under (env: AGENTRECEIPTS_CHAIN_ID)")
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
 	flag.Parse()
+
+	// Apply the <--key>.pub default now that flag.Parse has finalised KeyPath.
+	// daemon.validateConfig also covers this path for library callers; doing
+	// it here too keeps the startup log line ("published public key to ...")
+	// printing the same path the daemon writes to.
+	if cfg.PublicKeyPath == "" {
+		cfg.PublicKeyPath = daemon.DefaultPublicKeyPath(cfg.KeyPath)
+	}
 
 	logger := log.New(os.Stderr, "agent-receipts-daemon ", log.LstdFlags|log.Lmicroseconds)
 	cfg.Logger = logger

--- a/daemon/cmd/agent-receipts/main.go
+++ b/daemon/cmd/agent-receipts/main.go
@@ -1,0 +1,37 @@
+// Command agent-receipts is the daemon's read-side companion CLI. The first
+// subcommand is `verify`, which validates the chain in a daemon-written
+// SQLite store using the daemon-published public key. Logic lives in
+// internal/verifycli so it can be tested without shelling out to the binary.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/agent-receipts/ar/daemon/internal/verifycli"
+)
+
+const usage = `Usage: agent-receipts <command> [flags]
+
+Commands:
+  verify   Verify a stored chain's signatures and hash links.
+
+Run 'agent-receipts <command> -h' for command-specific flags.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(verifycli.ExitUsageError)
+	}
+	switch os.Args[1] {
+	case "verify":
+		os.Exit(verifycli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
+	case "-h", "--help", "help":
+		fmt.Fprint(os.Stdout, usage)
+		os.Exit(verifycli.ExitOK)
+	default:
+		fmt.Fprintf(os.Stderr, "agent-receipts: unknown command %q\n\n%s", os.Args[1], usage)
+		os.Exit(verifycli.ExitUsageError)
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -32,6 +32,12 @@ type Config struct {
 	// KeyPath is the PEM-encoded Ed25519 private key path. Mode must be 0600.
 	KeyPath string
 
+	// PublicKeyPath is where the daemon publishes the matching SPKI public
+	// key in PEM form, mode 0644, on every startup. Read-side tools
+	// (`agent-receipts verify`) load it without needing access to KeyPath or
+	// the daemon's signing surface. Defaults to KeyPath + ".pub" when empty.
+	PublicKeyPath string
+
 	// ChainID is the chain id all incoming frames are written under. Phase 1
 	// supports one chain per daemon process.
 	ChainID string
@@ -94,6 +100,17 @@ func DefaultKeyPath() string {
 	return ""
 }
 
+// DefaultPublicKeyPath returns the default published public-key path: the
+// same directory as keyPath with the suffix ".pub". Empty when keyPath is
+// empty so cmd/main.go can surface a clearer "Config.KeyPath is required"
+// error from validateConfig instead of a less-helpful PublicKeyPath one.
+func DefaultPublicKeyPath(keyPath string) string {
+	if keyPath == "" {
+		return ""
+	}
+	return keyPath + ".pub"
+}
+
 // Run starts the daemon and blocks until ctx is cancelled. It returns the
 // first fatal error or nil on graceful shutdown.
 func Run(ctx context.Context, cfg Config) error {
@@ -146,6 +163,11 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("init keysource: %w", err)
 	}
 	defer func() { _ = ks.Teardown() }()
+
+	if err := publishPublicKey(ks, cfg.PublicKeyPath); err != nil {
+		return err
+	}
+	cfg.Logger.Printf("published public key to %s", cfg.PublicKeyPath)
 
 	state, err := chain.LoadFromStore(st, cfg.ChainID)
 	if err != nil {
@@ -236,6 +258,78 @@ func tightenDBFiles(dbPath string) error {
 	return nil
 }
 
+// publishPublicKey writes the keysource's PEM-encoded public key to path with
+// mode 0644 so independent verifiers can load it without needing access to
+// the private key path or the daemon's signing surface (this realises the
+// "agent-receipts verify reads DB and public key directly via filesystem"
+// acceptance criterion of issue #236).
+//
+// Behaviour:
+//   - File missing → write the current public key with mode 0644.
+//   - File present and identical to the current public key → no-op.
+//   - File present and differs from the current public key → refuse. A
+//     mismatch means either the private key changed (rotation, restored from
+//     backup) or the published file was tampered with; silently overwriting
+//     would invalidate verifiers' trust in receipts they already accepted.
+//     Operator must remove the stale file deliberately.
+//   - File present but a symlink, FIFO, device, etc. → refuse. A pre-created
+//     symlink would otherwise let an attacker with write access to the parent
+//     redirect the chmod / write to an arbitrary target.
+func publishPublicKey(ks keysource.KeySource, path string) error {
+	if path == "" {
+		return errors.New("Config.PublicKeyPath is required")
+	}
+	pubPEM, err := ks.PublicKey()
+	if err != nil {
+		return fmt.Errorf("read public key from keysource: %w", err)
+	}
+
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf(
+				"daemon: public-key path %s exists but is not a regular file (mode %s); refusing to overwrite",
+				path, info.Mode(),
+			)
+		}
+		existing, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read existing public-key file %s: %w", path, err)
+		}
+		if string(existing) == pubPEM {
+			// Already up-to-date. Re-chmod in case the file was created with
+			// a stricter umask but later loosened — converging the bit set is
+			// cheap and aligns with the "publish on every startup" contract.
+			if info.Mode().Perm() != 0o644 {
+				if err := os.Chmod(path, 0o644); err != nil {
+					return fmt.Errorf("chmod %s 0644: %w", path, err)
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf(
+			"daemon: public-key file %s differs from current keysource public key; refusing to overwrite. Remove the file deliberately if the signing key was rotated or restored from backup",
+			path,
+		)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat public-key path %s: %w", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create public-key dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(pubPEM), 0o644); err != nil {
+		return fmt.Errorf("write public-key file %s: %w", path, err)
+	}
+	// WriteFile honours the process umask, which the daemon tightens to 0027
+	// before this point — so a fresh write would be 0640 instead of the 0644
+	// we want for a public key. Chmod afterwards to land on the intended mode
+	// without reverting the umask (which would loosen WAL/SHM perms).
+	if err := os.Chmod(path, 0o644); err != nil {
+		return fmt.Errorf("chmod %s 0644: %w", path, err)
+	}
+	return nil
+}
+
 func validateConfig(cfg *Config) error {
 	if cfg.SocketPath == "" {
 		return errors.New("Config.SocketPath is required")
@@ -245,6 +339,9 @@ func validateConfig(cfg *Config) error {
 	}
 	if cfg.KeyPath == "" {
 		return errors.New("Config.KeyPath is required")
+	}
+	if cfg.PublicKeyPath == "" {
+		cfg.PublicKeyPath = DefaultPublicKeyPath(cfg.KeyPath)
 	}
 	if cfg.ChainID == "" {
 		return errors.New("Config.ChainID is required")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"syscall"
 
 	"github.com/agent-receipts/ar/daemon/internal/chain"
 	"github.com/agent-receipts/ar/daemon/internal/keysource"
@@ -324,7 +323,7 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 	// fresh-write half of the TOCTOU window Copilot flagged on PR #325.
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|oNoFollow, 0o644)
 	if err != nil {
-		if errors.Is(err, syscall.ELOOP) {
+		if isSymlinkLoop(err) {
 			return fmt.Errorf("daemon: public-key path %s appeared as a symlink between existence check and create; refusing", path)
 		}
 		return fmt.Errorf("create public-key file %s: %w", path, err)
@@ -364,7 +363,7 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 func reconcileExistingPublicKey(path, wantPubPEM string) error {
 	fh, err := os.OpenFile(path, os.O_RDONLY|oNoFollow, 0)
 	if err != nil {
-		if errors.Is(err, syscall.ELOOP) {
+		if isSymlinkLoop(err) {
 			return fmt.Errorf("daemon: public-key path %s changed to a symlink between check and open; refusing", path)
 		}
 		return fmt.Errorf("open public-key file %s: %w", path, err)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -8,10 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 
 	"github.com/agent-receipts/ar/daemon/internal/chain"
 	"github.com/agent-receipts/ar/daemon/internal/keysource"
@@ -266,7 +269,8 @@ func tightenDBFiles(dbPath string) error {
 //
 // Behaviour:
 //   - File missing → write the current public key with mode 0644.
-//   - File present and identical to the current public key → no-op.
+//   - File present and identical to the current public key → no-op (perms
+//     converged to 0644 if a stricter umask had loosened them).
 //   - File present and differs from the current public key → refuse. A
 //     mismatch means either the private key changed (rotation, restored from
 //     backup) or the published file was tampered with; silently overwriting
@@ -275,6 +279,11 @@ func tightenDBFiles(dbPath string) error {
 //   - File present but a symlink, FIFO, device, etc. → refuse. A pre-created
 //     symlink would otherwise let an attacker with write access to the parent
 //     redirect the chmod / write to an arbitrary target.
+//
+// All file operations use O_NOFOLLOW + an fstat on the open fd, and the
+// fresh-write path uses O_CREATE|O_EXCL, so an attacker who can race-replace
+// the path between the existence check and the write/chmod cannot trick the
+// daemon into writing through or chmod'ing a symlink target.
 func publishPublicKey(ks keysource.KeySource, path string) error {
 	if path == "" {
 		return errors.New("Config.PublicKeyPath is required")
@@ -284,48 +293,97 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 		return fmt.Errorf("read public key from keysource: %w", err)
 	}
 
-	if info, err := os.Lstat(path); err == nil {
+	// Lstat first so non-regular files (symlinks, FIFOs, devices, dirs)
+	// short-circuit without any open syscall — opening a FIFO RDONLY would
+	// block the daemon at startup waiting for a writer.
+	info, lstatErr := os.Lstat(path)
+	switch {
+	case lstatErr == nil:
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf(
 				"daemon: public-key path %s exists but is not a regular file (mode %s); refusing to overwrite",
 				path, info.Mode(),
 			)
 		}
-		existing, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read existing public-key file %s: %w", path, err)
-		}
-		if string(existing) == pubPEM {
-			// Already up-to-date. Re-chmod in case the file was created with
-			// a stricter umask but later loosened — converging the bit set is
-			// cheap and aligns with the "publish on every startup" contract.
-			if info.Mode().Perm() != 0o644 {
-				if err := os.Chmod(path, 0o644); err != nil {
-					return fmt.Errorf("chmod %s 0644: %w", path, err)
-				}
-			}
-			return nil
-		}
-		return fmt.Errorf(
-			"daemon: public-key file %s differs from current keysource public key; refusing to overwrite. Remove the file deliberately if the signing key was rotated or restored from backup",
-			path,
-		)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat public-key path %s: %w", path, err)
+		return reconcileExistingPublicKey(path, pubPEM)
+
+	case errors.Is(lstatErr, fs.ErrNotExist):
+		// Fall through to the fresh-write path below.
+
+	default:
+		return fmt.Errorf("stat public-key path %s: %w", path, lstatErr)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("create public-key dir: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(pubPEM), 0o644); err != nil {
+	// O_CREATE|O_EXCL + O_NOFOLLOW: refuses to follow a symlink AND refuses
+	// any pre-existing file. An attacker who creates a symlink at path
+	// between the Lstat ENOENT above and this Open will trip O_EXCL (the
+	// symlink dirent exists), so we never write through it — closes the
+	// fresh-write half of the TOCTOU window Copilot flagged on PR #325.
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|oNoFollow, 0o644)
+	if err != nil {
+		if errors.Is(err, syscall.ELOOP) {
+			return fmt.Errorf("daemon: public-key path %s appeared as a symlink between existence check and create; refusing", path)
+		}
+		return fmt.Errorf("create public-key file %s: %w", path, err)
+	}
+	defer fh.Close()
+	if _, err := fh.Write([]byte(pubPEM)); err != nil {
 		return fmt.Errorf("write public-key file %s: %w", path, err)
 	}
-	// WriteFile honours the process umask, which the daemon tightens to 0027
-	// before this point — so a fresh write would be 0640 instead of the 0644
-	// we want for a public key. Chmod afterwards to land on the intended mode
-	// without reverting the umask (which would loosen WAL/SHM perms).
-	if err := os.Chmod(path, 0o644); err != nil {
+	// fchmod via the open fd, not path-based Chmod, so the mode applies to
+	// the inode we just created — no symlink-target chmod risk even if the
+	// directory entry is replaced after we write.
+	if err := fh.Chmod(0o644); err != nil {
 		return fmt.Errorf("chmod %s 0644: %w", path, err)
+	}
+	return nil
+}
+
+// reconcileExistingPublicKey handles the case where Lstat saw a regular file
+// at path. It opens with O_NOFOLLOW + fstat to confirm we read the same inode
+// Lstat saw (closing the Lstat→Open race), then no-ops, fchmod's, or refuses
+// based on whether the on-disk contents match the current keysource.
+func reconcileExistingPublicKey(path, wantPubPEM string) error {
+	fh, err := os.OpenFile(path, os.O_RDONLY|oNoFollow, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ELOOP) {
+			return fmt.Errorf("daemon: public-key path %s changed to a symlink between check and open; refusing", path)
+		}
+		return fmt.Errorf("open public-key file %s: %w", path, err)
+	}
+	defer fh.Close()
+	info, err := fh.Stat()
+	if err != nil {
+		return fmt.Errorf("fstat public-key file %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf(
+			"daemon: public-key path %s opened as non-regular (mode %s); refusing",
+			path, info.Mode(),
+		)
+	}
+	// 16 KiB cap matches keysource.MaxKeyFileBytes; PEM-encoded SPKI public
+	// keys are ~120 bytes, so anything larger is a misconfiguration we'd
+	// rather refuse loudly than parse defensively.
+	existing, err := io.ReadAll(io.LimitReader(fh, 16*1024))
+	if err != nil {
+		return fmt.Errorf("read existing public-key file %s: %w", path, err)
+	}
+	if string(existing) != wantPubPEM {
+		return fmt.Errorf(
+			"daemon: public-key file %s differs from current keysource public key; refusing to overwrite. Remove the file deliberately if the signing key was rotated or restored from backup",
+			path,
+		)
+	}
+	if info.Mode().Perm() != 0o644 {
+		// fchmod via the open fd: the mode applies to this inode regardless
+		// of any directory-entry swap that happened after Lstat.
+		if err := fh.Chmod(0o644); err != nil {
+			return fmt.Errorf("chmod %s 0644: %w", path, err)
+		}
 	}
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -269,7 +269,8 @@ func tightenDBFiles(dbPath string) error {
 // Behaviour:
 //   - File missing → write the current public key with mode 0644.
 //   - File present and identical to the current public key → no-op (perms
-//     converged to 0644 if a stricter umask had loosened them).
+//     converged to 0644 if a stricter umask had narrowed them at create time,
+//     e.g. 0640).
 //   - File present and differs from the current public key → refuse. A
 //     mismatch means either the private key changed (rotation, restored from
 //     backup) or the published file was tampered with; silently overwriting
@@ -317,10 +318,10 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 		return fmt.Errorf("create public-key dir: %w", err)
 	}
 	// O_CREATE|O_EXCL + O_NOFOLLOW: refuses to follow a symlink AND refuses
-	// any pre-existing file. An attacker who creates a symlink at path
-	// between the Lstat ENOENT above and this Open will trip O_EXCL (the
-	// symlink dirent exists), so we never write through it — closes the
-	// fresh-write half of the TOCTOU window Copilot flagged on PR #325.
+	// any pre-existing file. An attacker who creates a symlink (or any other
+	// dirent) at path between the Lstat ENOENT above and this Open will trip
+	// O_EXCL — the dirent exists — so the daemon never writes through it.
+	// That closes the fresh-write half of the Lstat→Open TOCTOU window.
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|oNoFollow, 0o644)
 	if err != nil {
 		if isSymlinkLoop(err) {
@@ -357,11 +358,21 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 }
 
 // reconcileExistingPublicKey handles the case where Lstat saw a regular file
-// at path. It opens with O_NOFOLLOW + fstat to confirm we read the same inode
-// Lstat saw (closing the Lstat→Open race), then no-ops, fchmod's, or refuses
-// based on whether the on-disk contents match the current keysource.
+// at path. It then no-ops, fchmod's, or refuses based on whether the on-disk
+// contents match the current keysource.
+//
+// The open uses O_NOFOLLOW so a regular-file→symlink swap between Lstat and
+// Open trips ELOOP and is refused; it adds O_NONBLOCK so a regular-file→FIFO
+// swap can't park the daemon at startup waiting for a writer. The fstat-on-fd
+// after Open re-rejects any non-regular file that slipped past Lstat (FIFO,
+// device, …); it does NOT compare st_ino/st_dev against the earlier Lstat
+// result — the file-permission and content checks are what we rely on, not
+// inode identity.
 func reconcileExistingPublicKey(path, wantPubPEM string) error {
-	fh, err := os.OpenFile(path, os.O_RDONLY|oNoFollow, 0)
+	// O_NONBLOCK is a no-op on regular files (Linux/Darwin) but prevents an
+	// O_RDONLY open from blocking on a FIFO that a racing attacker might
+	// substitute for the regular file we Lstat'd.
+	fh, err := os.OpenFile(path, os.O_RDONLY|oNoFollow|oNonblock, 0)
 	if err != nil {
 		if isSymlinkLoop(err) {
 			return fmt.Errorf("daemon: public-key path %s changed to a symlink between check and open; refusing", path)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -329,7 +329,18 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 		}
 		return fmt.Errorf("create public-key file %s: %w", path, err)
 	}
-	defer fh.Close()
+	// Writable handle: a deferred Close() that ignores the error can mask a
+	// Close-time write failure (NFS commit failure, disk-full, quota
+	// exceeded) and silently lose the public key bytes we just wrote. Track
+	// closed state so the deferred best-effort Close on early-error paths
+	// doesn't double-close, and surface a clean Close() error to the caller
+	// on the success path.
+	closed := false
+	defer func() {
+		if !closed {
+			_ = fh.Close()
+		}
+	}()
 	if _, err := fh.Write([]byte(pubPEM)); err != nil {
 		return fmt.Errorf("write public-key file %s: %w", path, err)
 	}
@@ -338,6 +349,10 @@ func publishPublicKey(ks keysource.KeySource, path string) error {
 	// directory entry is replaced after we write.
 	if err := fh.Chmod(0o644); err != nil {
 		return fmt.Errorf("chmod %s 0644: %w", path, err)
+	}
+	closed = true
+	if err := fh.Close(); err != nil {
+		return fmt.Errorf("close public-key file %s: %w", path, err)
 	}
 	return nil
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -232,6 +232,45 @@ func TestPublishPublicKey_RefusesSymlinkAtPath(t *testing.T) {
 	}
 }
 
+// TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink is the regression
+// test for the symlink-race Copilot flagged on PR #325: even when Lstat
+// reports the path missing, an attacker who plants a symlink before the
+// create-and-write must not get the daemon to write/chmod the symlink target.
+// The O_CREATE|O_EXCL|O_NOFOLLOW open is what closes the window.
+func TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "attacker-target")
+	if err := os.WriteFile(target, []byte("victim"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "signing.key.pub")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+
+	err := publishPublicKey(&stubKeySource{pub: "PUBKEY"}, link)
+	if err == nil {
+		t.Fatal("expected refusal when public-key path is a pre-existing symlink")
+	}
+
+	// Whichever code path catches it (Lstat→non-regular or create→ELOOP),
+	// the target file must remain untouched.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "victim" {
+		t.Errorf("symlink target was overwritten; got %q want %q", got, "victim")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("symlink target perm changed to %o (want 0600); chmod followed the symlink", perm)
+	}
+}
+
 func TestPublishPublicKey_RequiresPath(t *testing.T) {
 	if err := publishPublicKey(&stubKeySource{pub: "x"}, ""); err == nil {
 		t.Fatal("expected error when PublicKeyPath is empty")

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -107,12 +107,12 @@ type stubKeySource struct {
 	pubErr error
 }
 
-func (s *stubKeySource) Init() error                      { return nil }
-func (s *stubKeySource) Sign(_ []byte) ([]byte, error)    { return nil, nil }
-func (s *stubKeySource) PublicKey() (string, error)       { return s.pub, s.pubErr }
-func (s *stubKeySource) VerificationMethod() string       { return "did:test#k1" }
-func (s *stubKeySource) Rotate() error                    { return keysource.ErrNotImplemented }
-func (s *stubKeySource) Teardown() error                  { return nil }
+func (s *stubKeySource) Init() error                   { return nil }
+func (s *stubKeySource) Sign(_ []byte) ([]byte, error) { return nil, nil }
+func (s *stubKeySource) PublicKey() (string, error)    { return s.pub, s.pubErr }
+func (s *stubKeySource) VerificationMethod() string    { return "did:test#k1" }
+func (s *stubKeySource) Rotate() error                 { return keysource.ErrNotImplemented }
+func (s *stubKeySource) Teardown() error               { return nil }
 
 func TestPublishPublicKey_WritesFreshFile(t *testing.T) {
 	dir := t.TempDir()

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -271,6 +271,50 @@ func TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink(t *testing.T) {
 	}
 }
 
+// TestValidateConfig_PublicKeyPathDefaultsFromKeyPath pins the contract the
+// agent-receipts-daemon CLI relies on after the PR #325 review fix: when
+// PublicKeyPath is left empty by the caller, validateConfig fills it from
+// the final KeyPath, so a `--key /tmp/x.key` invocation publishes to
+// `/tmp/x.key.pub` — not whatever path was computed before flag.Parse.
+func TestValidateConfig_PublicKeyPathDefaultsFromKeyPath(t *testing.T) {
+	cfg := Config{
+		SocketPath:           "/tmp/sock",
+		DBPath:               "/tmp/db",
+		KeyPath:              "/tmp/custom.key",
+		PublicKeyPath:        "", // operator did not set --public-key / env
+		ChainID:              "c",
+		IssuerID:             "i",
+		VerificationMethodID: "v",
+	}
+	if err := validateConfig(&cfg); err != nil {
+		t.Fatalf("validateConfig: %v", err)
+	}
+	if want := "/tmp/custom.key.pub"; cfg.PublicKeyPath != want {
+		t.Errorf("PublicKeyPath = %q, want %q (must track --key)", cfg.PublicKeyPath, want)
+	}
+}
+
+// TestValidateConfig_PublicKeyPathExplicitWins ensures an explicitly set
+// PublicKeyPath is not clobbered by the KeyPath-derived default — the
+// fallback only applies when the operator left it empty.
+func TestValidateConfig_PublicKeyPathExplicitWins(t *testing.T) {
+	cfg := Config{
+		SocketPath:           "/tmp/sock",
+		DBPath:               "/tmp/db",
+		KeyPath:              "/tmp/custom.key",
+		PublicKeyPath:        "/etc/agentreceipts/signing.pub",
+		ChainID:              "c",
+		IssuerID:             "i",
+		VerificationMethodID: "v",
+	}
+	if err := validateConfig(&cfg); err != nil {
+		t.Fatalf("validateConfig: %v", err)
+	}
+	if want := "/etc/agentreceipts/signing.pub"; cfg.PublicKeyPath != want {
+		t.Errorf("PublicKeyPath = %q, want %q (explicit must not be overwritten)", cfg.PublicKeyPath, want)
+	}
+}
+
 func TestPublishPublicKey_RequiresPath(t *testing.T) {
 	if err := publishPublicKey(&stubKeySource{pub: "x"}, ""); err == nil {
 		t.Fatal("expected error when PublicKeyPath is empty")

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,10 +1,16 @@
 package daemon
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/agent-receipts/ar/daemon/internal/keysource"
 )
 
 func TestTightenDBFiles_TightensFresh0644(t *testing.T) {
@@ -91,6 +97,207 @@ func TestTightenDBFiles_NoErrorWhenAbsent(t *testing.T) {
 	dir := t.TempDir()
 	if err := tightenDBFiles(filepath.Join(dir, "does-not-exist.db")); err != nil {
 		t.Errorf("absent DB should be a no-op, got: %v", err)
+	}
+}
+
+// stubKeySource lets publishPublicKey tests inject deterministic / malformed
+// public keys without spinning up a real keysource.File from disk.
+type stubKeySource struct {
+	pub    string
+	pubErr error
+}
+
+func (s *stubKeySource) Init() error                      { return nil }
+func (s *stubKeySource) Sign(_ []byte) ([]byte, error)    { return nil, nil }
+func (s *stubKeySource) PublicKey() (string, error)       { return s.pub, s.pubErr }
+func (s *stubKeySource) VerificationMethod() string       { return "did:test#k1" }
+func (s *stubKeySource) Rotate() error                    { return keysource.ErrNotImplemented }
+func (s *stubKeySource) Teardown() error                  { return nil }
+
+func TestPublishPublicKey_WritesFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signing.key.pub")
+	ks := &stubKeySource{pub: "-----BEGIN PUBLIC KEY-----\nABCD\n-----END PUBLIC KEY-----\n"}
+
+	if err := publishPublicKey(ks, path); err != nil {
+		t.Fatalf("publishPublicKey: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != ks.pub {
+		t.Errorf("contents = %q, want %q", got, ks.pub)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("perm = %o, want 0644", perm)
+	}
+}
+
+func TestPublishPublicKey_NoOpOnIdenticalContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signing.key.pub")
+	pub := "-----BEGIN PUBLIC KEY-----\nABCD\n-----END PUBLIC KEY-----\n"
+	if err := os.WriteFile(path, []byte(pub), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishPublicKey(&stubKeySource{pub: pub}, path); err != nil {
+		t.Fatalf("publishPublicKey: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("mtime changed (%s -> %s) — identical-contents path should not rewrite", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestPublishPublicKey_TightensLooseModeOnIdenticalContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signing.key.pub")
+	pub := "-----BEGIN PUBLIC KEY-----\nABCD\n-----END PUBLIC KEY-----\n"
+	// Public key file already has correct contents but a non-0644 mode (e.g.
+	// 0640 left over from a strict umask). Publishing should converge to 0644
+	// without rewriting the bytes.
+	if err := os.WriteFile(path, []byte(pub), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishPublicKey(&stubKeySource{pub: pub}, path); err != nil {
+		t.Fatalf("publishPublicKey: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("perm = %o, want 0644", perm)
+	}
+}
+
+func TestPublishPublicKey_RefusesMismatchedExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signing.key.pub")
+	if err := os.WriteFile(path, []byte("OLD KEY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := publishPublicKey(&stubKeySource{pub: "NEW KEY"}, path)
+	if err == nil {
+		t.Fatal("expected refusal when published key differs from current keysource")
+	}
+	if !strings.Contains(err.Error(), "differs") {
+		t.Errorf("error %q should mention the mismatch", err.Error())
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "OLD KEY" {
+		t.Errorf("file should not have been overwritten; got %q", got)
+	}
+}
+
+func TestPublishPublicKey_RefusesSymlinkAtPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.pub")
+	link := filepath.Join(dir, "signing.key.pub")
+	if err := os.WriteFile(target, []byte("anything"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+
+	err := publishPublicKey(&stubKeySource{pub: "anything"}, link)
+	if err == nil {
+		t.Fatal("expected refusal when public-key path is a symlink")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error %q should mention non-regular file", err.Error())
+	}
+}
+
+func TestPublishPublicKey_RequiresPath(t *testing.T) {
+	if err := publishPublicKey(&stubKeySource{pub: "x"}, ""); err == nil {
+		t.Fatal("expected error when PublicKeyPath is empty")
+	}
+}
+
+func TestPublishPublicKey_PropagatesKeySourceError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signing.key.pub")
+	want := errors.New("kms unavailable")
+
+	err := publishPublicKey(&stubKeySource{pubErr: want}, path)
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected wrapped %v, got %v", want, err)
+	}
+}
+
+// TestPublishPublicKey_WithRealFileKeySource exercises the publishing path
+// end-to-end against keysource.File so a future change to PublicKey()'s output
+// shape (e.g. adding a header / changing PEM block type) breaks the publishing
+// test loudly rather than silently producing files that cmd/agent-receipts
+// can't parse.
+func TestPublishPublicKey_WithRealFileKeySource(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ks := keysource.NewFile(keyPath, "did:test#k1")
+	if err := ks.Init(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ks.Teardown() })
+
+	if err := publishPublicKey(ks, pubPath); err != nil {
+		t.Fatalf("publishPublicKey: %v", err)
+	}
+
+	pubPEM, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(pubPEM)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		t.Fatalf("published file is not a PUBLIC KEY PEM: %s", pubPEM)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse published public key: %v", err)
+	}
+	if _, ok := parsed.(ed25519.PublicKey); !ok {
+		t.Fatalf("published key is %T, want ed25519.PublicKey", parsed)
 	}
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -232,11 +232,11 @@ func TestPublishPublicKey_RefusesSymlinkAtPath(t *testing.T) {
 	}
 }
 
-// TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink is the regression
-// test for the symlink-race Copilot flagged on PR #325: even when Lstat
-// reports the path missing, an attacker who plants a symlink before the
-// create-and-write must not get the daemon to write/chmod the symlink target.
-// The O_CREATE|O_EXCL|O_NOFOLLOW open is what closes the window.
+// TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink pins the
+// fresh-write half of the Lstat→Open TOCTOU defence: even if Lstat sees the
+// path missing, an attacker who plants a symlink at the path before the
+// create-and-write must not get the daemon to write/chmod the symlink
+// target. O_CREATE|O_EXCL|O_NOFOLLOW is what closes the window.
 func TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "attacker-target")
@@ -272,10 +272,10 @@ func TestPublishPublicKey_FreshWriteRefusesPreCreatedSymlink(t *testing.T) {
 }
 
 // TestValidateConfig_PublicKeyPathDefaultsFromKeyPath pins the contract the
-// agent-receipts-daemon CLI relies on after the PR #325 review fix: when
-// PublicKeyPath is left empty by the caller, validateConfig fills it from
-// the final KeyPath, so a `--key /tmp/x.key` invocation publishes to
-// `/tmp/x.key.pub` — not whatever path was computed before flag.Parse.
+// agent-receipts-daemon CLI relies on: when PublicKeyPath is left empty by
+// the caller, validateConfig fills it from the final KeyPath, so a
+// `--key /tmp/x.key` invocation publishes to `/tmp/x.key.pub` — not whatever
+// path was computed before flag.Parse.
 func TestValidateConfig_PublicKeyPathDefaultsFromKeyPath(t *testing.T) {
 	cfg := Config{
 		SocketPath:           "/tmp/sock",

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -11,6 +11,7 @@
 package daemon_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/x509"
@@ -23,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +32,7 @@ import (
 	"github.com/agent-receipts/ar/daemon"
 	"github.com/agent-receipts/ar/daemon/internal/pipeline"
 	"github.com/agent-receipts/ar/daemon/internal/socket"
+	"github.com/agent-receipts/ar/daemon/internal/verifycli"
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
@@ -60,6 +63,7 @@ func startDaemon(t *testing.T) (cfg daemon.Config, pubPEM string, cancel func())
 		SocketPath:           filepath.Join(dir, "events.sock"),
 		DBPath:               filepath.Join(dir, "receipts.db"),
 		KeyPath:              filepath.Join(dir, "signing.key"),
+		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),
 		ChainID:              "it-chain",
 		IssuerID:             "did:agent-receipts-daemon:integration",
 		VerificationMethodID: "did:agent-receipts-daemon:integration#k1",
@@ -391,5 +395,133 @@ func TestResumesChainAfterRestart(t *testing.T) {
 		if r.CredentialSubject.Chain.Sequence != i+1 {
 			t.Errorf("receipt %d: seq = %d, want %d", i, r.CredentialSubject.Chain.Sequence, i+1)
 		}
+	}
+}
+
+// TestPublishedPublicKeyHasMode0644 confirms the daemon writes the public-key
+// sibling file at the documented mode on every startup. The verify CLI relies
+// on this file being world-readable so a non-daemon-user verifier (operator,
+// CI runner, audit script) can load it without elevated access.
+func TestPublishedPublicKeyHasMode0644(t *testing.T) {
+	cfg, _, _ := startDaemon(t)
+
+	info, err := os.Stat(cfg.PublicKeyPath)
+	if err != nil {
+		t.Fatalf("daemon did not publish public key at %s: %v", cfg.PublicKeyPath, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("public key perm = %o, want 0644", perm)
+	}
+}
+
+// TestVerifyCLIWhileDaemonRunning is the read-side counterpart to the chain-
+// integrity test: with the daemon actively writing, agent-receipts verify
+// must succeed using the published public-key file and the OpenReadOnly DB
+// path. This is the "must not collide with the daemon's exclusive ownership
+// of the write side" half of the acceptance criterion.
+func TestVerifyCLIWhileDaemonRunning(t *testing.T) {
+	cfg, _, _ := startDaemon(t)
+
+	const frames = 5
+	for i := 0; i < frames; i++ {
+		emitFrame(t, cfg.SocketPath, pipeline.EmitterFrame{
+			Version:   "1",
+			TsEmit:    time.Now().UTC().Format(time.RFC3339Nano),
+			SessionID: "verify-while-running",
+			Channel:   "sdk",
+			Tool:      pipeline.EmitterTool{Name: "noop"},
+			Decision:  "allowed",
+		})
+	}
+	_ = waitForReceiptCount(t, cfg.DBPath, cfg.ChainID, frames, 5*time.Second)
+
+	var stdout, stderr bytes.Buffer
+	code := verifycli.Run(
+		[]string{"--db", cfg.DBPath, "--public-key", cfg.PublicKeyPath, "--chain-id", cfg.ChainID},
+		&stdout, &stderr,
+		func(string) string { return "" },
+	)
+	if code != verifycli.ExitOK {
+		t.Fatalf("verify exit = %d, want %d (stdout=%q stderr=%q)", code, verifycli.ExitOK, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), fmt.Sprintf("Chain %s: VALID", cfg.ChainID)) {
+		t.Errorf("stdout = %q, expected VALID line", stdout.String())
+	}
+}
+
+// TestVerifyCLIWithDaemonStopped is the "Independent verifiability is not
+// gated on daemon availability" acceptance criterion. Start the daemon, emit
+// some receipts, shut the daemon down, then run agent-receipts verify against
+// the on-disk DB and the published public key. Must succeed.
+func TestVerifyCLIWithDaemonStopped(t *testing.T) {
+	dir := t.TempDir()
+	cfg := daemon.Config{
+		SocketPath:           filepath.Join(dir, "events.sock"),
+		DBPath:               filepath.Join(dir, "receipts.db"),
+		KeyPath:              filepath.Join(dir, "signing.key"),
+		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),
+		ChainID:              "stopped-chain",
+		IssuerID:             "did:agent-receipts-daemon:integration",
+		VerificationMethodID: "did:agent-receipts-daemon:integration#k1",
+		Logger:               log.New(io.Discard, "", 0),
+	}
+	writeTestKey(t, cfg.KeyPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(cfg.SocketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("socket did not appear")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	const frames = 3
+	for i := 0; i < frames; i++ {
+		emitFrame(t, cfg.SocketPath, pipeline.EmitterFrame{
+			Version:   "1",
+			TsEmit:    time.Now().UTC().Format(time.RFC3339Nano),
+			SessionID: "verify-after-stop",
+			Channel:   "sdk",
+			Tool:      pipeline.EmitterTool{Name: "noop"},
+			Decision:  "allowed",
+		})
+	}
+	_ = waitForReceiptCount(t, cfg.DBPath, cfg.ChainID, frames, 5*time.Second)
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Logf("daemon Run returned: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not shut down within 3s")
+	}
+
+	// Sanity-check the daemon really is gone before running verify; otherwise
+	// a passing test wouldn't actually demonstrate the daemon-down property.
+	if _, err := net.Dial("unix", cfg.SocketPath); err == nil {
+		t.Fatal("socket still accepting connections after cancel — daemon did not stop")
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := verifycli.Run(
+		[]string{"--db", cfg.DBPath, "--public-key", cfg.PublicKeyPath, "--chain-id", cfg.ChainID},
+		&stdout, &stderr,
+		func(string) string { return "" },
+	)
+	if code != verifycli.ExitOK {
+		t.Fatalf("verify with daemon stopped: exit = %d, want %d (stdout=%q stderr=%q)", code, verifycli.ExitOK, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), fmt.Sprintf("Chain %s: VALID (%d receipts)", cfg.ChainID, frames)) {
+		t.Errorf("stdout = %q, expected VALID + count line", stdout.String())
 	}
 }

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -508,7 +508,8 @@ func TestVerifyCLIWithDaemonStopped(t *testing.T) {
 
 	// Sanity-check the daemon really is gone before running verify; otherwise
 	// a passing test wouldn't actually demonstrate the daemon-down property.
-	if _, err := net.Dial("unix", cfg.SocketPath); err == nil {
+	if conn, err := net.Dial("unix", cfg.SocketPath); err == nil {
+		conn.Close()
 		t.Fatal("socket still accepting connections after cancel — daemon did not stop")
 	}
 

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -71,6 +71,14 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		}
 		return ExitUsageError
 	}
+	// `verify` takes no positional arguments — chain selection is via
+	// --chain-id. Surface stray args as a usage error so a typo like
+	// `agent-receipts verify --db /path/to.db extra` doesn't silently succeed
+	// and hide a scripting mistake.
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "agent-receipts verify: unexpected positional argument(s): %v (use --chain-id for chain selection)\n", fs.Args())
+		return ExitUsageError
+	}
 	if *dbPath == "" {
 		fmt.Fprintln(stderr, "agent-receipts verify: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -12,6 +12,7 @@
 package verifycli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -48,12 +49,26 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return fallback
 	}
 
+	// Resolve the public-key default in two steps so the flag declaration
+	// stays readable: --public-key inherits AGENTRECEIPTS_PUBLIC_KEY when set,
+	// otherwise it falls back to <KeyPath>.pub computed from the same KeyPath
+	// the daemon would use, so a verify run with no flags works after the
+	// daemon has run at least once with the same per-user paths.
+	keyPath := envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
+	defaultPubKey := envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath))
+
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
-	pubKeyPath := fs.String("public-key", envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath()))), "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
 	chainID := fs.String("chain-id", envOr("AGENTRECEIPTS_CHAIN_ID", "default"), "Chain id to verify (env: AGENTRECEIPTS_CHAIN_ID)")
 	if err := fs.Parse(args); err != nil {
+		// `-h` / `--help` is intentional, not an error — flag.ContinueOnError
+		// surfaces it as flag.ErrHelp after writing the usage message. Exit 0
+		// so scripts that probe `agent-receipts verify -h` don't see a failure.
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitUsageError
 	}
 	if *dbPath == "" {

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -12,6 +12,9 @@
 package verifycli
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -84,13 +87,21 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitUsageError
 	}
 	if *pubKeyPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts verify: --public-key is required (no AGENTRECEIPTS_PUBLIC_KEY/_KEY and no home directory)")
+		fmt.Fprintln(stderr, "agent-receipts verify: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived; both are unset and no home directory is available)")
 		return ExitUsageError
 	}
 
 	pubPEM, err := os.ReadFile(*pubKeyPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "agent-receipts verify: read public key: %v\n", err)
+		return ExitUsageError
+	}
+	// Validate the public key's PEM/SPKI shape upfront so a malformed key
+	// surfaces as a usage error instead of being routed through
+	// VerifyStoredChain → ExitChainBad, which would falsely suggest the chain
+	// itself was tampered with.
+	if err := validatePublicKeyPEM(pubPEM); err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify: invalid public key at %s: %v\n", *pubKeyPath, err)
 		return ExitUsageError
 	}
 
@@ -116,6 +127,12 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitOK
 	}
 	fmt.Fprintf(stdout, "Chain %s: BROKEN at receipt %d\n", *chainID, result.BrokenAt)
+	if result.Error != "" {
+		// Surface the structured failure cause from VerifyChain — for hash
+		// recompute / response_hash / chain-length / terminal-receipt errors
+		// it carries detail the per-receipt status lines can't express.
+		fmt.Fprintf(stdout, "  cause: %s\n", result.Error)
+	}
 	for _, rv := range result.Receipts {
 		status := "ok"
 		switch {
@@ -129,4 +146,27 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		fmt.Fprintf(stdout, "  [%d] %s — %s\n", rv.Index, rv.ReceiptID, status)
 	}
 	return ExitChainBad
+}
+
+// validatePublicKeyPEM rejects PEM bytes that don't decode to an Ed25519 SPKI
+// public key. Catching key-format errors here lets the CLI surface them as
+// ExitUsageError instead of routing them through VerifyStoredChain, where a
+// malformed key would surface as a "BROKEN" chain — falsely implicating the
+// receipts.
+func validatePublicKeyPEM(pubPEM []byte) error {
+	block, _ := pem.Decode(pubPEM)
+	if block == nil {
+		return errors.New("PEM decode failed (no PUBLIC KEY block)")
+	}
+	if block.Type != "PUBLIC KEY" {
+		return fmt.Errorf("PEM block type is %q, want PUBLIC KEY", block.Type)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse SPKI public key: %w", err)
+	}
+	if _, ok := parsed.(ed25519.PublicKey); !ok {
+		return fmt.Errorf("public key is %T, want ed25519.PublicKey", parsed)
+	}
+	return nil
 }

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -1,0 +1,109 @@
+// Package verifycli implements the `agent-receipts verify` subcommand:
+// validate a stored chain's signatures and hash links using a daemon-written
+// SQLite store and the daemon-published public key. It opens the database
+// read-only (sdk/go/store.OpenReadOnly) so it is safe to run while the daemon
+// is the active writer, and it does not require the daemon socket to be
+// reachable — independent verifiability is not gated on daemon availability
+// (issue #236, Section 4).
+//
+// Logic lives here, away from cmd/agent-receipts/main.go, so tests can drive
+// the subcommand directly with arbitrary args / captured I/O without shelling
+// out to a built binary.
+package verifycli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// Exit codes are part of the CLI contract — scripts and CI checks pivot on
+// them. Keep these stable.
+const (
+	ExitOK         = 0 // chain verified
+	ExitChainBad   = 1 // chain failed verification
+	ExitUsageError = 2 // bad flags / unreadable DB or key file
+)
+
+// Run executes the verify subcommand with the given args (sans the program
+// name and "verify" subcommand token), writing human-readable output to
+// stdout and diagnostics to stderr. Returns one of the Exit* constants;
+// cmd/agent-receipts/main.go forwards it to os.Exit.
+//
+// envLookup is split out so tests can inject a deterministic environment
+// without touching the real process env. Pass os.Getenv for the production
+// caller.
+func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string) int {
+	if envLookup == nil {
+		envLookup = os.Getenv
+	}
+	envOr := func(key, fallback string) string {
+		if v := envLookup(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+
+	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
+	pubKeyPath := fs.String("public-key", envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath()))), "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	chainID := fs.String("chain-id", envOr("AGENTRECEIPTS_CHAIN_ID", "default"), "Chain id to verify (env: AGENTRECEIPTS_CHAIN_ID)")
+	if err := fs.Parse(args); err != nil {
+		return ExitUsageError
+	}
+	if *dbPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts verify: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		return ExitUsageError
+	}
+	if *pubKeyPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts verify: --public-key is required (no AGENTRECEIPTS_PUBLIC_KEY/_KEY and no home directory)")
+		return ExitUsageError
+	}
+
+	pubPEM, err := os.ReadFile(*pubKeyPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify: read public key: %v\n", err)
+		return ExitUsageError
+	}
+
+	s, err := store.OpenReadOnly(*dbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify: open store: %v\n", err)
+		return ExitUsageError
+	}
+	defer s.Close()
+
+	result, err := s.VerifyStoredChain(*chainID, string(pubPEM))
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify: %v\n", err)
+		return ExitUsageError
+	}
+
+	if result.ResponseHashNote != "" {
+		fmt.Fprintf(stderr, "Note: %s\n", result.ResponseHashNote)
+	}
+
+	if result.Valid {
+		fmt.Fprintf(stdout, "Chain %s: VALID (%d receipts)\n", *chainID, result.Length)
+		return ExitOK
+	}
+	fmt.Fprintf(stdout, "Chain %s: BROKEN at receipt %d\n", *chainID, result.BrokenAt)
+	for _, rv := range result.Receipts {
+		status := "ok"
+		switch {
+		case !rv.SignatureValid:
+			status = "BAD SIGNATURE"
+		case !rv.HashLinkValid:
+			status = "BAD HASH LINK"
+		case !rv.SequenceValid:
+			status = "BAD SEQUENCE"
+		}
+		fmt.Fprintf(stdout, "  [%d] %s — %s\n", rv.Index, rv.ReceiptID, status)
+	}
+	return ExitChainBad
+}

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -170,6 +170,27 @@ func TestRun_BadFlagIsUsageError(t *testing.T) {
 	}
 }
 
+func TestRun_MalformedPublicKeyIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _ := fixtureChain(t, dir, "chain-1", 1)
+	pubKeyPath := filepath.Join(dir, "garbage.pub")
+	if err := os.WriteFile(pubKeyPath, []byte("not a pem block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d (malformed key should be a usage error, not ExitChainBad)", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "invalid public key") {
+		t.Errorf("stderr = %q, expected 'invalid public key' diagnostic", stderr)
+	}
+}
+
 func TestRun_RejectsPositionalArgs(t *testing.T) {
 	dir := t.TempDir()
 	dbPath, pubKeyPath := fixtureChain(t, dir, "chain-1", 1)

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -166,3 +166,16 @@ func TestRun_BadFlagIsUsageError(t *testing.T) {
 		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
 	}
 }
+
+func TestRun_HelpFlagExitsCleanly(t *testing.T) {
+	code, _, stderr := runOnce(t, []string{"-h"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (asking for help is not an error)", code, ExitOK)
+	}
+	// The flag package writes the usage to fs.Output, which we redirected to
+	// stderr. Sanity-check it lists at least one of our flags so a refactor
+	// that drops the auto-generated usage block trips the test.
+	if !strings.Contains(stderr, "--db") && !strings.Contains(stderr, "-db") {
+		t.Errorf("stderr should mention --db; got %q", stderr)
+	}
+}

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -1,0 +1,168 @@
+package verifycli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// fixtureChain writes a daemon-shaped DB at dbPath containing `count` valid
+// signed receipts on chain `chainID`, and returns the matching public-key PEM
+// path the verify CLI should be pointed at.
+func fixtureChain(t *testing.T, dir, chainID string, count int) (dbPath, pubKeyPath string) {
+	t.Helper()
+
+	dbPath = filepath.Join(dir, "receipts.db")
+	pubKeyPath = filepath.Join(dir, "signing.key.pub")
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	if err := os.WriteFile(pubKeyPath, pubPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var prevHash *string
+	for i := 1; i <= count; i++ {
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow},
+			Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:     receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: chainID},
+		})
+		signed, err := receipt.Sign(unsigned, privPEM, "did:test#k1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := receipt.HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+	return dbPath, pubKeyPath
+}
+
+func runOnce(t *testing.T, args []string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	// Empty env lookup so the test never accidentally inherits real
+	// AGENTRECEIPTS_* values from the developer's shell.
+	code = Run(args, &out, &errb, func(string) string { return "" })
+	return code, out.String(), errb.String()
+}
+
+func TestRun_VerifiesGoodChain(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath := fixtureChain(t, dir, "chain-1", 3)
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	if !strings.Contains(stdout, "VALID (3 receipts)") {
+		t.Errorf("stdout = %q, expected VALID with count", stdout)
+	}
+}
+
+func TestRun_ReportsBrokenChain(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _ := fixtureChain(t, dir, "chain-1", 2)
+
+	// Use a *different* public key so signatures fail to verify.
+	otherPub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDER, _ := x509.MarshalPKIXPublicKey(otherPub)
+	wrongPubPath := filepath.Join(dir, "wrong.pub")
+	if err := os.WriteFile(wrongPubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: otherDER}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", wrongPubPath,
+		"--chain-id", "chain-1",
+	})
+	if code != ExitChainBad {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitChainBad, stderr)
+	}
+	if !strings.Contains(stdout, "BROKEN") || !strings.Contains(stdout, "BAD SIGNATURE") {
+		t.Errorf("stdout = %q, expected BROKEN + BAD SIGNATURE lines", stdout)
+	}
+}
+
+func TestRun_MissingPublicKeyIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _ := fixtureChain(t, dir, "chain-1", 1)
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", filepath.Join(dir, "does-not-exist.pub"),
+		"--chain-id", "chain-1",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "read public key") {
+		t.Errorf("stderr = %q, expected 'read public key' diagnostic", stderr)
+	}
+}
+
+func TestRun_UnknownDBIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	_, pubKeyPath := fixtureChain(t, dir, "chain-1", 1)
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", filepath.Join(dir, "no-such.db"),
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "open store") && !strings.Contains(stderr, "verify:") {
+		t.Errorf("stderr = %q, expected open-store diagnostic", stderr)
+	}
+}
+
+func TestRun_BadFlagIsUsageError(t *testing.T) {
+	code, _, _ := runOnce(t, []string{"--bogus"})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+}

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -107,7 +107,10 @@ func TestRun_ReportsBrokenChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	otherDER, _ := x509.MarshalPKIXPublicKey(otherPub)
+	otherDER, err := x509.MarshalPKIXPublicKey(otherPub)
+	if err != nil {
+		t.Fatal(err)
+	}
 	wrongPubPath := filepath.Join(dir, "wrong.pub")
 	if err := os.WriteFile(wrongPubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: otherDER}), 0o644); err != nil {
 		t.Fatal(err)

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -167,6 +167,24 @@ func TestRun_BadFlagIsUsageError(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsPositionalArgs(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath := fixtureChain(t, dir, "chain-1", 1)
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+		"chain-1", // typo: chain-id passed positionally as well
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d (positional args should be a usage error)", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "unexpected positional argument") {
+		t.Errorf("stderr = %q, expected unexpected-positional diagnostic", stderr)
+	}
+}
+
 func TestRun_HelpFlagExitsCleanly(t *testing.T) {
 	code, _, stderr := runOnce(t, []string{"-h"})
 	if code != ExitOK {

--- a/daemon/nofollow_other.go
+++ b/daemon/nofollow_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package daemon
+
+// oNoFollow is a no-op on non-POSIX platforms. The daemon refuses to start on
+// these platforms (see Run's platform gate), so this constant exists solely
+// to keep the package compilable in cross-platform CI.
+const oNoFollow = 0

--- a/daemon/nofollow_other.go
+++ b/daemon/nofollow_other.go
@@ -8,7 +8,7 @@ package daemon
 const oNoFollow = 0
 
 // isSymlinkLoop is unreachable on non-unix platforms — the daemon's runtime
-// gate refuses to start there — and existing solely so daemon.go's symlink
+// gate refuses to start there — and exists solely so daemon.go's symlink
 // diagnostic compiles in cross-platform CI without referencing
 // syscall.ELOOP, which is not defined on every Go port.
 func isSymlinkLoop(_ error) bool { return false }

--- a/daemon/nofollow_other.go
+++ b/daemon/nofollow_other.go
@@ -6,3 +6,9 @@ package daemon
 // these platforms (see Run's platform gate), so this constant exists solely
 // to keep the package compilable in cross-platform CI.
 const oNoFollow = 0
+
+// isSymlinkLoop is unreachable on non-unix platforms — the daemon's runtime
+// gate refuses to start there — and existing solely so daemon.go's symlink
+// diagnostic compiles in cross-platform CI without referencing
+// syscall.ELOOP, which is not defined on every Go port.
+func isSymlinkLoop(_ error) bool { return false }

--- a/daemon/nofollow_other.go
+++ b/daemon/nofollow_other.go
@@ -2,10 +2,13 @@
 
 package daemon
 
-// oNoFollow is a no-op on non-POSIX platforms. The daemon refuses to start on
-// these platforms (see Run's platform gate), so this constant exists solely
-// to keep the package compilable in cross-platform CI.
-const oNoFollow = 0
+// oNoFollow / oNonblock are no-ops on non-POSIX platforms. The daemon refuses
+// to start on these platforms (see Run's platform gate), so these constants
+// exist solely to keep the package compilable in cross-platform CI.
+const (
+	oNoFollow = 0
+	oNonblock = 0
+)
 
 // isSymlinkLoop is unreachable on non-unix platforms — the daemon's runtime
 // gate refuses to start there — and exists solely so daemon.go's symlink

--- a/daemon/nofollow_unix.go
+++ b/daemon/nofollow_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package daemon
+
+import "syscall"
+
+// oNoFollow is OR'd into OpenFile flags so the open call refuses to follow a
+// symlink at the target path itself. Combined with an O_EXCL on create paths
+// and an fstat-after-open on read paths, this closes the TOCTOU window where
+// an Lstat-then-Open pair could be tricked by an attacker who swaps the path
+// between the two syscalls. Mirrors the same-named constant in
+// internal/keysource so the two file-handling sites stay symmetrical.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/daemon/nofollow_unix.go
+++ b/daemon/nofollow_unix.go
@@ -15,6 +15,13 @@ import (
 // internal/keysource so the two file-handling sites stay symmetrical.
 const oNoFollow = syscall.O_NOFOLLOW
 
+// oNonblock is OR'd into O_RDONLY opens of paths the daemon already Lstat'd
+// as a regular file. On regular files O_NONBLOCK is a no-op on Linux/Darwin;
+// on a FIFO it makes the read end open without parking the daemon waiting
+// for a writer. That defends against a regular-file→FIFO swap between Lstat
+// and Open — fstat-on-fd then rejects the non-regular file.
+const oNonblock = syscall.O_NONBLOCK
+
 // isSymlinkLoop reports whether err is the kernel's "would-follow-a-symlink"
 // errno (ELOOP) returned when O_NOFOLLOW is set on an OpenFile against a
 // symlink target. Wrapping the check in a build-tagged helper avoids

--- a/daemon/nofollow_unix.go
+++ b/daemon/nofollow_unix.go
@@ -2,7 +2,10 @@
 
 package daemon
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 // oNoFollow is OR'd into OpenFile flags so the open call refuses to follow a
 // symlink at the target path itself. Combined with an O_EXCL on create paths
@@ -11,3 +14,12 @@ import "syscall"
 // between the two syscalls. Mirrors the same-named constant in
 // internal/keysource so the two file-handling sites stay symmetrical.
 const oNoFollow = syscall.O_NOFOLLOW
+
+// isSymlinkLoop reports whether err is the kernel's "would-follow-a-symlink"
+// errno (ELOOP) returned when O_NOFOLLOW is set on an OpenFile against a
+// symlink target. Wrapping the check in a build-tagged helper avoids
+// referencing syscall.ELOOP from the cross-platform daemon.go — not every
+// Go platform port defines that constant, so a direct reference would break
+// `go build` on the !unix variant the daemon refuses to run on but that CI
+// still compiles.
+func isSymlinkLoop(err error) bool { return errors.Is(err, syscall.ELOOP) }

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -6,6 +6,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -111,6 +113,48 @@ func Open(dbPath string) (*Store, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate tool_name: %w", err)
 	}
+	return &Store{db: db}, nil
+}
+
+// OpenReadOnly opens the SQLite store at dbPath without any schema or
+// migration writes. It is the entry point for tools that must coexist with
+// a running daemon (the sole writer) — e.g. agent-receipts verify, which is
+// required to work whether the daemon is up or down. The returned *Store
+// supports the read-side query API (GetChain, GetChainTail, VerifyStoredChain,
+// QueryReceipts, …); callers that invoke Insert against a read-only handle
+// will get a SQLite "attempt to write a readonly database" error from the
+// driver.
+//
+// dbPath must be a real filesystem path; ":memory:" is rejected because a
+// fresh in-memory database has no rows to read. The path is resolved to
+// absolute form so the resulting "file:" URI is unambiguous regardless of
+// the caller's working directory.
+func OpenReadOnly(dbPath string) (*Store, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("OpenReadOnly: dbPath is required")
+	}
+	if dbPath == ":memory:" {
+		return nil, fmt.Errorf("OpenReadOnly: in-memory databases cannot be opened read-only")
+	}
+	abs, err := filepath.Abs(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve db path: %w", err)
+	}
+	// SQLite URI form: file:<abs>?mode=ro. mode=ro opens the main DB file
+	// read-only without taking the immutable=1 path — that matters because
+	// a daemon crash mid-checkpoint still needs WAL recovery to be possible
+	// when the verify CLI runs. busy_timeout via _pragma keeps brief writer
+	// contention from surfacing as SQLITE_BUSY in the verify path.
+	dsn := "file:" + url.PathEscape(abs) + "?mode=ro&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database read-only: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("open database read-only: %w", err)
+	}
+	db.SetMaxOpenConns(1)
 	return &Store{db: db}, nil
 }
 

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -140,12 +140,20 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve db path: %w", err)
 	}
-	// SQLite URI form: file:<abs>?mode=ro. mode=ro opens the main DB file
-	// read-only without taking the immutable=1 path — that matters because
+	// Build the SQLite URI via url.URL + filepath.ToSlash so reserved
+	// characters in the path (spaces, '?', '#', etc.) are percent-encoded
+	// correctly without mangling the path separators, and Windows '\' gets
+	// normalised to '/' for the URI form. Mirrors the pattern in
+	// mcp-proxy/internal/audit/store.go.OpenReadOnly. mode=ro opens the main
+	// DB read-only without taking the immutable=1 path — that matters because
 	// a daemon crash mid-checkpoint still needs WAL recovery to be possible
 	// when the verify CLI runs. busy_timeout via _pragma keeps brief writer
 	// contention from surfacing as SQLITE_BUSY in the verify path.
-	dsn := "file:" + url.PathEscape(abs) + "?mode=ro&_pragma=busy_timeout(5000)"
+	dsn := (&url.URL{
+		Scheme:   "file",
+		Path:     filepath.ToSlash(abs),
+		RawQuery: "mode=ro&_pragma=busy_timeout(5000)",
+	}).String()
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database read-only: %w", err)

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -632,10 +631,12 @@ func TestOpenReadOnlyRejectsWrites(t *testing.T) {
 	kp, _ := receipt.GenerateKeyPair()
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
 	h, _ := receipt.HashReceipt(r)
+	// We deliberately don't pin a specific SQLite error string here — the
+	// driver's wording around read-only rejection has shifted between
+	// modernc.org/sqlite versions, and the behaviour we actually care about
+	// is "the write was rejected", regardless of how it's phrased.
 	if err := ro.Insert(r, h); err == nil {
 		t.Fatal("expected Insert against read-only handle to fail, got nil")
-	} else if !strings.Contains(err.Error(), "readonly") {
-		t.Fatalf("expected SQLite readonly error, got: %v", err)
 	}
 }
 

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -567,6 +569,122 @@ func TestCloseMultipleTimes(t *testing.T) {
 	}
 	// Second close should not panic.
 	_ = s.Close()
+}
+
+func TestOpenReadOnlyVerifiesExistingChain(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "receipts.db")
+
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kp, _ := receipt.GenerateKeyPair()
+	var prevHash *string
+	for i := 1; i <= 3; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := rw.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	t.Cleanup(func() { ro.Close() })
+
+	result, err := ro.VerifyStoredChain("chain-1", kp.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyStoredChain on read-only handle: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid chain, broken at %d", result.BrokenAt)
+	}
+	if result.Length != 3 {
+		t.Fatalf("expected 3 receipts verified, got %d", result.Length)
+	}
+}
+
+func TestOpenReadOnlyRejectsWrites(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "receipts.db")
+
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ro.Close() })
+
+	kp, _ := receipt.GenerateKeyPair()
+	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
+	h, _ := receipt.HashReceipt(r)
+	if err := ro.Insert(r, h); err == nil {
+		t.Fatal("expected Insert against read-only handle to fail, got nil")
+	} else if !strings.Contains(err.Error(), "readonly") {
+		t.Fatalf("expected SQLite readonly error, got: %v", err)
+	}
+}
+
+func TestOpenReadOnlyConcurrentWithWriter(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "receipts.db")
+
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rw.Close() })
+
+	kp, _ := receipt.GenerateKeyPair()
+	var prevHash *string
+	for i := 1; i <= 2; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
+		h, _ := receipt.HashReceipt(r)
+		if err := rw.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	// Open read-only while the writer handle is still live — verifies the
+	// daemon-up case where agent-receipts verify must not collide with the
+	// daemon's exclusive ownership of the write side.
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly while writer is open: %v", err)
+	}
+	t.Cleanup(func() { ro.Close() })
+
+	got, err := ro.GetChain("chain-1")
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 receipts, got %d", len(got))
+	}
+}
+
+func TestOpenReadOnlyRejectsMemoryAndEmpty(t *testing.T) {
+	if _, err := OpenReadOnly(""); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if _, err := OpenReadOnly(":memory:"); err == nil {
+		t.Fatal("expected error for :memory:")
+	}
 }
 
 func TestVerifyStoredChain(t *testing.T) {


### PR DESCRIPTION
Phase 1+ slice of issue #236: closes the daemon-side leftovers in Section 2
and the read-interface block in Section 4 of the work breakdown.

What lands:

- sdk/go/store.OpenReadOnly: opens the SQLite store with `?mode=ro`, no
  schema/migration writes, single conn. Lets read-side tools coexist with
  the daemon (the sole writer) without taking SQLITE_BUSY or accidentally
  attempting an ALTER TABLE on a daemon-owned DB. Tests cover successful
  verify against an existing chain, write-rejection, concurrent-with-writer
  read, and the rejected `:memory:` / empty-path inputs.

- daemon publishes the SPKI public key on every startup at
  `<KeyPath>.pub` (overridable via --public-key / AGENTRECEIPTS_PUBLIC_KEY)
  with mode 0644. Idempotent on identical contents (no rewrite, but tightens
  perms back to 0644 if a stricter umask had loosened them); refuses to
  overwrite a mismatched file (rotation / restored-from-backup / tamper);
  refuses non-regular paths (symlinks etc.). The publish step is in
  daemon.Run, not the keysource adapter, so future PKCS#11 / KMS adapters
  inherit the same publishing contract for free.

- agent-receipts CLI (cmd/agent-receipts): `verify <chain-id>` subcommand.
  Logic lives in internal/verifycli so tests drive it directly without
  shelling out. Defaults align with the daemon's defaults — a verify run
  with no flags works once the daemon has run at least once with the same
  per-user paths. Stable exit codes: 0 valid, 1 broken, 2 usage error.

- Integration tests for the two acceptance criteria from #236:
  TestVerifyCLIWithDaemonStopped exercises "Independent verifiability is
  not gated on daemon availability"; TestVerifyCLIWhileDaemonRunning
  exercises the read-only-coexistence half. TestPublishedPublicKeyHasMode0644
  pins the documented mode so a future umask change can't silently regress
  it.

Deliberately deferred (called out in daemon/README.md, not in this PR):

- `events_dropped` synthetic receipts. Per ADR-0010 these belong on the
  emitter side with EAGAIN handling and ship with the thin-emitter refactor.

- Owner/group ownership (`agentreceipts` user / `agentreceipts-read`
  group). Daemon caps file modes; assigning ownership is a packaging
  concern (Homebrew / launchd / systemd) and lands with packaging.

Verification:

  cd sdk/go    && go vet ./... && go test ./...
  cd daemon    && go vet ./... && go vet -tags=integration ./... \
               && go test ./... && go test -tags=integration ./... \
               && go test -race ./...
  cd mcp-proxy && go vet ./... && go test ./...

All green on linux/amd64.

Refs: #236