### PR TITLE
ci(release): support pre-release tags across release tooling

### DIFF
--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -48,5 +48,18 @@ jobs:
       - run: pnpm test
       - run: pnpm run build
 
+      # Pre-release versions go to a non-default dist-tag so they don't
+      # clobber `latest` for users on the stable line. Extracts the
+      # pre-release identifier from semver (alpha/beta/rc/...).
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+) ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -49,14 +49,28 @@ jobs:
       - run: pnpm run build
 
       # Pre-release versions go to a non-default dist-tag so they don't
-      # clobber `latest` for users on the stable line. Extracts the
-      # pre-release identifier from semver (alpha/beta/rc/...).
+      # clobber `latest` for users on the stable line. Two-phase logic:
+      #   1. Strip SemVer build metadata (after '+'); if a '-' remains
+      #      anywhere in the core version, this is a pre-release.
+      #   2. Extract a leading [A-Za-z]+ identifier from the pre-release
+      #      portion (lowercased). Falls back to `prerelease` if the
+      #      identifier is purely numeric or otherwise unparseable —
+      #      never falls through to `latest`, which would defeat the
+      #      whole purpose.
       - name: Determine npm dist-tag
         id: dist_tag
+        shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+) ]]; then
-            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          CORE="${PKG_VERSION%%+*}"
+          if [[ "$CORE" == *-* ]]; then
+            PRE="${CORE#*-}"
+            if [[ "$PRE" =~ ^([A-Za-z]+) ]]; then
+              TAG_NAME="${BASH_REMATCH[1],,}"
+            else
+              TAG_NAME="prerelease"
+            fi
+            echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release-mcp-proxy.yml
+++ b/.github/workflows/release-mcp-proxy.yml
@@ -54,8 +54,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Mark pre-release tags (e.g. v0.8.0-alpha.1) so they don't show
+          # up as "latest" on the GitHub Releases page.
+          PRERELEASE_ARG=()
+          if [[ "${MCP_PROXY_VERSION}" == *-* ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
           gh release create "${GITHUB_REF_NAME}" \
             --title "mcp-proxy ${MCP_PROXY_VERSION}" \
             --generate-notes \
+            "${PRERELEASE_ARG[@]}" \
             mcp-proxy/dist/*.tar.gz \
             mcp-proxy/dist/checksums.txt

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -40,6 +40,12 @@ release:
 
 brews:
   - name: mcp-proxy
+    # `auto` skips the formula bump PR when the release version contains a
+    # pre-release suffix (e.g. v0.8.0-alpha.1). The Homebrew tap stays
+    # locked to the latest stable mcp-proxy until a non-pre-release tag
+    # is cut, so `brew install agent-receipts/tap/mcp-proxy` keeps giving
+    # users a non-alpha build during the daemon-backed cutover soak.
+    skip_upload: auto
     repository:
       owner: agent-receipts
       name: homebrew-tap

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -166,7 +166,11 @@ echo "--- All checks passed"
 echo ""
 
 PRERELEASE=false
-[[ "$VERSION" == *-* ]] && PRERELEASE=true
+# Strip SemVer build metadata before detecting pre-release: build metadata
+# (anything after '+') can legally contain '-', so a naive *-* glob would
+# misclassify e.g. 1.2.3+build-4 as a pre-release.
+CORE_VERSION="${VERSION%%+*}"
+[[ "$CORE_VERSION" == *-* ]] && PRERELEASE=true
 
 echo "Will create release:"
 echo "  Tag:         $TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,20 +3,32 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") <module> <version>
+Usage: $(basename "$0") [--dry-run] <module> <version>
 
 Create a GitHub Release for a module in this monorepo.
 
 Modules:
-  sdk-go       Go SDK         (tag: sdk/go/vVERSION)
-  sdk-ts       TypeScript SDK (tag: sdk-ts-vVERSION)
-  sdk-py       Python SDK     (tag: sdk-py-vVERSION)
-  mcp-proxy    MCP proxy      (tag: mcp-proxy/vVERSION)
+  sdk-go       Go SDK                 (tag: sdk/go/vVERSION)
+  sdk-ts       TypeScript SDK         (tag: sdk-ts-vVERSION)
+  sdk-py       Python SDK             (tag: sdk-py-vVERSION)
+  mcp-proxy    MCP proxy              (tag: mcp-proxy/vVERSION)
+  daemon       agent-receipts daemon  (tag: daemon/vVERSION)
+
+Flags:
+  --dry-run    Validate everything and print the actions, but do not push
+               tags or create releases.
+
+Notes:
+  - Pre-release versions (e.g. 0.8.0-alpha.1) are automatically marked
+    as GitHub pre-releases.
+  - mcp-proxy pushes the tag only and lets release-mcp-proxy.yml build
+    binaries and create the GitHub Release. Other modules use
+    'gh release create' directly.
 
 Examples:
   $(basename "$0") sdk-go 0.2.0
-  $(basename "$0") sdk-ts 0.3.0
-  $(basename "$0") mcp-proxy 0.1.0
+  $(basename "$0") --dry-run mcp-proxy 0.8.0-alpha.1
+  $(basename "$0") daemon 0.8.0-alpha.1
 EOF
   exit 1
 }
@@ -31,10 +43,19 @@ command -v git >/dev/null 2>&1 || fail "git is not installed"
 command -v gh >/dev/null 2>&1 || fail "gh CLI is not installed — see https://cli.github.com"
 gh auth status >/dev/null 2>&1 || fail "gh is not authenticated — run gh auth login"
 
-[[ $# -eq 2 ]] || usage
+DRY_RUN=false
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help) usage ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+[[ ${#ARGS[@]} -eq 2 ]] || usage
 
-MODULE="$1"
-VERSION="$2"
+MODULE="${ARGS[0]}"
+VERSION="${ARGS[1]}"
 
 # Validate version format
 [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]] || \
@@ -53,7 +74,7 @@ REMOTE=$(git rev-parse origin/main)
 
 # Go modules don't support build metadata in tags
 case "$MODULE" in
-  sdk-go|mcp-proxy)
+  sdk-go|mcp-proxy|daemon)
     [[ "$VERSION" != *+* ]] || fail "Go module versions cannot contain build metadata (+...)"
     ;;
 esac
@@ -74,6 +95,10 @@ case "$MODULE" in
   mcp-proxy)
     TAG="mcp-proxy/v${VERSION}"
     DIR="mcp-proxy"
+    ;;
+  daemon)
+    TAG="daemon/v${VERSION}"
+    DIR="daemon"
     ;;
   *)
     fail "unknown module '$MODULE' — run with no args for usage"
@@ -103,6 +128,11 @@ case "$MODULE" in
     fi
     echo "--- Running Go checks in $DIR"
     (cd "$DIR" && go vet ./... && go test ./...)
+    ;;
+  daemon)
+    command -v go >/dev/null 2>&1 || fail "go is not installed"
+    echo "--- Running Go checks in $DIR (matches daemon.yml: -race -tags=integration)"
+    (cd "$DIR" && go vet ./... && go test -race -tags=integration ./...)
     ;;
   sdk-ts)
     command -v node >/dev/null 2>&1 || fail "node is not installed"
@@ -134,15 +164,46 @@ esac
 echo ""
 echo "--- All checks passed"
 echo ""
+
+PRERELEASE=false
+[[ "$VERSION" == *-* ]] && PRERELEASE=true
+
 echo "Will create release:"
-echo "  Tag:    $TAG"
-echo "  Title:  $MODULE v$VERSION"
+echo "  Tag:         $TAG"
+echo "  Title:       $MODULE v$VERSION"
+[[ "$PRERELEASE" == "true" ]] && echo "  Pre-release: yes (version contains '-')"
+if [[ "$MODULE" == "mcp-proxy" ]]; then
+  echo "  Action:      push tag only; release-mcp-proxy.yml builds binaries and creates the GitHub Release"
+else
+  echo "  Action:      gh release create"
+fi
 echo ""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "==> Dry run; not pushing tag or creating release."
+  exit 0
+fi
+
 read -rp "Proceed? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
 REPO_URL=$(gh repo view --json url -q '.url')
-gh release create "$TAG" --title "$MODULE v$VERSION" --generate-notes
-echo ""
-echo "==> Released $MODULE v$VERSION"
-echo "    ${REPO_URL}/releases/tag/$TAG"
+
+if [[ "$MODULE" == "mcp-proxy" ]]; then
+  # release-mcp-proxy.yml owns release creation; we only push the tag.
+  # Avoids "release already exists" conflict between this script and the
+  # workflow when both call gh release create against the same tag.
+  git tag "$TAG"
+  git push origin "$TAG"
+  echo ""
+  echo "==> Pushed tag $TAG"
+  echo "    release-mcp-proxy.yml builds binaries and creates the GitHub Release."
+  echo "    ${REPO_URL}/actions/workflows/release-mcp-proxy.yml"
+else
+  PRERELEASE_FLAG=()
+  [[ "$PRERELEASE" == "true" ]] && PRERELEASE_FLAG=("--prerelease")
+  gh release create "$TAG" --title "$MODULE v$VERSION" --generate-notes "${PRERELEASE_FLAG[@]}"
+  echo ""
+  echo "==> Released $MODULE v$VERSION"
+  echo "    ${REPO_URL}/releases/tag/$TAG"
+fi


### PR DESCRIPTION
## What

Four small changes that together make pre-release tags safe to cut across the stack:

| File | Change |
|---|---|
| `scripts/release.sh` | `--dry-run` flag, `daemon` module case, pre-release auto-detection (passes `--prerelease` to `gh release create`), and mcp-proxy push-tag-only (lets `release-mcp-proxy.yml` create the release). Resolves the existing "release already exists" conflict where script + workflow both called `gh release create`. |
| `.github/workflows/publish-ts.yml` | Route pre-release versions to a non-default npm dist-tag — extracts the semver pre-release identifier (`alpha`/`beta`/`rc`/...) from `package.json` and passes it as `npm publish --tag <name>`. Stable releases keep going to `latest`. |
| `.github/workflows/release-mcp-proxy.yml` | Pass `--prerelease` to `gh release create` when the tag has a pre-release suffix, so alphas don't show up as the latest GitHub Release. |
| `mcp-proxy/.goreleaser.yaml` | `brews[0].skip_upload: auto` — Homebrew formula bump PR is skipped on pre-release tags so the tap stays locked to the latest stable mcp-proxy during soak. |

## Why

Preparation for the v0.8.0-alpha.1 daemon-backed cutover ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md), #236). Without these changes:

- An alpha published to npm would clobber the `latest` dist-tag and get installed by every existing v0.6.x user on their next `pnpm install`.
- An alpha GitHub Release would show up as "latest" and bury the stable releases.
- A `mcp-proxy/v0.8.0-alpha.1` tag would push a Homebrew formula PR, replacing the stable `mcp-proxy` formula in the tap with an alpha build.
- `release.sh mcp-proxy ...` would fail with "release already exists" because both the script and `release-mcp-proxy.yml` called `gh release create` on the same tag.

The unifying property: pre-release tags do not surface as the default install for users on the stable line.

## Out of scope

- The same npm dist-tag fix is needed in `agent-receipts/openclaw`'s `publish.yml`; tracked separately as a sister change in that repo (the github-audited PAT used here lacks `workflow` scope).
- A larger restructure — move release creation from `release.sh` entirely into per-module workflows so the script becomes "tag and push only" — is tracked as #341. This PR is the smaller, in-place patch that unblocks the alpha cut.
- No daemon publish workflow yet. For `-alpha.1` the daemon ships via `go install`/`brew install --HEAD`; a `release-daemon.yml` will land before `-beta.1`.

## Checklist

- [x] Tests pass for all changed components — N/A (CI/release tooling, not code under test)
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable) — `shellcheck` clean on `scripts/release.sh`
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A
- [x] AGENTS.md updated (if project structure changed) — N/A
- [x] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Verifying locally

After merging and syncing main:

```sh
# Preflight only — no tag, no release
./scripts/release.sh --dry-run daemon 0.8.0-alpha.1
./scripts/release.sh --dry-run mcp-proxy 0.8.0-alpha.1
```

The dry-run prints the action plan (tag, title, pre-release y/n, gh-release-create vs push-tag-only) and exits before touching anything.