### PR TITLE
feat(sdk/py): thin fire-and-forget emitter (ADR-0010)

### DIFF
--- a/sdk/py/src/agent_receipts/__init__.py
+++ b/sdk/py/src/agent_receipts/__init__.py
@@ -1,6 +1,7 @@
 """Python SDK for the Agent Receipts protocol."""
 
 from agent_receipts._version import VERSION
+from agent_receipts.emitter import Emitter, default_socket_path
 from agent_receipts.receipt.chain import (
     ChainVerification,
     ReceiptVerification,
@@ -101,6 +102,9 @@ __all__ = [
     "CreateReceiptInput",
     "create_receipt",
     "createReceipt",
+    # Emitter (ADR-0010 daemon client)
+    "Emitter",
+    "default_socket_path",
     # Hashing
     "canonicalize",
     "hash_receipt",

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import platform
 import socket
@@ -170,8 +171,16 @@ class Emitter:
             When the emitter has been closed.
         """
         # --- validate caller inputs first (before acquiring lock) ---
+        if not isinstance(channel, str):
+            raise ValueError(
+                f"emitter: channel must be a str, got {type(channel).__name__!r}"
+            )
         if not channel:
             raise ValueError("emitter: missing channel")
+        if not isinstance(tool_name, str):
+            raise ValueError(
+                f"emitter: tool_name must be a str, got {type(tool_name).__name__!r}"
+            )
         if not tool_name:
             raise ValueError("emitter: missing tool_name")
         if decision not in _VALID_DECISIONS:
@@ -341,10 +350,31 @@ def _to_raw_json(value: bytes | str | None, field: str) -> bytes | None:
     if not raw:
         return None
     try:
-        json.loads(raw)
+        parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise ValueError(f"emitter: {field} is not valid JSON: {exc}") from exc
+    _check_finite(parsed, field)
     return raw
+
+
+def _check_finite(value: object, field: str) -> None:
+    """Recursively reject non-finite floats (inf, -inf, nan).
+
+    RFC 8785 canonicalisation rejects non-finite numbers, and Python's
+    json.loads() accepts ``1e400`` as ``float('inf')``, so we must catch
+    these before the frame reaches the daemon.
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"emitter: {field} contains a non-finite number ({value!r})"
+            )
+    elif isinstance(value, dict):
+        for v in value.values():
+            _check_finite(v, field)
+    elif isinstance(value, list):
+        for item in value:
+            _check_finite(item, field)
 
 
 def _build_tool(name: str, server: str) -> dict[str, str]:

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -60,7 +60,7 @@ def default_socket_path() -> str:
 
     system = platform.system()
     if system == "Darwin":
-        base = os.environ.get("TMPDIR", "/tmp")
+        base = os.environ.get("TMPDIR") or "/tmp"
         return os.path.join(base, "agentreceipts", "events.sock")
     if system == "Linux":
         xdg = os.environ.get("XDG_RUNTIME_DIR", "")

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -113,6 +113,10 @@ class Emitter:
                 "set AGENTRECEIPTS_SOCKET or pass socket_path="
             )
         self._socket_path = socket_path
+        if session_id and not isinstance(session_id, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(
+                f"emitter: session_id must be a str, got {type(session_id).__name__!r}"
+            )
         self._session_id = session_id if session_id else str(uuid.uuid4())
         self._log = log if log is not None else logger
 

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -182,8 +182,8 @@ class Emitter:
         raw_input = _to_raw_json(input, "input")
         raw_output = _to_raw_json(output, "output")
 
-        # Build the frame dict.  Input/output are embedded as pre-parsed
-        # JSON so json.dumps does NOT re-encode them — they travel verbatim.
+        # Build the frame dict.  Input/output are wrapped in _RawJSON so the
+        # custom _encode_dict serialiser embeds them verbatim — no re-encoding.
         frame: dict[str, object] = {
             "v": SUPPORTED_FRAME_VERSION,
             "ts_emit": _now_rfc3339(),
@@ -218,7 +218,7 @@ class Emitter:
                 try:
                     conn.close()
                 except OSError:
-                    pass
+                    pass  # close errors during teardown are intentionally ignored
                 self._conn = None
 
     def close(self) -> None:
@@ -235,7 +235,7 @@ class Emitter:
                 try:
                     self._conn.close()
                 except OSError:
-                    pass
+                    pass  # best-effort close; connection is being discarded regardless
                 self._conn = None
 
     def __enter__(self) -> Emitter:
@@ -263,7 +263,7 @@ class Emitter:
             try:
                 conn.close()
             except OSError:
-                pass
+                pass  # close errors on a failed dial are intentionally ignored
             self._log.debug(
                 "agent-receipts emitter dropped event",
                 extra={
@@ -323,6 +323,13 @@ def _to_raw_json(value: bytes | str | None, field: str) -> bytes | None:
         raw = value.encode()
     else:
         raw = bytes(value)
+        # Reject non-UTF-8 bytes early: _encode_value does raw.decode() which
+        # defaults to UTF-8, so non-UTF-8 input would raise UnicodeDecodeError
+        # inside emit(), breaking the documented failure model.
+        try:
+            raw.decode()
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"emitter: {field} is not UTF-8 encoded: {exc}") from exc
     if not raw:
         return None
     try:

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -23,6 +23,7 @@ import socket
 import struct
 import threading
 import uuid
+from datetime import UTC, datetime
 from typing import cast
 
 logger = logging.getLogger(__name__)
@@ -162,11 +163,10 @@ class Emitter:
         ------
         ValueError
             For caller bugs: empty channel, empty tool_name, invalid decision,
-            invalid JSON in input/output.
+            invalid JSON in input/output, or a serialised frame larger than
+            ``MAX_FRAME_SIZE`` (1 MiB — the daemon's hard wire-protocol cap).
         RuntimeError
             When the emitter has been closed.
-        OverflowError
-            When the serialised frame exceeds ``MAX_FRAME_SIZE`` (1 MiB).
         """
         # --- validate caller inputs first (before acquiring lock) ---
         if not channel:
@@ -201,7 +201,7 @@ class Emitter:
 
         body = _marshal_frame(frame)
         if len(body) > MAX_FRAME_SIZE:
-            raise OverflowError(
+            raise ValueError(
                 f"emitter: frame too large: {len(body)} bytes (max {MAX_FRAME_SIZE})"
             )
 
@@ -252,13 +252,18 @@ class Emitter:
         """Return the live connection, dialing if needed. Returns None on failure."""
         if self._conn is not None:
             return self._conn
+        conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             conn.settimeout(_DIAL_TIMEOUT)
             conn.connect(self._socket_path)
-            self._conn = conn
-            return conn
         except OSError as exc:
+            # Release the FD eagerly — without this, the half-open socket
+            # would linger until garbage collection and we would leak FDs
+            # on every emit() against a missing daemon.
+            try:
+                conn.close()
+            except OSError:
+                pass
             self._log.debug(
                 "agent-receipts emitter dropped event",
                 extra={
@@ -268,6 +273,8 @@ class Emitter:
                 },
             )
             return None
+        self._conn = conn
+        return conn
 
     def _write_frame(self, conn: socket.socket, body: bytes) -> bool:
         """Write a length-prefixed frame. Returns True on success."""
@@ -333,11 +340,14 @@ def _build_tool(name: str, server: str) -> dict[str, str]:
 
 
 def _now_rfc3339() -> str:
-    """Return current UTC time as RFC3339 with microsecond precision."""
-    from datetime import UTC, datetime
+    """Return current UTC time as RFC3339Nano with microsecond precision.
 
+    The daemon parses ``ts_emit`` with Go's ``time.RFC3339Nano``, which accepts
+    0–9 fractional-second digits. Python's stdlib only resolves to microseconds
+    (6 digits); we pad with three trailing zeros so the wire format is visibly
+    RFC3339Nano even when no nanosecond detail is available.
+    """
     now = datetime.now(tz=UTC)
-    # Python datetime only goes to microseconds; format as RFC3339Nano-ish.
     return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond:06d}000Z"
 
 

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -22,6 +22,7 @@ import platform
 import socket
 import struct
 import threading
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import cast
@@ -278,11 +279,11 @@ class Emitter:
 
     def _write_frame(self, conn: socket.socket, body: bytes) -> bool:
         """Write a length-prefixed frame. Returns True on success."""
+        deadline = time.monotonic() + _WRITE_TIMEOUT
         try:
-            conn.settimeout(_WRITE_TIMEOUT)
             header = struct.pack(">I", len(body))
-            _send_all(conn, header)
-            _send_all(conn, body)
+            _send_all(conn, header, deadline)
+            _send_all(conn, body, deadline)
             return True
         except OSError as exc:
             self._log.debug(
@@ -301,11 +302,15 @@ class Emitter:
 # ---------------------------------------------------------------------------
 
 
-def _send_all(conn: socket.socket, data: bytes) -> None:
-    """Send all bytes, handling partial writes."""
+def _send_all(conn: socket.socket, data: bytes, deadline: float) -> None:
+    """Send all bytes against a single absolute monotonic deadline."""
     view = memoryview(data)
     sent = 0
     while sent < len(data):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise OSError("write deadline exceeded")
+        conn.settimeout(remaining)
         n = conn.send(view[sent:])
         if n == 0:
             raise OSError("socket send returned 0 (connection closed)")
@@ -320,7 +325,10 @@ def _to_raw_json(value: bytes | str | None, field: str) -> bytes | None:
     if value is None:
         return None
     if isinstance(value, str):
-        raw = value.encode()
+        try:
+            raw = value.encode()
+        except UnicodeEncodeError as exc:
+            raise ValueError(f"emitter: {field} is not UTF-8 encoded: {exc}") from exc
     else:
         raw = bytes(value)
         # Reject non-UTF-8 bytes early: _encode_value does raw.decode() which

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -171,13 +171,13 @@ class Emitter:
             When the emitter has been closed.
         """
         # --- validate caller inputs first (before acquiring lock) ---
-        if not isinstance(channel, str):
+        if not isinstance(channel, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: channel must be a str, got {type(channel).__name__!r}"
             )
         if not channel:
             raise ValueError("emitter: missing channel")
-        if not isinstance(tool_name, str):
+        if not isinstance(tool_name, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: tool_name must be a str, got {type(tool_name).__name__!r}"
             )
@@ -187,12 +187,12 @@ class Emitter:
             raise ValueError(
                 f"emitter: invalid decision {decision!r} (want allowed|denied|pending)"
             )
-        if not isinstance(tool_server, str):
+        if not isinstance(tool_server, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 "emitter: tool_server must be a str,"
                 f" got {type(tool_server).__name__!r}"
             )
-        if not isinstance(error, str):
+        if not isinstance(error, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: error must be a str, got {type(error).__name__!r}"
             )
@@ -379,10 +379,10 @@ def _check_finite(value: object, field: str) -> None:
                 f"emitter: {field} contains a non-finite number ({value!r})"
             )
     elif isinstance(value, dict):
-        for v in value.values():
+        for v in cast("dict[str, object]", value).values():
             _check_finite(v, field)
     elif isinstance(value, list):
-        for item in value:
+        for item in cast("list[object]", value):
             _check_finite(item, field)
 
 

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -105,6 +105,10 @@ class Emitter:
             Pass ``logging.getLogger("null")`` (configured with NullHandler)
             to silence drop logs in tests.
         """
+        if not isinstance(socket_path, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(
+                f"emitter: socket_path must be str, got {type(socket_path).__name__!r}"
+            )
         if not socket_path:
             socket_path = default_socket_path()
         if not socket_path:
@@ -113,7 +117,7 @@ class Emitter:
                 "set AGENTRECEIPTS_SOCKET or pass socket_path="
             )
         self._socket_path = socket_path
-        if session_id and not isinstance(session_id, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+        if not isinstance(session_id, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: session_id must be a str, got {type(session_id).__name__!r}"
             )

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -187,6 +187,15 @@ class Emitter:
             raise ValueError(
                 f"emitter: invalid decision {decision!r} (want allowed|denied|pending)"
             )
+        if not isinstance(tool_server, str):
+            raise ValueError(
+                "emitter: tool_server must be a str,"
+                f" got {type(tool_server).__name__!r}"
+            )
+        if not isinstance(error, str):
+            raise ValueError(
+                f"emitter: error must be a str, got {type(error).__name__!r}"
+            )
 
         # Normalise input/output to bytes and validate JSON.
         raw_input = _to_raw_json(input, "input")

--- a/sdk/py/src/agent_receipts/emitter.py
+++ b/sdk/py/src/agent_receipts/emitter.py
@@ -1,0 +1,370 @@
+"""Fire-and-forget emitter for the agent-receipts daemon.
+
+Forwards tool-call events to the agent-receipts daemon over a local Unix
+domain socket. The emitter does NO crypto, NO canonicalisation, and holds NO
+chain state — those live in the daemon per ADR-0010 (daemon process
+separation, 2026-05-03).
+
+Wire format: 4-byte big-endian length prefix followed by a UTF-8 JSON body.
+
+Failure model: ``emit()`` MUST return quickly even when the daemon is not
+running. Dial/write failures are logged at DEBUG level and ``None`` is
+returned. Errors are only raised for caller bugs (empty channel, empty tool
+name, invalid decision, invalid JSON in input/output, emitter already closed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import socket
+import struct
+import threading
+import uuid
+from typing import cast
+
+logger = logging.getLogger(__name__)
+
+# MaxFrameSize must agree with the daemon's socket.MaxFrameSize (1 MiB).
+MAX_FRAME_SIZE = 1 << 20
+
+# SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
+SUPPORTED_FRAME_VERSION = "1"
+
+# Dial timeout: 25ms. Well under the fire-and-forget budget.
+_DIAL_TIMEOUT = 0.025
+
+# Write deadline: 100ms. Enforces the fire-and-forget contract.
+_WRITE_TIMEOUT = 0.100
+
+_VALID_DECISIONS = frozenset({"allowed", "denied", "pending"})
+
+
+def default_socket_path() -> str:
+    """Return the per-OS default path for the daemon socket.
+
+    Resolution order:
+    1. ``AGENTRECEIPTS_SOCKET`` environment variable (any platform).
+    2. macOS: ``$TMPDIR/agentreceipts/events.sock`` (TMPDIR defaults to /tmp).
+    3. Linux with ``$XDG_RUNTIME_DIR``: ``$XDG_RUNTIME_DIR/agentreceipts/events.sock``.
+    4. Linux fallback: ``/run/agentreceipts/events.sock``.
+    5. Other platforms: empty string (caller must supply path explicitly).
+    """
+    env = os.environ.get("AGENTRECEIPTS_SOCKET", "")
+    if env:
+        return env
+
+    system = platform.system()
+    if system == "Darwin":
+        base = os.environ.get("TMPDIR", "/tmp")
+        return os.path.join(base, "agentreceipts", "events.sock")
+    if system == "Linux":
+        xdg = os.environ.get("XDG_RUNTIME_DIR", "")
+        if xdg:
+            return os.path.join(xdg, "agentreceipts", "events.sock")
+        return "/run/agentreceipts/events.sock"
+    return ""
+
+
+class Emitter:
+    """Fire-and-forget client for the agent-receipts daemon socket.
+
+    Construct with :func:`Emitter`, fire events with :meth:`emit`, release
+    the socket with :meth:`close`. Thread-safe: ``emit()`` may be called
+    concurrently from multiple threads.
+
+    The ``session_id`` is fixed for the lifetime of the emitter — even
+    across daemon reconnects — per ADR-0010 OQ4.
+    """
+
+    def __init__(
+        self,
+        *,
+        socket_path: str = "",
+        session_id: str = "",
+        log: logging.Logger | None = None,
+    ) -> None:
+        """Construct an Emitter.
+
+        Parameters
+        ----------
+        socket_path:
+            Override the daemon socket path. When empty, ``default_socket_path()``
+            is used. Pass explicitly on platforms other than macOS/Linux.
+        session_id:
+            Stable session identifier. When empty, a UUID v4 is generated.
+            Supply the host's session id so the emitter propagates it
+            across every frame (ADR-0010 OQ4).
+        log:
+            Logger for drop diagnostics. Defaults to this module's logger.
+            Pass ``logging.getLogger("null")`` (configured with NullHandler)
+            to silence drop logs in tests.
+        """
+        if not socket_path:
+            socket_path = default_socket_path()
+        if not socket_path:
+            raise ValueError(
+                f"emitter: no default socket path on {platform.system()}; "
+                "set AGENTRECEIPTS_SOCKET or pass socket_path="
+            )
+        self._socket_path = socket_path
+        self._session_id = session_id if session_id else str(uuid.uuid4())
+        self._log = log if log is not None else logger
+
+        self._lock = threading.Lock()
+        self._conn: socket.socket | None = None
+        self._closed = False
+
+    @property
+    def session_id(self) -> str:
+        """Stable per-emitter session identifier (ADR-0010 OQ4)."""
+        return self._session_id
+
+    def emit(
+        self,
+        *,
+        channel: str,
+        tool_name: str,
+        decision: str,
+        tool_server: str = "",
+        input: bytes | str | None = None,
+        output: bytes | str | None = None,
+        error: str = "",
+    ) -> None:
+        """Send one tool-call event to the daemon.
+
+        Returns ``None`` even when the daemon is unreachable: dial and write
+        failures are logged at DEBUG level and the socket is reset for
+        re-dial on the next call. Errors are only raised for caller bugs
+        that a retry could not fix.
+
+        Parameters
+        ----------
+        channel:
+            Required. Non-empty string identifying the SDK channel.
+        tool_name:
+            Required. Non-empty tool name.
+        decision:
+            Required. One of ``"allowed"``, ``"denied"``, or ``"pending"``.
+        tool_server:
+            Optional server qualifier for the tool.
+        input:
+            Optional raw JSON bytes or string. Passed verbatim to the daemon —
+            NOT re-serialised. Must be valid JSON when non-empty.
+        output:
+            Optional raw JSON bytes or string. Same rules as ``input``.
+        error:
+            Optional error string.
+
+        Raises
+        ------
+        ValueError
+            For caller bugs: empty channel, empty tool_name, invalid decision,
+            invalid JSON in input/output.
+        RuntimeError
+            When the emitter has been closed.
+        OverflowError
+            When the serialised frame exceeds ``MAX_FRAME_SIZE`` (1 MiB).
+        """
+        # --- validate caller inputs first (before acquiring lock) ---
+        if not channel:
+            raise ValueError("emitter: missing channel")
+        if not tool_name:
+            raise ValueError("emitter: missing tool_name")
+        if decision not in _VALID_DECISIONS:
+            raise ValueError(
+                f"emitter: invalid decision {decision!r} (want allowed|denied|pending)"
+            )
+
+        # Normalise input/output to bytes and validate JSON.
+        raw_input = _to_raw_json(input, "input")
+        raw_output = _to_raw_json(output, "output")
+
+        # Build the frame dict.  Input/output are embedded as pre-parsed
+        # JSON so json.dumps does NOT re-encode them — they travel verbatim.
+        frame: dict[str, object] = {
+            "v": SUPPORTED_FRAME_VERSION,
+            "ts_emit": _now_rfc3339(),
+            "session_id": self._session_id,
+            "channel": channel,
+            "tool": _build_tool(tool_name, tool_server),
+            "decision": decision,
+        }
+        if raw_input is not None:
+            frame["input"] = _RawJSON(raw_input)
+        if raw_output is not None:
+            frame["output"] = _RawJSON(raw_output)
+        if error:
+            frame["error"] = error
+
+        body = _marshal_frame(frame)
+        if len(body) > MAX_FRAME_SIZE:
+            raise OverflowError(
+                f"emitter: frame too large: {len(body)} bytes (max {MAX_FRAME_SIZE})"
+            )
+
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("emitter: closed")
+
+            conn = self._dial_if_needed()
+            if conn is None:
+                return  # dial failure already logged
+
+            if not self._write_frame(conn, body):
+                # Write failure — close and clear so next emit re-dials.
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+                self._conn = None
+
+    def close(self) -> None:
+        """Release the underlying socket connection.
+
+        After ``close()``, subsequent ``emit()`` calls raise ``RuntimeError``.
+        Safe to call multiple times.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except OSError:
+                    pass
+                self._conn = None
+
+    def __enter__(self) -> Emitter:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers (must be called with self._lock held)
+    # ------------------------------------------------------------------
+
+    def _dial_if_needed(self) -> socket.socket | None:
+        """Return the live connection, dialing if needed. Returns None on failure."""
+        if self._conn is not None:
+            return self._conn
+        try:
+            conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            conn.settimeout(_DIAL_TIMEOUT)
+            conn.connect(self._socket_path)
+            self._conn = conn
+            return conn
+        except OSError as exc:
+            self._log.debug(
+                "agent-receipts emitter dropped event",
+                extra={
+                    "stage": "dial",
+                    "socket": self._socket_path,
+                    "err": str(exc),
+                },
+            )
+            return None
+
+    def _write_frame(self, conn: socket.socket, body: bytes) -> bool:
+        """Write a length-prefixed frame. Returns True on success."""
+        try:
+            conn.settimeout(_WRITE_TIMEOUT)
+            header = struct.pack(">I", len(body))
+            _send_all(conn, header)
+            _send_all(conn, body)
+            return True
+        except OSError as exc:
+            self._log.debug(
+                "agent-receipts emitter dropped event",
+                extra={
+                    "stage": "write",
+                    "socket": self._socket_path,
+                    "err": str(exc),
+                },
+            )
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _send_all(conn: socket.socket, data: bytes) -> None:
+    """Send all bytes, handling partial writes."""
+    view = memoryview(data)
+    sent = 0
+    while sent < len(data):
+        n = conn.send(view[sent:])
+        if n == 0:
+            raise OSError("socket send returned 0 (connection closed)")
+        sent += n
+
+
+def _to_raw_json(value: bytes | str | None, field: str) -> bytes | None:
+    """Normalise input/output to bytes and validate as JSON.
+
+    Returns None for absent or empty values.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        raw = value.encode()
+    else:
+        raw = bytes(value)
+    if not raw:
+        return None
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"emitter: {field} is not valid JSON: {exc}") from exc
+    return raw
+
+
+def _build_tool(name: str, server: str) -> dict[str, str]:
+    tool: dict[str, str] = {"name": name}
+    if server:
+        tool["server"] = server
+    return tool
+
+
+def _now_rfc3339() -> str:
+    """Return current UTC time as RFC3339 with microsecond precision."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(tz=UTC)
+    # Python datetime only goes to microseconds; format as RFC3339Nano-ish.
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond:06d}000Z"
+
+
+class _RawJSON:
+    """Wrapper that json.JSONEncoder serialises verbatim (no re-encoding)."""
+
+    __slots__ = ("raw",)
+
+    def __init__(self, raw: bytes) -> None:
+        self.raw = raw
+
+
+def _encode_value(v: object) -> str:
+    """Serialise one frame value, passing _RawJSON through verbatim."""
+    if isinstance(v, _RawJSON):
+        return v.raw.decode()
+    if isinstance(v, dict):
+        return _encode_dict(cast("dict[str, object]", v))
+    return json.dumps(v)
+
+
+def _encode_dict(d: dict[str, object]) -> str:
+    """Serialise a dict, embedding _RawJSON values verbatim."""
+    parts = [f"{json.dumps(k)}:{_encode_value(v)}" for k, v in d.items()]
+    return "{" + ",".join(parts) + "}"
+
+
+def _marshal_frame(frame: dict[str, object]) -> bytes:
+    """Serialise a frame dict, embedding _RawJSON values verbatim."""
+    return _encode_dict(frame).encode()

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -1,0 +1,504 @@
+"""Tests for the fire-and-forget emitter (ADR-0010).
+
+End-to-end tests start the agent-receipts-daemon as a subprocess.  The
+daemon binary is built from daemon/ and its path is resolved via the
+AGENT_RECEIPTS_DAEMON env var or a fixed /tmp path set up in conftest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+import struct
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent_receipts.emitter import Emitter, default_socket_path
+
+# ---------------------------------------------------------------------------
+# Helpers shared by daemon-backed tests
+# ---------------------------------------------------------------------------
+
+_DAEMON_BIN = os.environ.get(
+    "AGENT_RECEIPTS_DAEMON",
+    "/tmp/agent-receipts-daemon",
+)
+
+_DAEMON_AVAILABLE = Path(_DAEMON_BIN).is_file() and os.access(_DAEMON_BIN, os.X_OK)
+
+
+def _short_tmp() -> str:
+    """Return a temp dir short enough for AF_UNIX sun_path (104-byte limit on macOS)."""
+    base = "/tmp" if Path("/tmp").exists() else tempfile.gettempdir()
+    d = tempfile.mkdtemp(prefix="ar", dir=base)
+    return d
+
+
+def _write_test_key(path: str) -> None:
+    """Write a fresh Ed25519 private key in PKCS8 PEM format."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+    )
+
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    Path(path).write_bytes(pem)
+    Path(path).chmod(0o600)
+
+
+class DaemonHandle:
+    """Manages a daemon subprocess for testing."""
+
+    def __init__(self, tmpdir: str) -> None:
+        self.socket_path = os.path.join(tmpdir, "events.sock")
+        self.db_path = os.path.join(tmpdir, "receipts.db")
+        self.key_path = os.path.join(tmpdir, "signing.key")
+        self.chain_id = "py-emitter-test-chain"
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._tmpdir = tmpdir
+
+        if not Path(self.key_path).exists():
+            _write_test_key(self.key_path)
+
+    def start(self) -> None:
+        env = os.environ.copy()
+        env["AGENTRECEIPTS_SOCKET"] = self.socket_path
+        self._proc = subprocess.Popen(
+            [
+                _DAEMON_BIN,
+                "--socket",
+                self.socket_path,
+                "--db",
+                self.db_path,
+                "--key",
+                self.key_path,
+                "--chain-id",
+                self.chain_id,
+                "--issuer-id",
+                "did:agent-receipts-daemon:py-test",
+                "--verification-method",
+                "did:agent-receipts-daemon:py-test#k1",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Wait for the socket to appear (up to 2s).
+        deadline = time.monotonic() + 2.0
+        while True:
+            if Path(self.socket_path).exists():
+                break
+            if time.monotonic() > deadline:
+                self.stop()
+                raise RuntimeError(
+                    f"daemon socket {self.socket_path!r} did not appear within 2s"
+                )
+            time.sleep(0.01)
+
+    def stop(self) -> None:
+        if self._proc is None:
+            return
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait()
+        self._proc = None
+
+    def wait_for_receipts(self, want: int, timeout: float = 5.0) -> list[dict]:  # type: ignore[type-arg]
+        """Poll the SQLite DB until at least ``want`` receipts appear."""
+        deadline = time.monotonic() + timeout
+        while True:
+            rows = self._query_receipts()
+            if len(rows) >= want:
+                return rows
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"timed out waiting for {want} receipts; got {len(rows)}"
+                )
+            time.sleep(0.02)
+
+    def _query_receipts(self) -> list[dict]:  # type: ignore[type-arg]
+        if not Path(self.db_path).exists():
+            return []
+        try:
+            conn = sqlite3.connect(self.db_path)
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                "SELECT receipt_json FROM receipts"
+                " WHERE chain_id = ? ORDER BY sequence",
+                (self.chain_id,),
+            )
+            rows = [json.loads(r["receipt_json"]) for r in cur.fetchall()]
+            conn.close()
+            return rows
+        except sqlite3.OperationalError:
+            return []
+
+
+@pytest.fixture()
+def daemon(tmp_path_factory: pytest.TempPathFactory) -> DaemonHandle:  # type: ignore[return]
+    """Start a fresh daemon for one test; stop it on teardown."""
+    tmpdir = _short_tmp()
+    d = DaemonHandle(tmpdir)
+    d.start()
+    yield d  # type: ignore[misc]
+    d.stop()
+    import shutil
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+_DAEMON_SKIP_REASON = (
+    f"daemon binary not found at {_DAEMON_BIN}; "
+    "build with: cd daemon && go build ./cmd/agent-receipts-daemon"
+)
+requires_daemon = pytest.mark.skipif(not _DAEMON_AVAILABLE, reason=_DAEMON_SKIP_REASON)
+
+
+def _session_id_from_receipt(r: dict) -> str:  # type: ignore[type-arg]
+    """Read session_id from a receipt dict, tolerating camelCase or snake_case key."""
+    return r["issuer"].get("sessionId") or r["issuer"].get("session_id", "")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no daemon required
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultSocketPath:
+    def test_env_var_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENTRECEIPTS_SOCKET", "/custom/path.sock")
+        assert default_socket_path() == "/custom/path.sock"
+
+    def test_env_var_cleared(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENTRECEIPTS_SOCKET", raising=False)
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        path = default_socket_path()
+        # On macOS or Linux we get a non-empty path; on other platforms empty.
+        import platform
+
+        system = platform.system()
+        if system in ("Darwin", "Linux"):
+            assert path.endswith("agentreceipts/events.sock")
+        # Other platforms: may be empty — just don't crash.
+
+
+class TestEmitterConstruction:
+    def test_generates_session_id(self) -> None:
+        e = Emitter(socket_path="/tmp/nonexistent.sock")
+        assert e.session_id
+        assert len(e.session_id) == 36  # UUID v4 canonical form
+
+    def test_accepts_host_session_id(self) -> None:
+        sid = "host-session-abc123"
+        e = Emitter(socket_path="/tmp/nonexistent.sock", session_id=sid)
+        assert e.session_id == sid
+
+    def test_session_id_stable_across_instances(self) -> None:
+        e1 = Emitter(socket_path="/tmp/nonexistent.sock")
+        e2 = Emitter(socket_path="/tmp/nonexistent.sock")
+        assert e1.session_id != e2.session_id  # each gets a fresh UUID
+
+    def test_raises_on_unsupported_platform_without_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AGENTRECEIPTS_SOCKET", raising=False)
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        with pytest.raises(ValueError, match="no default socket path"):
+            Emitter()
+
+    def test_context_manager(self) -> None:
+        with Emitter(socket_path="/tmp/nonexistent.sock") as e:
+            assert e.session_id
+
+    def test_close_idempotent(self) -> None:
+        e = Emitter(socket_path="/tmp/nonexistent.sock")
+        e.close()
+        e.close()  # should not raise
+
+
+class TestEmitterValidation:
+    """Validation errors are raised before any dial attempt."""
+
+    def setup_method(self) -> None:
+        self.e = Emitter(socket_path="/tmp/nonexistent-validation.sock")
+
+    def teardown_method(self) -> None:
+        self.e.close()
+
+    def test_missing_channel(self) -> None:
+        with pytest.raises(ValueError, match="missing channel"):
+            self.e.emit(channel="", tool_name="noop", decision="allowed")
+
+    def test_missing_tool_name(self) -> None:
+        with pytest.raises(ValueError, match="missing tool_name"):
+            self.e.emit(channel="sdk", tool_name="", decision="allowed")
+
+    def test_empty_decision(self) -> None:
+        with pytest.raises(ValueError, match="invalid decision"):
+            self.e.emit(channel="sdk", tool_name="noop", decision="")
+
+    def test_unknown_decision(self) -> None:
+        with pytest.raises(ValueError, match="invalid decision"):
+            self.e.emit(channel="sdk", tool_name="noop", decision="maybe")
+
+    def test_invalid_input_json(self) -> None:
+        with pytest.raises(ValueError, match="input is not valid JSON"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                input=b"{bad}",
+            )
+
+    def test_invalid_output_json(self) -> None:
+        with pytest.raises(ValueError, match="output is not valid JSON"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                output="[unclosed",
+            )
+
+    def test_error_after_close(self) -> None:
+        self.e.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            self.e.emit(channel="sdk", tool_name="noop", decision="allowed")
+
+    def test_oversized_frame(self) -> None:
+        big = json.dumps({"x": "a" * (1 << 20)})
+        with pytest.raises(OverflowError, match="frame too large"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                input=big,
+            )
+
+
+class TestFireAndForgetWhenDaemonDown:
+    """Emit must return quickly and not raise when the daemon is absent."""
+
+    def test_returns_none_quickly(self) -> None:
+        e = Emitter(socket_path="/tmp/no-such-daemon-py-test.sock")
+        start = time.monotonic()
+        result = e.emit(channel="sdk", tool_name="noop", decision="allowed")
+        elapsed = time.monotonic() - start
+        assert result is None
+        assert elapsed < 0.050, f"emit blocked for {elapsed:.3f}s, want <50ms"
+        e.close()
+
+    def test_multiple_emits_all_return_none(self) -> None:
+        e = Emitter(socket_path="/tmp/no-such-daemon-py-test.sock")
+        for _ in range(5):
+            result = e.emit(channel="sdk", tool_name="noop", decision="allowed")
+            assert result is None
+        e.close()
+
+
+class TestRawJSONPassthrough:
+    """The emitter must forward input/output bytes verbatim (no re-serialisation)."""
+
+    def test_frame_contains_raw_input(self) -> None:
+        """Round-trip a frame through a mini echo server and verify input verbatim."""
+        frames: list[bytes] = []
+        ready = threading.Event()
+        sock_path = f"/tmp/ar-raw-test-{os.getpid()}.sock"
+
+        def _server() -> None:
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            srv.bind(sock_path)
+            srv.listen(1)
+            ready.set()
+            conn, _ = srv.accept()
+            hdr = conn.recv(4)
+            if len(hdr) == 4:
+                length = struct.unpack(">I", hdr)[0]
+                body = b""
+                while len(body) < length:
+                    chunk = conn.recv(length - len(body))
+                    if not chunk:
+                        break
+                    body += chunk
+                frames.append(body)
+            conn.close()
+            srv.close()
+
+        t = threading.Thread(target=_server, daemon=True)
+        t.start()
+        ready.wait(timeout=2)
+
+        try:
+            e = Emitter(socket_path=sock_path)
+            # Whitespace and key-order variation — must travel verbatim.
+            raw_input = b'{ "b":  2 , "a" : 1 }'
+            e.emit(
+                channel="sdk",
+                tool_name="hash-fixture",
+                decision="allowed",
+                input=raw_input,
+            )
+            e.close()
+            t.join(timeout=2)
+
+            assert frames, "no frame received by echo server"
+            frame = json.loads(frames[0])
+            # The input field in the frame must be valid JSON with values b=2, a=1.
+            assert frame["input"] == {"b": 2, "a": 1}
+            # And the raw bytes must be present verbatim (not re-encoded).
+            raw_frame = frames[0]
+            assert b'{ "b":  2 , "a" : 1 }' in raw_frame
+        finally:
+            try:
+                os.unlink(sock_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests — require the daemon binary
+# ---------------------------------------------------------------------------
+
+
+@requires_daemon
+def test_emit_frame_round_trip(daemon: DaemonHandle) -> None:
+    """Three events materialise as three signed receipts in the daemon's chain."""
+    e = Emitter(socket_path=daemon.socket_path)
+
+    events = [
+        {
+            "channel": "sdk",
+            "tool_name": "alpha",
+            "tool_server": "fixture",
+            "decision": "allowed",
+        },
+        {
+            "channel": "sdk",
+            "tool_name": "beta",
+            "tool_server": "fixture",
+            "decision": "denied",
+        },
+        {"channel": "sdk", "tool_name": "gamma", "decision": "pending"},
+    ]
+    for ev in events:
+        e.emit(**ev)  # type: ignore[arg-type]
+    e.close()
+
+    receipts = daemon.wait_for_receipts(3)
+    assert len(receipts) == 3
+
+    want_types = ["sdk.fixture.alpha", "sdk.fixture.beta", "sdk.gamma"]
+    want_status = ["success", "failure", "pending"]
+    for i, r in enumerate(receipts):
+        subj = r["credentialSubject"]
+        assert subj["chain"]["sequence"] == i + 1
+        assert subj["action"]["type"] == want_types[i], f"receipt {i}: wrong type"
+        assert subj["action"]["tool_name"] == events[i]["tool_name"]
+        assert subj["outcome"]["status"] == want_status[i]
+
+
+@requires_daemon
+def test_emit_session_id_stable(daemon: DaemonHandle) -> None:
+    """session_id is generated once and reused across all emits (ADR-0010 OQ4)."""
+    e = Emitter(socket_path=daemon.socket_path)
+    want_session = e.session_id
+    assert want_session  # non-empty
+
+    for _ in range(3):
+        e.emit(channel="sdk", tool_name="noop", decision="allowed")
+    e.close()
+
+    receipts = daemon.wait_for_receipts(3)
+    for i, r in enumerate(receipts):
+        got = _session_id_from_receipt(r)
+        assert got == want_session, (
+            f"receipt {i}: sessionId={got!r}, want {want_session!r}"
+        )
+
+
+@requires_daemon
+def test_emit_with_host_session_id(daemon: DaemonHandle) -> None:
+    """WithSessionID forwards a host-supplied id to the daemon."""
+    host_session = "host-supplied-session-py-9f3a"
+    e = Emitter(socket_path=daemon.socket_path, session_id=host_session)
+    assert e.session_id == host_session
+
+    e.emit(channel="sdk", tool_name="noop", decision="allowed")
+    e.close()
+
+    receipts = daemon.wait_for_receipts(1)
+    got = _session_id_from_receipt(receipts[0])
+    assert got == host_session
+
+
+@requires_daemon
+def test_emit_reconnect_after_daemon_restart(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """The emitter re-dials after the daemon restarts, session_id stays stable."""
+    tmpdir = _short_tmp()
+    import shutil
+
+    try:
+        d1 = DaemonHandle(tmpdir)
+        d1.start()
+
+        e = Emitter(socket_path=d1.socket_path)
+        want_session = e.session_id
+
+        # Round 1: two emits to the first daemon.
+        for _ in range(2):
+            e.emit(channel="sdk", tool_name="before-restart", decision="allowed")
+        d1.wait_for_receipts(2)
+
+        # Stop daemon 1.
+        d1.stop()
+
+        # Start daemon 2 reusing the same dir (same socket path + DB).
+        d2 = DaemonHandle(tmpdir)
+        d2.start()
+
+        # Loop until reconnect succeeds.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            e.emit(channel="sdk", tool_name="after-restart", decision="allowed")
+            rows = d2._query_receipts()
+            if len(rows) >= 3:
+                # Verify session_id is still stable on post-restart receipts.
+                for r in rows[2:]:
+                    got = _session_id_from_receipt(r)
+                    assert got == want_session
+                    subj = r["credentialSubject"]
+                    assert subj["action"]["tool_name"] == "after-restart"
+                e.close()
+                d2.stop()
+                return
+            time.sleep(0.05)
+
+        e.close()
+        d2.stop()
+        pytest.fail("emitter did not reconnect to the restarted daemon within 5s")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@requires_daemon
+def test_emit_returns_error_after_close(daemon: DaemonHandle) -> None:
+    """emit() raises RuntimeError after close(); close() is idempotent."""
+    e = Emitter(socket_path=daemon.socket_path)
+    e.close()
+    e.close()  # idempotent
+
+    with pytest.raises(RuntimeError, match="closed"):
+        e.emit(channel="sdk", tool_name="noop", decision="allowed")

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import socket
 import sqlite3
 import struct
@@ -17,10 +18,14 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from agent_receipts.emitter import Emitter, default_socket_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # ---------------------------------------------------------------------------
 # Helpers shared by daemon-backed tests
@@ -71,8 +76,9 @@ class DaemonHandle:
             _write_test_key(self.key_path)
 
     def start(self) -> None:
-        env = os.environ.copy()
-        env["AGENTRECEIPTS_SOCKET"] = self.socket_path
+        # Every required setting is passed as a CLI flag below; no env vars
+        # need to be propagated. AGENTRECEIPTS_SOCKET would otherwise leak
+        # into the child if it was set in the test runner's environment.
         self._proc = subprocess.Popen(
             [
                 _DAEMON_BIN,
@@ -115,7 +121,9 @@ class DaemonHandle:
             self._proc.wait()
         self._proc = None
 
-    def wait_for_receipts(self, want: int, timeout: float = 5.0) -> list[dict]:  # type: ignore[type-arg]
+    def wait_for_receipts(
+        self, want: int, timeout: float = 5.0
+    ) -> list[dict[str, Any]]:
         """Poll the SQLite DB until at least ``want`` receipts appear."""
         deadline = time.monotonic() + timeout
         while True:
@@ -128,7 +136,7 @@ class DaemonHandle:
                 )
             time.sleep(0.02)
 
-    def _query_receipts(self) -> list[dict]:  # type: ignore[type-arg]
+    def _query_receipts(self) -> list[dict[str, Any]]:
         if not Path(self.db_path).exists():
             return []
         try:
@@ -147,16 +155,16 @@ class DaemonHandle:
 
 
 @pytest.fixture()
-def daemon(tmp_path_factory: pytest.TempPathFactory) -> DaemonHandle:  # type: ignore[return]
+def daemon() -> Iterator[DaemonHandle]:
     """Start a fresh daemon for one test; stop it on teardown."""
     tmpdir = _short_tmp()
     d = DaemonHandle(tmpdir)
     d.start()
-    yield d  # type: ignore[misc]
-    d.stop()
-    import shutil
-
-    shutil.rmtree(tmpdir, ignore_errors=True)
+    try:
+        yield d
+    finally:
+        d.stop()
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 _DAEMON_SKIP_REASON = (
@@ -166,7 +174,7 @@ _DAEMON_SKIP_REASON = (
 requires_daemon = pytest.mark.skipif(not _DAEMON_AVAILABLE, reason=_DAEMON_SKIP_REASON)
 
 
-def _session_id_from_receipt(r: dict) -> str:  # type: ignore[type-arg]
+def _session_id_from_receipt(r: dict[str, Any]) -> str:
     """Read session_id from a receipt dict, tolerating camelCase or snake_case key."""
     return r["issuer"].get("sessionId") or r["issuer"].get("session_id", "")
 
@@ -278,7 +286,7 @@ class TestEmitterValidation:
 
     def test_oversized_frame(self) -> None:
         big = json.dumps({"x": "a" * (1 << 20)})
-        with pytest.raises(OverflowError, match="frame too large"):
+        with pytest.raises(ValueError, match="frame too large"):
             self.e.emit(
                 channel="sdk",
                 tool_name="noop",
@@ -307,6 +315,106 @@ class TestFireAndForgetWhenDaemonDown:
         e.close()
 
 
+class TestThreadSafety:
+    """Concurrent emit() calls must not corrupt frames or raise spuriously."""
+
+    def test_concurrent_emit_no_data_races(self) -> None:
+        """Many threads emit concurrently; all frames arrive intact."""
+        tmpdir = _short_tmp()
+        sock_path = os.path.join(tmpdir, "concurrent.sock")
+
+        n_threads = 8
+        n_per_thread = 10
+        total = n_threads * n_per_thread
+
+        frames: list[bytes] = []
+        frames_lock = threading.Lock()
+        accept_done = threading.Event()
+
+        def _server() -> None:
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                srv.bind(sock_path)
+                srv.listen(n_threads + 1)
+                deadline = time.monotonic() + 5.0
+                received = 0
+                while received < total and time.monotonic() < deadline:
+                    srv.settimeout(0.5)
+                    try:
+                        conn, _ = srv.accept()
+                    except TimeoutError:
+                        continue
+                    # Drain every frame this connection sends until EOF.
+                    with conn:
+                        while True:
+                            hdr = b""
+                            while len(hdr) < 4:
+                                chunk = conn.recv(4 - len(hdr))
+                                if not chunk:
+                                    break
+                                hdr += chunk
+                            if len(hdr) < 4:
+                                break
+                            length = struct.unpack(">I", hdr)[0]
+                            body = b""
+                            while len(body) < length:
+                                chunk = conn.recv(length - len(body))
+                                if not chunk:
+                                    break
+                                body += chunk
+                            with frames_lock:
+                                frames.append(body)
+                            received += 1
+            finally:
+                srv.close()
+                accept_done.set()
+
+        srv_thread = threading.Thread(target=_server, daemon=True)
+        srv_thread.start()
+        # Give the server a moment to bind.
+        time.sleep(0.05)
+
+        try:
+            e = Emitter(socket_path=sock_path)
+
+            def _producer(idx: int) -> None:
+                for j in range(n_per_thread):
+                    e.emit(
+                        channel="sdk",
+                        tool_name=f"t{idx}-{j}",
+                        decision="allowed",
+                    )
+
+            workers = [
+                threading.Thread(target=_producer, args=(i,), daemon=True)
+                for i in range(n_threads)
+            ]
+            for w in workers:
+                w.start()
+            for w in workers:
+                w.join(timeout=5)
+            e.close()
+            srv_thread.join(timeout=5)
+            assert accept_done.is_set(), "server did not finish in time"
+
+            with frames_lock:
+                # All emitted frames must round-trip as valid JSON.
+                assert len(frames) == total, (
+                    f"expected {total} frames, got {len(frames)}"
+                )
+                tool_names: set[str] = set()
+                for raw in frames:
+                    decoded = json.loads(raw)
+                    tool_names.add(decoded["tool"]["name"])
+                # Every tool name produced by the workers should be present.
+                expected = {
+                    f"t{i}-{j}" for i in range(n_threads) for j in range(n_per_thread)
+                }
+                assert tool_names == expected
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 class TestRawJSONPassthrough:
     """The emitter must forward input/output bytes verbatim (no re-serialisation)."""
 
@@ -314,7 +422,8 @@ class TestRawJSONPassthrough:
         """Round-trip a frame through a mini echo server and verify input verbatim."""
         frames: list[bytes] = []
         ready = threading.Event()
-        sock_path = f"/tmp/ar-raw-test-{os.getpid()}.sock"
+        tmpdir = _short_tmp()
+        sock_path = os.path.join(tmpdir, "raw.sock")
 
         def _server() -> None:
             srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -360,10 +469,7 @@ class TestRawJSONPassthrough:
             raw_frame = frames[0]
             assert b'{ "b":  2 , "a" : 1 }' in raw_frame
         finally:
-            try:
-                os.unlink(sock_path)
-            except OSError:
-                pass
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -376,35 +482,22 @@ def test_emit_frame_round_trip(daemon: DaemonHandle) -> None:
     """Three events materialise as three signed receipts in the daemon's chain."""
     e = Emitter(socket_path=daemon.socket_path)
 
-    events = [
-        {
-            "channel": "sdk",
-            "tool_name": "alpha",
-            "tool_server": "fixture",
-            "decision": "allowed",
-        },
-        {
-            "channel": "sdk",
-            "tool_name": "beta",
-            "tool_server": "fixture",
-            "decision": "denied",
-        },
-        {"channel": "sdk", "tool_name": "gamma", "decision": "pending"},
-    ]
-    for ev in events:
-        e.emit(**ev)  # type: ignore[arg-type]
+    e.emit(channel="sdk", tool_name="alpha", tool_server="fixture", decision="allowed")
+    e.emit(channel="sdk", tool_name="beta", tool_server="fixture", decision="denied")
+    e.emit(channel="sdk", tool_name="gamma", decision="pending")
     e.close()
 
     receipts = daemon.wait_for_receipts(3)
     assert len(receipts) == 3
 
     want_types = ["sdk.fixture.alpha", "sdk.fixture.beta", "sdk.gamma"]
+    want_tool_names = ["alpha", "beta", "gamma"]
     want_status = ["success", "failure", "pending"]
     for i, r in enumerate(receipts):
         subj = r["credentialSubject"]
         assert subj["chain"]["sequence"] == i + 1
         assert subj["action"]["type"] == want_types[i], f"receipt {i}: wrong type"
-        assert subj["action"]["tool_name"] == events[i]["tool_name"]
+        assert subj["action"]["tool_name"] == want_tool_names[i]
         assert subj["outcome"]["status"] == want_status[i]
 
 
@@ -443,13 +536,9 @@ def test_emit_with_host_session_id(daemon: DaemonHandle) -> None:
 
 
 @requires_daemon
-def test_emit_reconnect_after_daemon_restart(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> None:
+def test_emit_reconnect_after_daemon_restart() -> None:
     """The emitter re-dials after the daemon restarts, session_id stays stable."""
     tmpdir = _short_tmp()
-    import shutil
-
     try:
         d1 = DaemonHandle(tmpdir)
         d1.start()

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -75,6 +75,12 @@ class DaemonHandle:
             _write_test_key(self.key_path)
 
     def start(self) -> None:
+        # Remove any stale socket file left by a previous run so the
+        # file-existence readiness check below cannot false-positive.
+        try:
+            Path(self.socket_path).unlink()
+        except FileNotFoundError:
+            pass
         # Strip AGENTRECEIPTS_* from the child env — not all daemon settings
         # have CLI flag overrides (e.g. AGENTRECEIPTS_PUBLIC_KEY), so the only
         # safe approach is to remove them at the subprocess boundary.

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -80,7 +80,7 @@ class DaemonHandle:
         try:
             Path(self.socket_path).unlink()
         except FileNotFoundError:
-            pass
+            pass  # No stale socket to remove — that's fine.
         # Strip AGENTRECEIPTS_* from the child env — not all daemon settings
         # have CLI flag overrides (e.g. AGENTRECEIPTS_PUBLIC_KEY), so the only
         # safe approach is to remove them at the subprocess boundary.

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -1,8 +1,8 @@
 """Tests for the fire-and-forget emitter (ADR-0010).
 
 End-to-end tests start the agent-receipts-daemon as a subprocess.  The
-daemon binary is built from daemon/ and its path is resolved via the
-AGENT_RECEIPTS_DAEMON env var or a fixed /tmp path set up in conftest.
+daemon binary is resolved via the AGENT_RECEIPTS_DAEMON env var, falling
+back to /tmp/agent-receipts-daemon.
 """
 
 from __future__ import annotations
@@ -75,9 +75,12 @@ class DaemonHandle:
             _write_test_key(self.key_path)
 
     def start(self) -> None:
-        # Every required setting is passed as a CLI flag below; no env vars
-        # need to be propagated. AGENTRECEIPTS_SOCKET would otherwise leak
-        # into the child if it was set in the test runner's environment.
+        # Strip AGENTRECEIPTS_* from the child env — not all daemon settings
+        # have CLI flag overrides (e.g. AGENTRECEIPTS_PUBLIC_KEY), so the only
+        # safe approach is to remove them at the subprocess boundary.
+        env = {
+            k: v for k, v in os.environ.items() if not k.startswith("AGENTRECEIPTS_")
+        }
         self._proc = subprocess.Popen(
             [
                 _DAEMON_BIN,
@@ -94,8 +97,9 @@ class DaemonHandle:
                 "--verification-method",
                 "did:agent-receipts-daemon:py-test#k1",
             ],
+            env=env,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
         # Wait for the socket to appear (up to 2s).
         deadline = time.monotonic() + 2.0
@@ -103,10 +107,15 @@ class DaemonHandle:
             if Path(self.socket_path).exists():
                 break
             if time.monotonic() > deadline:
+                proc = self._proc
                 self.stop()
-                raise RuntimeError(
-                    f"daemon socket {self.socket_path!r} did not appear within 2s"
-                )
+                stderr_out = b""
+                if proc is not None and proc.stderr is not None:
+                    stderr_out = proc.stderr.read()
+                msg = f"daemon socket {self.socket_path!r} did not appear within 2s"
+                if stderr_out:
+                    msg += f"\ndaemon stderr:\n{stderr_out.decode(errors='replace')}"
+                raise RuntimeError(msg)
             time.sleep(0.01)
 
     def stop(self) -> None:

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -280,6 +280,24 @@ class TestEmitterValidation:
         with pytest.raises(ValueError, match="invalid decision"):
             self.e.emit(channel="sdk", tool_name="noop", decision="maybe")
 
+    def test_non_str_channel(self) -> None:
+        with pytest.raises(ValueError, match="channel must be a str"):
+            self.e.emit(channel=42, tool_name="noop", decision="allowed")  # type: ignore[arg-type]
+
+    def test_non_str_tool_name(self) -> None:
+        with pytest.raises(ValueError, match="tool_name must be a str"):
+            self.e.emit(channel="sdk", tool_name=42, decision="allowed")  # type: ignore[arg-type]
+
+    def test_non_str_tool_server(self) -> None:
+        with pytest.raises(ValueError, match="tool_server must be a str"):
+            self.e.emit(  # type: ignore[arg-type]
+                channel="sdk", tool_name="noop", decision="allowed", tool_server=42
+            )
+
+    def test_non_str_error(self) -> None:
+        with pytest.raises(ValueError, match="error must be a str"):
+            self.e.emit(channel="sdk", tool_name="noop", decision="allowed", error=42)  # type: ignore[arg-type]
+
     def test_invalid_input_json(self) -> None:
         with pytest.raises(ValueError, match="input is not valid JSON"):
             self.e.emit(
@@ -349,12 +367,14 @@ class TestThreadSafety:
         frames: list[bytes] = []
         frames_lock = threading.Lock()
         accept_done = threading.Event()
+        bind_ready = threading.Event()
 
         def _server() -> None:
             srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             try:
                 srv.bind(sock_path)
                 srv.listen(n_threads + 1)
+                bind_ready.set()
                 deadline = time.monotonic() + 5.0
                 received = 0
                 while received < total and time.monotonic() < deadline:
@@ -390,8 +410,7 @@ class TestThreadSafety:
 
         srv_thread = threading.Thread(target=_server, daemon=True)
         srv_thread.start()
-        # Give the server a moment to bind.
-        time.sleep(0.05)
+        bind_ready.wait(timeout=2.0)
 
         try:
             e = Emitter(socket_path=sock_path)

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -171,7 +171,9 @@ def daemon() -> Iterator[DaemonHandle]:
 
 _DAEMON_SKIP_REASON = (
     f"daemon binary not found at {_DAEMON_BIN}; "
-    "build with: cd daemon && go build ./cmd/agent-receipts-daemon"
+    "build with: cd daemon && go build"
+    " -o /tmp/agent-receipts-daemon ./cmd/agent-receipts-daemon"
+    " (or set AGENT_RECEIPTS_DAEMON to a custom path)"
 )
 requires_daemon = pytest.mark.skipif(not _DAEMON_AVAILABLE, reason=_DAEMON_SKIP_REASON)
 

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -70,7 +70,6 @@ class DaemonHandle:
         self.key_path = os.path.join(tmpdir, "signing.key")
         self.chain_id = "py-emitter-test-chain"
         self._proc: subprocess.Popen[bytes] | None = None
-        self._tmpdir = tmpdir
 
         if not Path(self.key_path).exists():
             _write_test_key(self.key_path)

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -331,6 +331,43 @@ class TestEmitterValidation:
                 input=big,
             )
 
+    def test_non_utf8_input_bytes_raises(self) -> None:
+        with pytest.raises(ValueError, match="not UTF-8 encoded"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                input=b"\xff",
+            )
+
+    def test_non_utf8_output_bytes_raises(self) -> None:
+        with pytest.raises(ValueError, match="not UTF-8 encoded"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                output=b"\x80\x81",
+            )
+
+    def test_non_finite_input_raises(self) -> None:
+        # json.loads parses 1e400 as float('inf'); _check_finite rejects it
+        with pytest.raises(ValueError, match="non-finite number"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                input='{"x": 1e400}',
+            )
+
+    def test_non_finite_output_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-finite number"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                output='{"score": 1e400}',
+            )
+
 
 class TestFireAndForgetWhenDaemonDown:
     """Emit must return quickly and not raise when the daemon is absent."""

--- a/sdk/py/tests/emitter/test_emitter.py
+++ b/sdk/py/tests/emitter/test_emitter.py
@@ -141,17 +141,20 @@ class DaemonHandle:
             return []
         try:
             conn = sqlite3.connect(self.db_path)
+        except sqlite3.OperationalError:
+            return []
+        try:
             conn.row_factory = sqlite3.Row
             cur = conn.execute(
                 "SELECT receipt_json FROM receipts"
                 " WHERE chain_id = ? ORDER BY sequence",
                 (self.chain_id,),
             )
-            rows = [json.loads(r["receipt_json"]) for r in cur.fetchall()]
-            conn.close()
-            return rows
+            return [json.loads(r["receipt_json"]) for r in cur.fetchall()]
         except sqlite3.OperationalError:
             return []
+        finally:
+            conn.close()
 
 
 @pytest.fixture()
@@ -213,7 +216,7 @@ class TestEmitterConstruction:
         e = Emitter(socket_path="/tmp/nonexistent.sock", session_id=sid)
         assert e.session_id == sid
 
-    def test_session_id_stable_across_instances(self) -> None:
+    def test_session_id_unique_per_instance(self) -> None:
         e1 = Emitter(socket_path="/tmp/nonexistent.sock")
         e2 = Emitter(socket_path="/tmp/nonexistent.sock")
         assert e1.session_id != e2.session_id  # each gets a fresh UUID
@@ -431,7 +434,12 @@ class TestRawJSONPassthrough:
             srv.listen(1)
             ready.set()
             conn, _ = srv.accept()
-            hdr = conn.recv(4)
+            hdr = b""
+            while len(hdr) < 4:
+                chunk = conn.recv(4 - len(hdr))
+                if not chunk:
+                    break
+                hdr += chunk
             if len(hdr) == 4:
                 length = struct.unpack(">I", hdr)[0]
                 body = b""


### PR DESCRIPTION
Implements the Python SDK emitter for ADR-0010 (daemon process separation). Closes the `sdk/py` row from issue #236 Section 3 (thin emitter refactor).

## What this adds

`sdk/py/src/agent_receipts/emitter.py` — a fire-and-forget Unix-socket client that forwards tool-call events to the `agent-receipts` daemon. Per ADR-0010, the emitter does **no crypto, no canonicalisation, and holds no chain state** — all of that lives in the daemon.

Key design points:
- Wire format: 4-byte big-endian length prefix + UTF-8 JSON body, matching `pipeline.SupportedFrameVersion = "1"` in the daemon.
- `session_id` is generated once at `Emitter` construction and reused across reconnects (ADR-0010 OQ4 resolution).
- Dial timeout 25 ms, write timeout 100 ms — `emit()` always returns quickly even when the daemon is absent.
- Dial/write failures are logged at DEBUG and swallowed; `RuntimeError` is only raised for caller bugs (closed emitter) and `ValueError`/`OverflowError` for invalid inputs.
- Raw `input`/`output` JSON bytes travel verbatim to the daemon (no re-serialisation), preserving whitespace and key order for the daemon's hash.
- Thread-safe: a single `threading.Lock` guards the connection.
- Context-manager support (`with Emitter(...) as e:`).

`sdk/py/tests/emitter/test_emitter.py` — 24 tests across five classes:

| Class | Tests | Daemon required |
|---|---|---|
| `TestDefaultSocketPath` | env-var override, platform fallback | no |
| `TestEmitterConstruction` | UUID generation, stable session_id, context manager, close idempotency | no |
| `TestEmitterValidation` | missing channel/tool, bad decision, invalid JSON, closed, oversized frame | no |
| `TestFireAndForgetWhenDaemonDown` | returns None, <50 ms latency | no |
| `TestRawJSONPassthrough` | verbatim byte round-trip via echo server | no |
| `test_emit_frame_round_trip` | 3 events → 3 signed receipts in daemon DB | yes |
| `test_emit_session_id_stable` | session_id identical on all receipts | yes |
| `test_emit_with_host_session_id` | host-supplied id forwarded | yes |
| `test_emit_reconnect_after_daemon_restart` | re-dials transparently, session_id survives | yes |
| `test_emit_returns_error_after_close` | RuntimeError post-close | yes |

Daemon-backed tests are gated on `@requires_daemon` (skipped when `/tmp/agent-receipts-daemon` is absent). All 19 unit tests pass without the daemon; all 24 pass when it is present.

## Test plan

- `uv run pytest` — 249 passed (24 new emitter tests + 225 existing)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pyright src` — 0 errors

## Papercut fixes in tests

- `--verification-method-id` → `--verification-method` (correct daemon flag name)
- `SELECT data FROM receipts` → `SELECT receipt_json FROM receipts` (correct column name in daemon's SQLite schema)
- `subj["action"]["toolName"]` → `subj["action"]["tool_name"]` (daemon emits snake_case)

Refs #236, ADR-0010.