### PR TITLE
build(daemon): add Linux systemd packaging

### DIFF
--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -1,0 +1,201 @@
+# Linux systemd packaging for agent-receipts-daemon
+
+Two unit files are provided:
+
+| File | Target | Use case |
+|------|--------|----------|
+| `agent-receipts-daemon.service` | `~/.config/systemd/user/` | Per-user install — no root required |
+| `agent-receipts-daemon.system.service` | `/etc/systemd/system/` | System-wide install with a dedicated service user |
+
+---
+
+## User-level install (recommended for beta)
+
+Runs as the logged-in user. No root or dedicated system user needed. Data lives in the user's home directory.
+
+### Prerequisites
+
+Install the binary (pick one):
+
+```sh
+# Via go install (once sdk/go v0.7+ is tagged):
+go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest
+
+# Or build from source:
+git clone https://github.com/agent-receipts/ar
+cd ar/daemon
+go build -o ~/.local/bin/agent-receipts-daemon ./cmd/agent-receipts-daemon
+```
+
+The unit file assumes `~/.local/bin/agent-receipts-daemon` (`%h/.local/bin/…`). If the binary is elsewhere, edit `ExecStart` before installing the unit.
+
+### 1 — Generate the signing key (once)
+
+```sh
+agent-receipts-daemon -init
+```
+
+This creates `~/.local/share/agent-receipts/signing.key` (0600) and
+`~/.local/share/agent-receipts/signing.key.pub` (0644). The daemon refuses to
+start without a key. Run `-init` only once; re-running it overwrites the key
+and invalidates any existing receipt chain.
+
+> **Note:** the default key and database paths have recently moved to
+> `~/.local/share/agent-receipts/` (XDG Base Directory). If you ran an earlier
+> beta that wrote to `~/.agent-receipts/`, pass `-key` and `-db` flags or the
+> corresponding environment variables to point the daemon at the old paths, or
+> move the files to the new location.
+
+### 2 — Install and start the unit
+
+```sh
+mkdir -p ~/.config/systemd/user
+cp agent-receipts-daemon.service ~/.config/systemd/user/
+
+systemctl --user daemon-reload
+systemctl --user enable --now agent-receipts-daemon
+```
+
+### 3 — Check status and logs
+
+```sh
+systemctl --user status agent-receipts-daemon
+journalctl --user -u agent-receipts-daemon -f
+```
+
+### Stopping / disabling
+
+```sh
+systemctl --user stop agent-receipts-daemon
+systemctl --user disable agent-receipts-daemon
+```
+
+---
+
+## System-level install (production)
+
+Runs as a dedicated `agentreceipts` system user with restricted filesystem permissions and seccomp-style systemd hardening.
+
+### Prerequisites
+
+Install the binary to `/usr/local/bin/`:
+
+```sh
+# Build from source, then:
+install -m 0755 agent-receipts-daemon /usr/local/bin/
+```
+
+### 1 — Create the `agentreceipts` user/group
+
+**Option A — via systemd-sysusers (preferred on systemd distros):**
+
+```sh
+cp agent-receipts-daemon.system.sysusers /etc/sysusers.d/agent-receipts.conf
+systemd-sysusers /etc/sysusers.d/agent-receipts.conf
+```
+
+> **Note:** `StateDirectory=agent-receipts` in the unit file causes systemd to create
+> `/var/lib/agent-receipts` (owned by `agentreceipts`) on the first service start. If
+> you use the sysusers approach, you do **not** need to create this directory manually.
+
+**Option B — manually:**
+
+```sh
+useradd --system --no-create-home \
+        --home-dir /var/lib/agent-receipts \
+        --comment "Agent Receipts daemon" \
+        --shell /usr/sbin/nologin \
+        agentreceipts
+```
+
+### 2 — Generate the signing key (once)
+
+The key must exist before the service first starts. Generate it as root and hand it to the service user:
+
+```sh
+# Create the config directory (systemd will also do this on first start, but
+# we need it to exist before we write the key).
+install -d -m 0750 -o agentreceipts -g agentreceipts /etc/agent-receipts
+
+# Generate the key as the service user so ownership is correct from the start.
+sudo -u agentreceipts \
+  agent-receipts-daemon \
+    -init \
+    -key /etc/agent-receipts/signing.key \
+    -db /var/lib/agent-receipts/receipts.db
+```
+
+The `-init` command writes `signing.key` (0600) and `signing.key.pub` (0644).
+
+### 3 — Install and start the unit
+
+```sh
+cp agent-receipts-daemon.system.service /etc/systemd/system/agent-receipts-daemon.service
+
+systemctl daemon-reload
+systemctl enable --now agent-receipts-daemon
+```
+
+### 4 — Check status and logs
+
+```sh
+systemctl status agent-receipts-daemon
+journalctl -u agent-receipts-daemon -f
+```
+
+### Stopping / disabling
+
+```sh
+systemctl stop agent-receipts-daemon
+systemctl disable agent-receipts-daemon
+```
+
+---
+
+## Socket path and emitter discovery
+
+The daemon listens on a Unix-domain socket. Emitters (mcp-proxy, SDK consumers) connect to it to submit event frames.
+
+| Install type | Default socket path |
+|---|---|
+| User-level | `$XDG_RUNTIME_DIR/agentreceipts/events.sock` (falls back to `/run/agentreceipts/events.sock`) |
+| System-level | `/run/agentreceipts/events.sock` (set explicitly via `-socket`) |
+
+Override at runtime:
+
+```sh
+# Daemon side:
+agent-receipts-daemon -socket /custom/path/events.sock
+# or:
+AGENTRECEIPTS_SOCKET=/custom/path/events.sock agent-receipts-daemon
+
+# Emitter side (mcp-proxy or SDK):
+AGENTRECEIPTS_SOCKET=/custom/path/events.sock mcp-proxy ...
+```
+
+For the system-level unit, the socket lives under `/run/agentreceipts/` which `RuntimeDirectory=agentreceipts` creates (mode 0750, owned by `agentreceipts`). Emitter processes that need to connect must run as the `agentreceipts` user **or** be added to the `agentreceipts` group:
+
+```sh
+usermod -aG agentreceipts <emitter-user>
+```
+
+The socket itself is created with mode `0660` (owner `agentreceipts`, group `agentreceipts`), so group members can connect.
+
+---
+
+## Verifying the receipt chain
+
+The `agent-receipts verify` CLI reads the SQLite store directly (read-only, safe to run while the daemon is running):
+
+```sh
+# User-level (uses default paths):
+agent-receipts verify
+
+# System-level (explicit paths):
+agent-receipts verify \
+  -db /var/lib/agent-receipts/receipts.db \
+  -public-key /etc/agent-receipts/signing.key.pub \
+  -chain-id default
+```
+
+Exit codes: `0` = verified, `1` = chain failed verification, `2` = usage error.

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -112,11 +112,10 @@ useradd --system --no-create-home \
 The key must exist before the service first starts. Generate it as root and hand it to the service user:
 
 ```sh
-# Create the config directory with open permissions temporarily so root can write
-# into it, then tighten after key generation.
-# systemd does NOT manage /etc/agentreceipts (no ConfigurationDirectory= in the
-# unit) so the packaging step must create it. Root owns it; the service user can
-# read but not write, which prevents a compromised daemon from overwriting the key.
+# Create the config directory owned by root, group agentreceipts, mode 0750.
+# Root can write into it (for key generation below); the service user can traverse
+# but not create or unlink files. systemd does NOT manage this directory
+# (no ConfigurationDirectory= in the unit) — the packaging step must create it.
 install -d -m 0750 -o root -g agentreceipts /etc/agentreceipts
 
 # Generate the key as root. /etc/agentreceipts is 0750 (root:agentreceipts): root

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -37,8 +37,10 @@ agent-receipts-daemon -init
 
 This creates `~/.local/share/agent-receipts/signing.key` (0600) and
 `~/.local/share/agent-receipts/signing.key.pub` (0644). The daemon refuses to
-start without a key. Run `-init` only once; re-running it overwrites the key
-and invalidates any existing receipt chain.
+start without a key. Run `-init` only once — if the key files already exist,
+`-init` will fail with an error rather than overwrite them. To rotate keys,
+remove the existing key files first, then re-run `-init` (this invalidates the
+existing receipt chain).
 
 > **Note:** the default key and database paths have recently moved to
 > `~/.local/share/agent-receipts/` (XDG Base Directory). If you ran an earlier

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -112,24 +112,32 @@ useradd --system --no-create-home \
 The key must exist before the service first starts. Generate it as root and hand it to the service user:
 
 ```sh
-# Create the config directory with restricted permissions.
+# Create the config directory with open permissions temporarily so root can write
+# into it, then tighten after key generation.
 # systemd does NOT manage /etc/agentreceipts (no ConfigurationDirectory= in the
 # unit) so the packaging step must create it. Root owns it; the service user can
 # read but not write, which prevents a compromised daemon from overwriting the key.
 install -d -m 0750 -o root -g agentreceipts /etc/agentreceipts
 
-# Generate the key as the service user so ownership is correct from the start.
+# Generate the key as root. /etc/agentreceipts is 0750 (root:agentreceipts): root
+# can write into it; the service user can traverse but not create files.
 # -public-key points the pub file to the writable StateDirectory so that
 # /etc/agentreceipts can be mounted read-only by the service unit.
-sudo -u agentreceipts \
-  agent-receipts-daemon \
-    -init \
-    -key /etc/agentreceipts/signing.key \
-    -public-key /var/lib/agentreceipts/signing.key.pub \
-    -db /var/lib/agentreceipts/receipts.db
+agent-receipts-daemon \
+  -init \
+  -key /etc/agentreceipts/signing.key \
+  -public-key /var/lib/agentreceipts/signing.key.pub \
+  -db /var/lib/agentreceipts/receipts.db
+
+# Hand the private key to the service user (read-only).
+chown agentreceipts:agentreceipts /etc/agentreceipts/signing.key
+chmod 0600 /etc/agentreceipts/signing.key
 ```
 
-The `-init` command writes `signing.key` (0600) and `signing.key.pub` (0644).
+The `-init` command writes `signing.key` (0600) and `signing.key.pub` (0644). After
+the `chown`/`chmod` above, `/etc/agentreceipts` is 0750 (root:agentreceipts) and
+`signing.key` is owned by `agentreceipts` with mode 0600 — the daemon can read it
+but nothing else can write to the directory.
 
 ### 3 — Install and start the unit
 
@@ -184,6 +192,13 @@ usermod -aG agentreceipts <emitter-user>
 ```
 
 The socket itself is created with mode `0660` (owner `agentreceipts`, group `agentreceipts`), so group members can connect.
+
+> **Note:** Members of the `agentreceipts` group also gain traversal access to
+> `/var/lib/agentreceipts` (mode 0750) and read access to the receipt store at
+> `/var/lib/agentreceipts/receipts.db` (mode 0640, group-readable). If that is
+> undesirable, consider a dedicated socket group or set `SocketGroup=` in a
+> `.socket` unit so that socket access and store access can be granted
+> independently.
 
 ---
 

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -93,15 +93,15 @@ cp agent-receipts-daemon.system.sysusers /etc/sysusers.d/agent-receipts.conf
 systemd-sysusers /etc/sysusers.d/agent-receipts.conf
 ```
 
-> **Note:** `StateDirectory=agent-receipts` in the unit file causes systemd to create
-> `/var/lib/agent-receipts` (owned by `agentreceipts`) on the first service start. If
+> **Note:** `StateDirectory=agentreceipts` in the unit file causes systemd to create
+> `/var/lib/agentreceipts` (owned by `agentreceipts`) on the first service start. If
 > you use the sysusers approach, you do **not** need to create this directory manually.
 
 **Option B — manually:**
 
 ```sh
 useradd --system --no-create-home \
-        --home-dir /var/lib/agent-receipts \
+        --home-dir /var/lib/agentreceipts \
         --comment "Agent Receipts daemon" \
         --shell /usr/sbin/nologin \
         agentreceipts
@@ -112,19 +112,21 @@ useradd --system --no-create-home \
 The key must exist before the service first starts. Generate it as root and hand it to the service user:
 
 ```sh
-# Create the config directory (systemd will also do this on first start, but
-# we need it to exist before we write the key).
-install -d -m 0750 -o agentreceipts -g agentreceipts /etc/agent-receipts
+# Create the config directory with restricted permissions.
+# systemd does NOT manage /etc/agentreceipts (no ConfigurationDirectory= in the
+# unit) so the packaging step must create it. Root owns it; the service user can
+# read but not write, which prevents a compromised daemon from overwriting the key.
+install -d -m 0750 -o root -g agentreceipts /etc/agentreceipts
 
 # Generate the key as the service user so ownership is correct from the start.
 # -public-key points the pub file to the writable StateDirectory so that
-# /etc/agent-receipts can be mounted read-only by the service unit.
+# /etc/agentreceipts can be mounted read-only by the service unit.
 sudo -u agentreceipts \
   agent-receipts-daemon \
     -init \
-    -key /etc/agent-receipts/signing.key \
-    -public-key /var/lib/agent-receipts/signing.key.pub \
-    -db /var/lib/agent-receipts/receipts.db
+    -key /etc/agentreceipts/signing.key \
+    -public-key /var/lib/agentreceipts/signing.key.pub \
+    -db /var/lib/agentreceipts/receipts.db
 ```
 
 The `-init` command writes `signing.key` (0600) and `signing.key.pub` (0644).
@@ -195,8 +197,8 @@ agent-receipts verify
 
 # System-level (explicit paths):
 agent-receipts verify \
-  -db /var/lib/agent-receipts/receipts.db \
-  -public-key /var/lib/agent-receipts/signing.key.pub \
+  -db /var/lib/agentreceipts/receipts.db \
+  -public-key /var/lib/agentreceipts/signing.key.pub \
   -chain-id default
 ```
 

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -18,10 +18,7 @@ Runs as the logged-in user. No root or dedicated system user needed. Data lives 
 Install the binary (pick one):
 
 ```sh
-# Via go install (once sdk/go v0.7+ is tagged):
-go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest
-
-# Or build from source:
+# Build from source (go install @latest is not yet supported — see daemon/README.md):
 git clone https://github.com/agent-receipts/ar
 cd ar/daemon
 go build -o ~/.local/bin/agent-receipts-daemon ./cmd/agent-receipts-daemon
@@ -76,7 +73,7 @@ systemctl --user disable agent-receipts-daemon
 
 ## System-level install (production)
 
-Runs as a dedicated `agentreceipts` system user with restricted filesystem permissions and seccomp-style systemd hardening.
+Runs as a dedicated `agentreceipts` system user with restricted filesystem permissions and systemd sandboxing/hardening.
 
 ### Prerequisites
 
@@ -120,10 +117,13 @@ The key must exist before the service first starts. Generate it as root and hand
 install -d -m 0750 -o agentreceipts -g agentreceipts /etc/agent-receipts
 
 # Generate the key as the service user so ownership is correct from the start.
+# -public-key points the pub file to the writable StateDirectory so that
+# /etc/agent-receipts can be mounted read-only by the service unit.
 sudo -u agentreceipts \
   agent-receipts-daemon \
     -init \
     -key /etc/agent-receipts/signing.key \
+    -public-key /var/lib/agent-receipts/signing.key.pub \
     -db /var/lib/agent-receipts/receipts.db
 ```
 
@@ -196,7 +196,7 @@ agent-receipts verify
 # System-level (explicit paths):
 agent-receipts verify \
   -db /var/lib/agent-receipts/receipts.db \
-  -public-key /etc/agent-receipts/signing.key.pub \
+  -public-key /var/lib/agent-receipts/signing.key.pub \
   -chain-id default
 ```
 

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -131,13 +131,14 @@ agent-receipts-daemon \
 
 # Hand the private key to the service user (read-only).
 chown agentreceipts:agentreceipts /etc/agentreceipts/signing.key
-chmod 0600 /etc/agentreceipts/signing.key
+chmod 0400 /etc/agentreceipts/signing.key
 ```
 
 The `-init` command writes `signing.key` (0600) and `signing.key.pub` (0644). After
-the `chown`/`chmod` above, `/etc/agentreceipts` is 0750 (root:agentreceipts) and
-`signing.key` is owned by `agentreceipts` with mode 0600 — the daemon can read it
-but nothing else can write to the directory.
+the `chown`/`chmod` above, `signing.key` is owned by `agentreceipts` with mode 0400
+(owner-read-only) — the daemon can read the key but cannot overwrite it. Runtime
+immutability is reinforced by `ReadOnlyPaths=/etc/agentreceipts` in the unit, which
+prevents writes even if the file permissions are later relaxed.
 
 ### 3 — Install and start the unit
 

--- a/daemon/packaging/linux/agent-receipts-daemon.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Agent Receipts signing daemon
+Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
+
+[Service]
+Type=simple
+# Adjust ExecStart to wherever the binary is installed.
+# Common locations: %h/.local/bin/agent-receipts-daemon (per-user install)
+#                   /usr/local/bin/agent-receipts-daemon (system-wide install)
+#
+# Run once before enabling to generate the signing key:
+#   agent-receipts-daemon -init
+#
+# %t expands to $XDG_RUNTIME_DIR, ensuring the socket path is correct even when
+# the service is started outside a PAM session (where XDG_RUNTIME_DIR may be unset).
+ExecStart=%h/.local/bin/agent-receipts-daemon \
+  -socket %t/agentreceipts/events.sock
+Restart=on-failure
+RestartSec=5s
+
+# Logging — journal captures stderr automatically; no need to redirect.
+
+[Install]
+WantedBy=default.target

--- a/daemon/packaging/linux/agent-receipts-daemon.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.service
@@ -18,6 +18,10 @@ ExecStart=%h/.local/bin/agent-receipts-daemon \
 Restart=on-failure
 RestartSec=5s
 
+# Ensure %t/agentreceipts/ exists before the socket bind.
+RuntimeDirectory=agentreceipts
+RuntimeDirectoryMode=0700
+
 # Logging — journal captures stderr automatically; no need to redirect.
 
 [Install]

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -9,25 +9,25 @@ Group=agentreceipts
 
 # Run once before enabling the service to generate the signing key:
 #   sudo -u agentreceipts agent-receipts-daemon -init \
-#     -key /etc/agent-receipts/signing.key \
-#     -public-key /var/lib/agent-receipts/signing.key.pub \
-#     -db /var/lib/agent-receipts/receipts.db
+#     -key /etc/agentreceipts/signing.key \
+#     -public-key /var/lib/agentreceipts/signing.key.pub \
+#     -db /var/lib/agentreceipts/receipts.db
 ExecStart=/usr/local/bin/agent-receipts-daemon \
-  -db /var/lib/agent-receipts/receipts.db \
-  -key /etc/agent-receipts/signing.key \
-  -public-key /var/lib/agent-receipts/signing.key.pub \
+  -db /var/lib/agentreceipts/receipts.db \
+  -key /etc/agentreceipts/signing.key \
+  -public-key /var/lib/agentreceipts/signing.key.pub \
   -socket /run/agentreceipts/events.sock
 
 # Directories managed by systemd (created before ExecStart).
 # RuntimeDirectory is ephemeral: /run/agentreceipts is removed on stop.
 RuntimeDirectory=agentreceipts
 RuntimeDirectoryMode=0750
-# StateDirectory is persistent: /var/lib/agent-receipts survives stop/restart.
-StateDirectory=agent-receipts
+# StateDirectory is persistent: /var/lib/agentreceipts survives stop/restart.
+StateDirectory=agentreceipts
 StateDirectoryMode=0750
-# ConfigurationDirectory is persistent: /etc/agent-receipts survives stop/restart.
-ConfigurationDirectory=agent-receipts
-ConfigurationDirectoryMode=0750
+# /etc/agentreceipts is NOT managed by ConfigurationDirectory= — systemd would
+# make it writable, which conflicts with the read-only intent below.
+# Instead, create it during installation (see README § System-level install).
 
 Restart=on-failure
 RestartSec=5s
@@ -49,14 +49,14 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 RemoveIPC=yes
 # Allow writes to managed data and runtime directories.
-# /etc/agent-receipts is read-only: the daemon only needs to read signing.key at
+# /etc/agentreceipts is read-only: the daemon only needs to read signing.key at
 # runtime. Write access to the key directory would allow a compromised daemon to
 # overwrite the private key. The -public-key flag points signing.key.pub to the
 # writable StateDirectory instead (see ExecStart above).
-# systemd manages /var/lib/agent-receipts (StateDirectory) and /run/agentreceipts
+# systemd manages /var/lib/agentreceipts (StateDirectory) and /run/agentreceipts
 # (RuntimeDirectory) and grants write access to those automatically.
-ReadWritePaths=/var/lib/agent-receipts /run/agentreceipts
-ReadOnlyPaths=/etc/agent-receipts
+ReadWritePaths=/var/lib/agentreceipts /run/agentreceipts
+ReadOnlyPaths=/etc/agentreceipts
 
 [Install]
 WantedBy=multi-user.target

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -13,7 +13,7 @@ Group=agentreceipts
 #     -public-key /var/lib/agentreceipts/signing.key.pub \
 #     -db /var/lib/agentreceipts/receipts.db
 #   chown agentreceipts:agentreceipts /etc/agentreceipts/signing.key
-#   chmod 0600 /etc/agentreceipts/signing.key
+#   chmod 0400 /etc/agentreceipts/signing.key
 # See README § System-level install for the full setup sequence.
 ExecStart=/usr/local/bin/agent-receipts-daemon \
   -db /var/lib/agentreceipts/receipts.db \

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -16,14 +16,14 @@ ExecStart=/usr/local/bin/agent-receipts-daemon \
   -key /etc/agent-receipts/signing.key \
   -socket /run/agentreceipts/events.sock
 
-# Directories managed by systemd (created before ExecStart, removed on stop).
-# RuntimeDirectory creates /run/agentreceipts — the socket lives here.
+# Directories managed by systemd (created before ExecStart).
+# RuntimeDirectory is ephemeral: /run/agentreceipts is removed on stop.
 RuntimeDirectory=agentreceipts
 RuntimeDirectoryMode=0750
-# StateDirectory creates /var/lib/agent-receipts — the SQLite receipt store.
+# StateDirectory is persistent: /var/lib/agent-receipts survives stop/restart.
 StateDirectory=agent-receipts
 StateDirectoryMode=0750
-# ConfigurationDirectory creates /etc/agent-receipts — the signing key.
+# ConfigurationDirectory is persistent: /etc/agent-receipts survives stop/restart.
 ConfigurationDirectory=agent-receipts
 ConfigurationDirectoryMode=0750
 

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -7,11 +7,14 @@ Type=simple
 User=agentreceipts
 Group=agentreceipts
 
-# Run once before enabling the service to generate the signing key:
-#   sudo -u agentreceipts agent-receipts-daemon -init \
+# Run once (as root) before enabling the service to generate the signing key:
+#   agent-receipts-daemon -init \
 #     -key /etc/agentreceipts/signing.key \
 #     -public-key /var/lib/agentreceipts/signing.key.pub \
 #     -db /var/lib/agentreceipts/receipts.db
+#   chown agentreceipts:agentreceipts /etc/agentreceipts/signing.key
+#   chmod 0600 /etc/agentreceipts/signing.key
+# See README § System-level install for the full setup sequence.
 ExecStart=/usr/local/bin/agent-receipts-daemon \
   -db /var/lib/agentreceipts/receipts.db \
   -key /etc/agentreceipts/signing.key \

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Agent Receipts signing daemon
+Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
+
+[Service]
+Type=simple
+User=agentreceipts
+Group=agentreceipts
+
+# Run once before enabling the service to generate the signing key:
+#   sudo -u agentreceipts agent-receipts-daemon -init \
+#     -key /etc/agent-receipts/signing.key \
+#     -db /var/lib/agent-receipts/receipts.db
+ExecStart=/usr/local/bin/agent-receipts-daemon \
+  -db /var/lib/agent-receipts/receipts.db \
+  -key /etc/agent-receipts/signing.key \
+  -socket /run/agentreceipts/events.sock
+
+# Directories managed by systemd (created before ExecStart, removed on stop).
+# RuntimeDirectory creates /run/agentreceipts — the socket lives here.
+RuntimeDirectory=agentreceipts
+RuntimeDirectoryMode=0750
+# StateDirectory creates /var/lib/agent-receipts — the SQLite receipt store.
+StateDirectory=agent-receipts
+StateDirectoryMode=0750
+# ConfigurationDirectory creates /etc/agent-receipts — the signing key.
+ConfigurationDirectory=agent-receipts
+ConfigurationDirectoryMode=0750
+
+Restart=on-failure
+RestartSec=5s
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+# MemoryDenyWriteExecute omitted: Go uses W+X memory internally and crashes with it.
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+# Allow writes to managed directories; /etc/agent-receipts is needed because the
+# daemon re-writes signing.key.pub on every startup.
+ReadWritePaths=/var/lib/agent-receipts /run/agentreceipts /etc/agent-receipts
+
+[Install]
+WantedBy=multi-user.target

--- a/daemon/packaging/linux/agent-receipts-daemon.system.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.service
@@ -10,10 +10,12 @@ Group=agentreceipts
 # Run once before enabling the service to generate the signing key:
 #   sudo -u agentreceipts agent-receipts-daemon -init \
 #     -key /etc/agent-receipts/signing.key \
+#     -public-key /var/lib/agent-receipts/signing.key.pub \
 #     -db /var/lib/agent-receipts/receipts.db
 ExecStart=/usr/local/bin/agent-receipts-daemon \
   -db /var/lib/agent-receipts/receipts.db \
   -key /etc/agent-receipts/signing.key \
+  -public-key /var/lib/agent-receipts/signing.key.pub \
   -socket /run/agentreceipts/events.sock
 
 # Directories managed by systemd (created before ExecStart).
@@ -46,9 +48,15 @@ LockPersonality=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 RemoveIPC=yes
-# Allow writes to managed directories; /etc/agent-receipts is needed because the
-# daemon re-writes signing.key.pub on every startup.
-ReadWritePaths=/var/lib/agent-receipts /run/agentreceipts /etc/agent-receipts
+# Allow writes to managed data and runtime directories.
+# /etc/agent-receipts is read-only: the daemon only needs to read signing.key at
+# runtime. Write access to the key directory would allow a compromised daemon to
+# overwrite the private key. The -public-key flag points signing.key.pub to the
+# writable StateDirectory instead (see ExecStart above).
+# systemd manages /var/lib/agent-receipts (StateDirectory) and /run/agentreceipts
+# (RuntimeDirectory) and grants write access to those automatically.
+ReadWritePaths=/var/lib/agent-receipts /run/agentreceipts
+ReadOnlyPaths=/etc/agent-receipts
 
 [Install]
 WantedBy=multi-user.target

--- a/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
@@ -1,2 +1,3 @@
 #Type Name           ID   GECOS                          Home directory
+g     agentreceipts  -    -
 u     agentreceipts  -    "Agent Receipts daemon"        /var/lib/agentreceipts

--- a/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
@@ -1,2 +1,2 @@
 #Type Name           ID   GECOS                          Home directory
-u     agentreceipts  -    "Agent Receipts daemon"        /var/lib/agent-receipts
+u     agentreceipts  -    "Agent Receipts daemon"        /var/lib/agentreceipts

--- a/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
@@ -1,0 +1,2 @@
+#Type Name           ID   GECOS                          Home directory
+u     agentreceipts  -    "Agent Receipts daemon"        /var/lib/agent-receipts

--- a/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
+++ b/daemon/packaging/linux/agent-receipts-daemon.system.sysusers
@@ -1,3 +1,3 @@
 #Type Name           ID   GECOS                          Home directory
-g     agentreceipts  -    -
+g     agentreceipts  -
 u     agentreceipts  -    "Agent Receipts daemon"        /var/lib/agentreceipts


### PR DESCRIPTION
## What

Adds Linux systemd packaging for `agent-receipts-daemon`:

- `daemon/packaging/linux/agent-receipts-daemon.service` — user-level unit (`~/.config/systemd/user/`)
- `daemon/packaging/linux/agent-receipts-daemon.system.service` — system-level unit (`/etc/systemd/system/`) with a dedicated `agentreceipts` service account and hardening
- `daemon/packaging/linux/agent-receipts-daemon.system.sysusers` — sysusers config to create the service account
- `daemon/packaging/linux/README.md` — install guide covering key generation, unit install, log inspection, and receipt verification

## Why

Makes it straightforward to run the daemon under systemd for both developer machines (user unit, no root) and production servers (system unit with hardening). Without these files, users must write their own unit files from scratch.

## Key decisions

- `MemoryDenyWriteExecute` is **omitted** from the system unit — Go&#39;s runtime uses W+X memory pages and the process crashes with this setting enabled.
- `After=network.target` removed from both units — the daemon only listens on a Unix-domain socket and has no network dependency.
- User unit uses the `%t` specifier (`$XDG_RUNTIME_DIR`) for the socket path so it resolves correctly even when started outside a PAM session.
- README flag syntax uses single-dash form (`-db`, `-public-key`, `-chain-id`) matching Go&#39;s `flag` package — verified against the binary.
- `StateDirectory=agentreceipts` in the system unit causes systemd to create `/var/lib/agentreceipts` on first start; README notes this so operators using the sysusers path don&#39;t manually create it.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [ ] AGENTS.md updated (if project structure changed)
- [ ] Spec changes have been reviewed by a maintainer (if applicable)