### PR TITLE
docs(dashboard): reflect default -db path

### DIFF
--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -29,10 +29,10 @@ make build
 
 ## Usage
 
-Point the dashboard at a receipt database:
+If you use the standard per-user path (`~/.agent-receipts/receipts.db`), no flags are needed:
 
 ```sh
-dashboard -db ./receipts.db
+dashboard
 ```
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
@@ -41,15 +41,18 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | *(required)* | Path to a receipt SQLite database |
+| `-db` | `~/.agent-receipts/receipts.db` | Path to a receipt SQLite database |
 | `-port` | `8080` | Port to serve on |
 
 ### Example
 
 ```sh
-# View receipts from the MCP proxy
-dashboard -db ~/.config/ar/receipts.db
+# Standard local install — no flags required
+dashboard
+
+# Point at a custom database
+dashboard -db ./receipts.db
 
 # Use a custom port
-dashboard -db ./receipts.db -port 9090
+dashboard -port 9090
 ```


### PR DESCRIPTION
## What

Update the dashboard installation docs to reflect that `-db` now defaults to `~/.agent-receipts/receipts.db` (dashboard/pull/44).

## Why

The options table listed `-db` as `*(required)*` and examples always passed it explicitly — both are wrong once the default lands. Leading with the zero-arg form matches the UX improvement the upstream PR is making.

Changes:
- Usage section leads with bare `dashboard` invocation
- Options table shows the default path instead of *(required)*
- Examples updated to show the no-flag form first

## Checklist

- [x] No real keys or secrets in the diff
- [x] Linter passes