### PR TITLE
mcp-proxy: wire fire-and-forget emitter for ADR-0010 daemon forwarding

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -150,8 +151,11 @@ func waitForDaemonReceipts(t *testing.T, dbPath, chainID string, want int, timeo
 	}
 }
 
-// silentEmitterLogger discards drop-log output to keep test output clean.
-var silentEmitterLogger = log.New(io.Discard, "", 0)
+// silentSlog returns a slog.Logger that discards every level. Tests pass it
+// to emitter.New so dial/write drops do not pollute `go test -v` output.
+func silentSlog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 // newSilentEmitter returns an Emitter that discards its slog drop output.
 func newSilentEmitter(t *testing.T, socketPath, sessionID string) *emitter.Emitter {
@@ -159,6 +163,7 @@ func newSilentEmitter(t *testing.T, socketPath, sessionID string) *emitter.Emitt
 	em, err := emitter.New(
 		emitter.WithSocketPath(socketPath),
 		emitter.WithSessionID(sessionID),
+		emitter.WithLogger(silentSlog()),
 	)
 	if err != nil {
 		t.Fatalf("emitter.New: %v", err)
@@ -259,6 +264,7 @@ func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
 	em, err := emitter.New(
 		emitter.WithSocketPath(filepath.Join(dir, "no-daemon.sock")),
 		emitter.WithSessionID("proxy-test-noDaemon"),
+		emitter.WithLogger(silentSlog()),
 	)
 	if err != nil {
 		t.Fatalf("emitter.New: %v", err)
@@ -290,6 +296,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 	em, err := emitter.New(
 		emitter.WithSocketPath(filepath.Join(dir, "no-daemon2.sock")),
 		emitter.WithSessionID("proxy-test-nilinputs"),
+		emitter.WithLogger(silentSlog()),
 	)
 	if err != nil {
 		t.Fatalf("emitter.New: %v", err)
@@ -299,4 +306,36 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 	// nil input and output are valid: the emitter accepts them and the daemon
 	// treats them as absent. No panic, no error returned.
 	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed")
+}
+
+// TestEmitToContext_SessionIDPropagatesToReceipts verifies the ADR-0010 OQ4
+// invariant that the proxy's session id (the same value the audit DB sees)
+// is the issuer.session_id of every receipt the daemon writes. Without this
+// the operator cannot correlate proxy logs with daemon-produced receipts.
+func TestEmitToContext_SessionIDPropagatesToReceipts(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	const sid = "proxy-session-id-stability-2026-05"
+	em := newSilentEmitter(t, d.cfg.SocketPath, sid)
+
+	for i := 0; i < 3; i++ {
+		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed")
+	}
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 3, 5*time.Second)
+
+	s, err := store.OpenReadOnly(d.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	receipts, err := s.GetChain(d.cfg.ChainID)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	for i, r := range receipts {
+		if r.Issuer.SessionID != sid {
+			t.Errorf("receipt[%d]: issuer.session_id = %q; want %q", i, r.Issuer.SessionID, sid)
+		}
+	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -1,0 +1,302 @@
+//go:build linux || darwin
+
+// Emitter integration tests verify that the mcp-proxy's emitToContext helper
+// correctly forwards tool-call events to a running agent-receipts daemon via
+// the Go SDK emitter. Tests run end-to-end against an in-process daemon so
+// the full wire path (emitter → AF_UNIX socket → daemon pipeline → SQLite
+// receipt store) is exercised. Build-tag-gated to linux/darwin because
+// daemon.Run refuses to start on other platforms.
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// shortSocketDirEmitter returns a temp directory with a short enough path that
+// a socket inside it fits within the 104-byte AF_UNIX sun_path limit on macOS.
+// t.TempDir() on macOS can produce ~119-char paths under /var/folders/…,
+// exceeding the limit and tripping "bind: invalid argument".
+func shortSocketDirEmitter(t *testing.T) string {
+	t.Helper()
+	base := "/tmp"
+	if _, err := os.Stat(base); err != nil {
+		base = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(base, "arproxy*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func writeTestKeyForProxy(t *testing.T, path string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type testDaemonHandle struct {
+	cfg      daemon.Config
+	cancel   context.CancelFunc
+	done     <-chan error
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func startTestDaemon(t *testing.T, dir string) *testDaemonHandle {
+	t.Helper()
+	cfg := daemon.Config{
+		SocketPath:           filepath.Join(dir, "events.sock"),
+		DBPath:               filepath.Join(dir, "receipts.db"),
+		KeyPath:              filepath.Join(dir, "signing.key"),
+		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),
+		ChainID:              "mcp-proxy-emitter-test",
+		IssuerID:             "did:agent-receipts-daemon:proxy-test",
+		VerificationMethodID: "did:agent-receipts-daemon:proxy-test#k1",
+		Logger:               log.New(io.Discard, "", 0),
+	}
+	if _, err := os.Stat(cfg.KeyPath); os.IsNotExist(err) {
+		writeTestKeyForProxy(t, cfg.KeyPath)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(cfg.SocketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	d := &testDaemonHandle{cfg: cfg, cancel: cancel, done: done}
+	t.Cleanup(func() { d.stop(t) })
+	return d
+}
+
+func (d *testDaemonHandle) stop(t *testing.T) {
+	t.Helper()
+	d.stopOnce.Do(func() {
+		d.cancel()
+		select {
+		case err := <-d.done:
+			if err != nil {
+				t.Logf("daemon Run returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			d.stopErr = errors.New("daemon did not shut down within 3s")
+		}
+		if conn, err := net.Dial("unix", d.cfg.SocketPath); err == nil {
+			conn.Close()
+			d.stopErr = errors.New("socket still accepting connections after stop")
+		}
+	})
+	if d.stopErr != nil {
+		t.Fatal(d.stopErr)
+	}
+}
+
+func waitForDaemonReceipts(t *testing.T, dbPath, chainID string, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		s, err := store.OpenReadOnly(dbPath)
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		got, err := s.GetChain(chainID)
+		s.Close()
+		if err == nil && len(got) >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d receipts in chain %s; got %d (err=%v)", want, chainID, len(got), err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// silentEmitterLogger discards drop-log output to keep test output clean.
+var silentEmitterLogger = log.New(io.Discard, "", 0)
+
+// newSilentEmitter returns an Emitter that discards its slog drop output.
+func newSilentEmitter(t *testing.T, socketPath, sessionID string) *emitter.Emitter {
+	t.Helper()
+	em, err := emitter.New(
+		emitter.WithSocketPath(socketPath),
+		emitter.WithSessionID(sessionID),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+	return em
+}
+
+// TestEmitToContext_AllowedToolCall is the basic acceptance test: an "allowed"
+// event forwarded through emitToContext materialises as a signed receipt in the
+// daemon's chain. It exercises the full wire path without using the proxy's
+// serve() function, so it isolates the emitToContext helper cleanly.
+func TestEmitToContext_AllowedToolCall(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	em := newSilentEmitter(t, d.cfg.SocketPath, "proxy-test-session-allowed")
+
+	emitToContext(em, "test-server", "read_file",
+		json.RawMessage(`{"path":"/tmp/test.txt"}`),
+		json.RawMessage(`{"content":"hello"}`),
+		"",
+		"allowed",
+	)
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+}
+
+// TestEmitToContext_DeniedToolCall verifies that a "denied" decision (blocked by
+// policy or rejected approval) is forwarded correctly. The daemon must accept
+// the frame and produce a receipt with a failure outcome.
+func TestEmitToContext_DeniedToolCall(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	em := newSilentEmitter(t, d.cfg.SocketPath, "proxy-test-session-denied")
+
+	emitToContext(em, "test-server", "delete_secrets",
+		json.RawMessage(`{"target":"all"}`),
+		nil,
+		"blocked by policy: delete_secrets matches block rule",
+		"denied",
+	)
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+}
+
+// TestEmitToContext_MultipleEvents verifies that several back-to-back calls
+// through emitToContext produce monotonically sequenced receipts in the daemon.
+func TestEmitToContext_MultipleEvents(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	em := newSilentEmitter(t, d.cfg.SocketPath, "proxy-test-session-multi")
+
+	events := []struct {
+		tool     string
+		input    json.RawMessage
+		output   json.RawMessage
+		decision string
+	}{
+		{"read_file", json.RawMessage(`{"path":"/a"}`), json.RawMessage(`{"ok":true}`), "allowed"},
+		{"write_file", json.RawMessage(`{"path":"/b","content":"x"}`), nil, "allowed"},
+		{"delete_secrets", json.RawMessage(`{}`), nil, "denied"},
+	}
+
+	for _, ev := range events {
+		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision)
+	}
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, len(events), 5*time.Second)
+
+	s, err := store.OpenReadOnly(d.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	receipts, err := s.GetChain(d.cfg.ChainID)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(receipts) != len(events) {
+		t.Fatalf("got %d receipts, want %d", len(receipts), len(events))
+	}
+
+	// Sequence numbers must be monotonically increasing from 1.
+	for i, r := range receipts {
+		if r.CredentialSubject.Chain.Sequence != i+1 {
+			t.Errorf("receipt[%d]: sequence = %d, want %d", i, r.CredentialSubject.Chain.Sequence, i+1)
+		}
+	}
+}
+
+// TestEmitToContext_FireAndForgetWhenNoDaemon verifies the core ADR-0010
+// fire-and-forget property: emitToContext MUST NOT block or panic when the
+// daemon socket does not exist. The call should return quickly (well under
+// 100ms) and log a drop.
+func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
+	dir := shortSocketDirEmitter(t)
+	em, err := emitter.New(
+		emitter.WithSocketPath(filepath.Join(dir, "no-daemon.sock")),
+		emitter.WithSessionID("proxy-test-noDaemon"),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	defer em.Close()
+
+	start := time.Now()
+	// emitToContext logs the drop via log.Printf — that's fine for tests.
+	emitToContext(em, "srv", "noop", nil, nil, "", "allowed")
+	elapsed := time.Since(start)
+
+	// 25ms dial timeout + 100ms write deadline = 125ms worst-case. We allow
+	// double that to absorb scheduling jitter on slow CI machines.
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("emitToContext blocked for %v; want <250ms (fire-and-forget contract)", elapsed)
+	}
+}
+
+// TestEmitToContext_NilEmitterIsNoOp guards the nil-check in serve(): when em
+// is nil (daemon socket empty or emitter init failed), emitToContext must not
+// be called — but if it were called with a nil *emitter.Emitter, it must not
+// panic. This test documents and validates that invariant.
+//
+// NOTE: emitToContext requires a non-nil *emitter.Emitter; callers in serve()
+// guard with `if em != nil`. This test uses a real (no-daemon) emitter instead
+// of a nil one so it validates the function signature without nil-deref risk.
+func TestEmitToContext_NilInputsAreValid(t *testing.T) {
+	dir := shortSocketDirEmitter(t)
+	em, err := emitter.New(
+		emitter.WithSocketPath(filepath.Join(dir, "no-daemon2.sock")),
+		emitter.WithSessionID("proxy-test-nilinputs"),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	defer em.Close()
+
+	// nil input and output are valid: the emitter accepts them and the daemon
+	// treats them as absent. No panic, no error returned.
+	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed")
+}

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -101,7 +101,13 @@ func startTestDaemon(t *testing.T, dir string) *testDaemonHandle {
 			cancel()
 			t.Fatalf("socket %s did not appear within 2s", cfg.SocketPath)
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case err := <-done:
+			cancel()
+			t.Fatalf("daemon exited prematurely during startup: %v", err)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 
 	d := &testDaemonHandle{cfg: cfg, cancel: cancel, done: done}

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -283,14 +283,10 @@ func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
 	}
 }
 
-// TestEmitToContext_NilEmitterIsNoOp guards the nil-check in serve(): when em
-// is nil (daemon socket empty or emitter init failed), emitToContext must not
-// be called — but if it were called with a nil *emitter.Emitter, it must not
-// panic. This test documents and validates that invariant.
-//
-// NOTE: emitToContext requires a non-nil *emitter.Emitter; callers in serve()
-// guard with `if em != nil`. This test uses a real (no-daemon) emitter instead
-// of a nil one so it validates the function signature without nil-deref risk.
+// TestEmitToContext_NilInputsAreValid verifies that nil input and output
+// arguments are accepted without panic. emitter.Emit treats nil JSON fields as
+// absent; the daemon skips hashing for missing payloads. The test uses a real
+// (no-daemon) emitter so the full Emit call path is exercised.
 func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 	dir := shortSocketDirEmitter(t)
 	em, err := emitter.New(
@@ -306,6 +302,16 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 	// nil input and output are valid: the emitter accepts them and the daemon
 	// treats them as absent. No panic, no error returned.
 	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed")
+}
+
+// TestEmitToContext_NilEmitterIsNoOp guards the nil-emitter path in serve():
+// when em is nil (daemon socket empty or emitter init failed), emitToContext
+// must silently return without panic. The nil guard in emitToContext makes the
+// `if em != nil` check in serve() redundant for safety purposes, but the
+// explicit guard at the call sites is kept for clarity.
+func TestEmitToContext_NilEmitterIsNoOp(t *testing.T) {
+	// Must not panic.
+	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed")
 }
 
 // TestEmitToContext_SessionIDPropagatesToReceipts verifies the ADR-0010 OQ4

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -905,7 +905,8 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 // Tool.Name. Together the daemon assembles them into action.type
 // "mcp.<server>.<tool>". input and output are raw JSON bytes; either may be
 // nil to signal "no payload" (the daemon will skip hashing in that case).
-// errStr carries the upstream error text (empty for successful calls).
+// errStr carries the error payload string (raw JSON-RPC error object JSON for
+// upstream errors, a policy message for denied calls; empty for success).
 // decision must be "allowed", "denied", or "pending".
 func emitToContext(em *emitter.Emitter, serverName, toolName string, input, output json.RawMessage, errStr, decision string) {
 	if em == nil {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -737,19 +737,16 @@ func serve() {
 				// (ADR-0010 fire-and-forget). We use the pre-redaction
 				// arguments map held in pc.arguments and the pre-encryption
 				// result string so the daemon receives raw JSON the same way
-				// the in-process receipt signer does. errorStr is always the
-				// raw (unencrypted) error text.
+				// the in-process receipt signer does. errorStr is raw JSON
+				// (the JSON-RPC error object from msg.Error).
 				//
 				// decision is always "allowed" here because reaching this
 				// branch means the proxy did NOT block the call — the policy
 				// engine permitted it through. The upstream's success-vs-
 				// failure outcome is communicated separately via the Error
-				// field; the daemon stores both decision and error on the
-				// receipt. (The in-process signer also derives outcome.status
-				// from msg.Error != nil; the daemon currently maps decision
-				// → status verbatim, so phase 3 receipts may report
-				// StatusSuccess for upstream-errored calls until the daemon
-				// learns to flip that. Tracking issue: #236 follow-ups.)
+				// field; the daemon derives outcome.status from both decision
+				// and the presence of a non-empty error (allowed+error →
+				// failure).
 				if em != nil {
 					var outputRaw json.RawMessage
 					if resultStr != "" && json.Valid([]byte(resultStr)) {

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -109,7 +109,7 @@ func serve() {
 		httpAddr           = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
 		approvalWait       = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 		strictPermissions  = flag.Bool("strict-permissions", false, "Fatal error if the private key file has permissions wider than 0600 (group/world-accessible)")
-		socketPath         = flag.String("socket", emitter.DefaultSocketPath(), "Unix-domain socket for the agent-receipts daemon (ADR-0010). Empty string disables the emitter. Overridden by AGENTRECEIPTS_SOCKET.")
+		socketPath         = flag.String("socket", emitter.DefaultSocketPath(), "Unix-domain socket for the agent-receipts daemon (ADR-0010). Defaults to AGENTRECEIPTS_SOCKET if set; explicit --socket wins. Empty string (--socket=\"\") disables the emitter.")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -169,10 +169,10 @@ func serve() {
 	// Wire the fire-and-forget daemon emitter (ADR-0010). The emitter is
 	// optional: when --socket is empty the proxy continues without forwarding
 	// events to the daemon (backwards-compatible default for installations
-	// that have not yet deployed the daemon). AGENTRECEIPTS_SOCKET takes
-	// precedence over --socket when both are set; emitter.DefaultSocketPath
-	// already applies that precedence rule, so overriding here keeps the two
-	// in sync.
+	// that have not yet deployed the daemon). AGENTRECEIPTS_SOCKET sets the
+	// default for --socket via emitter.DefaultSocketPath; an explicit
+	// --socket flag always wins, and --socket="" disables the emitter
+	// regardless of the env var.
 	var em *emitter.Emitter
 	if sp := *socketPath; sp != "" {
 		var initErr error
@@ -909,6 +909,9 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 // errStr carries the upstream error text (empty for successful calls).
 // decision must be "allowed", "denied", or "pending".
 func emitToContext(em *emitter.Emitter, serverName, toolName string, input, output json.RawMessage, errStr, decision string) {
+	if em == nil {
+		return
+	}
 	if err := em.Emit(context.Background(), emitter.Event{
 		Channel:  "mcp",
 		Tool:     emitter.Tool{Server: serverName, Name: toolName},

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -24,6 +25,7 @@ import (
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
+	"github.com/agent-receipts/ar/sdk/go/emitter"
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	receiptStore "github.com/agent-receipts/ar/sdk/go/store"
 	"github.com/agent-receipts/ar/sdk/go/taxonomy"
@@ -107,6 +109,7 @@ func serve() {
 		httpAddr           = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
 		approvalWait       = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 		strictPermissions  = flag.Bool("strict-permissions", false, "Fatal error if the private key file has permissions wider than 0600 (group/world-accessible)")
+		socketPath         = flag.String("socket", emitter.DefaultSocketPath(), "Unix-domain socket for the agent-receipts daemon (ADR-0010). Empty string disables the emitter. Overridden by AGENTRECEIPTS_SOCKET.")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -162,6 +165,30 @@ func serve() {
 		log.Fatalf("mcp-proxy: create session: %v", err)
 	}
 	defer auditDB.EndSession(sessionID)
+
+	// Wire the fire-and-forget daemon emitter (ADR-0010). The emitter is
+	// optional: when --socket is empty the proxy continues without forwarding
+	// events to the daemon (backwards-compatible default for installations
+	// that have not yet deployed the daemon). AGENTRECEIPTS_SOCKET takes
+	// precedence over --socket when both are set; emitter.DefaultSocketPath
+	// already applies that precedence rule, so overriding here keeps the two
+	// in sync.
+	var em *emitter.Emitter
+	if sp := *socketPath; sp != "" {
+		var initErr error
+		em, initErr = emitter.New(
+			emitter.WithSocketPath(sp),
+			emitter.WithSessionID(sessionID),
+		)
+		if initErr != nil {
+			// Log but don't abort: running without daemon is valid.
+			log.Printf("mcp-proxy: emitter init: %v (daemon forwarding disabled)", initErr)
+			em = nil
+		} else {
+			defer em.Close()
+			log.Printf("mcp-proxy: emitter targeting daemon socket %s", sp)
+		}
+	}
 
 	// Open receipt store.
 	if err := ensureDBDir(*receiptDB); err != nil {
@@ -427,6 +454,9 @@ func serve() {
 						requestedAt:  requestedAt,
 						policyEvalUs: policyEvalUs,
 					})
+					if em != nil {
+						emitToContext(em, *serverName, toolName, json.RawMessage(argJSON), nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied")
+					}
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -464,6 +494,9 @@ func serve() {
 							policyEvalUs:   policyEvalUs,
 							approvalWaitUs: approvalWaitUs,
 						})
+						if em != nil {
+							emitToContext(em, *serverName, toolName, json.RawMessage(argJSON), nil, message, "denied")
+						}
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(
@@ -699,6 +732,24 @@ func serve() {
 						log.Printf("mcp-proxy: update receipt sign timing: %v", updateErr)
 					}
 				}
+
+				// Forward the completed tool call to the daemon emitter
+				// (ADR-0010 fire-and-forget). We use the pre-redaction
+				// arguments map held in pc.arguments and the pre-encryption
+				// result string so the daemon receives raw JSON the same way
+				// the in-process receipt signer does. errorStr is always the
+				// raw (unencrypted) error text.
+				if em != nil {
+					var outputRaw json.RawMessage
+					if resultStr != "" && json.Valid([]byte(resultStr)) {
+						outputRaw = json.RawMessage(resultStr)
+					}
+					var inputRaw json.RawMessage
+					if b, marshalErr := json.Marshal(pc.arguments); marshalErr == nil {
+						inputRaw = json.RawMessage(b)
+					}
+					emitToContext(em, *serverName, pc.toolName, inputRaw, outputRaw, errorStr, "allowed")
+				}
 			}
 		}
 
@@ -828,6 +879,27 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 	}
 	if b, err := json.Marshal(payload); err == nil {
 		fmt.Fprintln(os.Stderr, string(b))
+	}
+}
+
+// emitToContext forwards one tool-call event to the daemon emitter (ADR-0010,
+// fire-and-forget). The emitter returns nil on transient failures, so the only
+// errors are caller bugs (closed emitter, invalid decision, etc.) — we log
+// those at warn level so they surface in tests without breaking normal operation.
+// serverName becomes the tool channel (e.g. the MCP server name). toolName is
+// the bare tool name. input and output are raw JSON bytes; either may be nil.
+// errStr carries the error text from the upstream server response (empty for
+// successful calls). decision must be "allowed", "denied", or "pending".
+func emitToContext(em *emitter.Emitter, serverName, toolName string, input, output json.RawMessage, errStr, decision string) {
+	if err := em.Emit(context.Background(), emitter.Event{
+		Channel:  "mcp",
+		Tool:     emitter.Tool{Server: serverName, Name: toolName},
+		Input:    input,
+		Output:   output,
+		Error:    errStr,
+		Decision: decision,
+	}); err != nil {
+		log.Printf("mcp-proxy: emitter: %v", err)
 	}
 }
 

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -739,6 +739,17 @@ func serve() {
 				// result string so the daemon receives raw JSON the same way
 				// the in-process receipt signer does. errorStr is always the
 				// raw (unencrypted) error text.
+				//
+				// decision is always "allowed" here because reaching this
+				// branch means the proxy did NOT block the call — the policy
+				// engine permitted it through. The upstream's success-vs-
+				// failure outcome is communicated separately via the Error
+				// field; the daemon stores both decision and error on the
+				// receipt. (The in-process signer also derives outcome.status
+				// from msg.Error != nil; the daemon currently maps decision
+				// → status verbatim, so phase 3 receipts may report
+				// StatusSuccess for upstream-errored calls until the daemon
+				// learns to flip that. Tracking issue: #236 follow-ups.)
 				if em != nil {
 					var outputRaw json.RawMessage
 					if resultStr != "" && json.Valid([]byte(resultStr)) {
@@ -883,13 +894,20 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 }
 
 // emitToContext forwards one tool-call event to the daemon emitter (ADR-0010,
-// fire-and-forget). The emitter returns nil on transient failures, so the only
-// errors are caller bugs (closed emitter, invalid decision, etc.) — we log
-// those at warn level so they surface in tests without breaking normal operation.
-// serverName becomes the tool channel (e.g. the MCP server name). toolName is
-// the bare tool name. input and output are raw JSON bytes; either may be nil.
-// errStr carries the error text from the upstream server response (empty for
-// successful calls). decision must be "allowed", "denied", or "pending".
+// fire-and-forget). The emitter returns nil on transient failures (no daemon,
+// broken socket); the only errors emerging here are caller bugs that no retry
+// could fix — closed emitter, empty channel, invalid decision, malformed
+// Input/Output JSON. We log them via log.Printf so misuse surfaces in proxy
+// logs rather than crashing the request flow.
+//
+// The Channel is hard-coded to "mcp" because every event from this proxy
+// originates from an MCP server tool call; serverName populates Tool.Server
+// (the upstream MCP server identifier, e.g. "github") and toolName populates
+// Tool.Name. Together the daemon assembles them into action.type
+// "mcp.<server>.<tool>". input and output are raw JSON bytes; either may be
+// nil to signal "no payload" (the daemon will skip hashing in that case).
+// errStr carries the upstream error text (empty for successful calls).
+// decision must be "allowed", "denied", or "pending".
 func emitToContext(em *emitter.Emitter, serverName, toolName string, input, output json.RawMessage, errStr, decision string) {
 	if err := em.Emit(context.Background(), emitter.Event{
 		Channel:  "mcp",

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -758,6 +758,8 @@ func serve() {
 					var inputRaw json.RawMessage
 					if b, marshalErr := json.Marshal(pc.arguments); marshalErr == nil {
 						inputRaw = json.RawMessage(b)
+					} else {
+						log.Printf("mcp-proxy: marshal arguments for daemon: %v; emitting nil input", marshalErr)
 					}
 					emitToContext(em, *serverName, pc.toolName, inputRaw, outputRaw, errorStr, "allowed")
 				}

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -22,6 +23,10 @@ import (
 	"testing"
 	"time"
 )
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 // shortSocketDir returns a temp directory whose path leaves room for an
 // AF_UNIX socket name. macOS sun_path is 104 bytes; t.TempDir() under

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -1,0 +1,413 @@
+//go:build linux || darwin
+
+// Unix-only tests that bind a real AF_UNIX listener and assert the wire
+// behaviour of Emit: length-prefix framing matches the daemon's reader,
+// reconnect after listener restart works without a Close/New dance,
+// and sessionID is stable across multiple Emits.
+//
+// Tests live in this file rather than emitter_test.go because Windows lacks
+// AF_UNIX in net.Listen for older Go releases used in CI matrix.
+package emitter
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// shortSocketDir returns a temp directory whose path leaves room for an
+// AF_UNIX socket name. macOS sun_path is 104 bytes; t.TempDir() under
+// /var/folders/… can produce ~119-char paths that overflow that limit.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	base := "/tmp"
+	if _, err := os.Stat(base); err != nil {
+		base = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(base, "aremit*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// recordingListener accepts on a Unix socket and records every length-prefix
+// frame it receives. Used to assert wire-format correctness without booting a
+// full daemon. Stop closes both the listener AND any in-flight peer
+// connections so reconnect tests can assert the emitter re-dials cleanly
+// after the daemon goes away.
+type recordingListener struct {
+	ln       *net.UnixListener
+	path     string
+	mu       sync.Mutex
+	frames   [][]byte
+	conns    map[net.Conn]struct{}
+	stopped  chan struct{}
+	stopOnce sync.Once
+}
+
+func newRecordingListener(t *testing.T, dir string) *recordingListener {
+	t.Helper()
+	path := filepath.Join(dir, "events.sock")
+	addr := &net.UnixAddr{Name: path, Net: "unix"}
+	ln, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	rl := &recordingListener{
+		ln:      ln,
+		path:    path,
+		conns:   make(map[net.Conn]struct{}),
+		stopped: make(chan struct{}),
+	}
+	go rl.acceptLoop()
+	t.Cleanup(rl.Stop)
+	return rl
+}
+
+func (r *recordingListener) acceptLoop() {
+	for {
+		conn, err := r.ln.Accept()
+		if err != nil {
+			select {
+			case <-r.stopped:
+				return
+			default:
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			return
+		}
+		r.mu.Lock()
+		select {
+		case <-r.stopped:
+			r.mu.Unlock()
+			conn.Close()
+			return
+		default:
+		}
+		r.conns[conn] = struct{}{}
+		r.mu.Unlock()
+		go r.serveConn(conn)
+	}
+}
+
+func (r *recordingListener) serveConn(conn net.Conn) {
+	defer func() {
+		r.mu.Lock()
+		delete(r.conns, conn)
+		r.mu.Unlock()
+		conn.Close()
+	}()
+	for {
+		var hdr [4]byte
+		if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+			return
+		}
+		n := binary.BigEndian.Uint32(hdr[:])
+		if n == 0 || n > MaxFrameSize {
+			return
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			return
+		}
+		r.mu.Lock()
+		r.frames = append(r.frames, buf)
+		r.mu.Unlock()
+	}
+}
+
+func (r *recordingListener) Stop() {
+	r.stopOnce.Do(func() {
+		r.mu.Lock()
+		close(r.stopped)
+		// Close every accepted conn so the emitter's cached connection
+		// observes EOF/EPIPE on its next write — this is what triggers the
+		// re-dial path the reconnect test exercises.
+		for c := range r.conns {
+			_ = c.Close()
+		}
+		r.mu.Unlock()
+		r.ln.Close()
+	})
+}
+
+// snapshot returns a copy of the frames received so far.
+func (r *recordingListener) snapshot() [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]byte, len(r.frames))
+	copy(out, r.frames)
+	return out
+}
+
+func (r *recordingListener) waitForFrames(t *testing.T, want int, timeout time.Duration) [][]byte {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		got := r.snapshot()
+		if len(got) >= want {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d frames received within %s; want %d", len(got), timeout, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestEmit_RoundTripWireFormat(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	em, err := New(
+		WithSocketPath(rl.path),
+		WithSessionID("wire-format-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	ev := Event{
+		Channel:  "mcp",
+		Tool:     Tool{Server: "github", Name: "list_repos"},
+		Input:    json.RawMessage(`{"owner":"foo"}`),
+		Output:   json.RawMessage(`{"count":3}`),
+		Decision: "allowed",
+	}
+	if err := em.Emit(context.Background(), ev); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	frames := rl.waitForFrames(t, 1, 2*time.Second)
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames; want 1", len(frames))
+	}
+
+	var got frame
+	if err := json.Unmarshal(frames[0], &got); err != nil {
+		t.Fatalf("unmarshal frame: %v (raw: %s)", err, frames[0])
+	}
+	if got.Version != SupportedFrameVersion {
+		t.Errorf("frame.v = %q; want %q", got.Version, SupportedFrameVersion)
+	}
+	if got.SessionID != "wire-format-test" {
+		t.Errorf("frame.session_id = %q; want %q", got.SessionID, "wire-format-test")
+	}
+	if got.Channel != "mcp" {
+		t.Errorf("frame.channel = %q; want %q", got.Channel, "mcp")
+	}
+	if got.Tool.Server != "github" || got.Tool.Name != "list_repos" {
+		t.Errorf("frame.tool = %+v; want {github list_repos}", got.Tool)
+	}
+	if got.Decision != "allowed" {
+		t.Errorf("frame.decision = %q; want allowed", got.Decision)
+	}
+	if !json.Valid(got.Input) || string(got.Input) != `{"owner":"foo"}` {
+		t.Errorf("frame.input = %s; want %s", got.Input, `{"owner":"foo"}`)
+	}
+	if !json.Valid(got.Output) || string(got.Output) != `{"count":3}` {
+		t.Errorf("frame.output = %s; want %s", got.Output, `{"count":3}`)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, got.TsEmit); err != nil {
+		t.Errorf("frame.ts_emit %q is not RFC3339Nano: %v", got.TsEmit, err)
+	}
+}
+
+func TestEmit_SessionIDStableAcrossCalls(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	const sid = "stable-session-2026-05"
+	em, err := New(
+		WithSocketPath(rl.path),
+		WithSessionID(sid),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	for i := 0; i < 3; i++ {
+		if err := em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "ping"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit %d: %v", i, err)
+		}
+	}
+
+	frames := rl.waitForFrames(t, 3, 2*time.Second)
+	for i, f := range frames {
+		var got frame
+		if err := json.Unmarshal(f, &got); err != nil {
+			t.Fatalf("frame %d: unmarshal: %v", i, err)
+		}
+		if got.SessionID != sid {
+			t.Errorf("frame %d: session_id = %q; want %q", i, got.SessionID, sid)
+		}
+	}
+}
+
+func TestEmit_ReconnectsAfterListenerRestart(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	rl1 := newRecordingListener(t, dir)
+	em, err := New(
+		WithSocketPath(rl1.path),
+		WithSessionID("reconnect-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	// First Emit reaches rl1.
+	if err := em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "first"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("Emit first: %v", err)
+	}
+	rl1.waitForFrames(t, 1, 2*time.Second)
+
+	// Stop the listener and remove the socket file: the next Emit should
+	// drop silently rather than hang or return an error.
+	rl1.Stop()
+	_ = os.Remove(rl1.path)
+
+	// Drive the in-Emitter conn into a write failure so the next-Emit
+	// re-dial path is exercised. Without an intermediate Emit the cached
+	// conn would still be valid (writes succeed into the kernel buffer
+	// even after the peer closes), so the second listener wouldn't see
+	// the next frame.
+	for i := 0; i < 3; i++ {
+		_ = em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "during-outage"},
+			Decision: "allowed",
+		})
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Bring up a fresh listener at the same path.
+	rl2 := newRecordingListener(t, dir)
+
+	// New Emit must reach rl2; the emitter re-dials transparently.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if err := em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "after-restart"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit after restart: %v", err)
+		}
+		got := rl2.snapshot()
+		if len(got) > 0 {
+			// Verify we received the post-restart frame.
+			var f frame
+			if err := json.Unmarshal(got[len(got)-1], &f); err != nil {
+				t.Fatalf("unmarshal frame: %v", err)
+			}
+			if f.Tool.Name == "after-restart" {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rl2 never received an after-restart frame; got %d frames total", len(got))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestEmit_FireAndForgetWhenSocketMissing(t *testing.T) {
+	em, err := New(
+		WithSocketPath("/tmp/agentreceipts-emitter-no-such-socket.sock"),
+		WithSessionID("no-daemon-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	start := time.Now()
+	err = em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "noop"},
+		Decision: "allowed",
+	})
+	elapsed := time.Since(start)
+
+	// Fire-and-forget: returns nil, not an error.
+	if err != nil {
+		t.Fatalf("Emit returned error %v; want nil (fire-and-forget)", err)
+	}
+	// 25ms dial timeout + 100ms write deadline = 125ms upper bound. Allow
+	// 2x for slow CI.
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("Emit took %s; want <250ms (fire-and-forget contract)", elapsed)
+	}
+}
+
+func TestEmit_ConcurrentCallsAreSerialised(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	em, err := New(
+		WithSocketPath(rl.path),
+		WithSessionID("concurrent-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = em.Emit(context.Background(), Event{
+				Channel:  "mcp",
+				Tool:     Tool{Name: "concurrent"},
+				Decision: "allowed",
+			})
+		}()
+	}
+	wg.Wait()
+
+	frames := rl.waitForFrames(t, n, 5*time.Second)
+	if len(frames) != n {
+		t.Fatalf("got %d frames; want %d", len(frames), n)
+	}
+	// Every frame must be parseable JSON: a torn write would corrupt the
+	// length prefix and the recording listener would log a read error,
+	// producing fewer than n frames or unparseable bytes here.
+	for i, f := range frames {
+		var got frame
+		if err := json.Unmarshal(f, &got); err != nil {
+			t.Errorf("frame %d: unmarshal: %v (raw: %s)", i, err, f)
+		}
+	}
+}

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -123,7 +123,7 @@ func (r *recordingListener) serveConn(conn net.Conn) {
 		if n == 0 || n > MaxFrameSize {
 			return
 		}
-		buf := make([]byte, n)
+		buf := make([]byte, int(n))
 		if _, err := io.ReadFull(conn, buf); err != nil {
 			return
 		}
@@ -344,8 +344,9 @@ func TestEmit_ReconnectsAfterListenerRestart(t *testing.T) {
 }
 
 func TestEmit_FireAndForgetWhenSocketMissing(t *testing.T) {
+	dir := shortSocketDir(t)
 	em, err := New(
-		WithSocketPath("/tmp/agentreceipts-emitter-no-such-socket.sock"),
+		WithSocketPath(filepath.Join(dir, "missing.sock")),
 		WithSessionID("no-daemon-test"),
 		WithLogger(silentLogger()),
 	)


### PR DESCRIPTION
## What

Wire the Go SDK fire-and-forget emitter into the mcp-proxy's tool-call event pipeline so events are forwarded to the agent-receipts daemon socket (ADR-0010). This is part of the daemon process separation work tracked in #236.

Three changes in one commit:

1. **`sdk/go/emitter/emitter.go`** — brings in the emitter package (ported from the `section-3` branch, which added it alongside the daemon). The mcp-proxy imports `sdk/go` via the repo-root `go.work`, so no `replace` directive is needed.

2. **`mcp-proxy/cmd/mcp-proxy/main.go`** — integrates the emitter into `serve()`:
   - New `--socket` flag (default: `AGENTRECEIPTS_SOCKET` env / OS default path; empty string disables forwarding for backwards-compatible deployments without the daemon).
   - `emitter.New()` called once at startup, forwarding the existing audit `sessionID` via `WithSessionID` so all receipts share one stable session (ADR-0010 OQ4).
   - `emitToContext()` helper calls `em.Emit()` at three points: completed tool calls (decision `"allowed"`), blocked calls (decision `"denied"`), rejected approvals (decision `"denied"`). Pre-redaction arguments and pre-encryption result strings are used so the daemon receives the same raw JSON as the in-process signer.

3. **`mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go`** — five end-to-end tests against an in-process daemon (build-tagged `linux || darwin`):
   - `TestEmitToContext_AllowedToolCall` — basic frame round-trip
   - `TestEmitToContext_DeniedToolCall` — denied frame forwarded
   - `TestEmitToContext_MultipleEvents` — monotonic sequencing across three events
   - `TestEmitToContext_FireAndForgetWhenNoDaemon` — no-daemon path completes <250ms
   - `TestEmitToContext_NilInputsAreValid` — nil input/output accepted without panic

## Why

ADR-0010 (daemon process separation) moves signing, canonicalisation, and chain management out of each SDK/proxy into a dedicated daemon. Phase 3 is connecting the existing in-process proxied tool-call events to the daemon's socket so the daemon can take over receipt production in a follow-up phase. This PR implements the "wire the emitter" step without yet removing the in-process crypto path.

## Checklist

- [x] Tests pass for all changed components (`go test -race ./...` clean on both `sdk/go` and `mcp-proxy`)
- [x] Linter passes (`go vet ./...` clean on both modules)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests not affected (no receipt format change)
- [x] AGENTS.md not changed (project structure unchanged)
- [x] No spec changes