### PR TITLE
chore(release): prep v0.8.0-alpha.1 — version bumps + PEP 440 support

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,9 +57,14 @@ done
 MODULE="${ARGS[0]}"
 VERSION="${ARGS[1]}"
 
-# Validate version format
-[[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]] || \
-  fail "invalid version '$VERSION' — expected semver (e.g. 0.2.0, 1.0.0-beta.1)"
+# Validate version format. Accepts SemVer (used by sdk-go, sdk-ts,
+# mcp-proxy, daemon) or PEP 440 pre-release form (used by sdk-py — PyPI
+# rejects SemVer-style hyphenated pre-releases, so the canonical form is
+# 0.8.0a1, 0.8.0b2, 0.8.0rc1).
+SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+PEP440_PRE_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(a|b|rc)[0-9]+$'
+[[ "$VERSION" =~ $SEMVER_RE ]] || [[ "$VERSION" =~ $PEP440_PRE_RE ]] || \
+  fail "invalid version '$VERSION' — expected SemVer (e.g. 0.2.0, 1.0.0-beta.1) or PEP 440 pre-release for sdk-py (e.g. 0.8.0a1)"
 
 # Ensure we're on main and up to date
 BRANCH=$(git branch --show-current)
@@ -168,9 +173,12 @@ echo ""
 PRERELEASE=false
 # Strip SemVer build metadata before detecting pre-release: build metadata
 # (anything after '+') can legally contain '-', so a naive *-* glob would
-# misclassify e.g. 1.2.3+build-4 as a pre-release.
+# misclassify e.g. 1.2.3+build-4 as a pre-release. Also flag PEP 440
+# pre-release suffixes (e.g. 0.8.0a1) which use no '-' separator.
 CORE_VERSION="${VERSION%%+*}"
-[[ "$CORE_VERSION" == *-* ]] && PRERELEASE=true
+if [[ "$CORE_VERSION" == *-* ]] || [[ "$CORE_VERSION" =~ [0-9]+(a|b|rc)[0-9]+$ ]]; then
+  PRERELEASE=true
+fi
 
 echo "Will create release:"
 echo "  Tag:         $TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,14 +57,26 @@ done
 MODULE="${ARGS[0]}"
 VERSION="${ARGS[1]}"
 
-# Validate version format. Accepts SemVer (used by sdk-go, sdk-ts,
-# mcp-proxy, daemon) or PEP 440 pre-release form (used by sdk-py — PyPI
-# rejects SemVer-style hyphenated pre-releases, so the canonical form is
-# 0.8.0a1, 0.8.0b2, 0.8.0rc1).
+# Validate version format. PEP 440 pre-release form (e.g. 0.8.0a1) is
+# accepted only for sdk-py because PyPI rejects SemVer-style hyphenated
+# pre-releases. Go modules (sdk-go, mcp-proxy, daemon) and the npm
+# module (sdk-ts) require SemVer; accepting PEP 440 there would silently
+# create tags that go.mod / npm cannot resolve.
 SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
 PEP440_PRE_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(a|b|rc)[0-9]+$'
-[[ "$VERSION" =~ $SEMVER_RE ]] || [[ "$VERSION" =~ $PEP440_PRE_RE ]] || \
-  fail "invalid version '$VERSION' — expected SemVer (e.g. 0.2.0, 1.0.0-beta.1) or PEP 440 pre-release for sdk-py (e.g. 0.8.0a1)"
+case "$MODULE" in
+  sdk-py)
+    [[ "$VERSION" =~ $SEMVER_RE ]] || [[ "$VERSION" =~ $PEP440_PRE_RE ]] || \
+      fail "invalid version '$VERSION' for sdk-py — expected SemVer (e.g. 0.5.0, 1.0.0-beta.1) or PEP 440 pre-release (e.g. 0.8.0a1)"
+    ;;
+  sdk-go|sdk-ts|mcp-proxy|daemon)
+    [[ "$VERSION" =~ $SEMVER_RE ]] || \
+      fail "invalid version '$VERSION' for $MODULE — expected SemVer (e.g. 0.2.0, 1.0.0-beta.1). PEP 440 form (e.g. 0.8.0a1) is accepted only for sdk-py."
+    ;;
+  *)
+    fail "unknown module '$MODULE' — run with no args for usage"
+    ;;
+esac
 
 # Ensure we're on main and up to date
 BRANCH=$(git branch --show-current)
@@ -183,7 +195,7 @@ fi
 echo "Will create release:"
 echo "  Tag:         $TAG"
 echo "  Title:       $MODULE v$VERSION"
-[[ "$PRERELEASE" == "true" ]] && echo "  Pre-release: yes (version contains '-')"
+[[ "$PRERELEASE" == "true" ]] && echo "  Pre-release: yes"
 if [[ "$MODULE" == "mcp-proxy" ]]; then
   echo "  Action:      push tag only; release-mcp-proxy.yml builds binaries and creates the GitHub Release"
 else

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.5.0"
+version = "0.8.0a1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/src/agent_receipts/_version.py
+++ b/sdk/py/src/agent_receipts/_version.py
@@ -1,1 +1,1 @@
-VERSION = "0.5.0"
+VERSION = "0.8.0a1"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.5.0"
+version = "0.8.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.6.0",
+	"version": "0.8.0-alpha.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## What

Three coordinated changes preparing the `v0.8.0-alpha.1` daemon-backed cutover:

| File | Change |
|---|---|
| `sdk/ts/package.json` | `0.6.0` → `0.8.0-alpha.1` |
| `sdk/py/pyproject.toml` | `0.5.0` → `0.8.0a1` (PEP 440 canonical) |
| `scripts/release.sh` | Accept PEP 440 pre-release form in version regex; flag PEP 440 suffixes in pre-release detection |

## Why

The Go modules (`daemon`, `sdk/go`, `mcp-proxy`) take their version from the tag — no source bump needed. The TypeScript and Python SDKs version their source files explicitly, so they need to land at the umbrella version before tagging.

**Why skip minors?** mcp-proxy is already at `0.7.0`; `0.8.0` is the first minor that's free across all five packages. The lower-versioned packages (`sdk/ts` 0.6.0, `sdk/py` 0.5.0) skip minors deliberately to align at one number for the coordinated cutover. From here on the stack stays lockstep until decoupled deliberately.

**Why PEP 440 form for `sdk/py`?** PyPI rejects SemVer-style hyphenated pre-releases (`0.8.0-alpha.1`). The canonical PEP 440 form is `0.8.0a1`. Keeping the tag and `pyproject.toml` literally identical (both `0.8.0a1`) means `scripts/release.sh`'s version-equality check works out of the box.

**Why extend `release.sh`?** The existing version regex only accepted SemVer; it would have rejected `0.8.0a1`. Two changes:

1. Accept either SemVer **or** PEP 440 pre-release form (`(a|b|rc)N` suffix).
2. Pre-release detection now also flags PEP 440 suffixes (which use no `-` separator) so `--prerelease` is correctly passed to `gh release create`.

## Test plan

Regex matrix verified locally:

| Version | Result |
|---|---|
| `0.8.0` | SemVer ok |
| `0.8.0-alpha.1` | SemVer ok |
| `0.8.0a1` | PEP 440 ok |
| `0.8.0b2` | PEP 440 ok |
| `0.8.0rc3` | PEP 440 ok |
| `0.5.0` | SemVer ok |
| `1.0.0-rc.1+build.5` | SemVer ok |
| `garbage` | rejected |
| `0.8.0a` | rejected (no trailing N) |
| `junk-version` | rejected |

`shellcheck` clean. `pnpm run typecheck` clean. `pnpm test` — 237 passed. `uv run pytest` — 258 passed. `pnpm run lint` (biome) clean. `uv run ruff check` clean. (All run by lefthook hooks during the push.)

The auto-generated `sdk/ts/src/version.ts` is regenerated by `pnpm sync-version` (hooked into prebuild/pretest/etc) and is gitignored — so no commit there.

## Checklist

- [x] Tests pass for all changed components — TS (237) and Py (258) green
- [x] Linter passes — `shellcheck`, `biome`, `ruff check`, `ruff format` all clean
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass — covered by `uv run pytest` (`tests/test_cross_language*`)
- [x] AGENTS.md updated — N/A (no project structure change)
- [x] Spec changes have been reviewed by a maintainer — N/A (no spec change)

## After this lands

The path to tag-cutting is:

1. Sync local main.
2. `./scripts/release.sh daemon 0.8.0-alpha.1` (creates `daemon/v0.8.0-alpha.1`, GH Release, marks pre-release)
3. `./scripts/release.sh sdk-go 0.8.0-alpha.1`
4. `./scripts/release.sh sdk-ts 0.8.0-alpha.1` → npm `@alpha`
5. `./scripts/release.sh sdk-py 0.8.0a1` → PyPI as pre-release
6. `./scripts/release.sh mcp-proxy 0.8.0-alpha.1` → tag pushed; `release-mcp-proxy.yml` builds binaries; Homebrew formula PR auto-skipped
7. OpenClaw tag in its repo (separate PR is open with the package.json bump there)
8. Umbrella `gh release create v0.8.0-alpha.1 --prerelease ...` with the cross-package changelog body