### PR TITLE
chore(release): version bumps for 0.8.0-alpha.2

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.8.0a1"
+version = "0.8.0a2"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.8.0-alpha.1",
+	"version": "0.8.0-alpha.2",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Version bumps preparing the 0.8.0-alpha.2 coordinated release across all modules:

- `sdk/ts/package.json`: 0.8.0-alpha.1 → 0.8.0-alpha.2
- `sdk/py/pyproject.toml`: 0.8.0a1 → 0.8.0a2

Changes since alpha.1: daemon XDG paths, --init flag, --version support, and Python SDK version metadata fix.