### PR TITLE
fix(goreleaser): persist service, caveats, and post_install across daemon releases

### DIFF
--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -106,7 +106,36 @@ brews:
     # `:github_latest` (which returns repo-wide latest). `:github_releases`
     # scans all releases; regex extracts version from the `daemon/vX.Y.Z`
     # tag prefix.
+    #
+    # post_install, service, and caveats are also emitted here so they survive
+    # formula regeneration on each release (GoReleaser overwrites the formula
+    # file; anything not in custom_block or the named fields would be lost).
     custom_block: |
+      def post_install
+        (var/"log").mkpath
+      end
+
+      service do
+        run opt_bin/"agent-receipts-daemon"
+        keep_alive crashed: true
+        log_path var/"log/agent-receipts-daemon.log"
+        error_log_path var/"log/agent-receipts-daemon.log"
+        working_dir var
+      end
+
+      caveats <<~EOS
+        Before starting the service for the first time, generate your signing key:
+          agent-receipts-daemon --init
+
+        Then start the daemon:
+          brew services start agent-receipts/tap/agent-receipts-daemon
+
+        Receipts database: ~/.local/share/agent-receipts/receipts.db
+        Signing key:       ~/.local/share/agent-receipts/signing.key
+        Socket (macOS):    $TMPDIR/agentreceipts/events.sock
+        Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
+      EOS
+
       livecheck do
         url "https://github.com/agent-receipts/ar"
         strategy :github_releases

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -123,20 +123,22 @@ brews:
         working_dir var
       end
 
-      caveats <<~EOS
-        Before starting the service for the first time, generate your signing key:
-          agent-receipts-daemon --init
+      def caveats
+        <<~EOS
+          Before starting the service for the first time, generate your signing key:
+            agent-receipts-daemon --init
 
-        Then start the daemon:
-          brew services start agent-receipts/tap/agent-receipts-daemon
+          Then start the daemon:
+            brew services start agent-receipts/tap/agent-receipts-daemon
 
-        Receipts database: ~/.local/share/agent-receipts/receipts.db
-        Signing key:       ~/.local/share/agent-receipts/signing.key
-        Socket (macOS):    $TMPDIR/agentreceipts/events.sock
-                           (falls back to /tmp/agentreceipts/events.sock when $TMPDIR is unset)
-        Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
-                           (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
-      EOS
+          Receipts database: ~/.local/share/agent-receipts/receipts.db
+          Signing key:       ~/.local/share/agent-receipts/signing.key
+          Socket (macOS):    $TMPDIR/agentreceipts/events.sock
+                             (falls back to /tmp/agentreceipts/events.sock when $TMPDIR is unset)
+          Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
+                             (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
+        EOS
+      end
 
       livecheck do
         url "https://github.com/agent-receipts/ar"

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -133,7 +133,9 @@ brews:
         Receipts database: ~/.local/share/agent-receipts/receipts.db
         Signing key:       ~/.local/share/agent-receipts/signing.key
         Socket (macOS):    $TMPDIR/agentreceipts/events.sock
+                           (falls back to /tmp/agentreceipts/events.sock when $TMPDIR is unset)
         Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
+                           (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
       EOS
 
       livecheck do

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -131,12 +131,18 @@ brews:
           Then start the daemon:
             brew services start agent-receipts/tap/agent-receipts-daemon
 
-          Receipts database: ~/.local/share/agent-receipts/receipts.db
-          Signing key:       ~/.local/share/agent-receipts/signing.key
+          Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
+                             (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)
+                             Override: AGENTRECEIPTS_DB
+          Signing key:       $XDG_DATA_HOME/agent-receipts/signing.key
+                             (falls back to ~/.local/share/agent-receipts/signing.key when $XDG_DATA_HOME is unset or relative)
+                             Override: AGENTRECEIPTS_KEY
           Socket (macOS):    $TMPDIR/agentreceipts/events.sock
                              (falls back to /tmp/agentreceipts/events.sock when $TMPDIR is unset)
+                             Override: AGENTRECEIPTS_SOCKET
           Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
                              (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
+                             Override: AGENTRECEIPTS_SOCKET
         EOS
       end
 


### PR DESCRIPTION
## What

Extend `custom_block` in `daemon/.goreleaser.yaml` to emit `post_install`, `service do`, and `caveats` blocks alongside the existing `livecheck` block. Correct the caveats text to describe the actual XDG_DATA_HOME resolution logic and surface env var overrides.

## Why

GoReleaser regenerates the Homebrew formula from scratch on every daemon release. Any blocks not expressed through GoReleaser config fields or `custom_block` are silently overwritten. The service and caveats blocks added in homebrew-tap PR #12 would be lost on the next `daemon/vX.Y.Z` tag.

The original caveats text also hard-coded `~/.local/share/agent-receipts/` as if it were the unconditional default, but the daemon resolves `$XDG_DATA_HOME/agent-receipts/…` first (falling back to `~/.local/share` only when `$XDG_DATA_HOME` is unset or not an absolute path, per the XDG Base Directory spec). The env vars `AGENTRECEIPTS_DB`, `AGENTRECEIPTS_KEY`, and `AGENTRECEIPTS_SOCKET` can override any of these paths.

## Changes

- `daemon/.goreleaser.yaml` — `custom_block` now emits:
  - `def post_install` — creates `var/log` so launchd can write logs on a fresh install
  - `service do` — wires up `brew services` with `keep_alive crashed: true` (restart on crash only, not clean exit)
  - `caveats` — `--init` reminder, `brew services start` command, macOS (`$TMPDIR`) and Linux (`$XDG_RUNTIME_DIR`) socket paths with fallbacks, and corrected DB/key paths that show `$XDG_DATA_HOME` as primary with `~/.local/share` fallback, plus `AGENTRECEIPTS_DB` / `AGENTRECEIPTS_KEY` / `AGENTRECEIPTS_SOCKET` override env vars
  - `livecheck` — unchanged, already present

**Scope**: this PR touches only `daemon/.goreleaser.yaml`. No SDK, test, or protocol spec files are changed.

## Checklist

- [x] No real keys or secrets in the diff
- [x] Only `daemon/.goreleaser.yaml` touched — no SDK, test, or protocol spec changes
- [x] Caveats reflect actual daemon path resolution logic (verified against `daemon/daemon.go` `xdgDataHome()`, `DefaultDBPath()`, `DefaultKeyPath()`, `DefaultSocketPath()`)