### PR TITLE
fix(release): handle pre-existing release in release-daemon.yml

### DIFF
--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -65,7 +65,14 @@ jobs:
           fi
           # Create the release if it doesn't already exist (e.g. pre-created
           # for release notes), then upload assets either way.
-          if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+          # If it already exists, normalise title and prerelease flag — a
+          # pre-created release may be missing --prerelease, which would cause
+          # a pre-release tag to appear as the latest stable release.
+          if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" \
+              --title "daemon ${DAEMON_VERSION}" \
+              "${PRERELEASE_ARG[@]}"
+          else
             gh release create "${GITHUB_REF_NAME}" \
               --title "daemon ${DAEMON_VERSION}" \
               --generate-notes \

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -63,9 +63,15 @@ jobs:
           if [[ "${DAEMON_VERSION}" == *-* ]]; then
             PRERELEASE_ARG+=(--prerelease)
           fi
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "daemon ${DAEMON_VERSION}" \
-            --generate-notes \
-            "${PRERELEASE_ARG[@]}" \
+          # Create the release if it doesn't already exist (e.g. pre-created
+          # for release notes), then upload assets either way.
+          if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "daemon ${DAEMON_VERSION}" \
+              --generate-notes \
+              "${PRERELEASE_ARG[@]}"
+          fi
+          gh release upload "${GITHUB_REF_NAME}" \
             daemon/dist/*.tar.gz \
-            daemon/dist/checksums.txt
+            daemon/dist/checksums.txt \
+            --clobber


### PR DESCRIPTION
Splits `gh release create` into a conditional create + unconditional `gh release upload --clobber`. If the release was pre-created (e.g. for release notes), the workflow now uploads assets to the existing release rather than failing.

Caught during the `daemon/v0.8.0` release — the release was pre-created before the workflow fired, causing the binary upload step to exit 1.