### PR TITLE
site: add SEO metadata (rel=me, JSON-LD) and crawlable GitHub URL

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -15,6 +15,31 @@ export default defineConfig({
     starlight({
       title: "Agent Receipts",
       tagline: "Cryptographically signed audit trails for AI agent actions",
+      head: [
+        {
+          tag: "link",
+          attrs: {
+            rel: "me",
+            href: "https://github.com/agent-receipts",
+          },
+        },
+        {
+          tag: "script",
+          attrs: { type: "application/ld+json" },
+          content: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "Agent Receipts",
+            url: "https://agentreceipts.ai",
+            publisher: {
+              "@type": "Organization",
+              name: "Agent Receipts",
+              url: "https://agentreceipts.ai",
+              sameAs: ["https://github.com/agent-receipts"],
+            },
+          }),
+        },
+      ],
       social: [
         {
           icon: "github",
@@ -22,6 +47,9 @@ export default defineConfig({
           href: "https://github.com/agent-receipts",
         },
       ],
+      components: {
+        SocialIcons: "./src/components/SocialIcons.astro",
+      },
       customCss: ["./src/styles/custom.css"],
       sidebar: [
         {

--- a/site/src/components/SocialIcons.astro
+++ b/site/src/components/SocialIcons.astro
@@ -1,0 +1,61 @@
+---
+import config from "virtual:starlight/user-config";
+import { Icon } from "@astrojs/starlight/components";
+
+const links = config.social ?? [];
+---
+
+{
+  links.length > 0 && (
+    <>
+      {links.map(({ href, icon, label }) =>
+        icon === "github" ? (
+          <a {href} rel="me" class="sl-flex github-org-link">
+            <Icon name={icon} />
+            <span class="sr-only sm-visible">{href.replace(/^https?:\/\//, "")}</span>
+          </a>
+        ) : (
+          <a {href} rel="me" class="sl-flex">
+            <span class="sr-only">{label}</span>
+            <Icon name={icon} />
+          </a>
+        )
+      )}
+    </>
+  )
+}
+
+<style>
+  a {
+    color: var(--sl-color-text-accent);
+    padding: 0.5em;
+    margin: -0.5em;
+  }
+  a:hover {
+    color: var(--sl-color-white);
+  }
+  .github-org-link {
+    align-items: center;
+    gap: 0.4rem;
+    text-decoration: none;
+  }
+  .sr-only {
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+  @media (min-width: 50em) {
+    .sm-visible {
+      clip-path: none;
+      height: auto;
+      overflow: visible;
+      position: static;
+      white-space: normal;
+      width: auto;
+      font-size: var(--sl-text-sm);
+    }
+  }
+</style>


### PR DESCRIPTION
## What

Adds three SEO additions to the Starlight docs site (`site/`):

1. **`<link rel="me">`** in `<head>` pointing to `https://github.com/agent-receipts` — confirms the GitHub org is "us" for IndieAuth / verified-link consumers.
2. **schema.org JSON-LD** in `<head>` — a `WebSite` with a `publisher` `Organization` whose `sameAs` points to the GitHub org. Helps search engines connect the site to the org's knowledge-graph entity.
3. **`SocialIcons` component override** — the GitHub social link now contains the visible anchor text `github.com/agent-receipts` (derived from the configured `href`) on desktop (≥ 50em). On mobile the text is `sr-only`-style hidden via `clip-path: inset(50%)` — still in the DOM and crawlable, but the header keeps its icon-only layout on phones.

## Why

The site previously emitted no machine-readable signal connecting `agentreceipts.ai` to the GitHub org, and the only GitHub link was an icon-only social anchor (no crawlable text). Together that meant search engines had to infer the relationship. These three additions give them an explicit, conventional signal on every page.

## Notes for review

- **Schema choice:** I went with `WebSite` + `publisher: Organization` rather than `SoftwareApplication`. The latter is intended for installable apps and would have flagged "missing `applicationCategory` / `operatingSystem`" in structured-data validators. The chosen shape has no required-but-missing properties.
- **Match strategy in the override:** the override checks `icon === "github"` rather than a hardcoded URL string-equality, and derives the visible text from the configured `href`. Single source of truth lives in the existing `social` array in `astro.config.mjs`.
- **No npm-org URL in `sameAs`:** the npm registry confirms `agnt-rcpt` is a scope, not an npm Organization (the `/-/org/agnt-rcpt` endpoint returns 404), so I omitted the npm URL rather than ship a 404 in our schema.org markup.
- **No CI / workflow / spec / crypto changes.** Site-only.

## Checklist

- [x] Tests pass for all changed components — site has no test suite; verified the override against the Starlight 0.38.4 source (`SocialIcons.astro`, `Head.astro`, `head` schema) on GitHub for API compatibility.
- [x] Linter passes — N/A for `.astro` / config in this repo's lint setup.
- [x] No real keys or secrets in the diff.
- [x] Cross-language tests pass — N/A (site-only, no receipt format changes).
- [x] AGENTS.md updated — N/A (no structural changes).
- [x] Spec changes — N/A.

> [!NOTE]
> I could not run `pnpm install && pnpm build` in my sandbox (no Node toolchain available). Please verify the build locally before merging.