### PR TITLE
docs(release): add v0.8.0-alpha.2 entries to all CHANGELOGs

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to `agent-receipts-daemon` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.8.0-alpha.2] - 2026-05-10
+
+### Added
+
+- **XDG-compliant default paths** ([#332](https://github.com/agent-receipts/ar/issues/332)):
+  SQLite store and signing key now default to `$XDG_DATA_HOME/agent-receipts/`
+  (typically `~/.local/share/agent-receipts/`) instead of `~/.agent-receipts/`.
+  Consistent across Linux and macOS, follows Unix conventions, and plays well
+  with standard tooling (commits `b8f9a3a`, `1f0dd21`, `081cd3e`).
+
+- **Explicit `--init` flag for key generation** ([#348](https://github.com/agent-receipts/ar/issues/348)):
+  New `agent-receipts-daemon --init` to create the signing key pair on fresh
+  install. The daemon refuses to start without an existing key and never silently
+  regenerates one. Prevents the footgun of accidentally replacing a deleted key
+  and orphaning all previously-signed receipts (commits `1f0dd21`, `7f7231c`).
+
+- **`--version` flag** ([#349](https://github.com/agent-receipts/ar/issues/349)):
+  `agent-receipts-daemon --version` returns the build version from three sources
+  in priority order: `-ldflags` injection (release pipeline), `debug.ReadBuildInfo()`
+  module version (set by `go install`), or literal `"dev"` (local `go build`).
+  Improves operational visibility during soaks and deployments (commit `b7589b5`).
+
+### Security
+
+- **TOCTOU-safe key generation** (commit `7f7231c`):
+  Replaced `os.Stat` + `os.WriteFile` pattern with `O_CREATE|O_EXCL|O_NOFOLLOW + fchmod`
+  to prevent symlink-based key redirection attacks during initial key write.
+  Consistent with the existing `publishPublicKey` pattern.
+
+### Tests
+
+- 19 new tests covering XDG path defaults, environment variable overrides,
+  and TOCTOU-safe key generation. Full integration suite passes including
+  chain continuity across daemon restart (issue #348).
+
+## [0.8.0-alpha.1] - 2026-05-09
+
+### Added (ADR-0010: Daemon Process Separation)
+
+- **New `agent-receipts-daemon` process** separates cryptographic operations
+  (signing, canonicalisation, chain management) from individual SDKs/proxies
+  into a dedicated daemon. SDKs emit fire-and-forget events to the daemon's
+  Unix socket; the daemon produces signed, chained receipts persisted to SQLite.
+  See [ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md).
+
+- **SQLite receipt store** with persistent chain state, verification CLI
+  (`agent-receipts-verify`), query support, and stats. Receipts are stored
+  as canonical JSON and indexed by session/timestamp.
+
+- **Ed25519 signing** with hierarchical key structure: one long-lived signing key
+  pair per daemon instance, discoverable public key at a well-known path for
+  out-of-band verification. Private keys stored with restrictive permissions (0600).
+
+- **Unix socket IPC** for receipt events. Wire protocol: 4-byte big-endian length
+  prefix + UTF-8 JSON body, matching `pipeline.SupportedFrameVersion = "1"`.
+
+- **Session-scoped chaining** ([ADR-0010 OQ4](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)):
+  All receipts in a session form a cryptographic chain. Each receipt includes
+  the hash of the prior receipt, enabling detection of tampering and enforcing
+  causality across a session (even across daemon restarts if the key is preserved).
+
+### Documentation
+
+- Comprehensive suite of integration tests covering socket communication,
+  chain continuity, key generation, and verification workflows.
+
+[0.8.0-alpha.2]: https://github.com/agent-receipts/ar/releases/tag/daemon/v0.8.0-alpha.2
+[0.8.0-alpha.1]: https://github.com/agent-receipts/ar/releases/tag/daemon/v0.8.0-alpha.1

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -9,6 +9,38 @@ This file starts at 0.6.2; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0-alpha.2] - 2026-05-10
+
+### Added
+
+- **Fire-and-forget daemon emitter integration** (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)):
+  Tool-call events are now forwarded to the `agent-receipts-daemon` Unix socket
+  for signature, canonicalisation, and chain management. New `--socket` flag
+  (default: `AGENTRECEIPTS_SOCKET` env / OS default path; empty string disables
+  daemon forwarding for backwards-compatible deployments). Existing in-process
+  receipt path remains active during alpha for dual verification. Fire-and-forget
+  design ensures tool calls complete within 250ms even if the daemon is absent
+  (commits `f1af054` and prior daemon work).
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.6.0` to `v0.8.0-alpha.2`,
+  picking up the fire-and-forget emitter.
+- Add `github.com/agent-receipts/ar/daemon` dependency at `v0.8.0-alpha.2`,
+  wired into the receipt event pipeline.
+
+### Tests
+
+- 5 new end-to-end integration tests against an in-process daemon covering
+  allowed/denied tool calls, event sequencing, fire-and-forget latency, and
+  nil-input safety (commit `f1af054`).
+
+## [0.8.0-alpha.1] - 2026-05-09
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.6.0` to `v0.8.0-alpha.1`.
+
 ## [0.7.0] - 2026-05-01
 
 ### Features

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -9,6 +9,31 @@ This file starts at 0.6.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0-alpha.2] - 2026-05-10
+
+### Changed
+
+- No SDK code changes; version bump to maintain lockstep across the coordinated
+  release (daemon process separation cutover). Releases as part of the daemon
+  refactor work (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+
+### Dependencies
+
+- Bump `daemon` to `v0.8.0-alpha.2` and `mcp-proxy` to `v0.8.0-alpha.2` for
+  consumers that depend on the daemon module.
+
+## [0.8.0-alpha.1] - 2026-05-09
+
+### Added
+
+- Fire-and-forget emitter (`emitter/emitter.go`) for forwarding tool-call events
+  to the `agent-receipts-daemon` Unix socket (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+  No crypto, no canonicalisation — the daemon handles those operations.
+
+### Dependencies
+
+- Bump `daemon` dependency to `v0.8.0-alpha.1` (initial daemon release).
+
 ## [0.6.0] - 2026-05-01
 
 ### Features

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,28 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0a2] - 2026-05-10
+
+### Changed
+
+- No SDK code changes; version bump to maintain lockstep across the coordinated
+  release (daemon process separation cutover). Releases as part of the daemon
+  refactor work (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+
+### Improved
+
+- `VERSION` now derived from package metadata at import time via
+  `importlib.metadata.version()`, making `pyproject.toml` the single source
+  of truth and eliminating version drift (closes [#345](https://github.com/agent-receipts/ar/issues/345)).
+
+## [0.8.0a1] - 2026-05-09
+
+### Added
+
+- Fire-and-forget emitter for forwarding tool-call events to the
+  `agent-receipts-daemon` Unix socket (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+  No crypto, no canonicalisation — the daemon handles those operations.
+
 ## [0.5.0] - 2026-05-01
 
 ### Hash compatibility note

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,6 +9,22 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0-alpha.2] - 2026-05-10
+
+### Changed
+
+- No SDK code changes; version bump to maintain lockstep across the coordinated
+  release (daemon process separation cutover). Releases as part of the daemon
+  refactor work (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+
+## [0.8.0-alpha.1] - 2026-05-09
+
+### Added
+
+- Fire-and-forget emitter for forwarding tool-call events to the
+  `agent-receipts-daemon` Unix socket (ADR-0010, [#236](https://github.com/agent-receipts/ar/issues/236)).
+  No crypto, no canonicalisation — the daemon handles those operations.
+
 ## [0.6.0] - 2026-05-01
 
 ### Breaking Changes


### PR DESCRIPTION
Comprehensive CHANGELOG entries for the v0.8.0-alpha.2 coordinated release across all modules.

## What's new

**daemon** (first release)
- New module implementing ADR-0010 (daemon process separation)
- XDG-compliant paths for DB and signing key
- Explicit `--init` flag for key generation (safety improvement)
- `--version` flag for operational visibility
- TOCTOU-safe key generation

**sdk-go, sdk-ts, sdk-py**
- Lockstep version bump (daemon refactor)
- Fire-and-forget emitter for daemon integration
- Python SDK: version now derived from package metadata

**mcp-proxy**
- Fire-and-forget daemon emitter integration
- Bumped sdk-go to v0.8.0-alpha.2
- New daemon dependency at v0.8.0-alpha.2
- 5 new integration tests

All entries follow Keep a Changelog format with references to ADRs, issues, and commits.