### PR TITLE
chore(hooks): add user-bin paths so Claude Code hooks find uv

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# Claude Code launches PostToolUse hooks in a minimal-PATH shell that doesn't
+# include user-installed binaries like `uv` (~/.local/bin/uv). Prepend the
+# common user-bin locations so `uv run ruff` resolves without each Python
+# edit needing to remember a manual PATH prefix.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "lint-on-edit: jq is not installed; skipping lint hook" >&2
   exit 0

--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Claude Code launches PreToolUse hooks in a minimal-PATH shell that doesn't
+# include user-installed binaries like `uv` (~/.local/bin/uv). Prepend the
+# common user-bin locations so `uv run pytest` resolves without each Python
+# push needing to remember a manual PATH prefix.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 # --- Filter: only run for `git push` -----------------------------------------
 
 extract_command() {


### PR DESCRIPTION
## What

Prepend `$HOME/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` to `PATH` at the top of both Claude Code hooks:

- `.claude/hooks/lint-on-edit.sh` (PostToolUse)
- `.claude/hooks/test-before-push.sh` (PreToolUse)

## Why

Both hooks invoke `uv run …` for the Python toolchain. Claude Code launches hooks in a minimal-PATH shell that doesn't include `~/.local/bin`, where `uv` is installed. Every Python edit/push from inside Claude Code was failing with `uv: command not found`.

The PreToolUse hook in particular can't be worked around with a `PATH=… git push` prefix — Claude Code runs the hook *before* the tool, in a fresh shell, not as a child of the user's command. So the fix has to live in the hook itself.

## Validation

After this change, `git push` from a Python-touching branch runs `uv run pytest` cleanly inside the Claude Code hook shell. Lefthook (separate from Claude Code's hooks) inherits PATH from the calling shell normally and is unaffected.

## Checklist

- [x] No real keys or secrets in the diff
- [ ] Tests / linter — N/A, hook script change only
- [ ] AGENTS.md / spec — N/A