### PR TITLE
fix(daemon/pipeline): outcome.status=failure when decision=allowed but error is non-empty

### DIFF
--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -210,10 +210,17 @@ func (p *Pipeline) buildAndSign(
 
 	// validateFrame already restricted f.Decision to the supported set, so the
 	// switch never falls through.
+	// A non-empty error field means the tool call ran but the upstream returned
+	// an error; even though the proxy permitted the call (decision="allowed"),
+	// the execution outcome is a failure.
 	var status receipt.OutcomeStatus
 	switch f.Decision {
 	case "allowed":
-		status = receipt.StatusSuccess
+		if f.Error != "" {
+			status = receipt.StatusFailure
+		} else {
+			status = receipt.StatusSuccess
+		}
 	case "denied":
 		status = receipt.StatusFailure
 	case "pending":

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -139,6 +139,52 @@ func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	}
 }
 
+func TestProcess_OutcomeStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		decision   string
+		errorField string
+		want       receipt.OutcomeStatus
+	}{
+		{"allowed no error", "allowed", "", receipt.StatusSuccess},
+		{"allowed with error", "allowed", "upstream timeout", receipt.StatusFailure},
+		{"denied", "denied", "", receipt.StatusFailure},
+		{"pending", "pending", "", receipt.StatusPending},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := newTestKeySource(t)
+			st := newTestStore(t)
+			state := chain.New("chain-1")
+			p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+			body, err := json.Marshal(EmitterFrame{
+				Version:   "1",
+				TsEmit:    "2026-05-03T00:00:00Z",
+				SessionID: "s",
+				Channel:   "sdk",
+				Tool:      EmitterTool{Name: "t"},
+				Decision:  tc.decision,
+				Error:     tc.errorField,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := p.Process(socket.Frame{Payload: body}); err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			receipts, err := st.GetChain("chain-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := receipts[0].CredentialSubject.Outcome.Status
+			if got != tc.want {
+				t.Errorf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProcess_AdvancesSequenceAndPrevHash(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)


### PR DESCRIPTION
## Summary

- `decision` is a policy decision (did the proxy permit the call?), orthogonal to whether the tool itself succeeded
- Previously the daemon mapped `allowed` → `status=success` unconditionally, so a tool call that errored was persisted as a success receipt
- Fix: when `decision="allowed"` and `error` is non-empty, set `outcome.status=failure` — the execution failed even though the policy permitted it
- Add table-driven tests covering all four status derivation cases: allowed/no-error, allowed/with-error, denied, pending

## Test plan

- [ ] `go test ./internal/pipeline/...` passes (new `TestProcess_OutcomeStatus` covers all four cases)
- [ ] `go test ./...` in daemon/ passes (all packages green)

Closes the status-derivation concern raised on #337.