### PR TITLE
site(mcp-proxy): fish-shell support + secrets-management patterns across integration pages

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -33,9 +33,9 @@ Re-running `init` is safe — it warns and skips if the key already exists. Use 
 
 ## Register the proxy with Claude Code
 
-Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. Your shell resolves the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`).
+Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. Your shell resolves the proxy, key, and server paths at paste time. The token is referenced as `${GITHUB_PERSONAL_ACCESS_TOKEN}` — Claude Code expands that placeholder at server-launch time, so the secret stays in your environment (or a secret manager) rather than in the stored config.
 
-**bash / zsh:**
+**bash / zsh** — `\$` escapes the placeholder so bash leaves it intact at paste time:
 
 ```bash
 # heredoc terminator (JSON) must be alone on its line; closing ) follows on the next
@@ -51,7 +51,7 @@ JSON_BODY=$(cat <<JSON
     "$(which github-mcp-server)", "stdio"
   ],
   "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }
 JSON
@@ -60,7 +60,7 @@ JSON
 claude mcp add-json github-audited --scope user "$JSON_BODY"
 ```
 
-**fish** (no heredoc support — build JSON via `printf` instead):
+**fish** (no heredoc support — build JSON via `printf` instead; the single-quoted format string passes the placeholder through literally):
 
 ```fish
 set MCP_PROXY (which mcp-proxy)
@@ -78,12 +78,14 @@ set json (printf '{
     "%s", "stdio"
   ],
   "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }' $MCP_PROXY $KEY $GITHUB_MCP | string collect)
 
 claude mcp add-json github-audited --scope user $json
 ```
+
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell rc (`~/.zshrc`, `~/.config/fish/config.fish`, etc.) — or fetch it on demand from a secret manager — before launching Claude Code. Verify the placeholder reached the stored config (and was *not* expanded at paste time) with `claude mcp get github-audited`.
 
 `--scope user` makes the server available across all projects. Omit it for project-local scope only.
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -33,10 +33,13 @@ Re-running `init` is safe — it warns and skips if the key already exists. Use 
 
 ## Register the proxy with Claude Code
 
-Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. The heredoc lets your shell resolve the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`):
+Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. Your shell resolves the proxy, key, and server paths at paste time — no manual substitution required (replace only `YOUR_TOKEN`).
+
+**bash / zsh:**
 
 ```bash
-claude mcp add-json github-audited --scope user "$(cat <<JSON
+# heredoc terminator (JSON) must be alone on its line; closing ) follows on the next
+JSON_BODY=$(cat <<JSON
 {
   "command": "$(which mcp-proxy)",
   "args": [
@@ -52,7 +55,34 @@ claude mcp add-json github-audited --scope user "$(cat <<JSON
   }
 }
 JSON
-)"
+)
+
+claude mcp add-json github-audited --scope user "$JSON_BODY"
+```
+
+**fish** (no heredoc support — build JSON via `printf` instead):
+
+```fish
+set MCP_PROXY (which mcp-proxy)
+set GITHUB_MCP (which github-mcp-server)
+set KEY $HOME/.agent-receipts/github-proxy.pem
+
+set json (printf '{
+  "command": "%s",
+  "args": [
+    "-name", "github",
+    "-key", "%s",
+    "-issuer-name", "Claude Code",
+    "-operator-id", "did:web:anthropic.com",
+    "-operator-name", "Anthropic",
+    "%s", "stdio"
+  ],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+  }
+}' $MCP_PROXY $KEY $GITHUB_MCP)
+
+claude mcp add-json github-audited --scope user $json
 ```
 
 `--scope user` makes the server available across all projects. Omit it for project-local scope only.
@@ -132,6 +162,8 @@ Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low
 ## Gotchas
 
 **Absolute paths required.** Claude Code launches MCP servers with a clean `PATH`. Use the full path to `mcp-proxy` (find it with `which mcp-proxy`) and the full path to the wrapped server binary.
+
+**fish shell.** Fish does not support heredocs — pasting the bash/zsh snippet as-is fails with `Expected a string, but found a redirection`. Use the [fish alternative above](#register-the-proxy-with-claude-code), which builds the JSON via `printf` and stores it in a variable.
 
 **Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. If your server exposes tools that cross the risk-score threshold (e.g. `create_token` = 50, `update_auth_config` = 70), pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with JSON-RPC code `-32003` (`no approver configured`). To prevent pausing entirely, drop `pause`/`block` rules from a custom `-rules` YAML.
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -9,6 +9,10 @@ Claude Code is a CLI-based agent that connects to MCP servers for tools like Git
 The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. If you're seeing `-32002` on tools that shouldn't pause, suspect client-side denial first — see [troubleshooting](/mcp-proxy/configuration/#-32002-errors-on-tool-calls).
 :::
 
+:::danger[Never put secrets in the config file]
+Both `claude mcp add-json` and `.mcp.json` persist their content as plaintext on disk (`~/.claude.json` and committed project files respectively). **Never** paste a token, API key, or other credential as a literal string into either one. Reference secrets via `${VAR}` placeholders — Claude Code expands them at server-launch time — and keep the actual values in your shell environment or a secret manager. The snippets on this page follow that pattern; if you adapt them for other servers, preserve it.
+:::
+
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -80,7 +80,7 @@ set json (printf '{
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
   }
-}' $MCP_PROXY $KEY $GITHUB_MCP)
+}' $MCP_PROXY $KEY $GITHUB_MCP | string collect)
 
 claude mcp add-json github-audited --scope user $json
 ```

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -105,11 +105,11 @@ security add-generic-password -s github-mcp -a "$USER" -w
 #!/usr/bin/env bash
 # ~/.agent-receipts/run-mcp-proxy-github.sh — chmod 700
 set -euo pipefail
-GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s github-mcp -w)" \
+GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s github-mcp -a "$USER" -w)" \
   exec /Users/YOU/go/bin/mcp-proxy "$@"
 ```
 
-**Linux**: swap the keychain calls for `secret-tool store --label=github-mcp service github-mcp` and `secret-tool lookup service github-mcp`. **Windows**: a `.ps1` wrapper using the [SecretManagement module](https://learn.microsoft.com/en-us/powershell/utility-modules/secretmanagement/overview) (`Get-Secret github-mcp`) plays the same role.
+**Linux**: swap the keychain calls for `secret-tool store --label=github-mcp service github-mcp account "$USER"` and `secret-tool lookup service github-mcp account "$USER"` (matching the same `account` qualifier on store and lookup avoids ambiguity if you ever store more than one entry under the same service name). **Windows**: a `.ps1` wrapper using the [SecretManagement module](https://learn.microsoft.com/en-us/powershell/utility-modules/secretmanagement/overview) (`Get-Secret github-mcp`) plays the same role.
 
 Point Claude Desktop at the launcher — no `env` block, since the script sets it:
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -78,6 +78,9 @@ Point Claude Desktop at `op run` — it resolves the `op://` reference at exec t
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-issuer-name", "Claude Desktop",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ]
     }
@@ -89,7 +92,7 @@ Point Claude Desktop at `op run` — it resolves the `op://` reference at exec t
 
 ### Fallback: OS keychain launcher script
 
-If you don't have a secret manager, store the token in the OS keychain and add a small launcher that exec's mcp-proxy with the secret in env. The launcher itself contains no secrets.
+If you don't have a secret manager, store the token in the OS keychain and add a small launcher that execs mcp-proxy with the secret in env. The launcher itself contains no secrets.
 
 **macOS** — store the token, then create the launcher:
 
@@ -118,6 +121,9 @@ Point Claude Desktop at the launcher — no `env` block, since the script sets i
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-issuer-name", "Claude Desktop",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ]
     }
@@ -137,6 +143,9 @@ Useful for kicking the tyres against a throwaway PAT before wiring up secret man
       "args": [
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-issuer-name", "Claude Desktop",
+        "-operator-id", "did:web:anthropic.com",
+        "-operator-name", "Anthropic",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
       ],
       "env": {

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -9,6 +9,10 @@ Claude Desktop connects to MCP servers via `claude_desktop_config.json`. The Age
 The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. See [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
+:::danger[Never put secrets in claude_desktop_config.json]
+`claude_desktop_config.json` is plaintext on disk, and Claude Desktop does **not** expand `${VAR}` references in `env` blocks — anything you write there is stored verbatim. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below. The literal-token snippet at the bottom is a demo-only path; treat the file as compromised the moment you save a real credential to it.
+:::
+
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
@@ -49,7 +53,81 @@ If the file doesn't exist yet, create it.
 
 If it already contains app preferences (for example, `{"preferences": {...}}`), that's normal. Add `mcpServers` as another top-level key rather than replacing the file — the result should look like `{"preferences": {...}, "mcpServers": {...}}` (mind the comma between sibling keys).
 
-Then substitute the three values into the `mcpServers` block below, and replace `YOUR_TOKEN` in `env` with your actual GitHub personal access token:
+The token needs to reach the MCP server's environment **without being written into the config file**. Pick whichever pattern matches your secrets setup; all three produce an equivalent wrapped server, only the credential plumbing differs.
+
+### Recommended: secret manager (`op run`, `aws-vault exec`, …)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Point Claude Desktop at `op run` — it resolves the `op://` reference at exec time, injects the value into the child process's env, and never writes the token to disk. Find your `op` path with `which op`:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/opt/homebrew/bin/op",
+      "args": [
+        "run",
+        "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
+        "-name", "github",
+        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`aws-vault exec`, `chamber exec` (AWS Parameter Store), and `direnv` with `op://` references all follow the same wrapping pattern — substitute whichever your team already deploys.
+
+### Fallback: OS keychain launcher script
+
+If you don't have a secret manager, store the token in the OS keychain and add a small launcher that exec's mcp-proxy with the secret in env. The launcher itself contains no secrets.
+
+**macOS** — store the token, then create the launcher:
+
+```bash
+security add-generic-password -s github-mcp -a "$USER" -w
+# (paste the PAT when prompted)
+```
+
+```bash
+#!/usr/bin/env bash
+# ~/.agent-receipts/run-mcp-proxy-github.sh — chmod 700
+set -euo pipefail
+GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s github-mcp -w)" \
+  exec /Users/YOU/go/bin/mcp-proxy "$@"
+```
+
+**Linux**: swap the keychain calls for `secret-tool store --label=github-mcp service github-mcp` and `secret-tool lookup service github-mcp`. **Windows**: a `.ps1` wrapper using the [SecretManagement module](https://learn.microsoft.com/en-us/powershell/utility-modules/secretmanagement/overview) (`Get-Secret github-mcp`) plays the same role.
+
+Point Claude Desktop at the launcher — no `env` block, since the script sets it:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/.agent-receipts/run-mcp-proxy-github.sh",
+      "args": [
+        "-name", "github",
+        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+### Demo only: literal token
+
+Useful for kicking the tyres against a throwaway PAT before wiring up secret management. **Treat the file as compromised the moment you save a real credential**, and rotate the PAT before moving to either pattern above.
 
 ```json
 {
@@ -69,11 +147,9 @@ Then substitute the three values into the `mcpServers` block below, and replace 
 }
 ```
 
-The approval listener is off by default. If the policy pauses a call (e.g. a high-risk tool your server exposes), it fails immediately with JSON-RPC code `-32003` (`no approver configured`). To enable approvals, add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+The approval listener is off by default. If the policy pauses a call (e.g. a high-risk tool your server exposes), it fails immediately with JSON-RPC code `-32003` (`no approver configured`). To enable approvals, add `-http 127.0.0.1:<port>` to `args` in any of the three configurations above and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
 
 Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — every tool call goes through it transparently.
-
-> **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
 
 ## Verifying receipts
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -9,6 +9,10 @@ OpenAI Codex (CLI and IDE extension) stores MCP configuration in `~/.codex/confi
 The default policy includes a `pause_high_risk` rule. When you generate a config with `mcp-proxy init`, the snippet includes `-http 127.0.0.1:7778` so the approval listener starts automatically. If you run the proxy manually without `-http`, the listener is off and paused calls fail fast with `-32003`. Pass `--no-approval` to `mcp-proxy init` to generate a snippet without `-http`. See [Approval Server](/mcp-proxy/approval-ui/).
 :::
 
+:::danger[Never put secrets in ~/.codex/config.toml]
+`~/.codex/config.toml` (and `.codex/config.toml`) is plaintext on disk, and `codex mcp add --env KEY=VALUE` stores whatever you pass it verbatim. Do **not** put real tokens, API keys, or other credentials there. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below. The literal-token snippet at the bottom is a demo-only path; treat the file as compromised the moment you save a real credential to it.
+:::
+
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
@@ -33,7 +37,51 @@ Re-running `init` is safe — it warns and skips if the key already exists. Use 
 
 ## Configure via CLI
 
-Use `codex mcp add` to register the proxy wrapping any MCP server. The shell resolves the proxy, key, and server paths at paste time (replace only `YOUR_TOKEN`):
+Use `codex mcp add` to register the proxy wrapping any MCP server. The shell resolves the proxy, key, and server paths at paste time. Pick whichever secrets pattern below matches your setup; **do not pass `--env GITHUB_PERSONAL_ACCESS_TOKEN=…`** in the recommended or fallback forms — the value would be persisted to `config.toml` verbatim, defeating the point.
+
+### Recommended: secret manager (`op run`)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Register `op run` as the command — it resolves `op://` references at exec time and injects them into the proxy's env without touching disk:
+
+```bash
+codex mcp add github-audited \
+  -- "$(which op)" run "--env-file=$HOME/.agent-receipts/mcp.env" -- \
+    "$(which mcp-proxy)" \
+    -name github \
+    -key "$HOME/.agent-receipts/github-proxy.pem" \
+    -issuer-name Codex \
+    -operator-id did:web:openai.com \
+    -operator-name OpenAI \
+    "$(which github-mcp-server)" stdio
+```
+
+`aws-vault exec`, `chamber exec`, and `direnv` with `op://` references follow the same wrapping pattern.
+
+### Fallback: OS keychain launcher
+
+Reuse the launcher script described in [Claude Desktop's keychain fallback](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) (one script works across clients). Register the script path as Codex's command:
+
+```bash
+codex mcp add github-audited \
+  -- "$HOME/.agent-receipts/run-mcp-proxy-github.sh" \
+    -name github \
+    -key "$HOME/.agent-receipts/github-proxy.pem" \
+    -issuer-name Codex \
+    -operator-id did:web:openai.com \
+    -operator-name OpenAI \
+    "$(which github-mcp-server)" stdio
+```
+
+### Demo only: literal token
+
+For kicking the tyres against a throwaway PAT. **Treat `config.toml` as compromised the moment you save a real credential**, and rotate before moving to either pattern above.
 
 ```bash
 codex mcp add github-audited \
@@ -47,26 +95,31 @@ codex mcp add github-audited \
     "$(which github-mcp-server)" stdio
 ```
 
-Add `--scope user` to make the server available across all projects (default is project-scoped).
+Add `--scope user` to any of the above to make the server available across all projects (default is project-scoped).
 
 `-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Codex` here (and to `Claude Code` in the [Claude Code integration](/mcp-proxy/claude-code/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the default `did:agent:mcp-proxy` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
 
 ## Configure via config.toml
 
-Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand, so print your absolute paths first:
+Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand and Codex doesn't expand `${VAR}` in env tables, so use the same secrets patterns as the CLI form above. Print your absolute paths first:
 
 ```bash
 echo "command: $(which mcp-proxy)"
 echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
+echo "op:      $(which op)"
 ```
 
-Then substitute them into the template:
+The recommended (secret-manager) form — `op run` resolves the `op://` reference in `mcp.env` at exec time, no env table needed in `config.toml`:
 
 ```toml
 [mcp_servers.github-audited]
-command = "/Users/YOU/go/bin/mcp-proxy"
+command = "/opt/homebrew/bin/op"
 args = [
+  "run",
+  "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+  "--",
+  "/Users/YOU/go/bin/mcp-proxy",
   "-name", "github",
   "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
   "-issuer-name", "Codex",
@@ -75,10 +128,9 @@ args = [
   "/opt/homebrew/bin/github-mcp-server", "stdio"
 ]
 enabled = true
-
-[mcp_servers.github-audited.env]
-GITHUB_PERSONAL_ACCESS_TOKEN = "YOUR_TOKEN"
 ```
+
+The keychain-launcher and demo-only equivalents follow the same shape — for the launcher, set `command` to the launcher script path and drop the env table (the script sets `GITHUB_PERSONAL_ACCESS_TOKEN`); for the demo path, use the original `command = "/path/to/mcp-proxy"` form and add `[mcp_servers.github-audited.env]` with the literal token (throwaway PATs only).
 
 For project-scoped setup, place the same config in `.codex/config.toml` at the project root (only applies in trusted projects).
 

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -111,7 +111,7 @@ claude mcp add-json github-audited --scope user '{
     "/opt/homebrew/bin/github-mcp-server", "stdio"
   ],
   "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }'
 ```

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -70,30 +70,31 @@ To enable the approval workflow, pass `-http 127.0.0.1:<port>` — see [Approval
 
 ## Claude Desktop integration
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS). Claude Desktop doesn't expand `${VAR}` in `env` blocks, so wrap the proxy in a secret manager (`op run`, `aws-vault exec`, …) — the snippet below uses 1Password CLI, with the token resolved from `op://` at exec time and never written to disk:
 
 ```json
 {
   "mcpServers": {
     "github-audited": {
-      "command": "/Users/YOU/go/bin/mcp-proxy",
+      "command": "/opt/homebrew/bin/op",
       "args": [
+        "run",
+        "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
         "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
         "/opt/homebrew/bin/github-mcp-server", "stdio"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN"
-      }
+      ]
     }
   }
 }
 ```
 
-> **Note:** `claude_desktop_config.json` is not encrypted. Avoid committing it to version control, and prefer sourcing tokens from your OS keychain or a secret manager where possible.
+`mcp.env` references the secret by path (`GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token`); see the [Claude Desktop integration guide](/mcp-proxy/claude-desktop/#configure-claude_desktop_configjson) for the OS-keychain-launcher fallback and other patterns.
 
 ## Claude Code integration
 


### PR DESCRIPTION
## Summary

Started as a fish-shell fix on the Claude Code integration page; expanded into a coherent secrets-handling story across all four MCP-proxy integration docs after `agentreceipts.ai/mcp-proxy/claude-code/` was flagged as encouraging users to paste literal PATs into config files — a poor default for an audit-trail tool.

### `claude-code.mdx`

- **Fish-shell variant** of the `claude mcp add-json` snippet (fish doesn't support heredocs — pasting the bash form failed with `Expected a string, but found a redirection`). Builds the JSON via `printf` piped through `string collect` (so the multi-line output stays a single arg).
- **Heredoc snippet disambiguated**: refactored the bash/zsh form into a `JSON_BODY` variable so the heredoc terminator `JSON` and the closing `)` are unambiguously on separate lines (previously a copy-paste hazard); inline `#` comment near the terminator marks the constraint.
- **Token kept out of stored config**: replaced literal `"YOUR_TOKEN"` with `"${GITHUB_PERSONAL_ACCESS_TOKEN}"` (Claude Code expands at server-launch time). bash/zsh uses `\$` to escape from paste-time expansion; fish's single-quoted `printf` format passes the placeholder through literally.
- **Page-level `:::danger`**: "Never put secrets in the config file."
- New Gotchas entry pointing fish users at the alternative snippet.

### `claude-desktop.mdx`

Claude Desktop has **no native `${VAR}` expansion** in `claude_desktop_config.json`, so the placeholder approach doesn't apply. Restructured the configure section into three patterns ordered by recommendation:

1. **Recommended: secret manager** — `op run --env-file mcp.env -- mcp-proxy …`, with `mcp.env` referencing `op://Personal/GitHub/token`. Same shape works for `aws-vault exec`, `chamber exec`, `direnv` + `op://`. Token never written to disk.
2. **Fallback: OS keychain launcher** — small shell script that loads the token from macOS `security` / Linux `secret-tool` / Windows PowerShell SecretManagement and `exec`s mcp-proxy. The launcher contains no secrets.
3. **Demo only: literal token** — kept for kicking the tyres against a throwaway PAT, with explicit "treat the file as compromised the moment you save a real credential" framing.

Page-level `:::danger` admonition near the top.

### `codex.mdx`

Same three-pattern structure for both `codex mcp add` (CLI) and `~/.codex/config.toml` (direct edit). The TOML section keeps only the recommended pattern in full and points back to the CLI section for the launcher/demo equivalents — avoids six near-identical snippets on one page. Page-level `:::danger`.

### `overview.mdx`

- Claude Code snippet → `${GITHUB_PERSONAL_ACCESS_TOKEN}` placeholder (mirroring the dedicated page).
- Claude Desktop snippet → `op run` recommended pattern with a pointer to the dedicated page for keychain/demo fallbacks.

## Test plan

- [ ] `pnpm build` from `site/` succeeds (CI covers this; latest run on `ae9b656` was queued at push time).
- [ ] `pnpm dev` — eyeball the rendered code blocks on `/mcp-proxy/claude-code/`, `/mcp-proxy/claude-desktop/`, `/mcp-proxy/codex/`, `/mcp-proxy/`: `:::danger` admonitions render, all three pattern subsections are reachable, in-page anchor links resolve.
- [ ] Copy-paste each "Recommended" snippet against a real `op` install and confirm the proxy launches with `GITHUB_PERSONAL_ACCESS_TOKEN` set in its env (without the value ever appearing in any config file on disk).
- [ ] Copy-paste the "Fallback" launcher script against a token stored in the keychain and confirm the same.
- [ ] Verify the bash/zsh and fish Claude Code snippets register the server (`claude mcp list`) and that the placeholder reaches the stored config unexpanded (`claude mcp get github-audited`).