### PR TITLE
daemon(pipeline): hash emitter input/output into receipts

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -144,16 +144,20 @@ The JSON payload is the ADR-0010 emitter schema:
   "session_id": "uuid-v4",
   "channel": "mcp_proxy",
   "tool": { "server": "github", "name": "list_repos" },
-  "input": null,
-  "output": null,
+  "input": { "owner": "agent-receipts" },
+  "output": [ { "name": "ar" } ],
   "error": "",
   "decision": "allowed"
 }
 ```
 
-`decision` is one of `allowed` / `denied` / `pending`. The daemon adds
-`seq`, `prev_hash`, `ts_recv`, peer attestation, and the receipt id before
-signing, so emitters never see those fields and cannot forge them.
+`decision` is one of `allowed` / `denied` / `pending`. `input` and `output`
+accept any JSON value (object, array, primitive) or `null` / omitted for
+events with no payload; the daemon canonicalises (RFC 8785) and stores only
+the SHA-256 digest in `action.parameters_hash` and `outcome.response_hash`,
+never the raw bytes. The daemon adds `seq`, `prev_hash`, `ts_recv`, peer
+attestation, and the receipt id before signing, so emitters never see those
+fields and cannot forge them.
 
 ## Phase 1 scope and deviations
 

--- a/daemon/internal/chain/state.go
+++ b/daemon/internal/chain/state.go
@@ -75,12 +75,20 @@ func (s *State) NextSeq() int64 {
 
 // Allocation is a reservation of the next (sequence, prev_hash) pair. Callers
 // MUST eventually call Commit (with the freshly inserted receipt's hash) or
-// Rollback. Failing to do so deadlocks the daemon — the underlying mutex stays
-// held.
+// Rollback to release the State's mutex.
+//
+// Commit and Rollback are mutually exclusive and idempotent: whichever runs
+// first wins and any subsequent call is a no-op. This lets the daemon use
+// `defer alloc.Rollback()` immediately after Allocate as a panic-safety guard
+// without double-unlocking on the success path where Commit ran first.
 type Allocation struct {
 	state    *State
 	Sequence int64
 	PrevHash *string // copy; nil for the first receipt
+	// release is a heap-allocated sync.Once shared across value copies of the
+	// Allocation. The first Commit or Rollback runs the unlock; subsequent
+	// calls are no-ops via sync.Once's exactly-once guarantee.
+	release *sync.Once
 }
 
 // Allocate reserves the next chain slot and returns it. The State's mutex is
@@ -93,26 +101,38 @@ func (s *State) Allocate() Allocation {
 		v := *s.prevHash
 		prev = &v
 	}
-	return Allocation{state: s, Sequence: s.nextSeq, PrevHash: prev}
+	return Allocation{
+		state:    s,
+		Sequence: s.nextSeq,
+		PrevHash: prev,
+		release:  &sync.Once{},
+	}
 }
 
 // Commit advances the chain past this allocation. newHash is the hash of the
 // just-inserted receipt and becomes the prev_hash for the next allocation.
+// No-op if Commit or Rollback has already been called on this allocation.
 func (a Allocation) Commit(newHash string) {
 	if a.state == nil {
 		panic("chain.Allocation: Commit on zero-value Allocation")
 	}
-	a.state.nextSeq = a.Sequence + 1
-	h := newHash
-	a.state.prevHash = &h
-	a.state.mu.Unlock()
+	a.release.Do(func() {
+		a.state.nextSeq = a.Sequence + 1
+		h := newHash
+		a.state.prevHash = &h
+		a.state.mu.Unlock()
+	})
 }
 
 // Rollback releases the allocation without advancing the chain. Use this when
-// the build/sign/insert pipeline fails after Allocate.
+// the build/sign/insert pipeline fails after Allocate. Safe to defer: a
+// Rollback after a successful Commit is a no-op rather than an "unlock of
+// unlocked mutex" panic.
 func (a Allocation) Rollback() {
 	if a.state == nil {
 		panic("chain.Allocation: Rollback on zero-value Allocation")
 	}
-	a.state.mu.Unlock()
+	a.release.Do(func() {
+		a.state.mu.Unlock()
+	})
 }

--- a/daemon/internal/chain/state_test.go
+++ b/daemon/internal/chain/state_test.go
@@ -121,6 +121,46 @@ func TestRollbackReleasesLock(t *testing.T) {
 	}
 }
 
+// TestRollbackAfterCommitIsNoOp documents the property pipeline.Process relies
+// on: `defer alloc.Rollback()` is safe even when Commit ran first. Without
+// idempotency this would panic with "unlock of unlocked mutex" or advance the
+// chain twice.
+func TestRollbackAfterCommitIsNoOp(t *testing.T) {
+	s := New("c")
+	a := s.Allocate()
+	a.Commit("sha256:1")
+	a.Rollback() // must not panic, must not double-unlock
+
+	a2 := s.Allocate()
+	defer a2.Rollback()
+	if a2.Sequence != 2 {
+		t.Errorf("Rollback after Commit advanced or rewound the chain: seq = %d, want 2", a2.Sequence)
+	}
+}
+
+func TestCommitAfterRollbackIsNoOp(t *testing.T) {
+	s := New("c")
+	a := s.Allocate()
+	a.Rollback()
+	a.Commit("sha256:1") // must not panic, must not advance the chain
+
+	a2 := s.Allocate()
+	defer a2.Rollback()
+	if a2.Sequence != 1 {
+		t.Errorf("Commit after Rollback advanced the chain: seq = %d, want 1", a2.Sequence)
+	}
+	if a2.PrevHash != nil {
+		t.Errorf("Commit after Rollback set prev_hash: %v, want nil", a2.PrevHash)
+	}
+}
+
+func TestDoubleRollbackIsNoOp(t *testing.T) {
+	s := New("c")
+	a := s.Allocate()
+	a.Rollback()
+	a.Rollback() // must not panic with "unlock of unlocked mutex"
+}
+
 // intToString avoids strconv import in a tight loop just to keep the file
 // dependency-light. Used only for synthesizing unique commit hashes in tests.
 func intToString(n int64) string {

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -165,11 +165,13 @@ func hasJSONPayload(raw json.RawMessage) bool {
 // "sha256:<hex>" digest. Callers must check hasJSONPayload first; passing a
 // null/empty value canonicalises to "null" and produces a misleading hash.
 //
-// raw is expected to already be valid JSON — json.Unmarshal into EmitterFrame
-// would have failed earlier otherwise — so the unmarshal here cannot fail
-// in practice. We still surface the error rather than panicking; a daemon
-// crash on a malformed inbound frame would be the wrong failure mode even
-// for an "impossible" path.
+// Errors here are real and expected: json.RawMessage on a successfully-parsed
+// EmitterFrame is only guaranteed to be a syntactically valid JSON token.
+// Re-unmarshalling into Go's `any` can still fail — a JSON number like
+// `1e400` is valid JSON syntax but overflows float64. The daemon MUST
+// surface that as a per-frame error and keep running; a panic here would
+// let any authenticated emitter DoS every other emitter on the same socket
+// (and the orphaned chain.State allocation would leave the lock held).
 func canonicalSHA256(raw json.RawMessage) (string, error) {
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
@@ -262,13 +264,21 @@ func (p *Pipeline) buildAndSign(
 		action.ParametersHash = hash
 	}
 
-	// Pass Output through CreateInput.ResponseBody when present; receipt.Create
-	// canonicalises and hashes it into Outcome.ResponseHash. hasJSONPayload
-	// filters out null and the empty case so we don't commit to a hash of
-	// "null" for events that genuinely have no output.
-	var responseBody json.RawMessage
+	outcome := receipt.Outcome{
+		Status: status,
+		Error:  f.Error,
+	}
 	if hasJSONPayload(f.Output) {
-		responseBody = f.Output
+		// Hash Output here rather than via receipt.CreateInput.ResponseBody
+		// (which panics on bad JSON). f.Output is emitter-controlled and may
+		// be syntactically valid JSON yet still fail re-unmarshal — see
+		// canonicalSHA256 doc — so the daemon MUST surface that as an error,
+		// not a crash.
+		hash, err := canonicalSHA256(f.Output)
+		if err != nil {
+			return receipt.AgentReceipt{}, "", fmt.Errorf("hash output: %w", err)
+		}
+		outcome.ResponseHash = hash
 	}
 
 	unsigned := receipt.Create(receipt.CreateInput{
@@ -279,16 +289,12 @@ func (p *Pipeline) buildAndSign(
 		},
 		Principal: receipt.Principal{ID: "did:user:unknown"},
 		Action:    action,
-		Outcome: receipt.Outcome{
-			Status: status,
-			Error:  f.Error,
-		},
+		Outcome:   outcome,
 		Chain: receipt.Chain{
 			Sequence:            int(alloc.Sequence),
 			PreviousReceiptHash: alloc.PrevHash,
 			ChainID:             p.State.ChainID(),
 		},
-		ResponseBody: responseBody,
 	})
 	// receipt.Create stamps IssuanceDate from time.Now() internally. Replace it
 	// with our deterministic now so action.timestamp, issuanceDate, and

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -34,14 +34,12 @@ const SupportedFrameVersion = "1"
 // split". Fields the emitter does not populate are zero/empty; the daemon
 // fills in the authoritative chain/peer/id/ts_recv before signing.
 //
-// Phase 1 limitation: Input and Output are recognised in the schema (so the
-// wire format already matches what Phase 2 emitters will send) but the daemon
-// does not yet hash them into action.parameters_hash / outcome.response_hash.
-// Accepting non-empty Input/Output today would silently drop the payload from
-// the receipt and mislead emitter authors into thinking tool I/O is being
-// committed when it isn't. validateFrame rejects frames that populate them
-// until Phase 2 wires the canonical-hash path through receipt.Create's
-// ResponseBody and an explicit ParametersHash computation.
+// Input and Output carry the raw tool I/O. The daemon does NOT persist the
+// raw bytes in the receipt; it canonicalises them (RFC 8785) and stores only
+// the SHA-256 digests in action.parameters_hash and outcome.response_hash.
+// A literal JSON null (or omitted field) means "no payload" and produces no
+// hash — hashing the literal "null" would falsely commit the daemon to a
+// value the emitter did not send.
 type EmitterFrame struct {
 	Version   string          `json:"v"`
 	TsEmit    string          `json:"ts_emit"`
@@ -146,15 +144,10 @@ func validateFrame(f *EmitterFrame) error {
 	default:
 		return fmt.Errorf("unknown decision %q (want allowed|denied|pending)", f.Decision)
 	}
-	// Phase 1 hard-rejects non-null Input/Output rather than silently dropping
-	// them — see EmitterFrame doc comment. JSON null is treated as equivalent
-	// to omitted, since "v":"1","input":null is the documented wire form.
-	if hasJSONPayload(f.Input) {
-		return fmt.Errorf("input not supported in Phase 1 (would be silently dropped); see EmitterFrame doc")
-	}
-	if hasJSONPayload(f.Output) {
-		return fmt.Errorf("output not supported in Phase 1 (would be silently dropped); see EmitterFrame doc")
-	}
+	// Input and Output are accepted as any valid JSON value (object, array,
+	// primitive, or null). json.Unmarshal into EmitterFrame already validated
+	// JSON syntax, so anything reaching this point is well-formed. The hash
+	// computation happens in buildAndSign; null/empty are skipped there.
 	return nil
 }
 
@@ -166,6 +159,27 @@ func hasJSONPayload(raw json.RawMessage) bool {
 		return false
 	}
 	return !bytes.Equal(trimmed, []byte("null"))
+}
+
+// canonicalSHA256 unmarshals raw, canonicalises per RFC 8785, and returns the
+// "sha256:<hex>" digest. Callers must check hasJSONPayload first; passing a
+// null/empty value canonicalises to "null" and produces a misleading hash.
+//
+// raw is expected to already be valid JSON — json.Unmarshal into EmitterFrame
+// would have failed earlier otherwise — so the unmarshal here cannot fail
+// in practice. We still surface the error rather than panicking; a daemon
+// crash on a malformed inbound frame would be the wrong failure mode even
+// for an "impossible" path.
+func canonicalSHA256(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("unmarshal: %w", err)
+	}
+	canonical, err := receipt.Canonicalize(v)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize: %w", err)
+	}
+	return receipt.SHA256Hash(canonical), nil
 }
 
 func (p *Pipeline) buildAndSign(
@@ -233,6 +247,30 @@ func (p *Pipeline) buildAndSign(
 	// field once the emitter SDKs land.
 	risk := taxonomy.ResolveActionType(actionType).RiskLevel
 
+	action := receipt.Action{
+		Type:                 actionType,
+		ToolName:             f.Tool.Name,
+		RiskLevel:            risk,
+		Timestamp:            now,
+		ParametersDisclosure: disclosure,
+	}
+	if hasJSONPayload(f.Input) {
+		hash, err := canonicalSHA256(f.Input)
+		if err != nil {
+			return receipt.AgentReceipt{}, "", fmt.Errorf("hash input: %w", err)
+		}
+		action.ParametersHash = hash
+	}
+
+	// Pass Output through CreateInput.ResponseBody when present; receipt.Create
+	// canonicalises and hashes it into Outcome.ResponseHash. hasJSONPayload
+	// filters out null and the empty case so we don't commit to a hash of
+	// "null" for events that genuinely have no output.
+	var responseBody json.RawMessage
+	if hasJSONPayload(f.Output) {
+		responseBody = f.Output
+	}
+
 	unsigned := receipt.Create(receipt.CreateInput{
 		Issuer: receipt.Issuer{
 			ID:        p.IssuerID,
@@ -240,13 +278,7 @@ func (p *Pipeline) buildAndSign(
 			SessionID: f.SessionID,
 		},
 		Principal: receipt.Principal{ID: "did:user:unknown"},
-		Action: receipt.Action{
-			Type:                 actionType,
-			ToolName:             f.Tool.Name,
-			RiskLevel:            risk,
-			Timestamp:            now,
-			ParametersDisclosure: disclosure,
-		},
+		Action:    action,
 		Outcome: receipt.Outcome{
 			Status: status,
 			Error:  f.Error,
@@ -256,6 +288,7 @@ func (p *Pipeline) buildAndSign(
 			PreviousReceiptHash: alloc.PrevHash,
 			ChainID:             p.State.ChainID(),
 		},
+		ResponseBody: responseBody,
 	})
 	// receipt.Create stamps IssuanceDate from time.Now() internally. Replace it
 	// with our deterministic now so action.timestamp, issuanceDate, and

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -84,6 +84,12 @@ func New(s *chain.State, ks keysource.KeySource, store store.ReceiptStore, issue
 // the next chain slot, builds and signs the AgentReceipt, persists it via
 // store.Insert, and Commits the chain allocation. Any error before Commit
 // triggers Rollback so the chain state is not advanced past a missing receipt.
+//
+// Rollback is deferred — and chain.Allocation.Commit/Rollback are idempotent
+// via sync.Once — so the chain mutex is released even if buildAndSign or
+// Store.Insert panics. Without that guarantee, a single panicking frame would
+// orphan the lock and deadlock the daemon for every subsequent emitter on the
+// same socket.
 func (p *Pipeline) Process(f socket.Frame) error {
 	var frame EmitterFrame
 	if err := json.Unmarshal(f.Payload, &frame); err != nil {
@@ -94,13 +100,13 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	}
 
 	alloc := p.State.Allocate()
+	defer alloc.Rollback()
+
 	signed, hash, err := p.buildAndSign(&frame, f.Peer, alloc)
 	if err != nil {
-		alloc.Rollback()
 		return err
 	}
 	if err := p.Store.Insert(signed, hash); err != nil {
-		alloc.Rollback()
 		return fmt.Errorf("insert receipt: %w", err)
 	}
 	alloc.Commit(hash)

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -167,23 +167,27 @@ func hasJSONPayload(raw json.RawMessage) bool {
 	return !bytes.Equal(trimmed, []byte("null"))
 }
 
-// canonicalSHA256 unmarshals raw, canonicalises per RFC 8785, and returns the
-// "sha256:<hex>" digest. Callers must check hasJSONPayload first; passing a
-// null/empty value canonicalises to "null" and produces a misleading hash.
+// canonicalSHA256 canonicalises raw per RFC 8785 and returns the
+// "sha256:<hex>" digest. Callers MUST check hasJSONPayload first: a literal
+// JSON null reaches receipt.Canonicalize and hashes "null", which would
+// falsely commit the daemon to a value the emitter did not send.
 //
-// Errors here are real and expected: json.RawMessage on a successfully-parsed
-// EmitterFrame is only guaranteed to be a syntactically valid JSON token.
-// Re-unmarshalling into Go's `any` can still fail — a JSON number like
-// `1e400` is valid JSON syntax but overflows float64. The daemon MUST
-// surface that as a per-frame error and keep running; a panic here would
-// let any authenticated emitter DoS every other emitter on the same socket
-// (and the orphaned chain.State allocation would leave the lock held).
+// raw is passed to receipt.Canonicalize directly; json.RawMessage's
+// MarshalJSON returns its bytes verbatim, so Canonicalize's existing
+// marshal+unmarshal handles the parse without us doing an extra unmarshal
+// here. (Empty RawMessage is not a callable shape — Canonicalize would
+// return EOF — but hasJSONPayload rejects it before we get here.)
+//
+// Errors are real and expected: a JSON number like `1e400` is syntactically
+// valid (so it survives EmitterFrame's outer Unmarshal as a token) but
+// overflows float64 when Canonicalize re-parses into Go's `any`. The daemon
+// MUST surface that as a per-frame error and keep running; a panic here
+// would let any authenticated emitter DoS the daemon — and the orphaned
+// chain.State allocation, even with the deferred-Rollback guard in Process,
+// would still mean Process never returns to the listener loop for the bad
+// frame.
 func canonicalSHA256(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", fmt.Errorf("unmarshal: %w", err)
-	}
-	canonical, err := receipt.Canonicalize(v)
+	canonical, err := receipt.Canonicalize(raw)
 	if err != nil {
 		return "", fmt.Errorf("canonicalize: %w", err)
 	}

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -454,6 +454,53 @@ func TestProcess_RejectsUnrepresentableNumbers(t *testing.T) {
 	}
 }
 
+// panicSigningKeySource panics on Sign, simulating any unexpected runtime
+// failure between Allocate and Commit. Used to prove pipeline.Process releases
+// the chain mutex via deferred Rollback even when buildAndSign panics.
+type panicSigningKeySource struct{}
+
+func (panicSigningKeySource) Init() error                  { return nil }
+func (panicSigningKeySource) Teardown() error              { return nil }
+func (panicSigningKeySource) PublicKey() (string, error)   { return "", nil }
+func (panicSigningKeySource) VerificationMethod() string   { return "did:test#k1" }
+func (panicSigningKeySource) Rotate() error                { return nil }
+func (panicSigningKeySource) Sign(_ []byte) ([]byte, error) {
+	panic("simulated panic during signing")
+}
+
+func TestProcess_PanicReleasesChainAllocation(t *testing.T) {
+	// Any panic between Allocate and Commit MUST release the chain mutex via
+	// the deferred Rollback. Without that, a single bad frame would deadlock
+	// the daemon for every subsequent emitter on the same socket.
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, panicSigningKeySource{}, st, "did:agent-receipts-daemon:test")
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected Process to panic with the panicSigningKeySource stub; setup is broken")
+			}
+		}()
+		_ = p.Process(sampleFrame(t))
+	}()
+
+	// If the chain mutex is still held, the next Allocate would block forever.
+	// Run it on a goroutine with a tight timeout so the test fails loudly
+	// rather than hanging until the framework's default kill.
+	done := make(chan struct{})
+	go func() {
+		a := state.Allocate()
+		a.Rollback()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chain.State.Allocate timed out: panic in buildAndSign orphaned the mutex")
+	}
+}
+
 func TestProcess_DaemonControlsAllTimestamps(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -206,11 +206,209 @@ func TestProcess_AcceptsExplicitNullInputOutput(t *testing.T) {
 	state := chain.New("chain-1")
 	p := New(state, ks, st, "did:agent-receipts-daemon:test")
 
-	// "input": null and "output": null are the documented Phase 1 wire form
-	// (see daemon/README.md). They MUST be accepted as equivalent to absent.
+	// "input": null and "output": null are the documented wire form for events
+	// that genuinely have no payload (see daemon/README.md). They MUST be
+	// accepted as equivalent to absent — and MUST NOT produce hashes (a hash
+	// of literal null would falsely commit the daemon to "the input was null"
+	// vs. "no input was sent").
 	payload := []byte(`{"v":"1","ts_emit":"2026-05-03T00:00:00Z","session_id":"s","channel":"sdk","tool":{"name":"noop"},"input":null,"output":null,"decision":"allowed"}`)
 	if err := p.Process(socket.Frame{Payload: payload}); err != nil {
 		t.Fatalf("frame with explicit null input/output should be accepted: %v", err)
+	}
+	chainReceipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := chainReceipts[0]
+	if r.CredentialSubject.Action.ParametersHash != "" {
+		t.Errorf("null input must not produce parameters_hash, got %q", r.CredentialSubject.Action.ParametersHash)
+	}
+	if r.CredentialSubject.Outcome.ResponseHash != "" {
+		t.Errorf("null output must not produce response_hash, got %q", r.CredentialSubject.Outcome.ResponseHash)
+	}
+}
+
+func TestProcess_HashesInput(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	input := json.RawMessage(`{"path":"/etc/passwd","mode":"r"}`)
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Input:     input,
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("frame with input should be accepted: %v", err)
+	}
+	chainReceipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := chainReceipts[0]
+
+	// Recompute the expected hash via the same canonicalization path the
+	// receipt.Create helper uses — no shortcut through the daemon's internals.
+	var v any
+	if err := json.Unmarshal(input, &v); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := receipt.Canonicalize(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := receipt.SHA256Hash(canonical)
+	if got := r.CredentialSubject.Action.ParametersHash; got != want {
+		t.Errorf("parameters_hash = %q, want %q", got, want)
+	}
+}
+
+func TestProcess_HashesOutput(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	output := json.RawMessage(`{"bytes":1024,"checksum":"sha256:abc"}`)
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Output:    output,
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("frame with output should be accepted: %v", err)
+	}
+	chainReceipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := chainReceipts[0]
+
+	var v any
+	if err := json.Unmarshal(output, &v); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := receipt.Canonicalize(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := receipt.SHA256Hash(canonical)
+	if got := r.CredentialSubject.Outcome.ResponseHash; got != want {
+		t.Errorf("response_hash = %q, want %q", got, want)
+	}
+}
+
+func TestProcess_HashesAreCanonical(t *testing.T) {
+	// Same logical payload sent two different ways (key order, whitespace) MUST
+	// produce identical hashes — that's the property cross-language verifiers
+	// rely on. If this test ever fails, the canonicalizer regressed and every
+	// SDK that ever produced a hash is at risk of mismatch.
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	frameA, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Input:     json.RawMessage(`{"a":1,"b":2,"c":3}`),
+		Output:    json.RawMessage(`{"x":[1,2,3],"y":"ok"}`),
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frameB, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Input:     json.RawMessage(`{ "c":3, "b":2 ,  "a":1 }`),
+		Output:    json.RawMessage("{\n  \"y\":\"ok\",\n  \"x\":[1, 2, 3]\n}"),
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: frameA}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: frameB}); err != nil {
+		t.Fatal(err)
+	}
+	chainReceipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chainReceipts) != 2 {
+		t.Fatalf("got %d receipts, want 2", len(chainReceipts))
+	}
+	a, b := chainReceipts[0], chainReceipts[1]
+	if a.CredentialSubject.Action.ParametersHash != b.CredentialSubject.Action.ParametersHash {
+		t.Errorf("parameters_hash differs across whitespace/key-order variants:\n  a=%q\n  b=%q",
+			a.CredentialSubject.Action.ParametersHash, b.CredentialSubject.Action.ParametersHash)
+	}
+	if a.CredentialSubject.Outcome.ResponseHash != b.CredentialSubject.Outcome.ResponseHash {
+		t.Errorf("response_hash differs across whitespace/key-order variants:\n  a=%q\n  b=%q",
+			a.CredentialSubject.Outcome.ResponseHash, b.CredentialSubject.Outcome.ResponseHash)
+	}
+}
+
+func TestProcess_AcceptsPrimitiveInputOutput(t *testing.T) {
+	// MCP tool inputs are typically JSON objects, but tool outputs are
+	// commonly strings, numbers, or arrays. The wire schema MUST accept any
+	// valid JSON value and hash it consistently.
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "echo"},
+		Input:     json.RawMessage(`"hello"`),
+		Output:    json.RawMessage(`["a","b"]`),
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("primitive input + array output should be accepted: %v", err)
+	}
+	chainReceipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := chainReceipts[0]
+	if r.CredentialSubject.Action.ParametersHash == "" {
+		t.Error("primitive input must produce a parameters_hash")
+	}
+	if r.CredentialSubject.Outcome.ResponseHash == "" {
+		t.Error("array output must produce a response_hash")
 	}
 }
 
@@ -267,9 +465,6 @@ func TestProcess_RejectsMalformedFrames(t *testing.T) {
 		{"missing tool.name", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{},"decision":"allowed"}`},
 		{"missing decision", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"}}`},
 		{"unknown decision", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"maybe"}`},
-		{"input present (Phase 1 forbidden)", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"allowed","input":{"x":1}}`},
-		{"output present (Phase 1 forbidden)", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"allowed","output":{"y":2}}`},
-		{"input as primitive (Phase 1 forbidden)", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"allowed","input":"hello"}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -412,6 +412,48 @@ func TestProcess_AcceptsPrimitiveInputOutput(t *testing.T) {
 	}
 }
 
+func TestProcess_RejectsUnrepresentableNumbers(t *testing.T) {
+	// 1e400 is syntactically valid JSON, so it survives the EmitterFrame
+	// unmarshal (json.RawMessage stores the token verbatim without numeric
+	// parsing). Re-unmarshaling into Go's `any` for canonicalisation fails
+	// because the value overflows float64. The daemon MUST surface that as a
+	// per-frame error and keep running — a panic here would let any
+	// authenticated emitter DoS the daemon for every other emitter on the
+	// same socket.
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"input is unrepresentable number", []byte(`{"v":"1","ts_emit":"2026-05-03T00:00:00Z","session_id":"s","channel":"sdk","tool":{"name":"t"},"input":1e400,"decision":"allowed"}`)},
+		{"output is unrepresentable number", []byte(`{"v":"1","ts_emit":"2026-05-03T00:00:00Z","session_id":"s","channel":"sdk","tool":{"name":"t"},"output":1e400,"decision":"allowed"}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Process panicked on %s — daemon would crash: %v", tc.name, r)
+				}
+			}()
+			if err := p.Process(socket.Frame{Payload: tc.payload}); err == nil {
+				t.Errorf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+
+	// Chain state must NOT have advanced — error before persist means
+	// alloc.Rollback ran on every case.
+	a := state.Allocate()
+	defer a.Rollback()
+	if a.Sequence != 1 {
+		t.Errorf("after rejected frames, next seq = %d, want 1 (no advance)", a.Sequence)
+	}
+}
+
 func TestProcess_DaemonControlsAllTimestamps(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)


### PR DESCRIPTION
## What

Lift the Phase 1 hard-reject of non-null `input`/`output` in emitter frames. In `pipeline.buildAndSign`, hash any non-null `f.Input` and `f.Output` symmetrically via a new `canonicalSHA256` helper (`receipt.Canonicalize` + `SHA256Hash`); the digests land on `Action.ParametersHash` and `Outcome.ResponseHash` respectively. Both gate on `hasJSONPayload` so a literal JSON `null` (or omitted field) still produces no hash — hashing the literal `"null"` would falsely commit the daemon to a value the emitter never sent.

The implementation deliberately does not route Output through `receipt.CreateInput.ResponseBody`: that helper `panic`s on JSON unmarshal/canonicalize failure, and emitter-controlled bytes can be syntactically valid (so they pass `EmitterFrame` parse) yet fail re-unmarshal — `1e400` overflows float64. Routing Output through it would have given any authenticated emitter a remote DoS. Both hash paths now surface unmarshal/canonicalize errors as `buildAndSign` returns, which the caller maps to `alloc.Rollback()` and a clean per-frame failure.

`pipeline.Process` is also hardened against panics from any source between `Allocate` and `Commit`: `chain.Allocation.Commit`/`Rollback` are idempotent via `sync.Once`, and `Process` does `defer alloc.Rollback()` immediately after `Allocate`. Any panic now releases the chain mutex instead of orphaning it (the orphan would have deadlocked the daemon for every subsequent emitter).

The receipt format is unchanged: this enables the existing `action.parameters_hash` and `outcome.response_hash` fields. No SDK hashing path was touched.

## Why

Phase 1 of the daemon (#322) deliberately rejected `input`/`output` because the canonical-hash path was not yet wired through `receipt.Create`. Section 3 of the daemon-process-separation rollout (#236) refactors mcp-proxy and the three SDKs into thin emitters that send real tool I/O. Per OQ3 ([ADR-0010 amendment 2026-05-06](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md#2026-05-06-oq3--sdk-cutover-sequencing--single-shot-release)) those five modules ship in one release — none of them can ship until the daemon accepts what they need to send.

Closes #332.

## Tests

Added in `daemon/internal/pipeline/build_test.go`:

- `TestProcess_HashesInput` / `TestProcess_HashesOutput` — assert the resulting receipts' hashes match independent re-canonicalization of the original payload (no shortcut through the daemon's internals).
- `TestProcess_HashesAreCanonical` — same logical payload sent two different ways (key order, whitespace) MUST produce identical hashes. Guards the cross-language determinism property.
- `TestProcess_AcceptsPrimitiveInputOutput` — primitives (string) and arrays are accepted and hashed; not all tool I/O is a JSON object.
- `TestProcess_RejectsUnrepresentableNumbers` — emitter-controlled `1e400` (syntactically valid JSON, fails re-unmarshal into float64) returns a per-frame error, no panic, no chain advance.
- `TestProcess_PanicReleasesChainAllocation` — injects a `KeySource` that panics on `Sign`, expects `Process` to panic, then asserts the next `state.Allocate` returns within 2s rather than hanging. Guards future panic sources.
- Strengthened `TestProcess_AcceptsExplicitNullInputOutput` to assert that `null` produces empty hash fields (regression-safety on the documented null-as-absent behavior).
- Removed three cases from `TestProcess_RejectsMalformedFrames` that asserted the Phase 1 reject — the positive tests above replace that coverage.

Added in `daemon/internal/chain/state_test.go`:

- `TestRollbackAfterCommitIsNoOp` / `TestCommitAfterRollbackIsNoOp` / `TestDoubleRollbackIsNoOp` — pin the `sync.Once`-guarded idempotency that pipeline's deferred `Rollback` relies on.

## Checklist

- [x] Tests pass for all changed components — `daemon/internal/pipeline` and `daemon/internal/chain` green with `-race`; full unit suite passes; cross-sdk-tests integration suite passes
- [x] Linter passes (`go vet ./...`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (`cross-sdk-tests` `go test -tags=integration` ✓; no SDK hashing or canonicalization logic changed, daemon uses `sdk/go/receipt.Canonicalize`/`SHA256Hash` unchanged)
- [ ] AGENTS.md updated — N/A (no project structure change)
- [ ] Spec changes have been reviewed by a maintainer — N/A (no spec change; this enables existing `parameters_hash` / `response_hash` fields documented in spec/)

## Pre-existing flake noticed (out of scope)

Five integration tests in `daemon/integration_test.go` and one in `daemon/internal/socket/listener_test.go` fail on macOS hosts whose `t.TempDir()` produces socket paths longer than the 104-byte `AF_UNIX` `sun_path` limit (`/var/folders/.../events.sock` is typically ~119 chars). Reproduces on `main` without these changes; passes on GitHub's macOS runner (shorter `$TMPDIR`). Worth a short follow-up to use a shorter path or honor a test override; not appropriate to fix in this PR's scope.