### PR TITLE
chore(mcp-proxy): bump sdk/go and daemon to v0.8.0-alpha.1

### DIFF
--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -3,7 +3,8 @@ module github.com/agent-receipts/ar/mcp-proxy
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.6.0
+	github.com/agent-receipts/ar/daemon v0.8.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1
 	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,5 +1,7 @@
-github.com/agent-receipts/ar/sdk/go v0.6.0 h1:zSpXnUOJFWRBikQmT1brOaEVv68eiFsLQSp+ZPAgHxw=
-github.com/agent-receipts/ar/sdk/go v0.6.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/daemon v0.8.0-alpha.1 h1:S0UslWHQtSlSzZXPqCSO4xgalCBgooZGUitQswNgV0g=
+github.com/agent-receipts/ar/daemon v0.8.0-alpha.1/go.mod h1:88Ulq1jLnIOt8NK+zlL5TDqDB9Y/lU0gHa4A7ibB2Kw=
+github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1 h1:6SWk87A5ku3QzArLyr8dDEMUN124CbajwwuQScYLnyo=
+github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## What

`mcp-proxy/go.mod` only:

- `require github.com/agent-receipts/ar/sdk/go` bumps `v0.6.0` → `v0.8.0-alpha.1`.
- Add `require github.com/agent-receipts/ar/daemon v0.8.0-alpha.1`. Previously the daemon import in `mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go` (build tag `linux || darwin`) was resolved via the repo-root `go.work`; now it's pinned for external installs.
- `go.sum` updated for both module zips.

## Why

Last `go.mod` prep before cutting `mcp-proxy/v0.8.0-alpha.1`. With `sdk/go v0.8.0-alpha.1` and `daemon/v0.8.0-alpha.1` already published, mcp-proxy can require clean tagged versions of both — no pseudo-version commit lands in the published `go.mod`.

This pairs with [#344](https://github.com/agent-receipts/ar/pull/344) (daemon's go.mod bump). The two were split deliberately: bumping mcp-proxy in #344 would have introduced a transient `daemon` pseudo-version commit because `daemon/v0.8.0-alpha.1` didn't exist yet. Splitting kept both PRs clean.

## Verification

Tested against the published alphas with the workspace off:

```
cd mcp-proxy
GOWORK=off go vet ./...       # ok
GOWORK=off go build ./...     # ok
GOWORK=off go test ./...      # 5 packages green, including cmd/mcp-proxy
                              # (which runs emitter_integration_test on darwin)
```

The `emitter_integration_test.go` runs the proxy → daemon AF_UNIX wire path against the published `daemon/v0.8.0-alpha.1` module zip — same code path users hit on `go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@v0.8.0-alpha.1` once this lands and the mcp-proxy tag is cut.

## Checklist

- [x] Tests pass for all changed components — mcp-proxy 5/5 packages green with workspace off
- [x] Linter passes — `go vet ./...` clean (also enforced by `mcp-proxy-vet` lefthook hook)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass — N/A (no behaviour change; pure dep bump)
- [x] AGENTS.md updated — N/A
- [x] Spec changes have been reviewed by a maintainer — N/A

## After this lands

Final two steps in the cutover:

1. `./scripts/release.sh mcp-proxy 0.8.0-alpha.1` — pushes the tag; `release-mcp-proxy.yml` builds Linux/macOS amd64+arm64 binaries, attaches them to the GitHub Release, marks pre-release, and (per the `skip_upload: auto` setting in `.goreleaser.yaml`) skips the Homebrew formula bump PR.
2. Umbrella `gh release create v0.8.0-alpha.1 --prerelease ...` with the cross-package changelog body.