### PR TITLE
build(daemon): tidy Homebrew service block (log path subdir, drop unused working_dir, surface log path in caveats)

### DIFF
--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -112,14 +112,14 @@ brews:
     # file; anything not in custom_block or the named fields would be lost).
     custom_block: |
       def post_install
-        (var/"log").mkpath
+        (var/"log/agent-receipts").mkpath
       end
 
       service do
         run opt_bin/"agent-receipts-daemon"
         keep_alive crashed: true
-        log_path var/"log/agent-receipts-daemon.log"
-        error_log_path var/"log/agent-receipts-daemon.log"
+        log_path var/"log/agent-receipts/daemon.log"
+        error_log_path var/"log/agent-receipts/daemon.log"
         working_dir var
       end
 

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -120,7 +120,6 @@ brews:
         keep_alive crashed: true
         log_path var/"log/agent-receipts/daemon.log"
         error_log_path var/"log/agent-receipts/daemon.log"
-        working_dir var
       end
 
       def caveats
@@ -143,6 +142,8 @@ brews:
           Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
                              (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
                              Override: AGENTRECEIPTS_SOCKET
+          Daemon logs:       #{var}/log/agent-receipts/daemon.log
+                             (stdout + stderr, written by launchd when started via `brew services`)
         EOS
       end
 


### PR DESCRIPTION
## Summary

Closes #379 (the bulk of which already shipped in `51b18e5`).

The `service do`, `post_install`, and `caveats` blocks were added to `daemon/.goreleaser.yaml`'s `brews[0].custom_block` on 2026-05-11, so `brew services start agent-receipts-daemon` will work out of the box on macOS on the **next** daemon release (the published `daemon/v0.8.0` formula predates that commit and is unaffected).

This PR tightens three small things before that release ships, surfaced by a follow-up review of the brew service block:

1. **Move logs to a subdirectory.** `var/"log/agent-receipts-daemon.log"` → `var/"log/agent-receipts/daemon.log"`. `post_install` now mkpaths `var/"log/agent-receipts"` instead of `var/"log"`. Matches the path suggested in #379 and parallels the in-tree macOS plist convention (`~/Library/Logs/agent-receipts/daemon.log` in `daemon/packaging/macos/ai.agentreceipts.daemon.plist`). Keeps `$(brew --prefix)/var/log/` uncluttered if other AR components ever ship their own logs.

2. **Drop `working_dir var`** from the `service do` block. The daemon resolves every path via XDG and rejects relative paths at the flag/env boundary (confirmed by inspecting `daemon/daemon.go` and `daemon/cmd/`), so the working directory is inert. Removing it keeps the generated formula honest and avoids a "why is this here?" question.

3. **Surface the log path in caveats.** Added one line:
   ```
   Daemon logs:       #{var}/log/agent-receipts/daemon.log
                      (stdout + stderr, written by launchd when started via `brew services`)
   ```
   `#{var}` interpolates to the Homebrew prefix at install time, so the rendered caveats show an absolute, tail-able path (e.g. `/opt/homebrew/var/log/agent-receipts/daemon.log` on Apple Silicon). `brew services` has no `log` subcommand, so documenting the path saves a debugging round trip.

## Test plan

- [x] YAML parses (verified with PyYAML).
- [x] `grep` confirms no other repo files reference the old `agent-receipts-daemon.log` path or `working_dir`.
- [x] Daemon source audited for relative-path I/O — all paths come from XDG/flag resolution, so dropping `working_dir` cannot affect runtime.
- [ ] Verified at next daemon release: the generated formula in `agent-receipts/homebrew-tap` contains `log_path var/"log/agent-receipts/daemon.log"`, no `working_dir`, and `brew install` + `brew services start agent-receipts-daemon` works on a clean macOS host. Confirm `brew info agent-receipts-daemon` shows the new caveats with an interpolated absolute log path.