### PR TITLE
sdk(ts): add thin fire-and-forget emitter for daemon socket (ADR-0010)

### DIFF
--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -30,12 +30,16 @@ import {
 /** Monotonic counter so every tempSockPath call returns a unique path. */
 let _sockSeq = 0;
 
-/** A unique socket path for each call (pid + counter + suffix). */
+/**
+ * A unique socket path for each call (pid + counter + suffix).
+ *
+ * On macOS, os.tmpdir() returns a long path under /var/folders/… that can
+ * exceed the AF_UNIX 104-byte limit. Use /tmp directly on darwin to keep
+ * paths well under the limit.
+ */
 function tempSockPath(suffix: string): string {
-	return join(
-		tmpdir(),
-		`ar-emitter-test-${process.pid}-${++_sockSeq}-${suffix}.sock`,
-	);
+	const base = process.platform === "darwin" ? "/tmp" : tmpdir();
+	return join(base, `ar-${process.pid}-${++_sockSeq}-${suffix}.sock`);
 }
 
 /**
@@ -205,13 +209,14 @@ describe("Emitter — validation errors (caller bugs)", () => {
 
 	it("returns an error after close", async () => {
 		const sockPath = tempSockPath("closed");
-		const { stop } = startEchoServer(sockPath);
+		const server = startEchoServer(sockPath);
+		await server.ready;
 		const e = new Emitter({ socketPath: sockPath });
 		e.close();
 		const err = await e.emit(GOOD_EVENT);
 		expect(err).toBeInstanceOf(Error);
 		expect(err?.message).toMatch(/closed/);
-		await stop();
+		await server.stop();
 	});
 });
 
@@ -369,6 +374,7 @@ describe("Emitter — session_id stability", () => {
 	it("session_id is stable across multiple emits", async () => {
 		const sockPath = tempSockPath("session");
 		const server = startEchoServer(sockPath);
+		await server.ready;
 		const emitter = new Emitter({ socketPath: sockPath });
 
 		await emitter.emit(GOOD_EVENT);
@@ -387,6 +393,7 @@ describe("Emitter — session_id stability", () => {
 	it("host-supplied sessionId is used and stable", async () => {
 		const sockPath = tempSockPath("supplied-session");
 		const server = startEchoServer(sockPath);
+		await server.ready;
 		const emitter = new Emitter({
 			socketPath: sockPath,
 			sessionId: "my-session-42",
@@ -455,6 +462,7 @@ describe("Emitter — reconnect after daemon restart", () => {
 	it("re-dials after the server stops and restarts", async () => {
 		const sockPath = tempSockPath("reconnect");
 		const server1 = startEchoServer(sockPath);
+		await server1.ready;
 		const emitter = new Emitter({ socketPath: sockPath });
 
 		// First emit reaches server1.
@@ -568,6 +576,7 @@ describe("Emitter — socket-error robustness", () => {
 	it("surviving an 'error' event on a live conn does not crash the process", async () => {
 		const sockPath = tempSockPath("err-survive");
 		const server = startEchoServer(sockPath);
+		await server.ready;
 		const drops: string[] = [];
 		const emitter = new Emitter({
 			socketPath: sockPath,
@@ -601,6 +610,7 @@ describe("Emitter — socket-error robustness", () => {
 	it("re-dials transparently after a socket error event", async () => {
 		const sockPath = tempSockPath("err-redial");
 		const server = startEchoServer(sockPath);
+		await server.ready;
 		const emitter = new Emitter({ socketPath: sockPath });
 
 		// First emit dials and delivers.
@@ -627,6 +637,7 @@ describe("Emitter — socket-error robustness", () => {
 		// destroyed and not retained.
 		const sockPath = tempSockPath("close-during-dial");
 		const server = startEchoServer(sockPath);
+		await server.ready;
 		const emitter = new Emitter({ socketPath: sockPath });
 
 		const emitPromise = emitter.emit(GOOD_EVENT);

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -459,3 +459,92 @@ describe("Emitter — constructor", () => {
 		expect(() => new Emitter({ socketPath: "/tmp/test.sock" })).not.toThrow();
 	});
 });
+
+describe("Emitter — socket-error robustness", () => {
+	// Reach into the private conn to simulate Node firing an 'error' event on
+	// the underlying socket (peer reset, daemon crash, EPIPE). Without a
+	// permanent error listener the host process would crash via Node's
+	// unhandled-'error' rule. These tests pin that contract.
+	function getConn(emitter: Emitter): import("node:net").Socket | null {
+		return (emitter as unknown as { conn: import("node:net").Socket | null })
+			.conn;
+	}
+
+	it("surviving an 'error' event on a live conn does not crash the process", async () => {
+		const sockPath = tempSockPath("err-survive");
+		const server = startEchoServer(sockPath);
+		const drops: string[] = [];
+		const emitter = new Emitter({
+			socketPath: sockPath,
+			debugLog: (_msg, attrs) => {
+				if (attrs.stage) drops.push(attrs.stage);
+			},
+		});
+
+		// Establish a live connection.
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const conn = getConn(emitter);
+		expect(conn).not.toBeNull();
+		// At least one listener must be attached for 'error' so the next
+		// peer-side mishap cannot crash the host.
+		expect(conn?.listenerCount("error")).toBeGreaterThan(0);
+
+		// Simulate a peer reset. Without the permanent listener this would
+		// throw an unhandled 'error' and tear the process down.
+		conn?.emit("error", new Error("synthetic ECONNRESET"));
+
+		// Listener should have logged the drop and cleared the conn.
+		expect(drops).toContain("socket");
+		expect(getConn(emitter)).toBeNull();
+
+		emitter.close();
+		await server.stop();
+	});
+
+	it("re-dials transparently after a socket error event", async () => {
+		const sockPath = tempSockPath("err-redial");
+		const server = startEchoServer(sockPath);
+		const emitter = new Emitter({ socketPath: sockPath });
+
+		// First emit dials and delivers.
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		// Inject a synthetic error on the live conn — the permanent listener
+		// must clear it without throwing.
+		getConn(emitter)?.emit("error", new Error("synthetic peer reset"));
+
+		// Next emit should re-dial and deliver another frame to the SAME
+		// echo server (it never went away).
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length >= 2);
+		expect(await server.frames()).toHaveLength(2);
+
+		emitter.close();
+		await server.stop();
+	});
+
+	it("is safe to close while a dial is in flight", async () => {
+		// Connect to a server that exists, then call close() before the
+		// connect callback has fired. The freshly connected socket must be
+		// destroyed and not retained.
+		const sockPath = tempSockPath("close-during-dial");
+		const server = startEchoServer(sockPath);
+		const emitter = new Emitter({ socketPath: sockPath });
+
+		const emitPromise = emitter.emit(GOOD_EVENT);
+		// Close immediately. Depending on timing this may or may not race
+		// the connect callback, but neither outcome must crash or leak.
+		emitter.close();
+
+		const result = await emitPromise;
+		// Either null (silently dropped) or the closed Error — both acceptable.
+		if (result !== null) {
+			expect(result.message).toMatch(/closed/);
+		}
+
+		await server.stop();
+	});
+});

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Tests for the fire-and-forget Unix socket emitter (ADR-0010).
+ *
+ * Test categories:
+ *   - Frame round-trip: events reach a local echo server
+ *   - session_id stability: same value across emits and reconnects
+ *   - Fire-and-forget: returns null quickly when daemon is down
+ *   - Reconnect: re-dials transparently after server restart
+ *   - Error after close: returns Error for closed emitter
+ *   - Validation: caller-bug errors for bad inputs
+ *   - Frame size: oversized frames return an Error
+ *   - defaultSocketPath: env-var and OS-default resolution
+ */
+
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	defaultSocketPath,
+	type EmitEvent,
+	Emitter,
+	MAX_FRAME_SIZE,
+	SUPPORTED_FRAME_VERSION,
+} from "./emitter.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** A unique socket path for this test run. */
+function tempSockPath(suffix: string): string {
+	return join(tmpdir(), `ar-emitter-test-${process.pid}-${suffix}.sock`);
+}
+
+/**
+ * Minimal echo server that reads length-prefixed frames and collects the JSON
+ * body of each frame. Returns the socket path and a way to read received
+ * frames.
+ */
+function startEchoServer(sockPath: string): {
+	frames: () => Promise<string[]>;
+	stop: () => Promise<void>;
+} {
+	const received: string[] = [];
+	// Track open client sockets so stop() can forcefully destroy them,
+	// ensuring the emitter sees the connection die immediately.
+	const openSockets = new Set<import("node:net").Socket>();
+
+	const server = createServer((socket) => {
+		openSockets.add(socket);
+		socket.once("close", () => openSockets.delete(socket));
+
+		let buf = Buffer.alloc(0);
+		socket.on("data", (chunk: Buffer) => {
+			buf = Buffer.concat([buf, chunk]);
+			// Parse as many complete frames as possible.
+			while (buf.length >= 4) {
+				const len = buf.readUInt32BE(0);
+				if (buf.length < 4 + len) {
+					break;
+				}
+				received.push(buf.subarray(4, 4 + len).toString("utf8"));
+				buf = buf.subarray(4 + len);
+			}
+		});
+	});
+
+	server.listen(sockPath);
+
+	return {
+		frames: () =>
+			new Promise<string[]>((resolve) => {
+				// Give the OS a tick to deliver any in-flight data.
+				setTimeout(() => resolve([...received]), 10);
+			}),
+		stop: () =>
+			new Promise<void>((resolve, reject) => {
+				// Destroy all open client sockets so the emitter sees the connection
+				// die immediately rather than waiting for a graceful FIN.
+				for (const s of openSockets) {
+					s.destroy();
+				}
+				server.close((err) => (err ? reject(err) : resolve()));
+			}),
+	};
+}
+
+/** Wait up to `ms` for `predicate()` to return true, polling every 5 ms. */
+async function waitFor(
+	predicate: () => boolean | Promise<boolean>,
+	ms = 500,
+): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (Date.now() < deadline) {
+		if (await predicate()) {
+			return;
+		}
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitFor timed out after ${ms}ms`);
+}
+
+const GOOD_EVENT: EmitEvent = {
+	channel: "test-channel",
+	tool: { name: "my_tool" },
+	decision: "allowed",
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("Emitter — validation errors (caller bugs)", () => {
+	it("returns an error for empty channel", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, channel: "" });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/missing channel/);
+		e.close();
+	});
+
+	it("returns an error for empty tool.name", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, tool: { name: "" } });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/missing tool\.name/);
+		e.close();
+	});
+
+	it("returns an error for invalid decision", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			// biome-ignore lint/suspicious/noExplicitAny: testing invalid value
+			decision: "maybe" as any,
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/invalid decision/);
+		e.close();
+	});
+
+	it("returns an error for malformed input JSON", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, input: "{bad json}" });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/input is not valid JSON/);
+		e.close();
+	});
+
+	it("returns an error for malformed output JSON", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, output: "[unclosed" });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/output is not valid JSON/);
+		e.close();
+	});
+
+	it("returns an error after close", async () => {
+		const sockPath = tempSockPath("closed");
+		const { stop } = startEchoServer(sockPath);
+		const e = new Emitter({ socketPath: sockPath });
+		e.close();
+		const err = await e.emit(GOOD_EVENT);
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/closed/);
+		await stop();
+	});
+});
+
+describe("Emitter — frame round-trip", () => {
+	let sockPath: string;
+	let server: ReturnType<typeof startEchoServer>;
+	let emitter: Emitter;
+
+	beforeEach(() => {
+		sockPath = tempSockPath("roundtrip");
+		server = startEchoServer(sockPath);
+		emitter = new Emitter({ socketPath: sockPath });
+	});
+
+	afterEach(async () => {
+		emitter.close();
+		await server.stop();
+	});
+
+	it("delivers a frame to the server", async () => {
+		const err = await emitter.emit(GOOD_EVENT);
+		expect(err).toBeNull();
+
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		expect(frames).toHaveLength(1);
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.v).toBe(SUPPORTED_FRAME_VERSION);
+		expect(f.channel).toBe("test-channel");
+		expect(f.tool.name).toBe("my_tool");
+		expect(f.decision).toBe("allowed");
+	});
+
+	it("frame contains session_id matching emitter.sessionId", async () => {
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.session_id).toBe(emitter.sessionId);
+	});
+
+	it("ts_emit is RFC3339Nano UTC", async () => {
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		// e.g. "2026-05-07T12:34:56.789000000Z"
+		expect(f.ts_emit).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/);
+		expect(f.ts_emit.endsWith("Z")).toBe(true);
+	});
+
+	it("optional tool.server is included when provided", async () => {
+		await emitter.emit({
+			...GOOD_EVENT,
+			tool: { server: "mcp-server", name: "read_file" },
+		});
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.tool.server).toBe("mcp-server");
+		expect(f.tool.name).toBe("read_file");
+	});
+
+	it("tool.server is absent when not provided", async () => {
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.tool).not.toHaveProperty("server");
+	});
+
+	it("input and output are forwarded as raw JSON values (not double-encoded)", async () => {
+		await emitter.emit({
+			...GOOD_EVENT,
+			input: '{"key":"value"}',
+			output: "[1,2,3]",
+		});
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.input).toEqual({ key: "value" });
+		expect(f.output).toEqual([1, 2, 3]);
+	});
+
+	it("omits input and output when not provided", async () => {
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f).not.toHaveProperty("input");
+		expect(f).not.toHaveProperty("output");
+	});
+
+	it("includes error field when provided", async () => {
+		await emitter.emit({ ...GOOD_EVENT, error: "tool failed" });
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.error).toBe("tool failed");
+	});
+
+	it("sends multiple frames in order", async () => {
+		for (const decision of ["allowed", "denied", "pending"] as const) {
+			await emitter.emit({ ...GOOD_EVENT, decision });
+		}
+		await waitFor(async () => (await server.frames()).length >= 3);
+
+		const frames = await server.frames();
+		expect(frames).toHaveLength(3);
+		const decisions = frames.map((raw) => JSON.parse(raw).decision);
+		expect(decisions).toEqual(["allowed", "denied", "pending"]);
+	});
+});
+
+describe("Emitter — session_id stability", () => {
+	it("session_id is stable across multiple emits", async () => {
+		const sockPath = tempSockPath("session");
+		const server = startEchoServer(sockPath);
+		const emitter = new Emitter({ socketPath: sockPath });
+
+		await emitter.emit(GOOD_EVENT);
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length >= 2);
+
+		const frames = await server.frames();
+		const ids = frames.map((raw) => JSON.parse(raw).session_id);
+		expect(ids[0]).toBe(ids[1]);
+		expect(ids[0]).toBe(emitter.sessionId);
+
+		emitter.close();
+		await server.stop();
+	});
+
+	it("host-supplied sessionId is used and stable", async () => {
+		const sockPath = tempSockPath("supplied-session");
+		const server = startEchoServer(sockPath);
+		const emitter = new Emitter({
+			socketPath: sockPath,
+			sessionId: "my-session-42",
+		});
+
+		expect(emitter.sessionId).toBe("my-session-42");
+
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.session_id).toBe("my-session-42");
+
+		emitter.close();
+		await server.stop();
+	});
+
+	it("empty sessionId falls back to a generated UUID", () => {
+		const emitter = new Emitter({
+			socketPath: tempSockPath("empty-session"),
+			sessionId: "",
+		});
+		expect(emitter.sessionId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+		emitter.close();
+	});
+});
+
+describe("Emitter — fire-and-forget when daemon is down", () => {
+	it("returns null quickly when no daemon is listening", async () => {
+		const sockPath = tempSockPath("down");
+		const emitter = new Emitter({ socketPath: sockPath });
+
+		const start = Date.now();
+		const err = await emitter.emit(GOOD_EVENT);
+		const elapsed = Date.now() - start;
+
+		expect(err).toBeNull();
+		// Must return within 50ms (dial timeout is 25ms + overhead).
+		expect(elapsed).toBeLessThan(150);
+
+		emitter.close();
+	});
+
+	it("logs a drop when daemon is down (debugLog is called)", async () => {
+		const sockPath = tempSockPath("drop-log");
+		const drops: Array<{ message: string; attrs: Record<string, string> }> = [];
+		const emitter = new Emitter({
+			socketPath: sockPath,
+			debugLog: (message, attrs) => drops.push({ message, attrs }),
+		});
+
+		await emitter.emit(GOOD_EVENT);
+
+		expect(drops).toHaveLength(1);
+		expect(drops[0]?.message).toMatch(/dropped event/);
+		expect(drops[0]?.attrs.stage).toBe("dial");
+
+		emitter.close();
+	});
+});
+
+describe("Emitter — reconnect after daemon restart", () => {
+	it("re-dials after the server stops and restarts", async () => {
+		const sockPath = tempSockPath("reconnect");
+		const server1 = startEchoServer(sockPath);
+		const emitter = new Emitter({ socketPath: sockPath });
+
+		// First emit reaches server1.
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server1.frames()).length > 0);
+		expect(await server1.frames()).toHaveLength(1);
+
+		// Stop server1 and emit — connection is broken, drop silently.
+		await server1.stop();
+		const errAfterStop = await emitter.emit(GOOD_EVENT);
+		expect(errAfterStop).toBeNull();
+
+		// Restart on the same socket path, then emit again — should re-dial.
+		const server2 = startEchoServer(sockPath);
+		// Give the OS a moment to bind.
+		await new Promise((r) => setTimeout(r, 20));
+
+		const errAfterRestart = await emitter.emit(GOOD_EVENT);
+		expect(errAfterRestart).toBeNull();
+
+		await waitFor(async () => (await server2.frames()).length > 0);
+		expect(await server2.frames()).toHaveLength(1);
+
+		emitter.close();
+		await server2.stop();
+	});
+});
+
+describe("Emitter — frame size limit", () => {
+	it("returns an error for oversized frames", async () => {
+		const sockPath = tempSockPath("oversize");
+		const emitter = new Emitter({ socketPath: sockPath });
+		// Construct a JSON string that, when marshalled into the full frame, exceeds 1 MiB.
+		// A 1 MiB payload string alone is sufficient.
+		const bigInput = JSON.stringify("x".repeat(MAX_FRAME_SIZE));
+		const err = await emitter.emit({ ...GOOD_EVENT, input: bigInput });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/frame too large/);
+		emitter.close();
+	});
+});
+
+describe("defaultSocketPath", () => {
+	it("respects AGENTRECEIPTS_SOCKET env var", () => {
+		const original = process.env.AGENTRECEIPTS_SOCKET;
+		process.env.AGENTRECEIPTS_SOCKET = "/custom/path.sock";
+		try {
+			expect(defaultSocketPath()).toBe("/custom/path.sock");
+		} finally {
+			if (original === undefined) {
+				delete process.env.AGENTRECEIPTS_SOCKET;
+			} else {
+				process.env.AGENTRECEIPTS_SOCKET = original;
+			}
+		}
+	});
+
+	it("returns a non-empty path on this platform (darwin or linux)", () => {
+		const original = process.env.AGENTRECEIPTS_SOCKET;
+		delete process.env.AGENTRECEIPTS_SOCKET;
+		try {
+			const p = defaultSocketPath();
+			// macOS and Linux both have defaults; only 'other' platforms return "".
+			const os = process.platform;
+			if (os === "darwin" || os === "linux") {
+				expect(p).not.toBe("");
+				expect(p).toMatch(/events\.sock$/);
+			}
+		} finally {
+			if (original !== undefined) {
+				process.env.AGENTRECEIPTS_SOCKET = original;
+			}
+		}
+	});
+});
+
+describe("Emitter — constructor", () => {
+	it("throws when no socket path is available on unsupported platform", () => {
+		// We can't change the real platform, but we can test with an explicit empty path.
+		// The only way defaultSocketPath returns "" is on non-darwin/linux, which we mock
+		// by passing socketPath: "" through options — which replicates the same code path.
+		// Actually, socketPath: "" is treated as undefined (falls through to defaultSocketPath).
+		// Instead just verify that socketPath: "/" does NOT throw.
+		expect(() => new Emitter({ socketPath: "/tmp/test.sock" })).not.toThrow();
+	});
+});

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -128,8 +128,8 @@ describe("Emitter — validation errors (caller bugs)", () => {
 		const e = new Emitter({ socketPath: tempSockPath("noop") });
 		const err = await e.emit({
 			...GOOD_EVENT,
-			// biome-ignore lint/suspicious/noExplicitAny: testing invalid value
-			decision: "maybe" as any,
+			// @ts-expect-error testing invalid decision value
+			decision: "maybe",
 		});
 		expect(err).toBeInstanceOf(Error);
 		expect(err?.message).toMatch(/invalid decision/);
@@ -249,6 +249,36 @@ describe("Emitter — frame round-trip", () => {
 		const f = JSON.parse(frames[0] ?? "{}");
 		expect(f.input).toEqual({ key: "value" });
 		expect(f.output).toEqual([1, 2, 3]);
+	});
+
+	it("input and output are byte-exact verbatim (whitespace preserved)", async () => {
+		// The daemon canonicalises (RFC 8785) and hashes the raw frame bytes,
+		// so any whitespace, key-order, or number-formatting changes here would
+		// silently change the receipt hash. Pin the verbatim guarantee.
+		const rawInput = '{ "b": 2,\n  "a": 1 }';
+		const rawOutput = "[\t1.0,\n2,\n3 ]";
+		await emitter.emit({
+			...GOOD_EVENT,
+			input: rawInput,
+			output: rawOutput,
+		});
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const raw = (await server.frames())[0] ?? "";
+		expect(raw).toContain(`"input":${rawInput}`);
+		expect(raw).toContain(`"output":${rawOutput}`);
+	});
+
+	it("preserves '$' sequences in input/output (no String.replace pattern interpretation)", async () => {
+		// String.prototype.replace treats '$&', '$1', etc. as backreferences when
+		// the replacement is a string. We use the function form to avoid that —
+		// pin it with a payload that would be mangled if we ever regressed.
+		const rawInput = '{"price":"$100","ref":"$1$&$\'"}';
+		await emitter.emit({ ...GOOD_EVENT, input: rawInput });
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const raw = (await server.frames())[0] ?? "";
+		expect(raw).toContain(`"input":${rawInput}`);
 	});
 
 	it("omits input and output when not provided", async () => {
@@ -450,12 +480,26 @@ describe("defaultSocketPath", () => {
 });
 
 describe("Emitter — constructor", () => {
-	it("throws when no socket path is available on unsupported platform", () => {
-		// We can't change the real platform, but we can test with an explicit empty path.
-		// The only way defaultSocketPath returns "" is on non-darwin/linux, which we mock
-		// by passing socketPath: "" through options — which replicates the same code path.
-		// Actually, socketPath: "" is treated as undefined (falls through to defaultSocketPath).
-		// Instead just verify that socketPath: "/" does NOT throw.
+	it("throws when socketPath is an empty string and no env override is set", () => {
+		// An explicit empty socketPath replicates the same failure code path
+		// that occurs on platforms where defaultSocketPath() returns "".
+		// (??-fallback only triggers on null/undefined, so "" reaches the
+		// !socketPath guard.) The constructor must reject this with an
+		// actionable error rather than silently producing an unusable emitter.
+		const original = process.env.AGENTRECEIPTS_SOCKET;
+		delete process.env.AGENTRECEIPTS_SOCKET;
+		try {
+			expect(() => new Emitter({ socketPath: "" })).toThrow(
+				/no default socket path/,
+			);
+		} finally {
+			if (original !== undefined) {
+				process.env.AGENTRECEIPTS_SOCKET = original;
+			}
+		}
+	});
+
+	it("does not throw when given a valid explicit socket path", () => {
 		expect(() => new Emitter({ socketPath: "/tmp/test.sock" })).not.toThrow();
 	});
 });

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -542,8 +542,8 @@ describe("Emitter — socket-error robustness", () => {
 	// permanent error listener the host process would crash via Node's
 	// unhandled-'error' rule. These tests pin that contract.
 	function getConn(emitter: Emitter): import("node:net").Socket | null {
-		return (emitter as unknown as { conn: import("node:net").Socket | null })
-			.conn;
+		// @ts-expect-error accessing private conn for test assertions
+		return emitter.conn;
 	}
 
 	it("surviving an 'error' event on a live conn does not crash the process", async () => {

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -12,6 +12,7 @@
  *   - defaultSocketPath: env-var and OS-default resolution
  */
 
+import { unlinkSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -26,19 +27,30 @@ import {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/** A unique socket path for this test run. */
+/** Monotonic counter so every tempSockPath call returns a unique path. */
+let _sockSeq = 0;
+
+/** A unique socket path for each call (pid + counter + suffix). */
 function tempSockPath(suffix: string): string {
-	return join(tmpdir(), `ar-emitter-test-${process.pid}-${suffix}.sock`);
+	return join(
+		tmpdir(),
+		`ar-emitter-test-${process.pid}-${++_sockSeq}-${suffix}.sock`,
+	);
 }
 
 /**
  * Minimal echo server that reads length-prefixed frames and collects the JSON
  * body of each frame. Returns the socket path and a way to read received
  * frames.
+ *
+ * `ready` resolves once the server is actually listening. Tests that emit
+ * immediately after construction should await it to avoid a race between the
+ * first connect and the server's bind completing.
  */
 function startEchoServer(sockPath: string): {
 	frames: () => Promise<string[]>;
 	stop: () => Promise<void>;
+	ready: Promise<void>;
 } {
 	const received: string[] = [];
 	// Track open client sockets so stop() can forcefully destroy them,
@@ -64,6 +76,18 @@ function startEchoServer(sockPath: string): {
 		});
 	});
 
+	// Unlink any stale socket file from a previous (possibly crashed) test run
+	// so server.listen() doesn't get EADDRINUSE.
+	try {
+		unlinkSync(sockPath);
+	} catch {
+		// Socket file didn't exist — fine.
+	}
+
+	const ready = new Promise<void>((resolve, reject) => {
+		server.once("listening", resolve);
+		server.once("error", reject);
+	});
 	server.listen(sockPath);
 
 	return {
@@ -81,6 +105,7 @@ function startEchoServer(sockPath: string): {
 				}
 				server.close((err) => (err ? reject(err) : resolve()));
 			}),
+		ready,
 	};
 }
 
@@ -169,9 +194,10 @@ describe("Emitter — frame round-trip", () => {
 	let server: ReturnType<typeof startEchoServer>;
 	let emitter: Emitter;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		sockPath = tempSockPath("roundtrip");
 		server = startEchoServer(sockPath);
+		await server.ready;
 		emitter = new Emitter({ socketPath: sockPath });
 	});
 

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -184,6 +184,25 @@ describe("Emitter — validation errors (caller bugs)", () => {
 		e.close();
 	});
 
+	it("returns an error for input containing a non-finite number", async () => {
+		// 1e400 overflows float64 to Infinity; JSON.parse accepts it but the
+		// daemon's RFC 8785 canonicaliser rejects it — catch it here as a
+		// caller-bug Error rather than letting it become a silent drop.
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, input: '{"n":1e400}' });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/input is not valid JSON/);
+		e.close();
+	});
+
+	it("returns an error for output containing a non-finite number", async () => {
+		const e = new Emitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({ ...GOOD_EVENT, output: "[1e400]" });
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/output is not valid JSON/);
+		e.close();
+	});
+
 	it("returns an error after close", async () => {
 		const sockPath = tempSockPath("closed");
 		const { stop } = startEchoServer(sockPath);

--- a/sdk/ts/src/emitter.test.ts
+++ b/sdk/ts/src/emitter.test.ts
@@ -103,7 +103,14 @@ function startEchoServer(sockPath: string): {
 				for (const s of openSockets) {
 					s.destroy();
 				}
-				server.close((err) => (err ? reject(err) : resolve()));
+				server.close((err) => {
+					try {
+						unlinkSync(sockPath);
+					} catch {
+						// Already gone — fine.
+					}
+					err ? reject(err) : resolve();
+				});
 			}),
 		ready,
 	};
@@ -443,8 +450,7 @@ describe("Emitter — reconnect after daemon restart", () => {
 
 		// Restart on the same socket path, then emit again — should re-dial.
 		const server2 = startEchoServer(sockPath);
-		// Give the OS a moment to bind.
-		await new Promise((r) => setTimeout(r, 20));
+		await server2.ready;
 
 		const errAfterRestart = await emitter.emit(GOOD_EVENT);
 		expect(errAfterRestart).toBeNull();

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -333,14 +333,19 @@ export class Emitter {
 	private async doWrite(body: Buffer): Promise<Error | null> {
 		const dialErr = await this.dialIfNeeded();
 		if (dialErr !== null) {
+			// "emitter: closed" is a caller-bug error — propagate it so
+			// emit() surfaces it even when close() raced past the entry check.
+			if (dialErr.message === "emitter: closed") {
+				return dialErr;
+			}
 			this.logDrop("dial", dialErr);
 			return null;
 		}
 
 		const conn = this.conn;
 		if (conn === null) {
-			// Closed between dial and write; drop silently.
-			return null;
+			// close() raced between dialIfNeeded and this read.
+			return this.closed ? new Error("emitter: closed") : null;
 		}
 
 		const writeErr = await this.writeFrame(conn, body);
@@ -402,6 +407,13 @@ export class Emitter {
 			}, DIAL_TIMEOUT_MS);
 
 			const socket = createConnection({ path: this.socketPath }, () => {
+				// Dial timeout already fired and destroyed this socket — the
+				// promise is settled. Discard the late-arriving connection
+				// without touching this.conn so the next emit() re-dials.
+				if (settled) {
+					socket.destroy();
+					return;
+				}
 				// Attach a permanent error listener BEFORE settling. Without
 				// it, any later 'error' event on this socket (peer reset,
 				// daemon crash, EPIPE on a half-open conn) crashes the host
@@ -496,12 +508,31 @@ export class Emitter {
 	}
 }
 
-/** Returns true if the string is syntactically valid JSON. */
+/**
+ * Returns true if the string is syntactically valid JSON and contains no
+ * non-finite numbers. JSON.parse accepts overflow values like 1e400 as
+ * Infinity, but the daemon's RFC 8785 canonicaliser rejects non-finite
+ * numbers — so we reject them here rather than silently dropping the frame.
+ */
 function isValidJson(s: string): boolean {
 	try {
-		JSON.parse(s);
-		return true;
+		return !hasNonFiniteNumber(JSON.parse(s));
 	} catch {
 		return false;
 	}
+}
+
+function hasNonFiniteNumber(val: unknown): boolean {
+	if (typeof val === "number") {
+		return !Number.isFinite(val);
+	}
+	if (Array.isArray(val)) {
+		return val.some(hasNonFiniteNumber);
+	}
+	if (val !== null && typeof val === "object") {
+		return Object.values(val as Record<string, unknown>).some(
+			hasNonFiniteNumber,
+		);
+	}
+	return false;
 }

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -147,7 +147,11 @@ export function defaultSocketPath(): string {
 	const os = platform();
 	if (os === "darwin") {
 		const tmpdir = process.env.TMPDIR ?? "/tmp";
-		return join(tmpdir, "agentreceipts", "events.sock");
+		const candidate = join(tmpdir, "agentreceipts", "events.sock");
+		// AF_UNIX sun_path is ~104 bytes on macOS; guard against unusually long $TMPDIR.
+		return candidate.length <= 90
+			? candidate
+			: "/tmp/agentreceipts/events.sock";
 	}
 	if (os === "linux") {
 		const xdgRuntime = process.env.XDG_RUNTIME_DIR;

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -319,14 +319,16 @@ export class Emitter {
 	 * doWrite dials if needed, then writes the framed body. Returns null on
 	 * success, logs and returns null on transient errors (fire-and-forget).
 	 *
-	 * If the write fails on a previously-established connection (e.g. the
-	 * daemon restarted), the dead connection is discarded and one transparent
-	 * re-dial + re-write is attempted before giving up. The transparent
-	 * retry exists because Node buffers writes optimistically: a write that
-	 * "succeeded" earlier may turn out to have been on a stale socket the
-	 * kernel only reports as dead on the next attempt, so the FIRST emit
-	 * after a daemon restart would otherwise be lost without anyone seeing
-	 * a transient failure.
+	 * Write timeouts are treated as drops without retry: a timeout does not
+	 * mean the frame was not received — the data may already be in-flight or
+	 * fully delivered, so retrying risks a duplicate receipt.
+	 *
+	 * Connection errors (EPIPE, ECONNRESET, etc.) on a previously-established
+	 * connection trigger one transparent re-dial + re-write. Node buffers
+	 * writes optimistically: a write that "succeeded" earlier may turn out to
+	 * have been on a stale socket the kernel only reports as dead on the next
+	 * attempt, so the FIRST emit after a daemon restart would otherwise be
+	 * lost without anyone seeing a transient failure.
 	 */
 	private async doWrite(body: Buffer): Promise<Error | null> {
 		const dialErr = await this.dialIfNeeded();
@@ -346,8 +348,16 @@ export class Emitter {
 			return null;
 		}
 
-		// First write failed: the conn is dead. Discard it, then attempt
-		// one transparent re-dial + re-write.
+		// A write timeout means the frame may already have been received by
+		// the daemon. Retrying risks a duplicate receipt — treat as a drop.
+		if (writeErr.message.startsWith("write timeout")) {
+			this.logDrop("write", writeErr);
+			this.discardConn(conn);
+			return null;
+		}
+
+		// Connection error: the daemon definitively did not receive the frame.
+		// Discard and attempt one transparent re-dial + re-write.
 		this.discardConn(conn);
 
 		const redialErr = await this.dialIfNeeded();

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -52,13 +52,17 @@ export interface EmitEvent {
 	channel: string;
 	tool: EmitTool;
 	/**
-	 * Raw JSON string for the tool input. Forwarded verbatim — NOT
-	 * re-serialised. Must be valid JSON if provided.
+	 * Raw JSON string for the tool input. Forwarded verbatim — the exact
+	 * bytes are embedded in the frame without re-parsing or reformatting,
+	 * so the daemon's RFC 8785 canonicalisation sees the same bytes the
+	 * caller produced. Must be valid JSON if provided.
 	 */
 	input?: string;
 	/**
-	 * Raw JSON string for the tool output. Forwarded verbatim — NOT
-	 * re-serialised. Must be valid JSON if provided.
+	 * Raw JSON string for the tool output. Forwarded verbatim — the exact
+	 * bytes are embedded in the frame without re-parsing or reformatting,
+	 * so the daemon's RFC 8785 canonicalisation sees the same bytes the
+	 * caller produced. Must be valid JSON if provided.
 	 */
 	output?: string;
 	/** Human-readable error message when the tool call failed. */
@@ -88,7 +92,13 @@ export interface EmitterOptions {
 	debugLog?: (message: string, attrs: Record<string, string>) => void;
 }
 
-/** Wire frame sent to the daemon (field names must match exactly). */
+/**
+ * Wire frame sent to the daemon (field names must match exactly).
+ *
+ * input/output are sentinel placeholder strings during JSON.stringify; the
+ * encoded sentinels are then replaced with the caller's raw JSON bytes so
+ * the daemon hashes the verbatim input/output the caller produced.
+ */
 interface WireFrame {
 	v: string;
 	ts_emit: string;
@@ -98,11 +108,26 @@ interface WireFrame {
 		server?: string;
 		name: string;
 	};
-	input?: unknown;
-	output?: unknown;
+	input?: string;
+	output?: string;
 	error?: string;
 	decision: string;
 }
+
+/**
+ * Sentinel placeholders for verbatim input/output pass-through. These strings
+ * are placed into the frame in the input/output slots, then JSON.stringify
+ * encodes them as JSON string literals (with surrounding quotes). After
+ * stringification we splice the encoded sentinel out and splice the caller's
+ * raw JSON bytes in, so the daemon's RFC 8785 canonicalisation sees the
+ * exact bytes the caller produced (no whitespace normalisation, no key
+ * reordering, no number reformatting).
+ *
+ * Sentinels include random hex so they cannot collide with caller content
+ * even if the caller deliberately tries to forge them.
+ */
+const RAW_INPUT_SENTINEL = `__AR_RAW_INPUT_${randomUUID()}__`;
+const RAW_OUTPUT_SENTINEL = `__AR_RAW_OUTPUT_${randomUUID()}__`;
 
 /**
  * Returns the per-OS default path for the daemon socket.
@@ -177,9 +202,8 @@ export class Emitter {
 			);
 		}
 		this.socketPath = socketPath;
-		this.sessionId = options.sessionId?.trim()
-			? options.sessionId
-			: randomUUID();
+		const trimmedSessionId = options.sessionId?.trim();
+		this.sessionId = trimmedSessionId ? trimmedSessionId : randomUUID();
 		this.debugLog = options.debugLog ?? (() => {});
 	}
 
@@ -213,6 +237,10 @@ export class Emitter {
 			return new Error("emitter: output is not valid JSON");
 		}
 
+		// Build the frame with sentinel placeholder strings for input/output.
+		// JSON.stringify will encode these as JSON string literals; we then
+		// splice the raw caller-supplied JSON bytes in so the daemon hashes
+		// the exact bytes the caller produced (verbatim pass-through).
 		const wireFrame: WireFrame = {
 			v: SUPPORTED_FRAME_VERSION,
 			ts_emit: rfc3339Nano(),
@@ -222,13 +250,28 @@ export class Emitter {
 				...(ev.tool.server ? { server: ev.tool.server } : {}),
 				name: ev.tool.name,
 			},
-			...(ev.input !== undefined ? { input: parseJsonRaw(ev.input) } : {}),
-			...(ev.output !== undefined ? { output: parseJsonRaw(ev.output) } : {}),
+			...(ev.input !== undefined ? { input: RAW_INPUT_SENTINEL } : {}),
+			...(ev.output !== undefined ? { output: RAW_OUTPUT_SENTINEL } : {}),
 			...(ev.error ? { error: ev.error } : {}),
 			decision: ev.decision,
 		};
 
-		const body = Buffer.from(JSON.stringify(wireFrame), "utf8");
+		let serialised = JSON.stringify(wireFrame);
+		if (ev.input !== undefined) {
+			// Use a function replacement so '$' sequences in ev.input are not
+			// interpreted as String.prototype.replace special patterns.
+			serialised = serialised.replace(
+				JSON.stringify(RAW_INPUT_SENTINEL),
+				() => ev.input as string,
+			);
+		}
+		if (ev.output !== undefined) {
+			serialised = serialised.replace(
+				JSON.stringify(RAW_OUTPUT_SENTINEL),
+				() => ev.output as string,
+			);
+		}
+		const body = Buffer.from(serialised, "utf8");
 		if (body.length > MAX_FRAME_SIZE) {
 			return new Error(
 				`emitter: frame too large: ${body.length} bytes (max ${MAX_FRAME_SIZE})`,
@@ -441,13 +484,4 @@ function isValidJson(s: string): boolean {
 	} catch {
 		return false;
 	}
-}
-
-/**
- * Parse a raw JSON string into a value that will be serialised verbatim by
- * JSON.stringify. Using JSON.parse ensures the value round-trips correctly
- * without double-encoding.
- */
-function parseJsonRaw(s: string): unknown {
-	return JSON.parse(s);
 }

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -213,6 +213,12 @@ export class Emitter {
 	 * the conn is reset for re-dial on the next emit(). Returns an Error only
 	 * for caller bugs (emitter closed, oversized frame, invalid event fields,
 	 * malformed input/output JSON) — situations a retry could not fix.
+	 *
+	 * Concurrent-close caveat: if close() is called concurrently with an
+	 * in-flight emit() that has already passed the initial closed check, the
+	 * emit may result in a silent drop (null) rather than an Error. This is
+	 * consistent with the fire-and-forget failure model — the daemon may or
+	 * may not have received the frame by the time close() interrupts.
 	 */
 	async emit(ev: EmitEvent): Promise<Error | null> {
 		// Validate caller-supplied fields first (before acquiring the write lock).

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -1,0 +1,391 @@
+/**
+ * Thin fire-and-forget emitter for the agent-receipts daemon's local Unix
+ * domain socket. Emit forwards a tool-call frame to the daemon, which
+ * captures peer credentials, canonicalises (RFC 8785), signs (Ed25519), and
+ * persists the receipt. The emitter does NO crypto, NO canonicalisation, and
+ * holds NO chain state — those moved to the daemon per ADR-0010 (daemon
+ * process separation, 2026-05-03).
+ *
+ * Concurrency: emit() is safe to call from multiple async contexts on a
+ * single Emitter instance. The internal write is serialised so concurrent
+ * calls cannot interleave bytes on the same socket connection.
+ *
+ * Failure model: emit() MUST NOT block the agent on the daemon. When the
+ * socket is unreachable (daemon not started, socket file missing, broken
+ * connection) emit() logs a debug-level drop and returns null within
+ * milliseconds. Returns an error only for caller bugs (missing channel,
+ * missing tool name, invalid decision, invalid JSON, emitter already closed)
+ * — situations a retry could not fix.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createConnection } from "node:net";
+import { platform } from "node:os";
+import { join } from "node:path";
+
+/** Maximum allowed frame size in bytes (1 MiB). Must match daemon's socket.MaxFrameSize. */
+export const MAX_FRAME_SIZE = 1 << 20;
+
+/** Wire format version. Must match daemon's pipeline.SupportedFrameVersion. */
+export const SUPPORTED_FRAME_VERSION = "1";
+
+/** Dial timeout in milliseconds — caps how long emit() blocks reaching the daemon. */
+const DIAL_TIMEOUT_MS = 25;
+
+/** Write deadline in milliseconds — caps how long a single frame write can block. */
+const WRITE_TIMEOUT_MS = 100;
+
+/** Valid decision values (must be lowercase to match the wire format). */
+const VALID_DECISIONS = new Set(["allowed", "denied", "pending"]);
+
+/** Tool identifies the tool the agent invoked. server is optional. */
+export interface EmitTool {
+	/** Optional server qualifier. When absent the action type is "channel.name". */
+	server?: string;
+	/** Tool name. Required and non-empty. */
+	name: string;
+}
+
+/** One tool invocation to forward to the daemon. */
+export interface EmitEvent {
+	/** Stable channel identifier (required, non-empty). */
+	channel: string;
+	tool: EmitTool;
+	/**
+	 * Raw JSON string for the tool input. Forwarded verbatim — NOT
+	 * re-serialised. Must be valid JSON if provided.
+	 */
+	input?: string;
+	/**
+	 * Raw JSON string for the tool output. Forwarded verbatim — NOT
+	 * re-serialised. Must be valid JSON if provided.
+	 */
+	output?: string;
+	/** Human-readable error message when the tool call failed. */
+	error?: string;
+	/** Policy decision for this call. */
+	decision: "allowed" | "denied" | "pending";
+}
+
+/** Options for constructing an Emitter. */
+export interface EmitterOptions {
+	/**
+	 * Override the daemon socket path. When unset, resolved from the
+	 * AGENTRECEIPTS_SOCKET env var then the per-OS default.
+	 */
+	socketPath?: string;
+	/**
+	 * Supply a host session identifier instead of generating a fresh UUID v4.
+	 * Per ADR-0010 OQ4, use the host's session id when available so a single
+	 * agent loop produces one logical session. An empty string is ignored and
+	 * a UUID is generated instead.
+	 */
+	sessionId?: string;
+	/**
+	 * Logger function for debug-level drop diagnostics. Defaults to no-op.
+	 * Pass `console.debug` or a structured logger to surface drops.
+	 */
+	debugLog?: (message: string, attrs: Record<string, string>) => void;
+}
+
+/** Wire frame sent to the daemon (field names must match exactly). */
+interface WireFrame {
+	v: string;
+	ts_emit: string;
+	session_id: string;
+	channel: string;
+	tool: {
+		server?: string;
+		name: string;
+	};
+	input?: unknown;
+	output?: unknown;
+	error?: string;
+	decision: string;
+}
+
+/**
+ * Returns the per-OS default path for the daemon socket.
+ *
+ * Resolution order:
+ * 1. AGENTRECEIPTS_SOCKET environment variable (any platform).
+ * 2. macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
+ * 3. Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/events.sock.
+ * 4. Linux fallback: /run/agentreceipts/events.sock.
+ * 5. Other platforms: empty string — pass socketPath explicitly.
+ */
+export function defaultSocketPath(): string {
+	const envPath = process.env.AGENTRECEIPTS_SOCKET;
+	if (envPath) {
+		return envPath;
+	}
+	const os = platform();
+	if (os === "darwin") {
+		const tmpdir = process.env.TMPDIR ?? "/tmp";
+		return join(tmpdir, "agentreceipts", "events.sock");
+	}
+	if (os === "linux") {
+		const xdgRuntime = process.env.XDG_RUNTIME_DIR;
+		if (xdgRuntime) {
+			return join(xdgRuntime, "agentreceipts", "events.sock");
+		}
+		return "/run/agentreceipts/events.sock";
+	}
+	return "";
+}
+
+/**
+ * RFC3339Nano timestamp: Node's toISOString() produces milliseconds only
+ * ("2026-05-07T12:34:56.789Z"). Extend to nanosecond-resolution zeros to
+ * match Go's time.RFC3339Nano format ("2026-05-07T12:34:56.789000000Z").
+ */
+function rfc3339Nano(): string {
+	return new Date().toISOString().replace(/\.(\d{3})Z$/, ".$1000000Z");
+}
+
+/**
+ * Emitter is the daemon-socket client. Construct with `new Emitter(...)`,
+ * fire events with `emit()`, release the socket with `close()`.
+ *
+ * The session_id is generated once at construction (UUID v4) and remains
+ * stable for the lifetime of this instance — including across daemon
+ * reconnects (ADR-0010 OQ4).
+ *
+ * Construction does NOT dial the daemon — dialing is lazy on the first
+ * `emit()` so that constructing an emitter cannot fail because the daemon
+ * happens to be down at the moment.
+ */
+export class Emitter {
+	readonly sessionId: string;
+
+	private readonly socketPath: string;
+	private readonly debugLog: (
+		message: string,
+		attrs: Record<string, string>,
+	) => void;
+
+	private conn: ReturnType<typeof createConnection> | null = null;
+	private closed = false;
+	// Serialise writes so concurrent emit() calls cannot interleave bytes.
+	private writeQueue: Promise<void> = Promise.resolve();
+
+	constructor(options: EmitterOptions = {}) {
+		const socketPath = options.socketPath ?? defaultSocketPath();
+		if (!socketPath) {
+			throw new Error(
+				`emitter: no default socket path on ${platform()}; set AGENTRECEIPTS_SOCKET or pass socketPath`,
+			);
+		}
+		this.socketPath = socketPath;
+		this.sessionId = options.sessionId?.trim()
+			? options.sessionId
+			: randomUUID();
+		this.debugLog = options.debugLog ?? (() => {});
+	}
+
+	/**
+	 * Emit sends one event to the daemon. Returns null even when the daemon
+	 * is unreachable: dial and write failures are logged at debug level and
+	 * the conn is reset for re-dial on the next emit(). Returns an Error only
+	 * for caller bugs (emitter closed, oversized frame, invalid event fields,
+	 * malformed input/output JSON) — situations a retry could not fix.
+	 */
+	async emit(ev: EmitEvent): Promise<Error | null> {
+		// Validate caller-supplied fields first (before acquiring the write lock).
+		if (this.closed) {
+			return new Error("emitter: closed");
+		}
+		if (!ev.channel) {
+			return new Error("emitter: missing channel");
+		}
+		if (!ev.tool.name) {
+			return new Error("emitter: missing tool.name");
+		}
+		if (!VALID_DECISIONS.has(ev.decision)) {
+			return new Error(
+				`emitter: invalid decision "${ev.decision}" (want allowed|denied|pending)`,
+			);
+		}
+		if (ev.input !== undefined && !isValidJson(ev.input)) {
+			return new Error("emitter: input is not valid JSON");
+		}
+		if (ev.output !== undefined && !isValidJson(ev.output)) {
+			return new Error("emitter: output is not valid JSON");
+		}
+
+		const wireFrame: WireFrame = {
+			v: SUPPORTED_FRAME_VERSION,
+			ts_emit: rfc3339Nano(),
+			session_id: this.sessionId,
+			channel: ev.channel,
+			tool: {
+				...(ev.tool.server ? { server: ev.tool.server } : {}),
+				name: ev.tool.name,
+			},
+			...(ev.input !== undefined ? { input: parseJsonRaw(ev.input) } : {}),
+			...(ev.output !== undefined ? { output: parseJsonRaw(ev.output) } : {}),
+			...(ev.error ? { error: ev.error } : {}),
+			decision: ev.decision,
+		};
+
+		const body = Buffer.from(JSON.stringify(wireFrame), "utf8");
+		if (body.length > MAX_FRAME_SIZE) {
+			return new Error(
+				`emitter: frame too large: ${body.length} bytes (max ${MAX_FRAME_SIZE})`,
+			);
+		}
+
+		// Serialise into the write queue so concurrent calls do not interleave.
+		return this.enqueueWrite(body);
+	}
+
+	/**
+	 * Close releases the underlying connection. After Close, subsequent emit()
+	 * calls return an Error. Safe to call multiple times.
+	 */
+	close(): void {
+		if (this.closed) {
+			return;
+		}
+		this.closed = true;
+		if (this.conn !== null) {
+			this.conn.destroy();
+			this.conn = null;
+		}
+	}
+
+	/**
+	 * Enqueue a serialised write onto the sequential write queue. All calls
+	 * run in order; a failed write drops and resets the connection.
+	 */
+	private enqueueWrite(body: Buffer): Promise<Error | null> {
+		const next = this.writeQueue.then(() => this.doWrite(body));
+		// Keep the queue moving even if doWrite rejects (it shouldn't, but guard it).
+		this.writeQueue = next.then(
+			() => {},
+			() => {},
+		);
+		return next;
+	}
+
+	/**
+	 * doWrite dials if needed, then writes the framed body. Returns null on
+	 * success, logs and returns null on transient errors (fire-and-forget).
+	 *
+	 * If the write fails on a previously-established connection (e.g. the
+	 * daemon restarted), the dead connection is discarded and one transparent
+	 * re-dial + re-write is attempted before giving up.
+	 */
+	private async doWrite(body: Buffer): Promise<Error | null> {
+		const dialErr = await this.dialIfNeeded();
+		if (dialErr !== null) {
+			this.logDrop("dial", dialErr);
+			return null;
+		}
+
+		const writeErr = await this.writeFrame(body);
+		if (writeErr !== null) {
+			// Discard the dead connection.
+			this.conn?.destroy();
+			this.conn = null;
+
+			// One transparent retry: re-dial and try again.
+			const redialErr = await this.dialIfNeeded();
+			if (redialErr !== null) {
+				this.logDrop("dial", redialErr);
+				return null;
+			}
+			const retryErr = await this.writeFrame(body);
+			if (retryErr !== null) {
+				this.logDrop("write", retryErr);
+				// TypeScript narrows this.conn to null after the earlier assignment;
+				// re-dial may have set it to a new socket, so capture before clearing.
+				const deadConn = this.conn as ReturnType<
+					typeof createConnection
+				> | null;
+				this.conn = null;
+				deadConn?.destroy();
+			}
+		}
+		return null;
+	}
+
+	/** Dial the daemon socket if not already connected. */
+	private dialIfNeeded(): Promise<Error | null> {
+		if (this.conn !== null) {
+			return Promise.resolve(null);
+		}
+		return new Promise((resolve) => {
+			const timer = setTimeout(() => {
+				socket.destroy();
+				resolve(new Error(`dial timeout after ${DIAL_TIMEOUT_MS}ms`));
+			}, DIAL_TIMEOUT_MS);
+
+			const socket = createConnection({ path: this.socketPath }, () => {
+				clearTimeout(timer);
+				this.conn = socket;
+				resolve(null);
+			});
+
+			socket.once("error", (err) => {
+				clearTimeout(timer);
+				resolve(err);
+			});
+		});
+	}
+
+	/** Write a 4-byte big-endian length prefix followed by the body. */
+	private writeFrame(body: Buffer): Promise<Error | null> {
+		return new Promise((resolve) => {
+			if (this.conn === null) {
+				resolve(new Error("no connection"));
+				return;
+			}
+			const conn = this.conn;
+
+			const header = Buffer.allocUnsafe(4);
+			header.writeUInt32BE(body.length, 0);
+			const frame = Buffer.concat([header, body]);
+
+			const timer = setTimeout(() => {
+				resolve(new Error(`write timeout after ${WRITE_TIMEOUT_MS}ms`));
+			}, WRITE_TIMEOUT_MS);
+
+			conn.write(frame, (err) => {
+				clearTimeout(timer);
+				if (err) {
+					resolve(err);
+				} else {
+					resolve(null);
+				}
+			});
+		});
+	}
+
+	private logDrop(stage: string, err: Error): void {
+		this.debugLog("agent-receipts emitter dropped event", {
+			stage,
+			socket: this.socketPath,
+			err: err.message,
+		});
+	}
+}
+
+/** Returns true if the string is syntactically valid JSON. */
+function isValidJson(s: string): boolean {
+	try {
+		JSON.parse(s);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Parse a raw JSON string into a value that will be serialised verbatim by
+ * JSON.stringify. Using JSON.parse ensures the value round-trips correctly
+ * without double-encoding.
+ */
+function parseJsonRaw(s: string): unknown {
+	return JSON.parse(s);
+}

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -19,7 +19,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createConnection } from "node:net";
+import { createConnection, type Socket } from "node:net";
 import { platform } from "node:os";
 import { join } from "node:path";
 
@@ -164,7 +164,7 @@ export class Emitter {
 		attrs: Record<string, string>,
 	) => void;
 
-	private conn: ReturnType<typeof createConnection> | null = null;
+	private conn: Socket | null = null;
 	private closed = false;
 	// Serialise writes so concurrent emit() calls cannot interleave bytes.
 	private writeQueue: Promise<void> = Promise.resolve();
@@ -274,7 +274,12 @@ export class Emitter {
 	 *
 	 * If the write fails on a previously-established connection (e.g. the
 	 * daemon restarted), the dead connection is discarded and one transparent
-	 * re-dial + re-write is attempted before giving up.
+	 * re-dial + re-write is attempted before giving up. The transparent
+	 * retry exists because Node buffers writes optimistically: a write that
+	 * "succeeded" earlier may turn out to have been on a stale socket the
+	 * kernel only reports as dead on the next attempt, so the FIRST emit
+	 * after a daemon restart would otherwise be lost without anyone seeing
+	 * a transient failure.
 	 */
 	private async doWrite(body: Buffer): Promise<Error | null> {
 		const dialErr = await this.dialIfNeeded();
@@ -283,29 +288,34 @@ export class Emitter {
 			return null;
 		}
 
-		const writeErr = await this.writeFrame(body);
-		if (writeErr !== null) {
-			// Discard the dead connection.
-			this.conn?.destroy();
-			this.conn = null;
+		const conn = this.conn;
+		if (conn === null) {
+			// Closed between dial and write; drop silently.
+			return null;
+		}
 
-			// One transparent retry: re-dial and try again.
-			const redialErr = await this.dialIfNeeded();
-			if (redialErr !== null) {
-				this.logDrop("dial", redialErr);
-				return null;
-			}
-			const retryErr = await this.writeFrame(body);
-			if (retryErr !== null) {
-				this.logDrop("write", retryErr);
-				// TypeScript narrows this.conn to null after the earlier assignment;
-				// re-dial may have set it to a new socket, so capture before clearing.
-				const deadConn = this.conn as ReturnType<
-					typeof createConnection
-				> | null;
-				this.conn = null;
-				deadConn?.destroy();
-			}
+		const writeErr = await this.writeFrame(conn, body);
+		if (writeErr === null) {
+			return null;
+		}
+
+		// First write failed: the conn is dead. Discard it, then attempt
+		// one transparent re-dial + re-write.
+		this.discardConn(conn);
+
+		const redialErr = await this.dialIfNeeded();
+		if (redialErr !== null) {
+			this.logDrop("dial", redialErr);
+			return null;
+		}
+		const newConn = this.conn;
+		if (newConn === null) {
+			return null;
+		}
+		const retryErr = await this.writeFrame(newConn, body);
+		if (retryErr !== null) {
+			this.logDrop("write", retryErr);
+			this.discardConn(newConn);
 		}
 		return null;
 	}
@@ -315,49 +325,101 @@ export class Emitter {
 		if (this.conn !== null) {
 			return Promise.resolve(null);
 		}
+		if (this.closed) {
+			return Promise.resolve(new Error("emitter: closed"));
+		}
 		return new Promise((resolve) => {
+			let settled = false;
+			const settle = (err: Error | null) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				resolve(err);
+			};
+
 			const timer = setTimeout(() => {
 				socket.destroy();
-				resolve(new Error(`dial timeout after ${DIAL_TIMEOUT_MS}ms`));
+				settle(new Error(`dial timeout after ${DIAL_TIMEOUT_MS}ms`));
 			}, DIAL_TIMEOUT_MS);
 
 			const socket = createConnection({ path: this.socketPath }, () => {
-				clearTimeout(timer);
+				// Attach a permanent error listener BEFORE settling. Without
+				// it, any later 'error' event on this socket (peer reset,
+				// daemon crash, EPIPE on a half-open conn) crashes the host
+				// process via Node's unhandled-'error' rule. The listener
+				// also discards the dead conn so the next emit() re-dials
+				// transparently.
+				socket.on("error", (err) => this.handleSocketError(socket, err));
+				// If close() ran while we were dialing, drop this freshly
+				// connected socket on the floor — the caller already asked
+				// to release resources.
+				if (this.closed) {
+					socket.destroy();
+					settle(new Error("emitter: closed"));
+					return;
+				}
 				this.conn = socket;
-				resolve(null);
+				settle(null);
 			});
 
 			socket.once("error", (err) => {
-				clearTimeout(timer);
-				resolve(err);
+				// Dial-time error: 'connect' never fired, so the permanent
+				// listener was never installed and this once-listener is
+				// the only one. settle() also clears the dial timer.
+				settle(err);
 			});
 		});
 	}
 
+	/**
+	 * Permanent socket error listener. Discards the dead conn so the next
+	 * emit() re-dials, and logs the drop. This listener is what prevents
+	 * a peer reset from crashing the host process via Node's unhandled-
+	 * 'error' rule.
+	 */
+	private handleSocketError(socket: Socket, err: Error): void {
+		this.logDrop("socket", err);
+		// Only forget conn if it still points at this socket; a later dial
+		// may have replaced it and we don't want to drop the live one.
+		if (this.conn === socket) {
+			this.conn = null;
+		}
+		socket.destroy();
+	}
+
+	/** Discard a connection: forget it if current, then destroy. */
+	private discardConn(socket: Socket): void {
+		if (this.conn === socket) {
+			this.conn = null;
+		}
+		socket.destroy();
+	}
+
 	/** Write a 4-byte big-endian length prefix followed by the body. */
-	private writeFrame(body: Buffer): Promise<Error | null> {
+	private writeFrame(conn: Socket, body: Buffer): Promise<Error | null> {
 		return new Promise((resolve) => {
-			if (this.conn === null) {
-				resolve(new Error("no connection"));
-				return;
-			}
-			const conn = this.conn;
+			let settled = false;
+			const settle = (err: Error | null) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				resolve(err);
+			};
 
 			const header = Buffer.allocUnsafe(4);
 			header.writeUInt32BE(body.length, 0);
 			const frame = Buffer.concat([header, body]);
 
 			const timer = setTimeout(() => {
-				resolve(new Error(`write timeout after ${WRITE_TIMEOUT_MS}ms`));
+				settle(new Error(`write timeout after ${WRITE_TIMEOUT_MS}ms`));
 			}, WRITE_TIMEOUT_MS);
 
 			conn.write(frame, (err) => {
-				clearTimeout(timer);
-				if (err) {
-					resolve(err);
-				} else {
-					resolve(null);
-				}
+				settle(err ?? null);
 			});
 		});
 	}

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -258,17 +258,21 @@ export class Emitter {
 
 		let serialised = JSON.stringify(wireFrame);
 		if (ev.input !== undefined) {
+			// Match "input":"<sentinel>" so the replacement can never target
+			// another field even if the sentinel appears elsewhere in the frame.
 			// Use a function replacement so '$' sequences in ev.input are not
 			// interpreted as String.prototype.replace special patterns.
+			const input = ev.input;
 			serialised = serialised.replace(
-				JSON.stringify(RAW_INPUT_SENTINEL),
-				() => ev.input as string,
+				`"input":${JSON.stringify(RAW_INPUT_SENTINEL)}`,
+				() => `"input":${input}`,
 			);
 		}
 		if (ev.output !== undefined) {
+			const output = ev.output;
 			serialised = serialised.replace(
-				JSON.stringify(RAW_OUTPUT_SENTINEL),
-				() => ev.output as string,
+				`"output":${JSON.stringify(RAW_OUTPUT_SENTINEL)}`,
+				() => `"output":${output}`,
 			);
 		}
 		const body = Buffer.from(serialised, "utf8");
@@ -455,13 +459,15 @@ export class Emitter {
 
 			const header = Buffer.allocUnsafe(4);
 			header.writeUInt32BE(body.length, 0);
-			const frame = Buffer.concat([header, body]);
 
 			const timer = setTimeout(() => {
 				settle(new Error(`write timeout after ${WRITE_TIMEOUT_MS}ms`));
 			}, WRITE_TIMEOUT_MS);
 
-			conn.write(frame, (err) => {
+			// Write header and body as two sequential calls to avoid allocating
+			// a concat buffer for every emit (avoids one copy of the full frame).
+			conn.write(header);
+			conn.write(body, (err) => {
 				settle(err ?? null);
 			});
 		});

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -530,9 +530,7 @@ function hasNonFiniteNumber(val: unknown): boolean {
 		return val.some(hasNonFiniteNumber);
 	}
 	if (val !== null && typeof val === "object") {
-		return Object.values(val as Record<string, unknown>).some(
-			hasNonFiniteNumber,
-		);
+		return Object.values(val).some(hasNonFiniteNumber);
 	}
 	return false;
 }

--- a/sdk/ts/src/emitter.ts
+++ b/sdk/ts/src/emitter.ts
@@ -484,11 +484,15 @@ export class Emitter {
 	}
 
 	private logDrop(stage: string, err: Error): void {
-		this.debugLog("agent-receipts emitter dropped event", {
-			stage,
-			socket: this.socketPath,
-			err: err.message,
-		});
+		try {
+			this.debugLog("agent-receipts emitter dropped event", {
+				stage,
+				socket: this.socketPath,
+				err: err.message,
+			});
+		} catch {
+			// A throwing debugLog must not take down the host process.
+		}
 	}
 }
 

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -1,4 +1,13 @@
 export {
+	defaultSocketPath,
+	type EmitEvent,
+	type EmitTool,
+	Emitter,
+	type EmitterOptions,
+	MAX_FRAME_SIZE,
+	SUPPORTED_FRAME_VERSION,
+} from "./emitter.js";
+export {
 	type ChainVerification,
 	type ReceiptVerification,
 	verifyChain,


### PR DESCRIPTION
Closes the TypeScript SDK portion of #236 (Section 3 — thin emitter refactor).

## What

Adds `Emitter`, `EmitEvent`, `EmitTool`, `EmitterOptions`, `defaultSocketPath`, `MAX_FRAME_SIZE`, and `SUPPORTED_FRAME_VERSION` to `@agnt-rcpt/sdk-ts`. All symbols are re-exported from `src/index.ts`.

The emitter forwards tool-call frames to the daemon's local Unix socket with **no crypto, no canonicalisation, and no chain state** — all of that lives in the daemon per [ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md).

## Wire format

A 4-byte big-endian length prefix followed by a UTF-8 JSON body:

```
{ v, ts_emit, session_id, channel, tool: { server?, name }, input?, output?, error?, decision }
```

`ts_emit` is RFC3339Nano UTC (nanosecond zeros appended to Node's millisecond `toISOString()` to match Go's `time.RFC3339Nano`). Field names match the daemon's `pipeline.Frame` exactly.

## Design highlights (per ADR-0010 OQ4 resolution)

- **session_id** is generated once at construction (UUID v4) and stays stable across reconnects. The host may supply its own id via `EmitterOptions.sessionId`.
- **Fire-and-forget failure model**: dial and write failures are logged at debug level and swallowed — the agent is never blocked on the daemon. Returns `Error` only for caller bugs (missing channel/tool name, invalid decision, malformed JSON, closed emitter, oversized frame — situations a retry cannot fix).
- **Serialised writes**: a `Promise` queue ensures concurrent `emit()` calls cannot interleave bytes on the same socket.
- **Transparent reconnect**: if a write fails on a stale connection (e.g. daemon restart), the dead socket is discarded and one re-dial + re-write is attempted before giving up. This avoids a two-emit penalty on the first frame after a reconnect.
- **Lazy dial**: construction never touches the socket, so constructing an `Emitter` cannot fail because the daemon is down.

## Socket path resolution

1. `AGENTRECEIPTS_SOCKET` env var (any platform)
2. macOS: `$TMPDIR/agentreceipts/events.sock`
3. Linux: `$XDG_RUNTIME_DIR/agentreceipts/events.sock` or `/run/agentreceipts/events.sock`
4. Other: empty string — pass `socketPath` explicitly or set the env var

## Tests (25 new, all passing)

- Frame round-trip via a local echo server (field values, session_id, ts_emit format, tool.server, input/output JSON pass-through, ordering)
- session_id stability across emits and reconnects; host-supplied id; empty-string fallback to UUID
- Fire-and-forget: returns `null` within 150 ms when no daemon is listening; `debugLog` is called with `stage: "dial"`
- Transparent reconnect after server stop + restart on the same socket path
- Frame size limit (>1 MiB returns `Error`)
- Validation errors (empty channel, empty tool.name, invalid decision, malformed input/output JSON, emit after close)
- `defaultSocketPath` env-var and OS-default resolution

## Files changed

- `sdk/ts/src/emitter.ts` — new: `Emitter` class, types, helpers
- `sdk/ts/src/emitter.test.ts` — new: 25 tests
- `sdk/ts/src/index.ts` — re-exports all public emitter symbols (added as first export block, before the existing receipt/store/taxonomy exports)