### PR TITLE
test(daemon): fix flaky TestConcurrentSDKEmitters on macOS

### DIFF
--- a/daemon/tests_concurrent_test.go
+++ b/daemon/tests_concurrent_test.go
@@ -67,8 +67,10 @@ func TestConcurrentSDKEmitters(t *testing.T) {
 		t.Fatalf("emitter failed: %v", err)
 	}
 
-	// Wait for all receipts (30 total)
-	receipts := f.WaitForReceiptCount(t, totalFrames, 10*time.Second)
+	// Wait for all receipts (30 total). 30 s gives macOS CI runners (which are
+	// slower than Linux) enough headroom; the poll exits as soon as all receipts
+	// arrive so the happy path is unaffected.
+	receipts := f.WaitForReceiptCount(t, totalFrames, 30*time.Second)
 
 	// store.GetChain orders by insert id, which under concurrent emitters does
 	// not necessarily match Chain.Sequence (frame-receive order vs.


### PR DESCRIPTION
## What

Increase the `WaitForReceiptCount` timeout in `TestConcurrentSDKEmitters` from 10 s to 30 s.

## Why

macOS CI runners are slower than Linux and occasionally deliver the final receipt just after the 10 s deadline, producing a spurious `got 29 (err=)` failure (issue #363). `WaitForReceiptCount` exits as soon as all receipts arrive, so the happy path timing is unaffected — only the failure ceiling changes.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, no protocol changes
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer — N/A