### PR TITLE
chore(daemon): bump sdk/go dependency to v0.8.0

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/daemon
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.8.0
 	golang.org/x/sys v0.43.0
 )
 

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1 h1:6SWk87A5ku3QzArLyr8dDEMUN124CbajwwuQScYLnyo=
-github.com/agent-receipts/ar/sdk/go v0.8.0-alpha.1/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
+github.com/agent-receipts/ar/sdk/go v0.8.0 h1:eslo3Zf9qoo+STBy/ge7ND8ZTGIMsOgfQGhZjo6hcWY=
+github.com/agent-receipts/ar/sdk/go v0.8.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Bumps `daemon/go.mod` from `sdk/go v0.8.0-alpha.1` to the just-tagged stable `sdk/go v0.8.0`. No source changes — `go.sum` updated accordingly.

After this merges, `daemon/v0.8.0` can be tagged to trigger the release pipeline (binary builds + Homebrew formula).