### PR TITLE
feat(daemon): add macOS LaunchAgent plist for manual install

### DIFF
--- a/daemon/packaging/macos/ai.agentreceipts.daemon.plist
+++ b/daemon/packaging/macos/ai.agentreceipts.daemon.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!-- User-level LaunchAgent for agent-receipts-daemon.
+
+     Install (macOS Monterey+):
+              cp ai.agentreceipts.daemon.plist ~/Library/LaunchAgents/
+              launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
+
+     One-time key initialisation (run before first load):
+              agent-receipts-daemon --init
+
+     Remove:  launchctl bootout gui/$(id -u)/ai.agentreceipts.daemon
+
+     Log location: managed by Homebrew's service block when installed via brew.
+     For manual installs, add StandardOutPath/StandardErrorPath keys with
+     absolute paths — launchd does not expand ~ or $HOME.
+
+     Binary path: /opt/homebrew/bin on Apple Silicon Macs; change to
+     /usr/local/bin on Intel Macs, or use the full path to your install. -->
+<dict>
+    <key>Label</key>
+    <string>ai.agentreceipts.daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <!-- Apple Silicon Homebrew path. Intel: /usr/local/bin/agent-receipts-daemon -->
+        <string>/opt/homebrew/bin/agent-receipts-daemon</string>
+    </array>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/daemon/packaging/macos/ai.agentreceipts.daemon.plist
+++ b/daemon/packaging/macos/ai.agentreceipts.daemon.plist
@@ -6,19 +6,21 @@
      Install (macOS Monterey+):
        1. Create the log directory:
               mkdir -p ~/Library/Logs/agent-receipts
-       2. Copy the plist, substituting your actual username for YOUR_USERNAME:
+       2. Ensure the LaunchAgents directory exists (may be absent on fresh installs):
+              mkdir -p ~/Library/LaunchAgents
+       3. Copy the plist, substituting your actual username for YOUR_USERNAME:
               sed "s/YOUR_USERNAME/$(whoami)/g" ai.agentreceipts.daemon.plist \
                 > ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
-       3. Run the one-time key initialisation:
+       4. Run the one-time key initialisation:
               agent-receipts-daemon --init
-       4. Load the agent:
+       5. Load the agent:
               launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
 
      Remove:  launchctl bootout gui/$(id -u)/ai.agentreceipts.daemon
 
      Log location: ~/Library/Logs/agent-receipts/daemon.log (stdout + stderr).
      launchd does not expand ~ or $HOME in path keys, so YOUR_USERNAME must be
-     substituted with your actual macOS username (step 2 above does this).
+     substituted with your actual macOS username (step 3 above does this).
 
      Binary path: /opt/homebrew/bin on Apple Silicon Macs; change to
      /usr/local/bin on Intel Macs, or use the full path to your install. -->

--- a/daemon/packaging/macos/ai.agentreceipts.daemon.plist
+++ b/daemon/packaging/macos/ai.agentreceipts.daemon.plist
@@ -4,17 +4,21 @@
 <!-- User-level LaunchAgent for agent-receipts-daemon.
 
      Install (macOS Monterey+):
-              cp ai.agentreceipts.daemon.plist ~/Library/LaunchAgents/
-              launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
-
-     One-time key initialisation (run before first load):
+       1. Create the log directory:
+              mkdir -p ~/Library/Logs/agent-receipts
+       2. Copy the plist, substituting your actual username for YOUR_USERNAME:
+              sed "s/YOUR_USERNAME/$(whoami)/g" ai.agentreceipts.daemon.plist \
+                > ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
+       3. Run the one-time key initialisation:
               agent-receipts-daemon --init
+       4. Load the agent:
+              launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
 
      Remove:  launchctl bootout gui/$(id -u)/ai.agentreceipts.daemon
 
-     Log location: managed by Homebrew's service block when installed via brew.
-     For manual installs, add StandardOutPath/StandardErrorPath keys with
-     absolute paths — launchd does not expand ~ or $HOME.
+     Log location: ~/Library/Logs/agent-receipts/daemon.log (stdout + stderr).
+     launchd does not expand ~ or $HOME in path keys, so YOUR_USERNAME must be
+     substituted with your actual macOS username (step 2 above does this).
 
      Binary path: /opt/homebrew/bin on Apple Silicon Macs; change to
      /usr/local/bin on Intel Macs, or use the full path to your install. -->
@@ -28,6 +32,8 @@
         <string>/opt/homebrew/bin/agent-receipts-daemon</string>
     </array>
 
+    <!-- Restart on crash or non-zero exit; do not restart on clean exit.
+         This prevents restart loops when the daemon exits intentionally (e.g. --init). -->
     <key>KeepAlive</key>
     <dict>
         <key>SuccessfulExit</key>
@@ -41,5 +47,11 @@
 
     <key>RunAtLoad</key>
     <true/>
+
+    <!-- launchd requires absolute paths; ~ and $HOME are not expanded. -->
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/agent-receipts/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/agent-receipts/daemon.log</string>
 </dict>
 </plist>

--- a/daemon/packaging/macos/ai.agentreceipts.daemon.plist
+++ b/daemon/packaging/macos/ai.agentreceipts.daemon.plist
@@ -8,8 +8,8 @@
               mkdir -p ~/Library/Logs/agent-receipts
        2. Ensure the LaunchAgents directory exists (may be absent on fresh installs):
               mkdir -p ~/Library/LaunchAgents
-       3. Copy the plist, substituting your actual username for YOUR_USERNAME:
-              sed "s/YOUR_USERNAME/$(whoami)/g" ai.agentreceipts.daemon.plist \
+       3. Copy the plist, substituting the placeholder with your home directory:
+              sed "s|/Users/YOUR_USERNAME|$HOME|g" ai.agentreceipts.daemon.plist \
                 > ~/Library/LaunchAgents/ai.agentreceipts.daemon.plist
        4. Run the one-time key initialisation:
               agent-receipts-daemon --init
@@ -19,8 +19,10 @@
      Remove:  launchctl bootout gui/$(id -u)/ai.agentreceipts.daemon
 
      Log location: ~/Library/Logs/agent-receipts/daemon.log (stdout + stderr).
-     launchd does not expand ~ or $HOME in path keys, so YOUR_USERNAME must be
-     substituted with your actual macOS username (step 3 above does this).
+     launchd does not expand ~ or $HOME in path keys, so the placeholder path
+     /Users/YOUR_USERNAME must be replaced with your actual home directory
+     (step 3 above does this using $HOME, which handles non-standard home
+     directory locations such as network accounts or custom $HOME values).
 
      Binary path: /opt/homebrew/bin on Apple Silicon Macs; change to
      /usr/local/bin on Intel Macs, or use the full path to your install. -->


### PR DESCRIPTION
## What

Adds `daemon/packaging/macos/ai.agentreceipts.daemon.plist` — a macOS user-level LaunchAgent plist for installing the daemon without Homebrew services.

## Why

Homebrew&#39;s `brew services` integration (handled in the tap PR) covers the common install path, but users who install the binary manually or prefer to manage their own launchd agents need a reference plist. This file ships in-tree so it&#39;s versioned alongside the daemon source and available from the release tarball or a clone.

## Details

- Label: `ai.agentreceipts.daemon` (reverse-DNS, matches daemon identity)
- Conditional `KeepAlive` dictionary: restarts on crash (`Crashed=true`) or non-zero exit, but does **not** restart on clean exit (`SuccessfulExit=false`). This prevents restart loops when the daemon exits intentionally (e.g. after `--init`).
- `RunAtLoad true` — starts the daemon when the agent is loaded
- Logs to `~/Library/Logs/agent-receipts/daemon.log` (stdout + stderr merged)
- Binary path defaults to `/opt/homebrew/bin/agent-receipts-daemon` (Apple Silicon); Intel path noted in XML comments
- XML comments cover the full install sequence: creating the log directory, ensuring `~/Library/LaunchAgents/` exists (may be absent on fresh installs), the one-time `--init` step, and loading the agent
- Validated with `plutil -lint` (passes)

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)