### PR TITLE
sdk/go(emitter): thin fire-and-forget client for daemon socket

### DIFF
--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -1,0 +1,338 @@
+// Package emitter is a thin fire-and-forget client for the agent-receipts
+// daemon's local Unix-domain socket. Emit forwards a tool-call frame to the
+// daemon, which captures peer credentials, canonicalises (RFC 8785), signs
+// (Ed25519), and persists the receipt. The emitter does NO crypto, NO
+// canonicalisation, and holds NO chain state — those moved to the daemon
+// per ADR-0010 (daemon process separation, 2026-05-03).
+//
+// Concurrency: Emit is safe to call from multiple goroutines on a single
+// Emitter instance. A mutex serialises the length-prefix + body write so
+// concurrent calls cannot interleave bytes on the same socket connection.
+//
+// Failure model: Emit MUST NOT block the agent on the daemon. When the
+// socket is unreachable (daemon not started, socket file missing, broken
+// connection) Emit logs a debug-level drop via the configured slog.Logger
+// and returns nil within milliseconds. Per ADR-0010 §"Permissions and
+// trust", a drop with the daemon NOT running is silent by design — there
+// is no daemon to record the gap. The EAGAIN-driven local drop counter
+// described in the same section ships in a follow-up commit; for now,
+// every drop reason takes the same silent path.
+package emitter
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MaxFrameSize must agree with the daemon's socket.MaxFrameSize (1 MiB).
+// Bodies larger than this are rejected at Emit; the daemon would refuse
+// them at read time anyway.
+const MaxFrameSize = 1 << 20
+
+// SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
+// The wire format is versioned; bumping it requires a daemon-side
+// translator, so a single supported value is the only safe contract.
+const SupportedFrameVersion = "1"
+
+// dialTimeout caps how long Emit blocks attempting to reach the daemon.
+// 25ms is well under the fire-and-forget budget but still tolerant of
+// slow filesystems on contended hosts; net.DialTimeout on AF_UNIX
+// typically returns in microseconds when the socket is present.
+const dialTimeout = 25 * time.Millisecond
+
+// writeTimeout caps how long a single frame write can block. Local
+// AF_UNIX writes of <1 MiB normally complete in microseconds; this
+// deadline exists to enforce the fire-and-forget contract if a
+// pathological case (full kernel send buffer, frozen daemon) appears.
+const writeTimeout = 100 * time.Millisecond
+
+// Tool identifies the tool the agent invoked. Server is optional — SDK
+// channels often have no server qualifier — and produces an action.type
+// of "channel.name" rather than "channel.server.name".
+type Tool struct {
+	Server string
+	Name   string
+}
+
+// Event is one tool invocation forwarded to the daemon. Input and Output
+// are raw JSON bytes; the daemon canonicalises them (RFC 8785) and writes
+// only the SHA-256 digest to the receipt. Either may be nil to indicate
+// no payload.
+type Event struct {
+	Channel  string
+	Tool     Tool
+	Input    json.RawMessage
+	Output   json.RawMessage
+	Error    string
+	Decision string
+}
+
+// Option configures an Emitter at construction.
+type Option func(*config)
+
+type config struct {
+	socketPath string
+	sessionID  string
+	logger     *slog.Logger
+}
+
+// WithSocketPath overrides the daemon socket path. When unset, the path
+// is resolved from the AGENTRECEIPTS_SOCKET environment variable, then
+// the per-OS default (see DefaultSocketPath).
+func WithSocketPath(path string) Option {
+	return func(c *config) { c.socketPath = path }
+}
+
+// WithSessionID forwards a host- or parent-process-supplied session
+// identifier instead of generating a fresh UUID v4. Per ADR-0010 OQ4
+// (amendment 2026-05-06), the host's session id is preferred when
+// available so a single agent loop produces one logical session across
+// every emitter inside it. An empty string is treated as "no host id
+// provided" and New falls back to a generated UUID, since the daemon
+// rejects frames with an empty session_id.
+func WithSessionID(id string) Option {
+	return func(c *config) { c.sessionID = id }
+}
+
+// WithLogger sets the slog.Logger used for drop diagnostics. Defaults to
+// slog.Default(). Pass slog.New(slog.NewTextHandler(io.Discard, nil)) to
+// silence drop logs entirely (e.g. in tests).
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) { c.logger = l }
+}
+
+// Emitter is the daemon-socket client. Construct with New, fire events
+// with Emit, release the socket with Close. Safe for concurrent Emit.
+type Emitter struct {
+	socketPath string
+	sessionID  string
+	logger     *slog.Logger
+
+	mu     sync.Mutex
+	conn   net.Conn
+	closed bool
+}
+
+// New returns an Emitter with the given options applied. The session_id
+// is fixed for the lifetime of the returned Emitter (ADR-0010 OQ4):
+// every Emit, including those after a daemon reconnect, carries the
+// same value. Call Close to release the socket.
+//
+// New does NOT dial the daemon — dialing is lazy on the first Emit so
+// that constructing an emitter cannot fail because the daemon happens
+// to be down at the moment.
+func New(opts ...Option) (*Emitter, error) {
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.socketPath == "" {
+		cfg.socketPath = DefaultSocketPath()
+	}
+	if cfg.socketPath == "" {
+		return nil, fmt.Errorf("emitter: no default socket path on %s; set AGENTRECEIPTS_SOCKET or pass WithSocketPath", runtime.GOOS)
+	}
+	if cfg.sessionID == "" {
+		cfg.sessionID = uuid.NewString()
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.Default()
+	}
+	return &Emitter{
+		socketPath: cfg.socketPath,
+		sessionID:  cfg.sessionID,
+		logger:     cfg.logger,
+	}, nil
+}
+
+// SessionID returns the stable per-emitter session identifier. Useful for
+// tests and for callers that want to log or correlate the value the
+// daemon is recording on every receipt.
+func (e *Emitter) SessionID() string { return e.sessionID }
+
+// frame mirrors daemon/internal/pipeline.EmitterFrame field-for-field.
+// Defined locally so the emitter does not import a daemon-internal
+// package; the wire format is the contract, not the type definition.
+type frame struct {
+	Version   string          `json:"v"`
+	TsEmit    string          `json:"ts_emit"`
+	SessionID string          `json:"session_id"`
+	Channel   string          `json:"channel"`
+	Tool      frameTool       `json:"tool"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Decision  string          `json:"decision"`
+}
+
+type frameTool struct {
+	Server string `json:"server,omitempty"`
+	Name   string `json:"name"`
+}
+
+// Emit sends one event to the daemon. Returns nil even when the daemon
+// is unreachable: dial and write failures are logged at debug level and
+// the conn is reset for re-dial on the next Emit. Returns an error only
+// for caller bugs (Emitter closed, oversized frame, malformed input
+// causing JSON marshal to fail) — situations a retry could not fix.
+func (e *Emitter) Emit(ctx context.Context, ev Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(frame{
+		Version:   SupportedFrameVersion,
+		TsEmit:    time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID: e.sessionID,
+		Channel:   ev.Channel,
+		Tool:      frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
+		Input:     ev.Input,
+		Output:    ev.Output,
+		Error:     ev.Error,
+		Decision:  ev.Decision,
+	})
+	if err != nil {
+		return fmt.Errorf("emitter: marshal frame: %w", err)
+	}
+	if len(body) > MaxFrameSize {
+		// Surface oversize as a returned error rather than silent drop:
+		// the daemon would reject the frame at read time too, so this
+		// is a logic bug in the caller, not a transient outage.
+		return fmt.Errorf("emitter: frame too large: %d bytes (max %d)", len(body), MaxFrameSize)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return errors.New("emitter: closed")
+	}
+
+	if err := e.dialIfNeededLocked(); err != nil {
+		e.logDrop(ctx, "dial", err)
+		return nil
+	}
+	if err := e.writeFrameLocked(body); err != nil {
+		e.logDrop(ctx, "write", err)
+		// A failed write almost always means the daemon went away. Drop
+		// the conn so the next Emit re-dials transparently. Per ADR-0010
+		// the redial happens on the FOLLOWING Emit, not as an inline
+		// retry — an inline retry would double the worst-case Emit
+		// latency on every actual outage.
+		_ = e.conn.Close()
+		e.conn = nil
+		return nil
+	}
+	return nil
+}
+
+// Close releases the underlying connection. After Close, subsequent Emit
+// calls return an error. Safe to call multiple times.
+func (e *Emitter) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return nil
+	}
+	e.closed = true
+	if e.conn == nil {
+		return nil
+	}
+	err := e.conn.Close()
+	e.conn = nil
+	return err
+}
+
+func (e *Emitter) dialIfNeededLocked() error {
+	if e.conn != nil {
+		return nil
+	}
+	conn, err := net.DialTimeout("unix", e.socketPath, dialTimeout)
+	if err != nil {
+		return err
+	}
+	e.conn = conn
+	return nil
+}
+
+func (e *Emitter) writeFrameLocked(body []byte) error {
+	if err := e.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return err
+	}
+	defer func() { _ = e.conn.SetWriteDeadline(time.Time{}) }()
+
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	if err := writeAll(e.conn, hdr[:]); err != nil {
+		return err
+	}
+	return writeAll(e.conn, body)
+}
+
+// writeAll handles the io.Writer short-write contract. Local AF_UNIX
+// streams almost always complete in one Write, but a partial write
+// would corrupt the length-prefix framing the daemon relies on, so the
+// loop is correctness, not paranoia.
+func writeAll(w io.Writer, buf []byte) error {
+	for len(buf) > 0 {
+		n, err := w.Write(buf)
+		if err != nil {
+			return err
+		}
+		buf = buf[n:]
+	}
+	return nil
+}
+
+func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
+	e.logger.LogAttrs(ctx, slog.LevelDebug, "agent-receipts emitter dropped event",
+		slog.String("stage", stage),
+		slog.String("socket", e.socketPath),
+		slog.String("err", err.Error()),
+	)
+}
+
+// DefaultSocketPath returns the per-OS default daemon socket path. Mirrors
+// daemon.DefaultSocketPath exactly so emitter and daemon agree without
+// either importing the other:
+//
+//   - AGENTRECEIPTS_SOCKET wins when set (any platform).
+//   - macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
+//   - Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/
+//     events.sock — per-user, unprivileged.
+//   - Linux fallback: /run/agentreceipts/events.sock (system-install path).
+//   - Other platforms: empty string. New returns an error in that case
+//     so callers must pass WithSocketPath explicitly.
+func DefaultSocketPath() string {
+	if p := os.Getenv("AGENTRECEIPTS_SOCKET"); p != "" {
+		return p
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		base := os.Getenv("TMPDIR")
+		if base == "" {
+			base = "/tmp"
+		}
+		return filepath.Join(base, "agentreceipts", "events.sock")
+	case "linux":
+		if base := os.Getenv("XDG_RUNTIME_DIR"); base != "" {
+			return filepath.Join(base, "agentreceipts", "events.sock")
+		}
+		return "/run/agentreceipts/events.sock"
+	default:
+		return ""
+	}
+}

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -215,12 +215,12 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	// the caller than to silently drop on the daemon side.
 	if len(ev.Input) > 0 {
 		if err := json.Unmarshal(ev.Input, new(interface{})); err != nil {
-			return fmt.Errorf("emitter: Input is not valid JSON: %w", err)
+			return fmt.Errorf("emitter: Input is not valid or representable JSON: %w", err)
 		}
 	}
 	if len(ev.Output) > 0 {
 		if err := json.Unmarshal(ev.Output, new(interface{})); err != nil {
-			return fmt.Errorf("emitter: Output is not valid JSON: %w", err)
+			return fmt.Errorf("emitter: Output is not valid or representable JSON: %w", err)
 		}
 	}
 

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -204,11 +204,20 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	default:
 		return fmt.Errorf("emitter: invalid decision %q (want allowed|denied|pending)", ev.Decision)
 	}
-	if len(ev.Input) > 0 && !json.Valid(ev.Input) {
-		return errors.New("emitter: Input is not valid JSON")
+	// json.Valid only checks lexical syntax — `1e400` parses as a token but
+	// overflows float64, so the daemon's RFC 8785 canonicalisation (which
+	// re-unmarshals into Go values) would reject it. Use Unmarshal here to
+	// gate exactly what the daemon can canonicalise; better to fail fast at
+	// the caller than to silently drop on the daemon side.
+	if len(ev.Input) > 0 {
+		if err := json.Unmarshal(ev.Input, new(interface{})); err != nil {
+			return fmt.Errorf("emitter: Input is not valid JSON: %w", err)
+		}
 	}
-	if len(ev.Output) > 0 && !json.Valid(ev.Output) {
-		return errors.New("emitter: Output is not valid JSON")
+	if len(ev.Output) > 0 {
+		if err := json.Unmarshal(ev.Output, new(interface{})); err != nil {
+			return fmt.Errorf("emitter: Output is not valid JSON: %w", err)
+		}
 	}
 
 	body, err := json.Marshal(frame{
@@ -239,11 +248,11 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		return errors.New("emitter: closed")
 	}
 
-	if err := e.dialIfNeededLocked(); err != nil {
+	if err := e.dialIfNeededLocked(ctx); err != nil {
 		e.logDrop(ctx, "dial", err)
 		return nil
 	}
-	if err := e.writeFrameLocked(body); err != nil {
+	if err := e.writeFrameLocked(ctx, body); err != nil {
 		e.logDrop(ctx, "write", err)
 		// A failed write almost always means the daemon went away. Drop
 		// the conn so the next Emit re-dials transparently. Per ADR-0010
@@ -274,11 +283,16 @@ func (e *Emitter) Close() error {
 	return err
 }
 
-func (e *Emitter) dialIfNeededLocked() error {
+func (e *Emitter) dialIfNeededLocked(ctx context.Context) error {
 	if e.conn != nil {
 		return nil
 	}
-	conn, err := net.DialTimeout("unix", e.socketPath, dialTimeout)
+	// Use DialContext rather than net.DialTimeout so that a caller-supplied
+	// ctx with a tighter deadline (or one that has been cancelled) cuts the
+	// dial short. net.DialTimeout would otherwise let Emit block up to the
+	// full dialTimeout regardless of ctx state.
+	d := net.Dialer{Timeout: dialTimeout}
+	conn, err := d.DialContext(ctx, "unix", e.socketPath)
 	if err != nil {
 		return err
 	}
@@ -286,8 +300,16 @@ func (e *Emitter) dialIfNeededLocked() error {
 	return nil
 }
 
-func (e *Emitter) writeFrameLocked(body []byte) error {
-	if err := e.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+func (e *Emitter) writeFrameLocked(ctx context.Context, body []byte) error {
+	// The effective write deadline is min(now+writeTimeout, ctx.Deadline()).
+	// Without honouring ctx here, a caller's tighter deadline could be
+	// silently extended up to writeTimeout, breaking the fire-and-forget
+	// budget callers expect when they pass a ctx with a deadline.
+	deadline := time.Now().Add(writeTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := e.conn.SetWriteDeadline(deadline); err != nil {
 		return err
 	}
 	defer func() { _ = e.conn.SetWriteDeadline(time.Time{}) }()

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -146,7 +146,7 @@ func New(opts ...Option) (*Emitter, error) {
 		cfg.socketPath = DefaultSocketPath()
 	}
 	if cfg.socketPath == "" {
-		return nil, fmt.Errorf("emitter: no default socket path on %s; set AGENTRECEIPTS_SOCKET or pass WithSocketPath", runtime.GOOS)
+		return nil, fmt.Errorf("emitter: no default socket path on %s; pass WithSocketPath", runtime.GOOS)
 	}
 	if cfg.sessionID == "" {
 		cfg.sessionID = uuid.NewString()
@@ -418,30 +418,33 @@ func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
 
 // DefaultSocketPath returns the per-OS default path for the daemon socket.
 // The OS rules match daemon.DefaultSocketPath; the emitter adds one layer:
-// AGENTRECEIPTS_SOCKET is consulted first so a single env var redirects
-// both daemon and emitter to a non-default socket. The daemon reads the
-// env var in main, not in its DefaultSocketPath, so the two functions are
-// not identical despite producing the same paths when the env var is unset.
+// AGENTRECEIPTS_SOCKET is consulted first on supported platforms so a
+// single env var redirects both daemon and emitter to a non-default socket.
+// The daemon reads the env var in main, not in its DefaultSocketPath, so
+// the two functions are not identical despite producing the same paths when
+// the env var is unset.
 //
-//   - AGENTRECEIPTS_SOCKET (any platform): overrides all OS rules.
-//   - macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
-//   - Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/
-//     events.sock — per-user, unprivileged.
-//   - Linux fallback: /run/agentreceipts/events.sock (system-install path).
-//   - Other platforms: empty string. New returns an error in that case
-//     so callers must pass WithSocketPath explicitly.
+//   - macOS: AGENTRECEIPTS_SOCKET if set, else $TMPDIR/agentreceipts/events.sock
+//     (TMPDIR defaults to /tmp).
+//   - Linux: AGENTRECEIPTS_SOCKET if set, else $XDG_RUNTIME_DIR/agentreceipts/
+//     events.sock when XDG_RUNTIME_DIR is set, else /run/agentreceipts/events.sock.
+//   - Other platforms: empty string. New returns an error in that case;
+//     callers must pass WithSocketPath explicitly.
 func DefaultSocketPath() string {
-	if p := os.Getenv("AGENTRECEIPTS_SOCKET"); p != "" {
-		return p
-	}
 	switch runtime.GOOS {
 	case "darwin":
+		if p := os.Getenv("AGENTRECEIPTS_SOCKET"); p != "" {
+			return p
+		}
 		base := os.Getenv("TMPDIR")
 		if base == "" {
 			base = "/tmp"
 		}
 		return filepath.Join(base, "agentreceipts", "events.sock")
 	case "linux":
+		if p := os.Getenv("AGENTRECEIPTS_SOCKET"); p != "" {
+			return p
+		}
 		if base := os.Getenv("XDG_RUNTIME_DIR"); base != "" {
 			return filepath.Join(base, "agentreceipts", "events.sock")
 		}

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -260,6 +260,9 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	if needDial {
 		dialed, err := e.dial(ctx)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			e.logDrop(ctx, "dial", err)
 			return nil
 		}
@@ -362,16 +365,19 @@ func (e *Emitter) writeFrame(ctx context.Context, conn net.Conn, body []byte) er
 		deadline = d
 	}
 	if err := conn.SetWriteDeadline(deadline); err != nil {
-		return err
+		return fmt.Errorf("set write deadline: %w", err)
 	}
 	defer func() { _ = conn.SetWriteDeadline(time.Time{}) }()
 
 	var hdr [4]byte
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
 	if err := writeAll(conn, hdr[:]); err != nil {
-		return err
+		return fmt.Errorf("write header: %w", err)
 	}
-	return writeAll(conn, body)
+	if err := writeAll(conn, body); err != nil {
+		return fmt.Errorf("write body: %w", err)
+	}
+	return nil
 }
 
 // writeAll handles the io.Writer short-write contract. Local AF_UNIX

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -8,6 +8,9 @@
 // Concurrency: Emit is safe to call from multiple goroutines on a single
 // Emitter instance. A mutex serialises the length-prefix + body write so
 // concurrent calls cannot interleave bytes on the same socket connection.
+// The dial step happens OUTSIDE the mutex so a slow accept (up to
+// dialTimeout) cannot stall sibling Emit calls past their fire-and-forget
+// budget; only the framed write itself holds the lock.
 //
 // Failure model: Emit MUST NOT block the agent on the daemon. When the
 // socket is unreachable (daemon not started, socket file missing, broken
@@ -241,25 +244,75 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		return fmt.Errorf("emitter: frame too large: %d bytes (max %d)", len(body), MaxFrameSize)
 	}
 
+	// Snapshot connection state under a brief lock. Holding e.mu across
+	// the dial would serialise every concurrent Emit on a single dial's
+	// 25ms timeout, blowing the per-call fire-and-forget budget under
+	// load; instead we only lock for the snapshot, the optional install,
+	// and the framed write.
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return errors.New("emitter: closed")
+	}
+	needDial := e.conn == nil
+	e.mu.Unlock()
+
+	if needDial {
+		dialed, err := e.dial(ctx)
+		if err != nil {
+			e.logDrop(ctx, "dial", err)
+			return nil
+		}
+		// Install with a check-and-set: if a sibling Emit dialled and
+		// installed first while we were dialling, prefer the established
+		// connection and discard ours. Costs one redundant dial in the
+		// race window — cheaper than serialising every Emit on a single
+		// dial. If the emitter was closed while we were dialling, drop
+		// our conn so it does not leak past Close.
+		e.mu.Lock()
+		switch {
+		case e.closed:
+			e.mu.Unlock()
+			_ = dialed.Close()
+			return errors.New("emitter: closed")
+		case e.conn == nil:
+			e.conn = dialed
+		default:
+			// Loser of the dial race. Close the redundant conn after
+			// releasing the mutex so we do not block sibling Emits on
+			// the kernel close path.
+			defer func() { _ = dialed.Close() }()
+		}
+		e.mu.Unlock()
+	}
+
+	// Hold e.mu across the write so concurrent Emits cannot interleave
+	// length-prefix + body bytes on the same conn. The write deadline
+	// caps how long the lock is held in the pathological case (frozen
+	// daemon with a full kernel send buffer).
 	e.mu.Lock()
 	defer e.mu.Unlock()
-
 	if e.closed {
 		return errors.New("emitter: closed")
 	}
-
-	if err := e.dialIfNeededLocked(ctx); err != nil {
-		e.logDrop(ctx, "dial", err)
+	conn := e.conn
+	if conn == nil {
+		// A sibling Emit's write failed and reset e.conn between our
+		// dial-install and write-lock acquisition. Re-dialing inline
+		// would double the worst-case Emit latency on every outage
+		// (ADR-0010 prefers next-Emit re-dial); drop and let the next
+		// Emit re-establish.
+		e.logDrop(ctx, "write", errors.New("connection reset by sibling Emit"))
 		return nil
 	}
-	if err := e.writeFrameLocked(ctx, body); err != nil {
+	if err := e.writeFrame(ctx, conn, body); err != nil {
 		e.logDrop(ctx, "write", err)
 		// A failed write almost always means the daemon went away. Drop
 		// the conn so the next Emit re-dials transparently. Per ADR-0010
 		// the redial happens on the FOLLOWING Emit, not as an inline
 		// retry — an inline retry would double the worst-case Emit
 		// latency on every actual outage.
-		_ = e.conn.Close()
+		_ = conn.Close()
 		e.conn = nil
 		return nil
 	}
@@ -280,27 +333,26 @@ func (e *Emitter) Close() error {
 	}
 	err := e.conn.Close()
 	e.conn = nil
-	return err
-}
-
-func (e *Emitter) dialIfNeededLocked(ctx context.Context) error {
-	if e.conn != nil {
-		return nil
-	}
-	// Use DialContext rather than net.DialTimeout so that a caller-supplied
-	// ctx with a tighter deadline (or one that has been cancelled) cuts the
-	// dial short. net.DialTimeout would otherwise let Emit block up to the
-	// full dialTimeout regardless of ctx state.
-	d := net.Dialer{Timeout: dialTimeout}
-	conn, err := d.DialContext(ctx, "unix", e.socketPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("emitter: close: %w", err)
 	}
-	e.conn = conn
 	return nil
 }
 
-func (e *Emitter) writeFrameLocked(ctx context.Context, body []byte) error {
+// dial opens a new connection to the daemon socket. Runs OUTSIDE e.mu so
+// concurrent Emit calls don't serialise on a single 25ms dialTimeout.
+// DialContext is used (not net.DialTimeout) so a caller-supplied ctx with
+// a tighter deadline cuts the dial short.
+func (e *Emitter) dial(ctx context.Context) (net.Conn, error) {
+	d := net.Dialer{Timeout: dialTimeout}
+	return d.DialContext(ctx, "unix", e.socketPath)
+}
+
+// writeFrame writes one length-prefixed frame to conn. The caller must
+// hold e.mu so concurrent writes cannot interleave bytes on the same
+// connection (the 4-byte header and body must reach the daemon as one
+// contiguous sequence).
+func (e *Emitter) writeFrame(ctx context.Context, conn net.Conn, body []byte) error {
 	// The effective write deadline is min(now+writeTimeout, ctx.Deadline()).
 	// Without honouring ctx here, a caller's tighter deadline could be
 	// silently extended up to writeTimeout, breaking the fire-and-forget
@@ -309,17 +361,17 @@ func (e *Emitter) writeFrameLocked(ctx context.Context, body []byte) error {
 	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
 		deadline = d
 	}
-	if err := e.conn.SetWriteDeadline(deadline); err != nil {
+	if err := conn.SetWriteDeadline(deadline); err != nil {
 		return err
 	}
-	defer func() { _ = e.conn.SetWriteDeadline(time.Time{}) }()
+	defer func() { _ = conn.SetWriteDeadline(time.Time{}) }()
 
 	var hdr [4]byte
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
-	if err := writeAll(e.conn, hdr[:]); err != nil {
+	if err := writeAll(conn, hdr[:]); err != nil {
 		return err
 	}
-	return writeAll(e.conn, body)
+	return writeAll(conn, body)
 }
 
 // writeAll handles the io.Writer short-write contract. Local AF_UNIX

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -217,7 +217,13 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	// json.Unmarshal pass. The daemon caps frames at MaxFrameSize anyway, so
 	// there is no point paying the Unmarshal cost on payloads that could never
 	// fit on the wire.
-	if len(ev.Input) > MaxFrameSize || len(ev.Output) > MaxFrameSize {
+	if ev.Input != nil && len(ev.Input) == 0 {
+		return fmt.Errorf("emitter: Input is a non-nil empty slice; pass nil to indicate no payload")
+	}
+	if ev.Output != nil && len(ev.Output) == 0 {
+		return fmt.Errorf("emitter: Output is a non-nil empty slice; pass nil to indicate no payload")
+	}
+	if len(ev.Input)+len(ev.Output) > MaxFrameSize {
 		return fmt.Errorf("emitter: Input or Output exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
 	}
 	// json.Valid only checks lexical syntax — `1e400` parses as a token but

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -95,6 +95,11 @@ type config struct {
 // WithSocketPath overrides the daemon socket path. When unset, the path
 // is resolved from the AGENTRECEIPTS_SOCKET environment variable, then
 // the per-OS default (see DefaultSocketPath).
+//
+// Callers that supply an explicit path bypass platform detection entirely
+// and take responsibility for ensuring the path is reachable on the
+// target OS. This is intentional: WithSocketPath works on any platform,
+// including those where DefaultSocketPath returns an empty string.
 func WithSocketPath(path string) Option {
 	return func(c *config) { c.socketPath = path }
 }
@@ -207,6 +212,13 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		// ok
 	default:
 		return fmt.Errorf("emitter: invalid decision %q (want allowed|denied|pending)", ev.Decision)
+	}
+	// Reject clearly oversized Input/Output before the more expensive
+	// json.Unmarshal pass. The daemon caps frames at MaxFrameSize anyway, so
+	// there is no point paying the Unmarshal cost on payloads that could never
+	// fit on the wire.
+	if len(ev.Input) > MaxFrameSize || len(ev.Output) > MaxFrameSize {
+		return fmt.Errorf("emitter: Input or Output exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
 	}
 	// json.Valid only checks lexical syntax — `1e400` parses as a token but
 	// overflows float64, so the daemon's RFC 8785 canonicalisation (which
@@ -397,7 +409,9 @@ func (e *Emitter) writeFrame(ctx context.Context, conn net.Conn, body []byte) er
 func writeAll(w io.Writer, buf []byte) error {
 	for len(buf) > 0 {
 		n, err := w.Write(buf)
-		buf = buf[n:]
+		if n > 0 {
+			buf = buf[n:]
+		}
 		if err != nil {
 			return err
 		}
@@ -423,6 +437,11 @@ func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
 // The daemon reads the env var in main, not in its DefaultSocketPath, so
 // the two functions are not identical despite producing the same paths when
 // the env var is unset.
+//
+// The platform gate in this function applies only to automatic default path
+// resolution. Callers that pass WithSocketPath to New bypass this function
+// entirely and can use any path on any OS — platform detection is not their
+// concern.
 //
 //   - macOS: AGENTRECEIPTS_SOCKET if set, else $TMPDIR/agentreceipts/events.sock
 //     (TMPDIR defaults to /tmp).

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -291,11 +291,13 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 
 	// Hold e.mu across the write so concurrent Emits cannot interleave
 	// length-prefix + body bytes on the same conn. The write deadline
-	// caps how long the lock is held in the pathological case (frozen
-	// daemon with a full kernel send buffer).
+	// caps how long the write itself blocks in the pathological case
+	// (frozen daemon with a full kernel send buffer). logDrop and
+	// conn.Close run outside the lock to avoid blocking sibling Emits
+	// on I/O while the mutex is held.
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if e.closed {
+		e.mu.Unlock()
 		return errors.New("emitter: closed")
 	}
 	conn := e.conn
@@ -305,20 +307,26 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		// would double the worst-case Emit latency on every outage
 		// (ADR-0010 prefers next-Emit re-dial); drop and let the next
 		// Emit re-establish.
+		e.mu.Unlock()
 		e.logDrop(ctx, "write", errors.New("connection reset by sibling Emit"))
 		return nil
 	}
 	if err := e.writeFrame(ctx, conn, body); err != nil {
-		e.logDrop(ctx, "write", err)
 		// A failed write almost always means the daemon went away. Drop
 		// the conn so the next Emit re-dials transparently. Per ADR-0010
 		// the redial happens on the FOLLOWING Emit, not as an inline
 		// retry — an inline retry would double the worst-case Emit
 		// latency on every actual outage.
-		_ = conn.Close()
+		// Nil conn before unlocking so sibling Emits see it gone; then
+		// call logDrop and conn.Close outside the lock (both can block
+		// on I/O — holding e.mu across them would stall sibling Emits).
 		e.conn = nil
+		e.mu.Unlock()
+		e.logDrop(ctx, "write", err)
+		_ = conn.Close()
 		return nil
 	}
+	e.mu.Unlock()
 	return nil
 }
 
@@ -387,13 +395,13 @@ func (e *Emitter) writeFrame(ctx context.Context, conn net.Conn, body []byte) er
 func writeAll(w io.Writer, buf []byte) error {
 	for len(buf) > 0 {
 		n, err := w.Write(buf)
+		buf = buf[n:]
 		if err != nil {
 			return err
 		}
 		if n == 0 {
 			return io.ErrShortWrite
 		}
-		buf = buf[n:]
 	}
 	return nil
 }

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -188,9 +188,10 @@ type frameTool struct {
 
 // Emit sends one event to the daemon. Returns nil even when the daemon
 // is unreachable: dial and write failures are logged at debug level and
-// the conn is reset for re-dial on the next Emit. Returns an error only
-// for caller bugs (Emitter closed, oversized frame, invalid event fields,
-// malformed Input/Output JSON) — situations a retry could not fix.
+// the conn is reset for re-dial on the next Emit. Returns an error for
+// caller bugs (Emitter closed, oversized frame, invalid event fields,
+// malformed Input/Output JSON — situations a retry could not fix) or
+// when ctx is already cancelled on entry or is cancelled while dialling.
 func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -334,17 +335,18 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 // calls return an error. Safe to call multiple times.
 func (e *Emitter) Close() error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if e.closed {
+		e.mu.Unlock()
 		return nil
 	}
 	e.closed = true
-	if e.conn == nil {
+	conn := e.conn
+	e.conn = nil
+	e.mu.Unlock()
+	if conn == nil {
 		return nil
 	}
-	err := e.conn.Close()
-	e.conn = nil
-	if err != nil {
+	if err := conn.Close(); err != nil {
 		return fmt.Errorf("emitter: close: %w", err)
 	}
 	return nil

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -224,7 +224,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		return fmt.Errorf("emitter: Output is a non-nil empty slice; pass nil to indicate no payload")
 	}
 	if len(ev.Input)+len(ev.Output) > MaxFrameSize {
-		return fmt.Errorf("emitter: Input or Output exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
+		return fmt.Errorf("emitter: combined Input+Output payload exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
 	}
 	// json.Valid only checks lexical syntax — `1e400` parses as a token but
 	// overflows float64, so the daemon's RFC 8785 canonicalisation (which

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -186,11 +186,29 @@ type frameTool struct {
 // Emit sends one event to the daemon. Returns nil even when the daemon
 // is unreachable: dial and write failures are logged at debug level and
 // the conn is reset for re-dial on the next Emit. Returns an error only
-// for caller bugs (Emitter closed, oversized frame, malformed input
-// causing JSON marshal to fail) — situations a retry could not fix.
+// for caller bugs (Emitter closed, oversized frame, invalid event fields,
+// malformed Input/Output JSON) — situations a retry could not fix.
 func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	if ev.Channel == "" {
+		return errors.New("emitter: missing channel")
+	}
+	if ev.Tool.Name == "" {
+		return errors.New("emitter: missing tool.name")
+	}
+	switch ev.Decision {
+	case "allowed", "denied", "pending":
+		// ok
+	default:
+		return fmt.Errorf("emitter: invalid decision %q (want allowed|denied|pending)", ev.Decision)
+	}
+	if len(ev.Input) > 0 && !json.Valid(ev.Input) {
+		return errors.New("emitter: Input is not valid JSON")
+	}
+	if len(ev.Output) > 0 && !json.Valid(ev.Output) {
+		return errors.New("emitter: Output is not valid JSON")
 	}
 
 	body, err := json.Marshal(frame{
@@ -292,6 +310,9 @@ func writeAll(w io.Writer, buf []byte) error {
 		if err != nil {
 			return err
 		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
 		buf = buf[n:]
 	}
 	return nil
@@ -305,11 +326,14 @@ func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
 	)
 }
 
-// DefaultSocketPath returns the per-OS default daemon socket path. Mirrors
-// daemon.DefaultSocketPath exactly so emitter and daemon agree without
-// either importing the other:
+// DefaultSocketPath returns the per-OS default path for the daemon socket.
+// The OS rules match daemon.DefaultSocketPath; the emitter adds one layer:
+// AGENTRECEIPTS_SOCKET is consulted first so a single env var redirects
+// both daemon and emitter to a non-default socket. The daemon reads the
+// env var in main, not in its DefaultSocketPath, so the two functions are
+// not identical despite producing the same paths when the env var is unset.
 //
-//   - AGENTRECEIPTS_SOCKET wins when set (any platform).
+//   - AGENTRECEIPTS_SOCKET (any platform): overrides all OS rules.
 //   - macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
 //   - Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/
 //     events.sock — per-user, unprivileged.

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -167,7 +167,9 @@ func waitForReceiptCount(t *testing.T, dbPath, chainID string, want int, timeout
 			t.Fatalf("open store: %v", err)
 		}
 		got, err := s.GetChain(chainID)
-		s.Close()
+		if cerr := s.Close(); cerr != nil {
+			t.Logf("close store: %v", cerr)
+		}
 		if err == nil && len(got) >= want {
 			return got
 		}

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -446,6 +446,58 @@ func TestEmit_ReturnsErrorAfterClose(t *testing.T) {
 	}
 }
 
+// TestEmit_ValidatesEvent checks that Emit returns an error immediately for
+// events the daemon would hard-reject, before any dial attempt. These are
+// caller bugs, not transient failures, so they must not be silently dropped.
+func TestEmit_ValidatesEvent(t *testing.T) {
+	em, err := emitter.New(
+		emitter.WithSocketPath("/nonexistent/events.sock"),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		ev   emitter.Event
+	}{
+		{
+			"missing channel",
+			emitter.Event{Tool: emitter.Tool{Name: "noop"}, Decision: "allowed"},
+		},
+		{
+			"missing tool.name",
+			emitter.Event{Channel: "sdk", Decision: "allowed"},
+		},
+		{
+			"empty decision",
+			emitter.Event{Channel: "sdk", Tool: emitter.Tool{Name: "noop"}},
+		},
+		{
+			"unknown decision",
+			emitter.Event{Channel: "sdk", Tool: emitter.Tool{Name: "noop"}, Decision: "maybe"},
+		},
+		{
+			"invalid Input JSON",
+			emitter.Event{Channel: "sdk", Tool: emitter.Tool{Name: "noop"}, Decision: "allowed", Input: json.RawMessage(`{bad}`)},
+		},
+		{
+			"invalid Output JSON",
+			emitter.Event{Channel: "sdk", Tool: emitter.Tool{Name: "noop"}, Decision: "allowed", Output: json.RawMessage(`[unclosed`)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := em.Emit(ctx, tc.ev); err == nil {
+				t.Error("Emit returned nil, want error")
+			}
+		})
+	}
+}
+
 // TestEmit_WithSessionIDOverride pins the OQ4 host-id forwarding path:
 // when WithSessionID supplies a non-empty value, every receipt carries
 // that exact id rather than a freshly generated UUID. Mirrors the

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -106,21 +106,23 @@ func startDaemon(t *testing.T, dir string) *daemonHandle {
 	done := make(chan error, 1)
 	go func() { done <- daemon.Run(ctx, cfg) }()
 
-	deadline := time.Now().Add(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
 	for {
 		if _, err := os.Stat(cfg.SocketPath); err == nil {
 			break
-		}
-		if time.Now().After(deadline) {
-			cancel()
-			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
 		}
 		select {
 		case err := <-done:
 			cancel()
 			t.Fatalf("daemon exited before socket appeared: %v", err)
-		default:
-			time.Sleep(10 * time.Millisecond)
+		case <-timeout.C:
+			cancel()
+			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
+		case <-ticker.C:
+			// poll again
 		}
 	}
 

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -1,0 +1,482 @@
+//go:build linux || darwin
+
+// Tests run end-to-end against an in-process agent-receipts daemon.
+// Build-tag-gated to linux/darwin because the emitter speaks AF_UNIX and the
+// daemon refuses to start on other platforms — running these tests on a
+// Windows builder would fail at daemon.Run, not at the emitter we want to
+// exercise.
+package emitter_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// shortSocketDir returns a temp directory whose path is short enough that a
+// socket filename inside it fits within the 104-byte AF_UNIX sun_path limit
+// on macOS. t.TempDir() on macOS produces ~119-char paths under
+// /var/folders/..., which exceed the limit and trip `bind: invalid argument`.
+//
+// Daemon-side tests use daemon/internal/sockettest.ShortSocketDir for the
+// same reason; that helper lives in an internal package and is not
+// importable from sdk/go, so this file inlines the same logic.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	base := "/tmp"
+	if _, err := os.Stat(base); err != nil {
+		base = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(base, "ar*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func writeTestKey(t *testing.T, path string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type daemonHandle struct {
+	cfg      daemon.Config
+	cancel   context.CancelFunc
+	done     <-chan error
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func startDaemon(t *testing.T, dir string) *daemonHandle {
+	t.Helper()
+	cfg := daemon.Config{
+		SocketPath:           filepath.Join(dir, "events.sock"),
+		DBPath:               filepath.Join(dir, "receipts.db"),
+		KeyPath:              filepath.Join(dir, "signing.key"),
+		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),
+		ChainID:              "emitter-test-chain",
+		IssuerID:             "did:agent-receipts-daemon:emitter-test",
+		VerificationMethodID: "did:agent-receipts-daemon:emitter-test#k1",
+		Logger:               log.New(io.Discard, "", 0),
+	}
+	if _, err := os.Stat(cfg.KeyPath); os.IsNotExist(err) {
+		writeTestKey(t, cfg.KeyPath)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(cfg.SocketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	d := &daemonHandle{cfg: cfg, cancel: cancel, done: done}
+	t.Cleanup(func() { d.stop(t) })
+	return d
+}
+
+// stop shuts the daemon down deterministically and waits for Run to return.
+// Idempotent via sync.Once so tests that explicitly stop a daemon mid-test
+// (TestEmit_ReconnectAfterDaemonRestart) do not race the t.Cleanup
+// registered by startDaemon — both paths converge on a single shutdown.
+func (d *daemonHandle) stop(t *testing.T) {
+	t.Helper()
+	d.stopOnce.Do(func() {
+		d.cancel()
+		select {
+		case err := <-d.done:
+			if err != nil {
+				t.Logf("daemon Run returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			d.stopErr = errors.New("daemon did not shut down within 3s")
+		}
+		// Confirm the socket is no longer accepting connections; a
+		// "reconnect" test that ran against a still-listening socket
+		// would silently pass without exercising the reconnect path.
+		if conn, err := net.Dial("unix", d.cfg.SocketPath); err == nil {
+			conn.Close()
+			d.stopErr = errors.New("socket still accepting connections after stop")
+		}
+	})
+	if d.stopErr != nil {
+		t.Fatal(d.stopErr)
+	}
+}
+
+func waitForReceiptCount(t *testing.T, dbPath, chainID string, want int, timeout time.Duration) []receipt.AgentReceipt {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		s, err := store.OpenReadOnly(dbPath)
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		got, err := s.GetChain(chainID)
+		s.Close()
+		if err == nil && len(got) >= want {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d receipts in chain %s; got %d (err=%v)", want, chainID, len(got), err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// silentLogger discards every log line so the fire-and-forget drop logs
+// do not pollute test output. Shared across tests rather than reallocated
+// per-call — the handler has no per-test state.
+var silentLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+// TestEmit_FrameRoundTrip is the basic acceptance test: three events fired
+// through the emitter materialise as three signed receipts in the daemon's
+// chain, with monotonic sequence and the channel/tool/decision values the
+// emitter sent.
+func TestEmit_FrameRoundTrip(t *testing.T) {
+	d := startDaemon(t, shortSocketDir(t))
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(d.cfg.SocketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	events := []emitter.Event{
+		{Channel: "sdk", Tool: emitter.Tool{Server: "fixture", Name: "alpha"}, Decision: "allowed"},
+		{Channel: "sdk", Tool: emitter.Tool{Server: "fixture", Name: "beta"}, Decision: "denied"},
+		{Channel: "sdk", Tool: emitter.Tool{Name: "gamma"}, Decision: "pending"},
+	}
+	ctx := context.Background()
+	for i, ev := range events {
+		if err := em.Emit(ctx, ev); err != nil {
+			t.Fatalf("Emit[%d]: %v", i, err)
+		}
+	}
+
+	receipts := waitForReceiptCount(t, d.cfg.DBPath, d.cfg.ChainID, len(events), 5*time.Second)
+	if len(receipts) != len(events) {
+		t.Fatalf("got %d receipts, want %d", len(receipts), len(events))
+	}
+
+	wantTypes := []string{"sdk.fixture.alpha", "sdk.fixture.beta", "sdk.gamma"}
+	wantStatus := []receipt.OutcomeStatus{receipt.StatusSuccess, receipt.StatusFailure, receipt.StatusPending}
+	for i, r := range receipts {
+		if r.CredentialSubject.Chain.Sequence != i+1 {
+			t.Errorf("receipt %d: seq = %d, want %d", i, r.CredentialSubject.Chain.Sequence, i+1)
+		}
+		if r.CredentialSubject.Action.Type != wantTypes[i] {
+			t.Errorf("receipt %d: action.type = %q, want %q", i, r.CredentialSubject.Action.Type, wantTypes[i])
+		}
+		if r.CredentialSubject.Action.ToolName != events[i].Tool.Name {
+			t.Errorf("receipt %d: action.tool_name = %q, want %q", i, r.CredentialSubject.Action.ToolName, events[i].Tool.Name)
+		}
+		if r.CredentialSubject.Outcome.Status != wantStatus[i] {
+			t.Errorf("receipt %d: outcome.status = %q, want %q", i, r.CredentialSubject.Outcome.Status, wantStatus[i])
+		}
+	}
+}
+
+// TestEmit_SessionIDStableAcrossEmits pins the OQ4 (ADR-0010, 2026-05-06)
+// rule: session_id is allocated once at New() and reused across every Emit
+// from the same emitter instance, never per-call. A regression that
+// generated a fresh UUID per emit would fragment a logical agent session
+// into N receipts with N session_ids.
+func TestEmit_SessionIDStableAcrossEmits(t *testing.T) {
+	d := startDaemon(t, shortSocketDir(t))
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(d.cfg.SocketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	wantSession := em.SessionID()
+	if wantSession == "" {
+		t.Fatal("emitter SessionID is empty; New() should generate a UUID v4")
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := em.Emit(ctx, emitter.Event{
+			Channel:  "sdk",
+			Tool:     emitter.Tool{Name: "noop"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit[%d]: %v", i, err)
+		}
+	}
+
+	receipts := waitForReceiptCount(t, d.cfg.DBPath, d.cfg.ChainID, 3, 5*time.Second)
+	for i, r := range receipts {
+		if r.Issuer.SessionID != wantSession {
+			t.Errorf("receipt %d: Issuer.SessionID = %q, want %q", i, r.Issuer.SessionID, wantSession)
+		}
+	}
+}
+
+// TestEmit_HashDeterminism guards that the emitter forwards Input bytes
+// faithfully — without re-encoding — so that the daemon's RFC 8785
+// canonicalisation is what actually determines parameters_hash. Two events
+// whose Input is logically identical but differs in whitespace and key
+// order MUST produce identical Action.ParametersHash. If the emitter ever
+// starts re-marshalling Input, one of the two payloads would canonicalise
+// to a different byte stream than the other, breaking this property.
+func TestEmit_HashDeterminism(t *testing.T) {
+	d := startDaemon(t, shortSocketDir(t))
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(d.cfg.SocketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	// Same logical {a:1, b:2} payload, different key order, different
+	// whitespace. RFC 8785 ignores both, so parameters_hash MUST match.
+	inputs := []json.RawMessage{
+		json.RawMessage(`{"a":1,"b":2}`),
+		json.RawMessage(`{ "b":  2 , "a" : 1 }`),
+	}
+	ctx := context.Background()
+	for i, in := range inputs {
+		if err := em.Emit(ctx, emitter.Event{
+			Channel:  "sdk",
+			Tool:     emitter.Tool{Name: "hash-fixture"},
+			Input:    in,
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit[%d]: %v", i, err)
+		}
+	}
+
+	receipts := waitForReceiptCount(t, d.cfg.DBPath, d.cfg.ChainID, len(inputs), 5*time.Second)
+	if h0, h1 := receipts[0].CredentialSubject.Action.ParametersHash, receipts[1].CredentialSubject.Action.ParametersHash; h0 == "" || h1 == "" || h0 != h1 {
+		t.Errorf("parameters_hash mismatch: receipt[0]=%q receipt[1]=%q (both must be non-empty and equal)", h0, h1)
+	}
+}
+
+// TestEmit_FireAndForgetWhenDaemonDown enforces the core fire-and-forget
+// contract from ADR-0010: an unreachable daemon MUST NOT block the agent.
+// Emit returns nil within milliseconds when the configured socket path
+// does not exist on disk.
+func TestEmit_FireAndForgetWhenDaemonDown(t *testing.T) {
+	dir := shortSocketDir(t)
+	socketPath := filepath.Join(dir, "no-such-daemon.sock")
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(socketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	ctx := context.Background()
+	start := time.Now()
+	err = em.Emit(ctx, emitter.Event{
+		Channel:  "sdk",
+		Tool:     emitter.Tool{Name: "noop"},
+		Decision: "allowed",
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("Emit returned err = %v, want nil (fire-and-forget)", err)
+	}
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("Emit blocked for %v, want <50ms (fire-and-forget contract)", elapsed)
+	}
+}
+
+// TestEmit_ReconnectAfterDaemonRestart proves the emitter survives a daemon
+// outage: connection drops, daemon comes back, the next Emit (or one of
+// the next few — ADR-0010 lets the emitter discover the broken conn at
+// write time and re-dial on the following Emit) succeeds with the same
+// session_id the emitter started with. Without lazy re-dial after a write
+// failure, every post-restart Emit would silently drop forever.
+func TestEmit_ReconnectAfterDaemonRestart(t *testing.T) {
+	dir := shortSocketDir(t)
+	d1 := startDaemon(t, dir)
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(d1.cfg.SocketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	wantSession := em.SessionID()
+	ctx := context.Background()
+
+	// Round 1: two events while the first daemon is up.
+	for i := 0; i < 2; i++ {
+		if err := em.Emit(ctx, emitter.Event{
+			Channel:  "sdk",
+			Tool:     emitter.Tool{Name: "before-restart"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("pre-restart Emit[%d]: %v", i, err)
+		}
+	}
+	_ = waitForReceiptCount(t, d1.cfg.DBPath, d1.cfg.ChainID, 2, 5*time.Second)
+
+	// Stop daemon 1, then start daemon 2 against the same DB / socket
+	// path. The second daemon resumes the existing chain (ADR-0010 OQ2:
+	// the daemon resumes from GetChainTail).
+	d1.stop(t)
+	d2 := startDaemon(t, dir)
+
+	// Loop until reconnect lands a receipt. The emitter holds a stale
+	// connection from daemon 1; the first Emit may fail at write time,
+	// after which the conn is closed and the next Emit redials. Tolerating
+	// a few attempts covers both orderings (immediate write failure
+	// vs. delayed broken-pipe detection) without a hard-coded retry count.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := em.Emit(ctx, emitter.Event{
+			Channel:  "sdk",
+			Tool:     emitter.Tool{Name: "after-restart"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("post-restart Emit: %v", err)
+		}
+		s, openErr := store.OpenReadOnly(d2.cfg.DBPath)
+		if openErr != nil {
+			t.Fatalf("open store: %v", openErr)
+		}
+		receipts, getErr := s.GetChain(d2.cfg.ChainID)
+		s.Close()
+		if getErr == nil && len(receipts) >= 3 {
+			// Verify at least one post-restart receipt carries the
+			// emitter's stable session_id. This is the OQ4 property
+			// (session_id persists across daemon reconnects).
+			for _, r := range receipts[2:] {
+				if r.Issuer.SessionID != wantSession {
+					t.Errorf("post-restart receipt session_id = %q, want %q", r.Issuer.SessionID, wantSession)
+				}
+				if r.CredentialSubject.Action.ToolName != "after-restart" {
+					t.Errorf("post-restart receipt tool_name = %q, want %q", r.CredentialSubject.Action.ToolName, "after-restart")
+				}
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("emitter did not reconnect to the restarted daemon within 5s")
+}
+
+// TestEmit_ReturnsErrorAfterClose pins the contract that Close finalises
+// the emitter: subsequent Emit calls return a clear error rather than
+// silently dropping. A silent post-Close drop would mask use-after-close
+// bugs in the caller (e.g. a deferred Emit firing after Close).
+func TestEmit_ReturnsErrorAfterClose(t *testing.T) {
+	dir := shortSocketDir(t)
+	d := startDaemon(t, dir)
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(d.cfg.SocketPath),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := em.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Second Close is a no-op — Close is idempotent.
+	if err := em.Close(); err != nil {
+		t.Errorf("second Close returned %v, want nil", err)
+	}
+
+	err = em.Emit(context.Background(), emitter.Event{
+		Channel: "sdk", Tool: emitter.Tool{Name: "noop"}, Decision: "allowed",
+	})
+	if err == nil {
+		t.Error("Emit after Close returned nil, want error")
+	}
+}
+
+// TestEmit_WithSessionIDOverride pins the OQ4 host-id forwarding path:
+// when WithSessionID supplies a non-empty value, every receipt carries
+// that exact id rather than a freshly generated UUID. Mirrors the
+// integration scenario where a host (Claude Code, an agent loop) owns
+// the session identifier and the emitter must propagate it untouched.
+func TestEmit_WithSessionIDOverride(t *testing.T) {
+	d := startDaemon(t, shortSocketDir(t))
+
+	const hostSession = "host-supplied-session-9f3a"
+	em, err := emitter.New(
+		emitter.WithSocketPath(d.cfg.SocketPath),
+		emitter.WithSessionID(hostSession),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+
+	if got := em.SessionID(); got != hostSession {
+		t.Fatalf("SessionID() = %q, want %q", got, hostSession)
+	}
+
+	if err := em.Emit(context.Background(), emitter.Event{
+		Channel: "sdk", Tool: emitter.Tool{Name: "noop"}, Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	receipts := waitForReceiptCount(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+	if got := receipts[0].Issuer.SessionID; got != hostSession {
+		t.Errorf("Issuer.SessionID = %q, want %q", got, hostSession)
+	}
+}

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -1,10 +1,20 @@
-//go:build linux || darwin
+//go:build integration && (linux || darwin)
 
 // Tests run end-to-end against an in-process agent-receipts daemon.
-// Build-tag-gated to linux/darwin because the emitter speaks AF_UNIX and the
-// daemon refuses to start on other platforms — running these tests on a
-// Windows builder would fail at daemon.Run, not at the emitter we want to
-// exercise.
+//
+// Build-tag-gated to:
+//   - integration: the test imports github.com/agent-receipts/ar/daemon, but
+//     sdk/go's published go.mod cannot require the daemon module — daemon
+//     already requires sdk/go, and a back-edge would create an import cycle.
+//     Under GOWORK=off (publish/verify path) the import would fail to resolve,
+//     so the integration tag keeps the test out of the default `go test ./...`
+//     run and pulls it in only via `go test -tags=integration` where go.work
+//     wires the two modules locally. Matches sdk/go/integration_test.go and
+//     sdk/go/cross_language_test.go which gate the same way for the same
+//     reason.
+//   - linux/darwin: the emitter speaks AF_UNIX and the daemon refuses to start
+//     on other platforms — running these tests on a Windows builder would fail
+//     at daemon.Run, not at the emitter we want to exercise.
 package emitter_test
 
 import (

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -115,7 +115,13 @@ func startDaemon(t *testing.T, dir string) *daemonHandle {
 			cancel()
 			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case err := <-done:
+			cancel()
+			t.Fatalf("daemon exited before socket appeared: %v", err)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 
 	d := &daemonHandle{cfg: cfg, cancel: cancel, done: done}


### PR DESCRIPTION
## What

New package `sdk/go/emitter` — a thin client that forwards tool-call events to the agent-receipts daemon over its local AF_UNIX socket. The package contains no crypto, no canonicalisation, and no chain state; `Emit` just marshals an `EmitterFrame`-shaped JSON, dials the daemon's socket lazily, and writes one length-prefixed frame per event. The daemon (post #322 + #333) does the rest: peer-credential capture, RFC 8785 canonicalisation, Ed25519 signing, persistence.

Public API:

```go
em, _ := emitter.New(emitter.WithSessionID(hostID))
defer em.Close()
em.Emit(ctx, emitter.Event{
    Channel: "sdk", Tool: emitter.Tool{Name: "lookup"},
    Input: payloadBytes, Decision: "allowed",
})
```

Wire format mirrors `daemon/internal/pipeline.EmitterFrame` field-for-field (the type is redeclared locally to avoid a daemon-internal import; the JSON contract is the source of truth — the daemon would reject any deviation at `validateFrame`).

## Why

Section 3 of the daemon-process-separation rollout ([#236](https://github.com/agent-receipts/ar/issues/236)) replaces five in-process emitters with thin clients pointed at the daemon. This is the first of those five (Go SDK); the four remaining modules (mcp-proxy, sdk/ts, sdk/py, openclaw) follow as separate small PRs rather than one bundled drop, so each gets focused review.

Per [ADR-0010 OQ4 amendment (2026-05-06)](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md#2026-05-06-oq4--session_id-allocation-rule--uuid-at-startup-persistent-across-reconnects), `session_id` is allocated once at `New()` and held for the lifetime of the `Emitter` — including across daemon reconnects. `WithSessionID` forwards a host-supplied id when the parent process owns one (Claude Code's session id, an agent-loop context id); empty string falls back to a generated UUID since the daemon rejects empty values.

Failure model is fire-and-forget per [ADR-0010 §"Permissions and trust"](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md#permissions-and-trust): a 25ms dial timeout and a 100ms write deadline cap `Emit` even on a frozen daemon. Failed writes close the conn so the next `Emit` re-dials transparently. The EAGAIN-driven local drop counter and `events_dropped` flush mechanism described in the same ADR section are deferred to a follow-up commit on `main` once this lands; for now every drop reason takes a `slog.Debug` log + `return nil` path. That deferral is the *only* explicit gap; everything else in this PR is the full intended design.

## Tests

End-to-end against an in-process daemon via the repo-root `go.work` link:

- `TestEmit_FrameRoundTrip` — channel/tool/decision land in the receipt with monotonic `chain.sequence`.
- `TestEmit_SessionIDStableAcrossEmits` — generated UUID survives every emit on the instance.
- `TestEmit_WithSessionIDOverride` — host-supplied id reaches `receipt.Issuer.SessionID` untouched (OQ4 forwarding path).
- `TestEmit_HashDeterminism` — differing whitespace and key order in `Input` MUST produce identical `parameters_hash`. Guards that the emitter does not re-encode bytes the daemon needs to canonicalise.
- `TestEmit_FireAndForgetWhenDaemonDown` — a missing socket returns nil within 50ms (the fire-and-forget contract).
- `TestEmit_ReconnectAfterDaemonRestart` — emitter recovers when the daemon goes away mid-session and comes back, with the same `session_id`.
- `TestEmit_ReturnsErrorAfterClose` — post-`Close` `Emit` surfaces an error rather than silently dropping; pins idempotent `Close`.

Verified locally:

```
sdk/go         go vet ./...                          clean
sdk/go         go test -race ./...                   ok
daemon         go test -race ./...                   ok
daemon         go test -tags=integration -race ./... ok
cross-sdk-tests go test -tags=integration ./...      ok
mcp-proxy      go test ./...                         ok (sanity, shared go.work)
```

## New dependency

None. The package uses `github.com/google/uuid` (already in `sdk/go/go.mod`) plus the standard library.

## Checklist

- [x] Tests pass for all changed components — `sdk/go`, `daemon` (incl. `-tags=integration -race`), `cross-sdk-tests`, `mcp-proxy` all green
- [x] Linter passes — `go vet ./...` clean in `sdk/go`
- [x] No real keys or secrets in the diff — test fixture generates ephemeral Ed25519 keys per-test, identical pattern to `daemon/integration_test.go`
- [x] Cross-language tests pass — emitter forwards bytes verbatim, no canonicalisation/signing/hashing logic touched
- [ ] AGENTS.md updated — N/A, no project structure change
- [ ] Spec changes have been reviewed by a maintainer — N/A, no spec change (frame schema mirrors the existing `daemon/internal/pipeline.EmitterFrame`)

## Follow-ups (separate PRs on `main`)

1. **`events_dropped` mechanism** — non-blocking conn, EAGAIN handling, atomic drop counter, flush field on `EmitterFrame` (or a control frame), daemon-side synthesis of `events_dropped` receipts. Schema decision required.
2. **Other four thin emitters** — mcp-proxy, sdk/ts, sdk/py, openclaw. Each as its own PR per the smaller-is-better rule.
3. **`daemon/internal/daemontest` companion to `sockettest`** — once mcp-proxy's emitter tests need the same `startDaemon` / `writeTestKey` helpers, consolidate the three copies.
