### PR TITLE
daemon: add --version flag (closes #349)

### DIFF
--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -11,10 +11,28 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/agent-receipts/ar/daemon"
 )
+
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z".
+// Falls back to the module version from Go's build info (set automatically
+// for binaries installed with `go install`), then to "dev". Mirrors the
+// resolveVersion pattern in mcp-proxy/cmd/mcp-proxy/main.go so operators
+// see a useful string from `--version` in any install scenario.
+var version string
+
+func resolveVersion() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}
 
 func main() {
 	cfg := daemon.Config{
@@ -33,6 +51,7 @@ func main() {
 	}
 
 	initKeys := flag.Bool("init", false, "Generate a new signing key pair and exit (must not exist)")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.StringVar(&cfg.SocketPath, "socket", cfg.SocketPath, "Unix-domain socket path (env: AGENTRECEIPTS_SOCKET)")
 	flag.StringVar(&cfg.DBPath, "db", cfg.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	flag.StringVar(&cfg.KeyPath, "key", cfg.KeyPath, "Ed25519 PEM private key path, mode 0600 (env: AGENTRECEIPTS_KEY)")
@@ -41,6 +60,11 @@ func main() {
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("agent-receipts-daemon %s\n", resolveVersion())
+		return
+	}
 
 	if *initKeys {
 		if cfg.PublicKeyPath == "" {

--- a/daemon/cmd/agent-receipts-daemon/main_test.go
+++ b/daemon/cmd/agent-receipts-daemon/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+// TestResolveVersion_PrefersLDFlagInjection pins the precedence the
+// release pipeline relies on: a -ldflags "-X main.version=..." build
+// wins over both Go's build info and the "dev" fallback.
+func TestResolveVersion_PrefersLDFlagInjection(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	version = "v9.9.9-test"
+	if got, want := resolveVersion(), "v9.9.9-test"; got != want {
+		t.Errorf("resolveVersion() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveVersion_FallsBackToDevWhenUnset is the contract when neither
+// the release pipeline injected a version nor `go install` produced a
+// module version: --version must still print something useful instead of
+// an empty string. "dev" matches mcp-proxy's behaviour.
+func TestResolveVersion_FallsBackToDevWhenUnset(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	version = ""
+	got := resolveVersion()
+	// Under `go test`, debug.ReadBuildInfo() can return either an empty
+	// or "(devel)" Main.Version depending on how the binary was invoked
+	// — both branches must yield a non-empty, sensible string. We accept
+	// either "dev" or any non-empty version-shaped value (anything that
+	// isn't the empty string the operator would never want to see).
+	if got == "" {
+		t.Error("resolveVersion() returned empty string; --version output would be empty")
+	}
+}


### PR DESCRIPTION
## What

Add `agent-receipts-daemon --version` (and `-version`). Returns the build version, falling back through three sources:

1. `-ldflags "-X main.version=..."` (release pipeline)
2. Go's `debug.ReadBuildInfo()` module version (set by `go install`)
3. Literal `"dev"` (local `go build` with no flags)

## Why

Surfaced during the v0.8.0-alpha.1 soak (#348) — the soak instructions ask for `agent-receipts-daemon --version` to confirm the build under test, but the daemon had no version flag. Filed as #349.

The implementation mirrors the existing `resolveVersion` in `mcp-proxy/cmd/mcp-proxy/main.go` so the two CLIs print version strings the same way.

## Validation

```
$ go build -o /tmp/d ./daemon/cmd/agent-receipts-daemon && /tmp/d --version
agent-receipts-daemon dev

$ go build -ldflags "-X main.version=v0.8.0-alpha.2" -o /tmp/d ./daemon/cmd/agent-receipts-daemon && /tmp/d --version
agent-receipts-daemon v0.8.0-alpha.2
```

Tests cover the ldflag-injected branch and the empty-string fallback.

## Out of scope

This PR does **not** wire `-X main.version=...` into the daemon's release workflow. The daemon doesn't have a `.goreleaser.yaml` of its own yet, so injection would be a separate change in a release-pipeline PR. Until then, `--version` reports the module version from `debug.ReadBuildInfo()` for `go install`-style builds and `"dev"` for plain `go build`. That's still useful — and matches what the soak needed.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — N/A, no receipt-format/signing/hashing changes
- [ ] AGENTS.md updated — N/A, no structure change
- [ ] Spec changes — N/A