### PR TITLE
sdk/py: derive VERSION from importlib.metadata (closes #345)

### DIFF
--- a/sdk/py/src/agent_receipts/_version.py
+++ b/sdk/py/src/agent_receipts/_version.py
@@ -1,1 +1,28 @@
-VERSION = "0.8.0a1"
+"""Package version, derived from installed package metadata.
+
+Reading the version from ``importlib.metadata`` keeps it in lockstep with
+``pyproject.toml`` automatically — no second hand-maintained constant to
+forget bumping. ``pyproject.toml`` is the single source of truth.
+
+If the package is imported from a checkout that hasn't been installed
+(e.g. running ``python -m`` against ``src/`` without ``uv sync`` or
+``pip install -e .`` first), ``importlib.metadata.version`` raises
+``PackageNotFoundError``. We surface a clearly-fake fallback so a stray
+import in such an environment doesn't crash on import — but every test
+and supported user path installs the package, so this fallback should
+never be observed in practice.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _resolve_version() -> str:
+    try:
+        return version("agent-receipts")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+VERSION = _resolve_version()

--- a/sdk/py/tests/test_version.py
+++ b/sdk/py/tests/test_version.py
@@ -1,0 +1,69 @@
+"""Test that ``agent_receipts.VERSION`` is derived from package metadata.
+
+Pins the contract introduced in #345: replacing the hand-maintained
+``VERSION = "..."`` constant with one read from ``importlib.metadata``
+removes a class of release-prep drift bugs (the kind that made it past
+review on #343). These tests guard against future regressions back to
+hand-maintenance.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import version
+
+import agent_receipts
+
+
+def test_version_matches_installed_package_metadata() -> None:
+    """``agent_receipts.VERSION`` must equal what pip / uv resolved."""
+
+    assert agent_receipts.VERSION == version("agent-receipts")
+
+
+def test_version_is_non_empty() -> None:
+    """Even on the PackageNotFoundError fallback path, VERSION must be a
+    non-empty string — diagnostics and crash reports that interpolate it
+    should never produce ``" "`` or ``""``."""
+
+    assert isinstance(agent_receipts.VERSION, str)
+    assert agent_receipts.VERSION  # truthy / non-empty
+
+
+def test_version_is_pep440_shaped() -> None:
+    """Catch a future regression where VERSION starts containing arbitrary
+    text. PEP 440 + the project's ``0.0.0+unknown`` fallback covers every
+    string we should ever surface."""
+
+    pep440_or_fallback = re.compile(
+        r"""
+        ^                    # full match
+        \d+(\.\d+)*          # release segment (e.g. 0.8.0)
+        (a\d+|b\d+|rc\d+)?   # optional pre-release (a1, b2, rc3)
+        (\+[a-zA-Z0-9.]+)?   # optional local version (+unknown, +g1234abcd)
+        $
+        """,
+        re.VERBOSE,
+    )
+    assert pep440_or_fallback.match(agent_receipts.VERSION), (
+        f"VERSION {agent_receipts.VERSION!r} does not look like a PEP 440 version"
+    )
+
+
+def test_version_is_distinct_from_receipt_schema_version() -> None:
+    """The package version (``VERSION``) and the receipt schema version
+    (``RECEIPT_VERSION``) are intentionally separate — see the note in
+    ``__init__.py``. Pin that the two don't accidentally converge in a
+    way that would mask drift between package release and schema bump."""
+
+    # Both exist and are independently exported.
+    assert agent_receipts.VERSION
+    assert agent_receipts.RECEIPT_VERSION
+    # Sanity: schema version stays at 0.2.x range (per receipt/types.py).
+    # If this ever fails, the schema bumped — review whether the test
+    # still expresses the right invariant.
+    schema = agent_receipts.RECEIPT_VERSION
+    assert schema.startswith("0.2."), (
+        f"receipt schema version moved past 0.2.x ({schema!r}); "
+        "update this guard if intentional"
+    )

--- a/sdk/py/tests/test_version.py
+++ b/sdk/py/tests/test_version.py
@@ -34,25 +34,30 @@ def test_version_is_non_empty() -> None:
 
 def test_version_matches_project_release_shape() -> None:
     """Catch a future regression where VERSION starts containing arbitrary
-    text. This isn't a full PEP 440 validator (it doesn't accept epochs,
-    post releases, or dev releases) — the project deliberately only ever
-    ships standard / pre-release semver + the ``0.0.0+unknown`` fallback,
-    so the regex is intentionally narrow. If the project starts shipping
-    `.postN` or `.devN` builds, broaden the pattern at that point."""
+    text. The pattern mirrors ``scripts/release.sh``'s ``SEMVER_RE`` and
+    ``PEP440_PRE_RE`` — strict ``X.Y.Z`` (no leading zeros, no two-part or
+    four-part variants), an optional PEP 440 pre-release suffix, plus a
+    SemVer ``+local`` tail to cover the ``0.0.0+unknown`` fallback. If the
+    release tooling ever broadens to accept ``.postN`` / ``.devN`` /
+    epochs, broaden this regex at the same time so the two stay in sync."""
 
+    # Mirrors release.sh's PEP440_PRE_RE / SEMVER_RE numeric component
+    # rule: zero, or any positive int with no leading zeros.
+    component = r"(0|[1-9]\d*)"
     project_release_shape = re.compile(
-        r"""
-        ^                    # full match
-        \d+(\.\d+)*          # release segment (e.g. 0.8.0)
-        (a\d+|b\d+|rc\d+)?   # optional pre-release (a1, b2, rc3)
-        (\+[a-zA-Z0-9.]+)?   # optional local version (+unknown, +g1234abcd)
+        rf"""
+        ^                                     # full match
+        {component}\.{component}\.{component} # strict X.Y.Z
+        ((a|b|rc)\d+)?                        # optional PEP 440 pre-release
+        (\+[0-9A-Za-z.-]+)?                   # optional +local (covers +unknown)
         $
         """,
         re.VERBOSE,
     )
     assert project_release_shape.match(agent_receipts.VERSION), (
-        f"VERSION {agent_receipts.VERSION!r} does not match the shapes this "
-        "project releases (semver + optional aN/bN/rcN + optional +local)"
+        f"VERSION {agent_receipts.VERSION!r} does not match the strict X.Y.Z "
+        "shape that scripts/release.sh accepts (no two-part / four-part / "
+        "leading-zero variants; pre-release must be aN/bN/rcN)"
     )
 
 
@@ -60,22 +65,16 @@ def test_version_is_distinct_from_receipt_schema_version() -> None:
     """The package version (``VERSION``) and the receipt schema version
     (``RECEIPT_VERSION``) are intentionally separate — see the note in
     ``__init__.py``. Pin that the two don't accidentally converge in a
-    way that would mask drift between package release and schema bump."""
+    way that would mask drift between package release and schema bump.
+
+    The exact-equals pin on ``RECEIPT_VERSION`` lives in
+    ``tests/receipt/test_types.py``; this test deliberately stays focused
+    on the ``VERSION != RECEIPT_VERSION`` invariant."""
 
     # Both exist and are independently exported.
     assert agent_receipts.VERSION
     assert agent_receipts.RECEIPT_VERSION
-    # The headline invariant the test name promises: package version and
-    # schema version are separate values from separate sources.
     assert agent_receipts.VERSION != agent_receipts.RECEIPT_VERSION, (
         "package VERSION and RECEIPT_VERSION converged — "
         "if intentional, drop this test; otherwise one of the constants drifted"
-    )
-    # Belt-and-braces: schema version stays in the 0.2.x range
-    # (per receipt/types.py). If this ever fails, the schema bumped —
-    # review whether the test still expresses the right invariant.
-    schema = agent_receipts.RECEIPT_VERSION
-    assert schema.startswith("0.2."), (
-        f"receipt schema version moved past 0.2.x ({schema!r}); "
-        "update this guard if intentional"
     )

--- a/sdk/py/tests/test_version.py
+++ b/sdk/py/tests/test_version.py
@@ -34,15 +34,24 @@ def test_version_is_non_empty() -> None:
 
 def test_version_matches_project_release_shape() -> None:
     """Catch a future regression where VERSION starts containing arbitrary
-    text. The pattern mirrors ``scripts/release.sh``'s ``SEMVER_RE`` and
-    ``PEP440_PRE_RE`` — strict ``X.Y.Z`` (no leading zeros, no two-part or
-    four-part variants), an optional PEP 440 pre-release suffix, plus a
-    SemVer ``+local`` tail to cover the ``0.0.0+unknown`` fallback. If the
-    release tooling ever broadens to accept ``.postN`` / ``.devN`` /
-    epochs, broaden this regex at the same time so the two stay in sync."""
+    text.
 
-    # Mirrors release.sh's PEP440_PRE_RE / SEMVER_RE numeric component
-    # rule: zero, or any positive int with no leading zeros.
+    Scope: this test enforces the Python-package version policy
+    specifically — strict ``X.Y.Z`` (no leading zeros, no two-part or
+    four-part variants), with an optional PEP 440 pre-release suffix
+    (``aN`` / ``bN`` / ``rcN``), plus a ``+local`` tail to cover the
+    ``0.0.0+unknown`` PackageNotFoundError fallback. PEP 440 disallows
+    the SemVer ``-beta.1`` hyphen form that ``scripts/release.sh``'s
+    ``SEMVER_RE`` accepts for the Go/TS components, so the policies
+    differ on purpose; this test deliberately doesn't try to mirror
+    ``release.sh`` for non-Python release shapes.
+
+    If sdk/py ever ships ``.postN`` / ``.devN`` / epoch versions,
+    broaden this regex (and update PyPI uploads accordingly)."""
+
+    # Numeric components: zero or any positive int with no leading
+    # zeros — matches the same rule release.sh's PEP440_PRE_RE applies
+    # to Python pre-release numerics.
     component = r"(0|[1-9]\d*)"
     project_release_shape = re.compile(
         rf"""
@@ -55,9 +64,9 @@ def test_version_matches_project_release_shape() -> None:
         re.VERBOSE,
     )
     assert project_release_shape.match(agent_receipts.VERSION), (
-        f"VERSION {agent_receipts.VERSION!r} does not match the strict X.Y.Z "
-        "shape that scripts/release.sh accepts (no two-part / four-part / "
-        "leading-zero variants; pre-release must be aN/bN/rcN)"
+        f"VERSION {agent_receipts.VERSION!r} does not match sdk/py's "
+        "release-version policy (strict X.Y.Z, optional PEP 440 aN/bN/rcN, "
+        "optional +local)"
     )
 
 

--- a/sdk/py/tests/test_version.py
+++ b/sdk/py/tests/test_version.py
@@ -24,18 +24,23 @@ def test_version_matches_installed_package_metadata() -> None:
 def test_version_is_non_empty() -> None:
     """Even on the PackageNotFoundError fallback path, VERSION must be a
     non-empty string — diagnostics and crash reports that interpolate it
-    should never produce ``" "`` or ``""``."""
+    should never produce ``" "`` or ``""``. Strip first so a single space
+    or all-whitespace value (which would still pass a plain truthiness
+    check) is also rejected."""
 
     assert isinstance(agent_receipts.VERSION, str)
-    assert agent_receipts.VERSION  # truthy / non-empty
+    assert agent_receipts.VERSION.strip()
 
 
-def test_version_is_pep440_shaped() -> None:
+def test_version_matches_project_release_shape() -> None:
     """Catch a future regression where VERSION starts containing arbitrary
-    text. PEP 440 + the project's ``0.0.0+unknown`` fallback covers every
-    string we should ever surface."""
+    text. This isn't a full PEP 440 validator (it doesn't accept epochs,
+    post releases, or dev releases) — the project deliberately only ever
+    ships standard / pre-release semver + the ``0.0.0+unknown`` fallback,
+    so the regex is intentionally narrow. If the project starts shipping
+    `.postN` or `.devN` builds, broaden the pattern at that point."""
 
-    pep440_or_fallback = re.compile(
+    project_release_shape = re.compile(
         r"""
         ^                    # full match
         \d+(\.\d+)*          # release segment (e.g. 0.8.0)
@@ -45,8 +50,9 @@ def test_version_is_pep440_shaped() -> None:
         """,
         re.VERBOSE,
     )
-    assert pep440_or_fallback.match(agent_receipts.VERSION), (
-        f"VERSION {agent_receipts.VERSION!r} does not look like a PEP 440 version"
+    assert project_release_shape.match(agent_receipts.VERSION), (
+        f"VERSION {agent_receipts.VERSION!r} does not match the shapes this "
+        "project releases (semver + optional aN/bN/rcN + optional +local)"
     )
 
 
@@ -59,9 +65,15 @@ def test_version_is_distinct_from_receipt_schema_version() -> None:
     # Both exist and are independently exported.
     assert agent_receipts.VERSION
     assert agent_receipts.RECEIPT_VERSION
-    # Sanity: schema version stays at 0.2.x range (per receipt/types.py).
-    # If this ever fails, the schema bumped — review whether the test
-    # still expresses the right invariant.
+    # The headline invariant the test name promises: package version and
+    # schema version are separate values from separate sources.
+    assert agent_receipts.VERSION != agent_receipts.RECEIPT_VERSION, (
+        "package VERSION and RECEIPT_VERSION converged — "
+        "if intentional, drop this test; otherwise one of the constants drifted"
+    )
+    # Belt-and-braces: schema version stays in the 0.2.x range
+    # (per receipt/types.py). If this ever fails, the schema bumped —
+    # review whether the test still expresses the right invariant.
     schema = agent_receipts.RECEIPT_VERSION
     assert schema.startswith("0.2."), (
         f"receipt schema version moved past 0.2.x ({schema!r}); "


### PR DESCRIPTION
## What

Replace the hand-maintained `VERSION = "..."` constant in `sdk/py/src/agent_receipts/_version.py` with one read from package metadata at import time:

```python
def _resolve_version() -> str:
    try:
        return version("agent-receipts")
    except PackageNotFoundError:
        return "0.0.0+unknown"

VERSION = _resolve_version()
```

`pyproject.toml` becomes the single source of truth.

## Why

Closes #345. During the v0.8.0-alpha.1 prep, `pyproject.toml` advanced to `0.8.0a1` but `_version.py` stayed pinned to `0.5.0` — caught by Copilot review on #343, but a class of bug that should be impossible by construction. This PR closes that drift class.

Symmetric to `sdk/ts`'s `scripts/sync-version.mjs`. The Python side gets there with a stdlib one-liner instead of a custom build script.

## Out of scope

`RECEIPT_VERSION` in `receipt/types.py` is intentionally separate (it's the receipt schema version, not the package version) and remains hand-maintained — same call as the issue makes.

## Validation

```
$ PATH="$HOME/.local/bin:$PATH" uv run pytest tests/test_version.py -v
test_version_matches_installed_package_metadata PASSED
test_version_is_non_empty PASSED
test_version_is_pep440_shaped PASSED
test_version_is_distinct_from_receipt_schema_version PASSED

$ PATH="$HOME/.local/bin:$PATH" uv run pytest
262 passed in 0.79s
```

Tests cover:
- VERSION matches installed metadata (the contract)
- VERSION is non-empty (so the fallback branch still produces something usable)
- VERSION is PEP 440-shaped (catches future drift to free-form text)
- VERSION stays distinct from RECEIPT_VERSION (guards the deliberate split)

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check`, `uv run ruff format --check`, `uv run pyright`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — N/A, version is package-internal, schema unchanged
- [ ] AGENTS.md updated — N/A, no structure change
- [ ] Spec changes — N/A