### PR TITLE
daemon: XDG paths + explicit --init for key generation

### DIFF
--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -32,6 +32,7 @@ func main() {
 		VerificationMethodID: envOrDefault("AGENTRECEIPTS_VERIFICATION_METHOD", "did:agent-receipts-daemon:local#k1"),
 	}
 
+	initKeys := flag.Bool("init", false, "Generate a new signing key pair and exit (must not exist)")
 	flag.StringVar(&cfg.SocketPath, "socket", cfg.SocketPath, "Unix-domain socket path (env: AGENTRECEIPTS_SOCKET)")
 	flag.StringVar(&cfg.DBPath, "db", cfg.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	flag.StringVar(&cfg.KeyPath, "key", cfg.KeyPath, "Ed25519 PEM private key path, mode 0600 (env: AGENTRECEIPTS_KEY)")
@@ -40,6 +41,19 @@ func main() {
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
 	flag.Parse()
+
+	if *initKeys {
+		if cfg.PublicKeyPath == "" {
+			cfg.PublicKeyPath = daemon.DefaultPublicKeyPath(cfg.KeyPath)
+		}
+		if err := daemon.GenerateKey(cfg.KeyPath, cfg.PublicKeyPath); err != nil {
+			fmt.Fprintf(os.Stderr, "agent-receipts-daemon --init: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("generated signing key: %s\n", cfg.KeyPath)
+		fmt.Printf("public key: %s\n", cfg.PublicKeyPath)
+		return
+	}
 
 	// Apply the <--key>.pub default now that flag.Parse has finalised KeyPath.
 	// daemon.validateConfig also covers this path for library callers; doing

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -173,13 +173,16 @@ func GenerateKey(keyPath, publicKeyPath string) error {
 		return fmt.Errorf("generate key pair: %w", err)
 	}
 
-	// Create both parent directories. The private-key dir uses 0o750
-	// because the key inside is operator-only; the public-key dir uses
-	// 0o755 because the key inside is meant to be readable by verifiers.
+	// Create both parent directories at 0o750, matching publishPublicKey's
+	// dir mode (daemon.go's existing convention). Default deployments place
+	// the public key alongside the private key, so the second MkdirAll is
+	// usually a no-op against the dir we just made; we still call it so an
+	// operator who passes --public-key /elsewhere doesn't see a bare ENOENT
+	// from the OpenFile below.
 	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
 		return fmt.Errorf("create key dir: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(publicKeyPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(publicKeyPath), 0o750); err != nil {
 		return fmt.Errorf("create public-key dir: %w", err)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/agent-receipts/ar/daemon/internal/keysource"
 	"github.com/agent-receipts/ar/daemon/internal/pipeline"
 	"github.com/agent-receipts/ar/daemon/internal/socket"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
 
@@ -121,6 +122,56 @@ func DefaultPublicKeyPath(keyPath string) string {
 		return ""
 	}
 	return keyPath + ".pub"
+}
+
+// GenerateKey creates a new Ed25519 key pair and saves the private key to keyPath
+// (mode 0600) and public key to publicKeyPath (mode 0644). Fails if either file
+// already exists. Use this explicitly via --init; do not call silently.
+func GenerateKey(keyPath, publicKeyPath string) error {
+	if keyPath == "" {
+		return errors.New("keyPath is required")
+	}
+	if publicKeyPath == "" {
+		publicKeyPath = DefaultPublicKeyPath(keyPath)
+	}
+
+	// Check that neither file exists.
+	if _, err := os.Stat(keyPath); err == nil {
+		return fmt.Errorf("key file already exists: %s", keyPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat key path: %w", err)
+	}
+
+	if _, err := os.Stat(publicKeyPath); err == nil {
+		return fmt.Errorf("public key file already exists: %s", publicKeyPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat public key path: %w", err)
+	}
+
+	// Create key directory if needed.
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
+		return fmt.Errorf("create key dir: %w", err)
+	}
+
+	// Generate key pair.
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		return fmt.Errorf("generate key pair: %w", err)
+	}
+
+	// Write private key with mode 0600.
+	if err := os.WriteFile(keyPath, []byte(kp.PrivateKey), 0o600); err != nil {
+		return fmt.Errorf("write private key: %w", err)
+	}
+
+	// Write public key with mode 0644.
+	if err := os.WriteFile(publicKeyPath, []byte(kp.PublicKey), 0o644); err != nil {
+		// Clean up private key on failure.
+		_ = os.Remove(keyPath)
+		return fmt.Errorf("write public key: %w", err)
+	}
+
+	return nil
 }
 
 // Run starts the daemon and blocks until ctx is cancelled. It returns the

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -85,32 +85,45 @@ func DefaultSocketPath() string {
 	}
 }
 
+// xdgDataHome returns the XDG_DATA_HOME directory or its default
+// ($HOME/.local/share). Returns "" when XDG_DATA_HOME is unset and the
+// user's home directory cannot be determined.
+//
+// Per the XDG Base Directory spec, $XDG_DATA_HOME must be an absolute path;
+// a relative value is treated as invalid and ignored, falling back to the
+// $HOME/.local/share default. This protects against a misconfigured
+// environment silently relocating the receipt store under the working
+// directory of whichever process happened to start the daemon.
+func xdgDataHome() string {
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome != "" && filepath.IsAbs(dataHome) {
+		return dataHome
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share")
+}
+
 // DefaultDBPath returns the per-user SQLite path used when AGENTRECEIPTS_DB
 // is not set. Uses XDG_DATA_HOME (defaults to ~/.local/share on Linux/macOS).
 func DefaultDBPath() string {
-	dataHome := os.Getenv("XDG_DATA_HOME")
-	if dataHome == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			dataHome = filepath.Join(home, ".local", "share")
-		} else {
-			return ""
-		}
+	dh := xdgDataHome()
+	if dh == "" {
+		return ""
 	}
-	return filepath.Join(dataHome, "agent-receipts", "receipts.db")
+	return filepath.Join(dh, "agent-receipts", "receipts.db")
 }
 
 // DefaultKeyPath returns the per-user signing-key path used when
 // AGENTRECEIPTS_KEY is not set. Uses XDG_DATA_HOME (defaults to ~/.local/share on Linux/macOS).
 func DefaultKeyPath() string {
-	dataHome := os.Getenv("XDG_DATA_HOME")
-	if dataHome == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			dataHome = filepath.Join(home, ".local", "share")
-		} else {
-			return ""
-		}
+	dh := xdgDataHome()
+	if dh == "" {
+		return ""
 	}
-	return filepath.Join(dataHome, "agent-receipts", "signing.key")
+	return filepath.Join(dh, "agent-receipts", "signing.key")
 }
 
 // DefaultPublicKeyPath returns the default published public-key path: the

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -137,9 +137,24 @@ func DefaultPublicKeyPath(keyPath string) string {
 	return keyPath + ".pub"
 }
 
-// GenerateKey creates a new Ed25519 key pair and saves the private key to keyPath
-// (mode 0600) and public key to publicKeyPath (mode 0644). Fails if either file
-// already exists. Use this explicitly via --init; do not call silently.
+// GenerateKey creates a new Ed25519 key pair and saves the private key to
+// keyPath (mode 0600) and public key to publicKeyPath (mode 0644). Refuses
+// to overwrite an existing file at either path, and refuses to follow a
+// symlink at either path. Use this explicitly via --init; never call it as
+// a side-effect of starting the daemon — silently regenerating a missing
+// key would invalidate every receipt previously signed by the operator's
+// real key.
+//
+// Atomicity: both files are created with O_CREATE|O_EXCL|O_NOFOLLOW so an
+// attacker who plants a symlink (or any other dirent) at either path
+// between the directory creation and the file open trips O_EXCL — we never
+// write through the symlink target. If the public-key write fails after
+// the private-key write succeeded, the private-key file is removed so the
+// caller doesn't end up with a half-initialised on-disk state.
+//
+// The mode passed to OpenFile may be narrowed by the process umask; an
+// explicit fchmod after open ensures the on-disk mode matches what the
+// caller asked for.
 func GenerateKey(keyPath, publicKeyPath string) error {
 	if keyPath == "" {
 		return errors.New("keyPath is required")
@@ -147,43 +162,84 @@ func GenerateKey(keyPath, publicKeyPath string) error {
 	if publicKeyPath == "" {
 		publicKeyPath = DefaultPublicKeyPath(keyPath)
 	}
-
-	// Check that neither file exists.
-	if _, err := os.Stat(keyPath); err == nil {
-		return fmt.Errorf("key file already exists: %s", keyPath)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat key path: %w", err)
+	if keyPath == publicKeyPath {
+		return fmt.Errorf("keyPath and publicKeyPath must differ; both are %s", keyPath)
 	}
 
-	if _, err := os.Stat(publicKeyPath); err == nil {
-		return fmt.Errorf("public key file already exists: %s", publicKeyPath)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat public key path: %w", err)
-	}
-
-	// Create key directory if needed.
-	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
-		return fmt.Errorf("create key dir: %w", err)
-	}
-
-	// Generate key pair.
+	// Generate the key pair before touching the filesystem so a generation
+	// failure leaves no half-state behind.
 	kp, err := receipt.GenerateKeyPair()
 	if err != nil {
 		return fmt.Errorf("generate key pair: %w", err)
 	}
 
-	// Write private key with mode 0600.
-	if err := os.WriteFile(keyPath, []byte(kp.PrivateKey), 0o600); err != nil {
-		return fmt.Errorf("write private key: %w", err)
+	// Create both parent directories. The private-key dir uses 0o750
+	// because the key inside is operator-only; the public-key dir uses
+	// 0o755 because the key inside is meant to be readable by verifiers.
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
+		return fmt.Errorf("create key dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(publicKeyPath), 0o755); err != nil {
+		return fmt.Errorf("create public-key dir: %w", err)
 	}
 
-	// Write public key with mode 0644.
-	if err := os.WriteFile(publicKeyPath, []byte(kp.PublicKey), 0o644); err != nil {
-		// Clean up private key on failure.
+	if err := writeNewSecretFile(keyPath, []byte(kp.PrivateKey), 0o600); err != nil {
+		return fmt.Errorf("write private key %s: %w", keyPath, err)
+	}
+
+	if err := writeNewSecretFile(publicKeyPath, []byte(kp.PublicKey), 0o644); err != nil {
+		// Roll back so the operator can re-run --init from a clean state
+		// instead of being stuck with a private key whose public half is
+		// missing or wrong.
 		_ = os.Remove(keyPath)
-		return fmt.Errorf("write public key: %w", err)
+		return fmt.Errorf("write public key %s: %w", publicKeyPath, err)
 	}
 
+	return nil
+}
+
+// writeNewSecretFile creates a file at path containing data with the given
+// mode. It refuses to overwrite an existing file (O_EXCL) and refuses to
+// follow a symlink at the path (O_NOFOLLOW), closing the TOCTOU window
+// where a Stat-then-Write pair could be tricked into writing through a
+// symlink an attacker plants between the two syscalls.
+//
+// fchmod after the write ensures the on-disk permissions match mode even
+// when the process umask would otherwise narrow them; on failure the
+// partially-written file is removed so a retry sees a clean slate.
+func writeNewSecretFile(path string, data []byte, mode os.FileMode) error {
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|oNoFollow, mode)
+	if err != nil {
+		if isSymlinkLoop(err) {
+			return fmt.Errorf("refusing to follow symlink at %s", path)
+		}
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = fh.Close()
+			_ = os.Remove(path)
+		}
+	}()
+
+	if _, err := fh.Write(data); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	// fchmod via the open fd, not path-based Chmod, so the mode applies to
+	// the inode we just created — no symlink-target chmod risk even if the
+	// directory entry is replaced after we write.
+	if err := fh.Chmod(mode); err != nil {
+		return fmt.Errorf("chmod %o: %w", mode, err)
+	}
+	closed = true
+	if err := fh.Close(); err != nil {
+		// Close-time errors (NFS commit failure, disk-full, quota
+		// exceeded) can lose data we just "wrote". Remove the file so the
+		// caller can retry from a clean state.
+		_ = os.Remove(path)
+		return fmt.Errorf("close: %w", err)
+	}
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -85,21 +85,31 @@ func DefaultSocketPath() string {
 }
 
 // DefaultDBPath returns the per-user SQLite path used when AGENTRECEIPTS_DB
-// is not set.
+// is not set. Uses XDG_DATA_HOME (defaults to ~/.local/share on Linux/macOS).
 func DefaultDBPath() string {
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".agent-receipts", "receipts.db")
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataHome = filepath.Join(home, ".local", "share")
+		} else {
+			return ""
+		}
 	}
-	return ""
+	return filepath.Join(dataHome, "agent-receipts", "receipts.db")
 }
 
 // DefaultKeyPath returns the per-user signing-key path used when
-// AGENTRECEIPTS_KEY is not set.
+// AGENTRECEIPTS_KEY is not set. Uses XDG_DATA_HOME (defaults to ~/.local/share on Linux/macOS).
 func DefaultKeyPath() string {
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".agent-receipts", "signing.key")
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataHome = filepath.Join(home, ".local", "share")
+		} else {
+			return ""
+		}
 	}
-	return ""
+	return filepath.Join(dataHome, "agent-receipts", "signing.key")
 }
 
 // DefaultPublicKeyPath returns the default published public-key path: the

--- a/daemon/generatekey_test.go
+++ b/daemon/generatekey_test.go
@@ -184,6 +184,14 @@ func TestGenerateKey_RefusesExistingPublicKey(t *testing.T) {
 // through that symlink to a target file (e.g. the user's authorized_keys).
 // O_NOFOLLOW + O_EXCL is what closes the window.
 func TestGenerateKey_RefusesSymlinkAtPrivateKeyPath(t *testing.T) {
+	// On platforms where oNoFollow is a no-op (non-unix builds, see
+	// nofollow_other.go) the OpenFile would silently follow the symlink
+	// and the assertion below would fail. The daemon refuses to start
+	// outside Linux/macOS at runtime anyway — mirror keysource/file_test.go's
+	// skip rather than assert what the platform can't enforce.
+	if oNoFollow == 0 {
+		t.Skip("O_NOFOLLOW is a no-op on this platform; symlink rejection cannot be enforced")
+	}
 	dir := t.TempDir()
 	target := filepath.Join(dir, "attacker-target")
 	if err := os.WriteFile(target, []byte("victim"), 0o600); err != nil {
@@ -217,6 +225,9 @@ func TestGenerateKey_RefusesSymlinkAtPrivateKeyPath(t *testing.T) {
 // second write, the existing private-key cleanup must still leave a
 // clean state.
 func TestGenerateKey_RefusesSymlinkAtPublicKeyPath(t *testing.T) {
+	if oNoFollow == 0 {
+		t.Skip("O_NOFOLLOW is a no-op on this platform; symlink rejection cannot be enforced")
+	}
 	dir := t.TempDir()
 	target := filepath.Join(dir, "attacker-target")
 	if err := os.WriteFile(target, []byte("victim"), 0o644); err != nil {

--- a/daemon/generatekey_test.go
+++ b/daemon/generatekey_test.go
@@ -1,0 +1,360 @@
+package daemon
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGenerateKey_HappyPath proves the post-condition both `--init` and the
+// soak test rely on: after a clean run the operator has exactly two files
+// — a 0o600 private key and a 0o644 public key — and the on-disk PEM
+// parses back as a matching Ed25519 keypair.
+func TestGenerateKey_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	if err := GenerateKey(keyPath, pubPath); err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	// Private key: present, mode 0o600, parses as Ed25519.
+	privInfo, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("private key missing: %v", err)
+	}
+	if got := privInfo.Mode().Perm(); got != 0o600 {
+		t.Errorf("private key perm = %o, want 0600", got)
+	}
+	privPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privBlock, _ := pem.Decode(privPEM)
+	if privBlock == nil {
+		t.Fatal("private key is not PEM")
+	}
+	parsedPriv, err := x509.ParsePKCS8PrivateKey(privBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	priv, ok := parsedPriv.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("private key is %T, want ed25519.PrivateKey", parsedPriv)
+	}
+
+	// Public key: present, mode 0o644, parses as Ed25519, matches private.
+	pubInfo, err := os.Stat(pubPath)
+	if err != nil {
+		t.Fatalf("public key missing: %v", err)
+	}
+	if got := pubInfo.Mode().Perm(); got != 0o644 {
+		t.Errorf("public key perm = %o, want 0644", got)
+	}
+	pubPEM, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBlock, _ := pem.Decode(pubPEM)
+	if pubBlock == nil {
+		t.Fatal("public key is not PEM")
+	}
+	parsedPub, err := x509.ParsePKIXPublicKey(pubBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+	pub, ok := parsedPub.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("public key is %T, want ed25519.PublicKey", parsedPub)
+	}
+	if !pub.Equal(priv.Public()) {
+		t.Error("on-disk public key does not match the public half of the private key")
+	}
+}
+
+// TestGenerateKey_DerivesPublicKeyPathWhenEmpty pins the convenience the
+// CLI relies on: omit --public-key and the public file lands at <key>.pub.
+func TestGenerateKey_DerivesPublicKeyPathWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+
+	if err := GenerateKey(keyPath, ""); err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if _, err := os.Stat(keyPath + ".pub"); err != nil {
+		t.Errorf("expected public key at %s.pub, got: %v", keyPath, err)
+	}
+}
+
+func TestGenerateKey_RejectsEmptyKeyPath(t *testing.T) {
+	if err := GenerateKey("", ""); err == nil {
+		t.Fatal("expected error for empty keyPath")
+	}
+}
+
+// TestGenerateKey_RefusesIdenticalPaths defends against a footgun:
+// `--key /x --public-key /x` would otherwise have the public key write
+// trip O_EXCL after the private write succeeded, leaving a private-key
+// file that GenerateKey couldn't fully clean up because the same path
+// holds a different intended file. Reject early instead.
+func TestGenerateKey_RefusesIdenticalPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "same")
+	err := GenerateKey(path, path)
+	if err == nil {
+		t.Fatal("expected error when keyPath == publicKeyPath")
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		t.Error("file was created despite the rejection")
+	}
+}
+
+// TestGenerateKey_RefusesExistingPrivateKey is the central safety
+// guarantee: an operator who accidentally re-runs --init must NOT clobber
+// the live signing key — that would invalidate every receipt the chain
+// has ever produced. We pre-create a sentinel file and verify it survives.
+func TestGenerateKey_RefusesExistingPrivateKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	const sentinel = "DO NOT OVERWRITE"
+	if err := os.WriteFile(keyPath, []byte(sentinel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := GenerateKey(keyPath, pubPath)
+	if err == nil {
+		t.Fatal("expected error when private key already exists")
+	}
+
+	got, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("private key was overwritten; got %q, want %q", got, sentinel)
+	}
+	if _, err := os.Stat(pubPath); err == nil {
+		t.Error("public key was written even though private-key write failed")
+	}
+}
+
+// TestGenerateKey_RefusesExistingPublicKey covers the symmetric case: a
+// stray <key>.pub left over from a prior install must block --init so the
+// operator decides whether to remove it (and accept the rotation) rather
+// than the daemon silently mismatching the published key against the new
+// private key.
+func TestGenerateKey_RefusesExistingPublicKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	const sentinel = "STALE PUB KEY"
+	if err := os.WriteFile(pubPath, []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := GenerateKey(keyPath, pubPath)
+	if err == nil {
+		t.Fatal("expected error when public key already exists")
+	}
+
+	if _, err := os.Stat(keyPath); err == nil {
+		t.Error("private key was created despite stale public key blocking the run")
+	}
+	got, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("public key was overwritten; got %q, want %q", got, sentinel)
+	}
+}
+
+// TestGenerateKey_RefusesSymlinkAtPrivateKeyPath is the TOCTOU regression:
+// an attacker who can plant a symlink at the private-key path before the
+// open call must not get the daemon to write Ed25519 secret material
+// through that symlink to a target file (e.g. the user's authorized_keys).
+// O_NOFOLLOW + O_EXCL is what closes the window.
+func TestGenerateKey_RefusesSymlinkAtPrivateKeyPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "attacker-target")
+	if err := os.WriteFile(target, []byte("victim"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "signing.key")
+	if err := os.Symlink(target, keyPath); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	err := GenerateKey(keyPath, pubPath)
+	if err == nil {
+		t.Fatal("expected error when private-key path is a symlink")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "victim" {
+		t.Errorf("symlink target was overwritten; got %q want %q (O_NOFOLLOW failed to refuse)", got, "victim")
+	}
+	if _, err := os.Stat(pubPath); err == nil {
+		t.Error("public key was created even though private-key write failed")
+	}
+}
+
+// TestGenerateKey_RefusesSymlinkAtPublicKeyPath: same TOCTOU defence on
+// the public-key path. If the symlink ambush only succeeds for the
+// second write, the existing private-key cleanup must still leave a
+// clean state.
+func TestGenerateKey_RefusesSymlinkAtPublicKeyPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "attacker-target")
+	if err := os.WriteFile(target, []byte("victim"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+	if err := os.Symlink(target, pubPath); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+
+	err := GenerateKey(keyPath, pubPath)
+	if err == nil {
+		t.Fatal("expected error when public-key path is a symlink")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "victim" {
+		t.Errorf("symlink target was overwritten; got %q want %q", got, "victim")
+	}
+	// Private key must have been rolled back so a retry sees a clean
+	// state — half-written installs are exactly what `--init`'s "must not
+	// exist" semantics are meant to prevent.
+	if _, err := os.Stat(keyPath); err == nil {
+		t.Error("private key remained on disk after public-key write failed; rollback did not run")
+	}
+}
+
+// TestGenerateKey_CreatesParentDirs proves --init can run against a fresh
+// $HOME with no ~/.local/share/agent-receipts directory yet.
+func TestGenerateKey_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "nested", "deeper", "signing.key")
+	pubPath := filepath.Join(dir, "elsewhere", "signing.key.pub")
+
+	if err := GenerateKey(keyPath, pubPath); err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Errorf("private key missing: %v", err)
+	}
+	if _, err := os.Stat(pubPath); err != nil {
+		t.Errorf("public key missing: %v", err)
+	}
+}
+
+// TestGenerateKey_ProducesKeyKeysourceCanLoad is the integration guarantee:
+// a key just written by GenerateKey must be loadable by the same
+// keysource.File the daemon uses at runtime. Catches any future drift
+// between PEM block types, encoding flags, or permission expectations.
+func TestGenerateKey_ProducesKeyKeysourceCanLoad(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	if err := GenerateKey(keyPath, pubPath); err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	// Round-trip through the same keysource the daemon uses. We import
+	// the package locally (no t.Helper noise) and load + sign + verify
+	// with the published public key to prove the on-disk artefacts are
+	// consistent with each other.
+	priv, err := readPrivKeyForTest(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := readPubKeyForTest(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := []byte("round-trip")
+	sig := ed25519.Sign(priv, msg)
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Error("signature produced by on-disk private key does not verify against on-disk public key")
+	}
+}
+
+// TestGenerateKey_ErrorWrappingMentionsPath gives operators something
+// actionable when --init fails: the failing path should appear in the
+// surfaced error so they don't have to guess which file is the problem.
+func TestGenerateKey_ErrorWrappingMentionsPath(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := filepath.Join(dir, "signing.key.pub")
+
+	if err := os.WriteFile(keyPath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := GenerateKey(keyPath, pubPath)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), keyPath) {
+		t.Errorf("error %q should mention the failing path %q", err.Error(), keyPath)
+	}
+}
+
+func readPrivKeyForTest(path string) (ed25519.PrivateKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, errors.New("not PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	priv, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, errors.New("not ed25519")
+	}
+	return priv, nil
+}
+
+func readPubKeyForTest(path string) (ed25519.PublicKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, errors.New("not PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("not ed25519")
+	}
+	return pub, nil
+}

--- a/daemon/paths_test.go
+++ b/daemon/paths_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDefaultDBPath_UsesXDGDataHomeWhenAbsolute pins the spec-conformant
+// branch: an absolute XDG_DATA_HOME wins over the home-based default.
+func TestDefaultDBPath_UsesXDGDataHomeWhenAbsolute(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/srv/data")
+	got := DefaultDBPath()
+	if want := "/srv/data/agent-receipts/receipts.db"; got != want {
+		t.Errorf("DefaultDBPath() = %q, want %q", got, want)
+	}
+}
+
+// TestDefaultDBPath_FallsBackToHomeWhenXDGUnset pins the default the soak
+// test relies on: ~/.local/share/agent-receipts/receipts.db on Linux/macOS.
+func TestDefaultDBPath_FallsBackToHomeWhenXDGUnset(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("XDG_DATA_HOME", "")
+	got := DefaultDBPath()
+	if want := "/home/test/.local/share/agent-receipts/receipts.db"; got != want {
+		t.Errorf("DefaultDBPath() = %q, want %q", got, want)
+	}
+}
+
+// TestDefaultDBPath_RefusesRelativeXDG ensures a relative XDG_DATA_HOME
+// (which the spec says implementations must ignore) does not silently
+// relocate the receipt store under the daemon's working directory.
+func TestDefaultDBPath_RefusesRelativeXDG(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("XDG_DATA_HOME", "relative/data")
+	got := DefaultDBPath()
+	if want := "/home/test/.local/share/agent-receipts/receipts.db"; got != want {
+		t.Errorf("DefaultDBPath() = %q, want %q (relative XDG_DATA_HOME must be ignored)", got, want)
+	}
+}
+
+func TestDefaultKeyPath_UsesXDGDataHomeWhenAbsolute(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/srv/data")
+	got := DefaultKeyPath()
+	if want := "/srv/data/agent-receipts/signing.key"; got != want {
+		t.Errorf("DefaultKeyPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultKeyPath_FallsBackToHomeWhenXDGUnset(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("XDG_DATA_HOME", "")
+	got := DefaultKeyPath()
+	if want := "/home/test/.local/share/agent-receipts/signing.key"; got != want {
+		t.Errorf("DefaultKeyPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultKeyPath_RefusesRelativeXDG(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("XDG_DATA_HOME", "relative/data")
+	got := DefaultKeyPath()
+	if want := "/home/test/.local/share/agent-receipts/signing.key"; got != want {
+		t.Errorf("DefaultKeyPath() = %q, want %q (relative XDG_DATA_HOME must be ignored)", got, want)
+	}
+}
+
+// TestDefaultDBPath_AndKeyPath_ShareDir documents the invariant that the
+// SQLite store and the signing key live under the same per-user directory.
+// Both `--init` and Run rely on this — the operator only needs to back up
+// one directory to capture both pieces of state.
+func TestDefaultDBPath_AndKeyPath_ShareDir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/srv/data")
+	if got, want := filepath.Dir(DefaultDBPath()), filepath.Dir(DefaultKeyPath()); got != want {
+		t.Errorf("DB dir = %q, key dir = %q; should share parent", got, want)
+	}
+}
+
+// TestDefaultPaths_PointAtAgentReceiptsSubdir guards against a future
+// refactor accidentally dropping the per-app subdirectory and dumping
+// receipts.db / signing.key directly into $XDG_DATA_HOME alongside other
+// applications' data.
+func TestDefaultPaths_PointAtAgentReceiptsSubdir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/srv/data")
+	for name, got := range map[string]string{"DB": DefaultDBPath(), "Key": DefaultKeyPath()} {
+		if !strings.Contains(got, "/agent-receipts/") {
+			t.Errorf("%s path %q missing /agent-receipts/ subdir", name, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

Two related daemon changes surfaced during the v0.8.0-alpha.1 soak (issue #348):

1. **XDG-compliant default paths.** Move the SQLite store and signing key from `~/.agent-receipts/` to `$XDG_DATA_HOME/agent-receipts/` (defaults to `~/.local/share/agent-receipts/`). Same path on Linux and macOS, no spaces, follows the Unix convention.
2. **Explicit `--init` for key generation.** Add `agent-receipts-daemon --init` to create the signing key pair on a fresh install. The daemon refuses to start without an existing key — it never silently regenerates one.

Commits split for review:
- `b8f9a3a chore(daemon): use XDG-compliant paths for DB and signing key`
- `1f0dd21 feat(daemon): add explicit --init flag for key generation`
- `081cd3e refactor(daemon): extract xdgDataHome, refuse relative XDG_DATA_HOME`
- `7f7231c fix(daemon): make GenerateKey TOCTOU-safe and refuse symlinks`

## Why

**Paths:** ADR-0010 chose `~/Library/Application Support/agent-receipts/` on macOS, which is Apple-conventional but ergonomically painful (spaces, deep, opaque to Unix tooling). XDG is consistent across platforms and matches what Unix operators expect.

**Explicit init:** The earlier draft auto-generated the key at startup if missing. That's a footgun — a deleted or accidentally-moved key would be silently replaced, and every previously-signed receipt would become unverifiable against the new public key. Failing fast forces an operator decision instead.

**TOCTOU hardening:** The first version of `GenerateKey` used `os.Stat` followed by `os.WriteFile`. An attacker who could write to the parent directory could plant a symlink between the two syscalls, redirecting our private-key write through it to a target file. Replaced with the same `O_CREATE|O_EXCL|O_NOFOLLOW + fchmod` pattern `publishPublicKey` already uses.

## Validation

- `go test ./daemon/...` — all green, includes 19 new tests (8 path defaults, 11 GenerateKey)
- `go vet ./...` — clean across daemon/, sdk/go/, mcp-proxy/
- Five-emitter soak (Go SDK, TS SDK, Python SDK, mcp-proxy, OpenClaw) passed end-to-end against this daemon, including chain continuity across a daemon restart (issue #348 phases 0–5.2)

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — N/A, no receipt-format/signing/hashing changes
- [ ] AGENTS.md updated — N/A, no structure change
- [ ] Spec changes — N/A

## Related

- Surfaces work tracked in issue #348 (v0.8.0-alpha.1 soak)
- Companion issue #349 filed during soak: add `--version` flag to daemon