### PR TITLE
chore(daemon): bump sdk/go to v0.8.0-alpha.1 and drop local replace

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -2,34 +2,10 @@ module github.com/agent-receipts/ar/daemon
 
 go 1.26.1
 
-// The pinned sdk/go version (v0.6.0) is the latest published tag at the time
-// this module landed. Phase 1 also introduced ReceiptStore.GetChainTail in
-// sdk/go, which is NOT in v0.6.0 — so standalone `go install` of this daemon
-// is not yet possible. The repo-root go.work resolves the in-tree sdk/go for
-// monorepo builds and CI. The follow-up release of sdk/go (the next semver
-// tag from .github/workflows/publish-go.yml) ships the new symbol, and a
-// small follow-up PR will bump this require accordingly — at which point the
-// `replace` below MUST be removed (this daemon module's first publish step
-// will be gated on the absence of local replace directives, mirroring the
-// sdk/go publish workflow).
-//
-// Tracked with the rest of Phase 2 sequencing in
-// https://github.com/agent-receipts/ar/issues/236.
 require (
-	github.com/agent-receipts/ar/sdk/go v0.6.0
+	github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1
 	golang.org/x/sys v0.43.0
 )
-
-// Local replace closes the GOWORK=off gap: in-repo developers and CI matrices
-// that disable the workspace (e.g. to verify each module's go.mod independently)
-// resolve sdk/go from the in-tree path that contains GetChainTail. Has no
-// effect for `go install` from a clone of an external project (those callers
-// see only the proxy-published require above, which is the documented
-// limitation in README.md until sdk/go's next semver tag publishes
-// GetChainTail).
-//
-// REMOVE BEFORE PUBLISHING THIS MODULE — see the comment block above.
-replace github.com/agent-receipts/ar/sdk/go => ../sdk/go
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.6.0 h1:zSpXnUOJFWRBikQmT1brOaEVv68eiFsLQSp+ZPAgHxw=
-github.com/agent-receipts/ar/sdk/go v0.6.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1 h1:6SWk87A5ku3QzArLyr8dDEMUN124CbajwwuQScYLnyo=
+github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## What

`daemon/go.mod` only:

- `require github.com/agent-receipts/ar/sdk/go` bumps `v0.6.0` → `v0.8.0-alpha.1`.
- Drop `replace github.com/agent-receipts/ar/sdk/go => ../sdk/go` (per AGENTS.md "Published `go.mod` files stay free of local `replace` directives").
- Strip the transitional comment block that explained the replace's existence.
- `go.sum` updated to match the new sdk/go module zip.

## Why

Phase 2 of the v0.8.0-alpha.1 daemon-backed cutover ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md), [#236](https://github.com/agent-receipts/ar/issues/236)). `sdk/go v0.8.0-alpha.1` is published — it ships `ReceiptStore.GetChainTail`, the symbol the daemon needs that wasn't in `v0.6.0`. With that hole closed, the gap-bridging local `replace` can come out and the daemon module is ready for its first publish (`daemon/v0.8.0-alpha.1`).

## Why daemon-only in this PR

`mcp-proxy/go.mod` also pins `sdk/go v0.6.0` and would benefit from the same bump, but lifting it introduces a transitive `daemon` require — `mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go` imports daemon code under build tag `linux || darwin`. With workspace off, `go mod tidy` resolves that to a `daemon` pseudo-version commit (e.g. `v0.0.0-20260509012403-2c80e63e09c8`).

Bumping mcp-proxy now would lock that pseudo-version into the published mcp-proxy/go.mod. Cleaner sequence:

1. **This PR**: daemon-only bump, removes the replace, sets up daemon for tagging.
2. Cut `daemon/v0.8.0-alpha.1` (release.sh).
3. **Follow-up PR**: bump mcp-proxy/go.mod to `sdk/go@v0.8.0-alpha.1` AND `daemon@v0.8.0-alpha.1`. Both clean tagged versions, no pseudo-version in published history.
4. Cut `mcp-proxy/v0.8.0-alpha.1`.

## Verification

Tested against the published sdk/go alpha with the workspace off (so `go mod tidy` resolves from the proxy, not in-tree):

```
cd daemon
GOWORK=off go build ./cmd/...                       # ok
GOWORK=off go test -race -tags=integration ./...    # all green
```

That exercises the daemon's full unit + integration suite (chain, keysource, pipeline, socket, verifycli) against the alpha-published sdk/go module zip — same path users will hit on `go install daemon@v0.8.0-alpha.1` after this lands and the daemon tag is cut.

## Checklist

- [x] Tests pass for all changed components — daemon tests green with `GOWORK=off -race -tags=integration`
- [x] Linter passes — N/A for go.mod-only change
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass — N/A (no behaviour change; this is just a dep bump)
- [x] AGENTS.md updated — N/A (no project structure change; the AGENTS.md rule about no `replace` directives is now being honoured for daemon, which is the point)
- [x] Spec changes have been reviewed by a maintainer — N/A