### PR TITLE
ci: add daemon module workflow

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -35,7 +35,9 @@ jobs:
         run: go build ./cmd/...
 
       - name: Test
-        run: go test -race ./... -v
-
-      - name: Integration tests
+        # Single tagged run covers unit + integration tests; the
+        # `integration` build tag only adds files (it does not exclude
+        # untagged ones), so this matches the coverage of running
+        # `go test ./...` and `go test -tags=integration ./...`
+        # separately, without re-running the untagged tests.
         run: go test -race -tags=integration ./... -v

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -32,9 +32,7 @@ jobs:
         run: go vet ./...
 
       - name: Build
-        run: |
-          go build ./cmd/agent-receipts-daemon
-          go build ./cmd/agent-receipts
+        run: go build ./cmd/...
 
       - name: Test
         run: go test -race ./... -v

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -1,0 +1,43 @@
+name: "CI: daemon"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "daemon/**"
+      - "sdk/go/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "daemon/**"
+      - "sdk/go/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: daemon
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: |
+          go build ./cmd/agent-receipts-daemon
+          go build ./cmd/agent-receipts
+
+      - name: Test
+        run: go test -race ./... -v
+
+      - name: Integration tests
+        run: go test -race -tags=integration ./... -v

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -35,18 +35,12 @@ the require in `daemon/go.mod`.
 
 ### CI coverage
 
-GitHub Actions workflow path filters in this repo currently target
-`sdk/go/**`, `mcp-proxy/**`, etc. — none cover `daemon/**`. Until a
-maintainer adds a `daemon.yml` workflow (AGENTS.md requires explicit human
-review for any CI change), Phase 1 daemon changes rely on:
-
-- The `mcp-proxy.yml` `sdk/go/**` trigger, which exercises the
-  `GetChainTail` change but not the daemon module itself.
-- Manual local verification per the *Build* section above (vet + tests with
-  and without `-tags=integration`, plus `-race`).
-
-The follow-up tracker in [#236](https://github.com/agent-receipts/ar/issues/236)
-includes "add daemon CI workflow" alongside emitter refactor and packaging.
+`.github/workflows/daemon.yml` runs `go vet`, builds both `cmd/`
+binaries, and runs unit + integration tests with `-race` on every push
+and pull request that touches `daemon/**` or `sdk/go/**` (the latter so
+that `sdk/go` changes which break the daemon are caught in the same PR
+that introduces them, mirroring how `mcp-proxy.yml` triggers on its
+upstream module).
 
 ## Run
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -36,10 +36,11 @@ the require in `daemon/go.mod`.
 ### CI coverage
 
 `.github/workflows/daemon.yml` runs `go vet`, builds `./cmd/...`, and
-runs unit + integration tests with `-race` on every push and pull
-request that touches `daemon/**` or `sdk/go/**`. The `sdk/go/**` trigger
-mirrors `mcp-proxy.yml` so that `sdk/go` changes which break the daemon
-are caught in the same PR that introduces them.
+runs the unit + integration test suite with `-race` and
+`-tags=integration` on pushes to `main` and on pull requests targeting
+`main` whose diff touches `daemon/**` or `sdk/go/**`. The `sdk/go/**`
+trigger mirrors `mcp-proxy.yml` so that `sdk/go` changes which break
+the daemon are caught in the same PR that introduces them.
 
 ## Run
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -35,12 +35,11 @@ the require in `daemon/go.mod`.
 
 ### CI coverage
 
-`.github/workflows/daemon.yml` runs `go vet`, builds both `cmd/`
-binaries, and runs unit + integration tests with `-race` on every push
-and pull request that touches `daemon/**` or `sdk/go/**` (the latter so
-that `sdk/go` changes which break the daemon are caught in the same PR
-that introduces them, mirroring how `mcp-proxy.yml` triggers on its
-upstream module).
+`.github/workflows/daemon.yml` runs `go vet`, builds `./cmd/...`, and
+runs unit + integration tests with `-race` on every push and pull
+request that touches `daemon/**` or `sdk/go/**`. The `sdk/go/**` trigger
+mirrors `mcp-proxy.yml` so that `sdk/go` changes which break the daemon
+are caught in the same PR that introduces them.
 
 ## Run
 


### PR DESCRIPTION
Adds .github/workflows/daemon.yml so changes under daemon/** (and the
sdk/go/** it depends on) trigger vet, build of both cmd/ binaries, and
unit + integration tests with -race. Closes the gap noted in the
"Phase 1 follow-ups" section of #236 and in daemon/README.md, where
mcp-proxy.yml's sdk/go/** trigger covered the GetChainTail change but
not the daemon-internal code.

Path filters and shape mirror mcp-proxy.yml so the upstream-trigger
behaviour is consistent across the two Go modules that consume sdk/go.
The integration test target uses the existing
`integration && (linux || darwin)` build tag, so ubuntu-latest exercises
the Linux peer-cred path; macOS coverage is a follow-up if/when other
workflows add a darwin runner.

Updates daemon/README.md "CI coverage" section to describe the active
workflow rather than the missing-workflow workaround.

https://claude.ai/code/session_016mXWFSspg1bRkSyewiwaiV