### PR TITLE
feat(daemon): Linux one-command install script (#380)

### DIFF
--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -89,13 +89,33 @@ main() {
   mkdir -p "${WORK_DIR}/extract"
   # Tarballs have a top-level directory (e.g. daemon_0.8.0_linux_amd64/); strip it.
   tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
+
+  # Smoke-test the extracted binary BEFORE overwriting any installed version.
+  # If the new binary is incompatible (glibc mismatch, bad arch) the existing
+  # install is preserved and the script aborts cleanly.
+  "${WORK_DIR}/extract/agent-receipts-daemon" --version >/dev/null 2>&1 || \
+    die "New binary failed to run on this host — aborting to preserve existing install"
+
   install -m 0755 "${WORK_DIR}/extract/agent-receipts-daemon" "${INSTALL_DIR}/"
   install -m 0755 "${WORK_DIR}/extract/agent-receipts"        "${INSTALL_DIR}/"
 
-  # Smoke-test the binary on this host before proceeding.
-  # Catches glibc mismatches, bad architectures, or corrupt archives early.
-  "${INSTALL_DIR}/agent-receipts-daemon" --version >/dev/null 2>&1 || \
-    die "Installed binary failed to run — check glibc compatibility or open an issue"
+  # Detect legacy beta key path (old installs wrote to ~/.agent-receipts/).
+  # An upgrade from that layout looks like a fresh install and would generate a
+  # new key under the new XDG path, creating a different signing identity while
+  # leaving existing receipts verifiable only via the old key.
+  LEGACY_KEY="${HOME}/.agent-receipts/signing.key"
+  if [ -f "$LEGACY_KEY" ]; then
+    printf '\n'
+    printf 'Warning: found a signing key at the legacy beta path:\n'
+    printf '  %s\n' "$LEGACY_KEY"
+    printf 'The daemon now uses:\n'
+    printf '  %s\n' "$KEY_FILE"
+    printf 'Move your key before continuing:\n'
+    printf '  mkdir -p "%s"\n' "$(dirname "$KEY_FILE")"
+    printf '  mv "%s" "%s"\n' "$LEGACY_KEY" "$KEY_FILE"
+    printf '  mv "%s.pub" "%s.pub"\n' "$LEGACY_KEY" "$KEY_FILE"
+    die "Aborting — move legacy keys and re-run the installer"
+  fi
 
   # Key init — try -init and handle both outcomes.
   # Attempting unconditionally (rather than pre-checking KEY_FILE) ensures
@@ -114,6 +134,8 @@ main() {
 
   # Install systemd user unit.
   # The embedded unit is kept in sync with daemon/packaging/linux/agent-receipts-daemon.service.
+  # Always written on install/upgrade — if you have custom Environment= settings, put them
+  # in a drop-in file instead: ~/.config/systemd/user/agent-receipts-daemon.service.d/override.conf
   step "Installing systemd user unit to ${UNIT_DIR}..."
   mkdir -p "$UNIT_DIR"
   cat > "${UNIT_DIR}/${UNIT_NAME}" << 'UNIT_EOF'
@@ -175,7 +197,8 @@ UNIT_EOF
   # to your shell rc file). Uses a marker comment for idempotency.
   if [ ! -f "$BASHRC" ]; then
     echo "    ~/.bashrc not found — skipping (add manually to your shell rc file if needed)"
-  elif grep -qF '# agent-receipts: XDG_RUNTIME_DIR' "$BASHRC"; then
+  elif grep -qF '# agent-receipts: XDG_RUNTIME_DIR' "$BASHRC" || \
+       grep -qE '^[[:space:]]*export[[:space:]]+XDG_RUNTIME_DIR' "$BASHRC"; then
     echo "    XDG_RUNTIME_DIR already in ${BASHRC} — skipping"
   else
     step "Adding XDG_RUNTIME_DIR to ${BASHRC}..."
@@ -202,10 +225,11 @@ UNIT_EOF
   printf '    sudo loginctl enable-linger %s\n' "$(id -un)"
   printf '\n'
   if [ "$STARTED" = "1" ]; then
-    printf 'The service is already running. Enable linger so it survives future logouts.\n'
+    printf 'The service is running. Enable linger so it survives future logouts and\n'
+    printf 'starts automatically on boot without requiring a login session.\n'
   else
-    printf 'Without linger, the daemon cannot start. After running the command above,\n'
-    printf 'log out and back in (or open a new SSH session) to activate it.\n'
+    printf 'Without linger the user manager does not persist across logouts. After\n'
+    printf 'enabling linger, log out and back in (or open a new SSH session).\n'
   fi
   printf '\n'
   printf 'Note: MCP emitters running as system services need this in their unit file:\n'

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# install.sh — user-level install for agent-receipts-daemon on Linux.
+# Usage: curl -fsSL https://github.com/agent-receipts/ar/releases/latest/download/install.sh | sh
+#
+# Installs to ~/.local/bin, sets up the systemd user unit, and generates the
+# signing key if one does not already exist. Safe to re-run for upgrades.
+set -eu
+
+REPO="agent-receipts/ar"
+INSTALL_DIR="${HOME}/.local/bin"
+KEY_FILE="${HOME}/.local/share/agent-receipts/signing.key"
+UNIT_DIR="${HOME}/.config/systemd/user"
+UNIT_NAME="agent-receipts-daemon.service"
+BASHRC="${HOME}/.bashrc"
+
+step() { printf '\n==> %s\n' "$*"; }
+die()  { printf '\nerror: %s\n' "$*" >&2; exit 1; }
+
+# Linux only
+[ "$(uname -s)" = "Linux" ] || die "Linux only. For macOS: brew install agent-receipts/tap/agent-receipts-daemon"
+
+# Require systemd
+command -v systemctl >/dev/null 2>&1 || die "systemctl not found — this installer requires systemd"
+
+# Map uname -m to GoReleaser arch labels
+case "$(uname -m)" in
+  x86_64)        GOARCH=amd64 ;;
+  aarch64|arm64) GOARCH=arm64 ;;
+  *)             die "Unsupported architecture: $(uname -m)" ;;
+esac
+
+# Resolve latest daemon release from the GitHub releases API.
+# The repo contains multiple components with distinct tag prefixes (sdk/go/v*,
+# mcp-proxy/v*, daemon/v*) so we filter specifically for daemon tags rather
+# than relying on the repo-wide "latest" release pointer.
+step "Resolving latest release..."
+VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
+  | grep '"tag_name"' \
+  | grep '"daemon/v' \
+  | head -1 \
+  | sed 's/.*"daemon\/v\([^"]*\)".*/\1/')
+[ -n "$VERSION" ] || die "Could not resolve latest daemon version from GitHub API"
+echo "    version: ${VERSION}"
+
+# Download
+ARCHIVE="daemon_${VERSION}_linux_${GOARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/daemon/v${VERSION}/${ARCHIVE}"
+
+step "Downloading ${ARCHIVE}..."
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+curl -fsSL -o "${WORK_DIR}/${ARCHIVE}" "$URL"
+
+# Install binaries
+step "Installing binaries to ${INSTALL_DIR}..."
+mkdir -p "$INSTALL_DIR"
+mkdir -p "${WORK_DIR}/extract"
+# Tarballs have a top-level directory (e.g. daemon_0.8.0_linux_amd64/); strip it.
+tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
+install -m 0755 "${WORK_DIR}/extract/agent-receipts-daemon" "${INSTALL_DIR}/"
+install -m 0755 "${WORK_DIR}/extract/agent-receipts"        "${INSTALL_DIR}/"
+
+# Key init — skip if key already exists (idempotent on upgrades)
+if [ -f "$KEY_FILE" ]; then
+  echo "    signing key already present — skipping -init"
+else
+  step "Generating signing key..."
+  "${INSTALL_DIR}/agent-receipts-daemon" -init
+fi
+
+# Install systemd user unit
+step "Installing systemd user unit to ${UNIT_DIR}..."
+mkdir -p "$UNIT_DIR"
+cat > "${UNIT_DIR}/${UNIT_NAME}" << 'UNIT_EOF'
+[Unit]
+Description=Agent Receipts signing daemon
+Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
+
+[Service]
+Type=simple
+# %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
+# socket path is correct even when the service starts outside a PAM session.
+ExecStartPre=/bin/sh -c 'test -f %h/.local/share/agent-receipts/signing.key || %h/.local/bin/agent-receipts-daemon -init'
+ExecStart=%h/.local/bin/agent-receipts-daemon \
+  -socket %t/agentreceipts/events.sock
+Restart=on-failure
+RestartSec=5s
+
+# Ensure %t/agentreceipts/ exists before the socket bind.
+RuntimeDirectory=agentreceipts
+RuntimeDirectoryMode=0700
+
+[Install]
+WantedBy=default.target
+UNIT_EOF
+
+# Enable and start (or restart on upgrade).
+# systemctl --user requires an active user session (XDG_RUNTIME_DIR set and
+# /run/user/<uid>/systemd/private reachable). Ensure the variable is set so
+# that installs over SSH without linger still attempt the enable step.
+step "Enabling agent-receipts-daemon..."
+XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export XDG_RUNTIME_DIR
+if systemctl --user daemon-reload 2>/dev/null; then
+  systemctl --user enable agent-receipts-daemon
+  systemctl --user restart agent-receipts-daemon
+  echo "    Service running."
+else
+  printf '    No active systemd user session detected.\n'
+  printf '    After enabling linger (see below) and logging back in, run:\n'
+  printf '      systemctl --user daemon-reload\n'
+  printf '      systemctl --user enable --now agent-receipts-daemon\n'
+fi
+
+# Add XDG_RUNTIME_DIR export to ~/.bashrc so that SSH sessions without a full
+# PAM login still have the variable set for user-service socket discovery.
+if grep -qF 'XDG_RUNTIME_DIR' "$BASHRC" 2>/dev/null; then
+  echo "    XDG_RUNTIME_DIR already in ${BASHRC} — skipping"
+else
+  step "Adding XDG_RUNTIME_DIR to ${BASHRC}..."
+  printf '\n# Required for systemd user services in SSH sessions (added by agent-receipts install.sh)\n' >> "$BASHRC"
+  # SC2016: single quotes are intentional — $(id -u) must expand at shell
+  # startup when .bashrc is sourced, not here during install.
+  # shellcheck disable=SC2016
+  printf 'export XDG_RUNTIME_DIR=/run/user/$(id -u)\n' >> "$BASHRC"
+fi
+
+# Done
+printf '\nagent-receipts-daemon v%s installed to %s.\n' "$VERSION" "$INSTALL_DIR"
+printf '\n'
+printf 'One root step required — enables the user session to persist across logouts:\n'
+printf '\n'
+printf '    sudo loginctl enable-linger %s\n' "$USER"
+printf '\n'
+printf 'Without linger, the daemon stops when you log out. After running the command\n'
+printf 'above, log out and back in (or open a new SSH session) to activate it.\n'
+printf '\n'
+printf 'Note: MCP emitters running as system services need this in their unit file:\n'
+printf '    Environment=XDG_RUNTIME_DIR=/run/user/<uid>\n'
+printf 'See: https://github.com/agent-receipts/ar/tree/main/daemon/packaging/linux\n'

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -45,6 +45,21 @@ main() {
     *)             die "Unsupported architecture: $(uname -m)" ;;
   esac
 
+  # Detect legacy beta key path before downloading anything.
+  # Old installs wrote to ~/.agent-receipts/; the daemon now uses the XDG path.
+  # An upgrade from the old layout would otherwise look like a fresh install and
+  # silently create a new signing identity under the new path.
+  LEGACY_KEY="${HOME}/.agent-receipts/signing.key"
+  if [ -f "$LEGACY_KEY" ]; then
+    printf '\nLegacy signing key found at: %s\n' "$LEGACY_KEY"
+    printf 'The daemon now uses:         %s\n' "$KEY_FILE"
+    printf 'Move your key before continuing:\n'
+    printf '  mkdir -p "%s"\n' "$(dirname "$KEY_FILE")"
+    printf '  mv "%s" "%s"\n' "$LEGACY_KEY" "$KEY_FILE"
+    printf '  mv "%s.pub" "%s.pub"\n' "$LEGACY_KEY" "$KEY_FILE"
+    die "Aborting — move legacy keys and re-run the installer"
+  fi
+
   # Resolve latest stable daemon release.
   # The repo has multiple component release trains (sdk/go/v*, mcp-proxy/v*,
   # daemon/v*) so we filter by tag prefix and skip pre-releases explicitly —
@@ -99,37 +114,20 @@ main() {
   install -m 0755 "${WORK_DIR}/extract/agent-receipts-daemon" "${INSTALL_DIR}/"
   install -m 0755 "${WORK_DIR}/extract/agent-receipts"        "${INSTALL_DIR}/"
 
-  # Detect legacy beta key path (old installs wrote to ~/.agent-receipts/).
-  # An upgrade from that layout looks like a fresh install and would generate a
-  # new key under the new XDG path, creating a different signing identity while
-  # leaving existing receipts verifiable only via the old key.
-  LEGACY_KEY="${HOME}/.agent-receipts/signing.key"
-  if [ -f "$LEGACY_KEY" ]; then
-    printf '\n'
-    printf 'Warning: found a signing key at the legacy beta path:\n'
-    printf '  %s\n' "$LEGACY_KEY"
-    printf 'The daemon now uses:\n'
-    printf '  %s\n' "$KEY_FILE"
-    printf 'Move your key before continuing:\n'
-    printf '  mkdir -p "%s"\n' "$(dirname "$KEY_FILE")"
-    printf '  mv "%s" "%s"\n' "$LEGACY_KEY" "$KEY_FILE"
-    printf '  mv "%s.pub" "%s.pub"\n' "$LEGACY_KEY" "$KEY_FILE"
-    die "Aborting — move legacy keys and re-run the installer"
-  fi
-
-  # Key init — try -init and handle both outcomes.
-  # Attempting unconditionally (rather than pre-checking KEY_FILE) ensures
-  # correctness when XDG_DATA_HOME overrides the default key location: if the
-  # key already exists at a non-default path, -init exits non-zero, and the
-  # fallback check at the default path distinguishes "already present" from a
-  # real failure.
+  # Key init — attempt unconditionally and handle both outcomes.
+  # When -init succeeds the key is at KEY_FILE (the XDG default).
+  # When -init fails: if KEY_FILE exists, treat it as "already present" (common
+  # on re-runs). Otherwise warn — the key may exist at a custom AGENTRECEIPTS_KEY
+  # or XDG_DATA_HOME path and the user should verify it before proceeding.
   step "Generating signing key..."
   if "${INSTALL_DIR}/agent-receipts-daemon" -init 2>"${WORK_DIR}/init.err"; then
     echo "    key: ${KEY_FILE}"
   elif [ -f "$KEY_FILE" ]; then
     echo "    signing key already present — skipping"
   else
-    die "-init failed: $(head -1 "${WORK_DIR}/init.err")"
+    printf '    Warning: -init reported: %s\n' "$(head -1 "${WORK_DIR}/init.err")"
+    printf '    If AGENTRECEIPTS_KEY or XDG_DATA_HOME is set, verify the key exists\n'
+    printf '    at the custom path before starting the service.\n'
   fi
 
   # Install systemd user unit.
@@ -147,7 +145,16 @@ Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
 Type=simple
 # %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
 # socket path is correct even when the service starts outside a PAM session.
-ExecStartPre=/bin/sh -c 'test -f "%h/.local/share/agent-receipts/signing.key" || "%h/.local/bin/agent-receipts-daemon" -init'
+# If ExecStart is changed to a different binary location, update ExecStartPre too.
+#
+# Key is generated only on a truly fresh install (no receipts.db). If the key is
+# missing but a database exists, the service fails loudly for operator recovery
+# rather than silently creating a new signing identity (see daemon/daemon.go:148-151).
+ExecStartPre=/bin/sh -c '\
+  if test -f "%h/.local/share/agent-receipts/signing.key"; then exit 0;\
+  elif test -f "%h/.local/share/agent-receipts/receipts.db"; then\
+    printf "signing key missing but receipts.db exists -- recover the key before restarting\n" >&2; exit 1;\
+  else exec "%h/.local/bin/agent-receipts-daemon" -init; fi'
 ExecStart=%h/.local/bin/agent-receipts-daemon \
   -socket %t/agentreceipts/events.sock
 Restart=on-failure
@@ -169,11 +176,14 @@ UNIT_EOF
   export XDG_RUNTIME_DIR
   SYSTEMCTL_ERR="${WORK_DIR}/systemctl.err"
   if systemctl --user daemon-reload 2>"$SYSTEMCTL_ERR"; then
-    if systemctl --user enable --now agent-receipts-daemon 2>>"$SYSTEMCTL_ERR"; then
+    # enable marks the unit for auto-start; restart starts or restarts the running
+    # process so upgrades take effect without a separate manual restart step.
+    if systemctl --user enable agent-receipts-daemon 2>>"$SYSTEMCTL_ERR" && \
+       systemctl --user restart agent-receipts-daemon 2>>"$SYSTEMCTL_ERR"; then
       STARTED=1
       echo "    Service running."
     else
-      printf '    Service enabled but failed to start.\n'
+      printf '    Service failed to start.\n'
       printf '    Diagnose with:\n'
       printf '      systemctl --user status agent-receipts-daemon\n'
       printf '      journalctl --user -u agent-receipts-daemon -n 20\n'

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -12,6 +12,8 @@ set -eu
 
 REPO="agent-receipts/ar"
 INSTALL_DIR="${HOME}/.local/bin"
+# KEY_FILE is the XDG default path. The installer targets the default install layout;
+# custom AGENTRECEIPTS_KEY or XDG_DATA_HOME overrides are out of scope here.
 KEY_FILE="${HOME}/.local/share/agent-receipts/signing.key"
 UNIT_DIR="${HOME}/.config/systemd/user"
 UNIT_NAME="agent-receipts-daemon.service"
@@ -53,11 +55,13 @@ main() {
   if [ -f "$LEGACY_KEY" ]; then
     printf '\nLegacy signing key found at: %s\n' "$LEGACY_KEY"
     printf 'The daemon now uses:         %s\n' "$KEY_FILE"
-    printf 'Move your key before continuing:\n'
+    printf 'Move your data before continuing:\n'
     printf '  mkdir -p "%s"\n' "$(dirname "$KEY_FILE")"
     printf '  mv "%s" "%s"\n' "$LEGACY_KEY" "$KEY_FILE"
     printf '  mv "%s.pub" "%s.pub"\n' "$LEGACY_KEY" "$KEY_FILE"
-    die "Aborting — move legacy keys and re-run the installer"
+    printf '  # Also move the receipt database (preserves chain history):\n'
+    printf '  mv "%s" "%s"\n' "${HOME}/.agent-receipts/receipts.db" "${HOME}/.local/share/agent-receipts/receipts.db"
+    die "Aborting — move legacy data and re-run the installer"
   fi
 
   # Resolve latest stable daemon release.
@@ -190,6 +194,7 @@ UNIT_EOF
       if [ -s "$SYSTEMCTL_ERR" ]; then
         printf '    systemctl error: %s\n' "$(head -1 "$SYSTEMCTL_ERR")"
       fi
+      exit 1
     fi
   else
     printf '    No active systemd user session'

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -50,7 +50,7 @@ main() {
   # daemon/v*) so we filter by tag prefix and skip pre-releases explicitly —
   # the repo-wide "latest" pointer is not reliable here.
   step "Resolving latest release..."
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" | \
+  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" | \
     awk '
       /"tag_name":.*"daemon\/v/ {
         match($0, /"daemon\/v[^"]+/)
@@ -64,7 +64,9 @@ main() {
 
   # Download
   ARCHIVE="daemon_${VERSION}_linux_${GOARCH}.tar.gz"
-  RELEASE_BASE="https://github.com/${REPO}/releases/download/daemon/v${VERSION}"
+  # %2F-encode the slash in the tag so the URL matches the canonical form used
+  # by the Homebrew formula (daemon/.goreleaser.yaml url_template).
+  RELEASE_BASE="https://github.com/${REPO}/releases/download/daemon%2Fv${VERSION}"
 
   step "Downloading ${ARCHIVE}..."
   WORK_DIR=$(mktemp -d)
@@ -74,7 +76,7 @@ main() {
   # This is a cryptographic signing daemon — supply chain integrity matters.
   step "Verifying checksum..."
   curl -fsSL -o "${WORK_DIR}/checksums.txt" "${RELEASE_BASE}/checksums.txt"
-  EXPECTED=$(grep "  ${ARCHIVE}$" "${WORK_DIR}/checksums.txt" | awk '{print $1}')
+  EXPECTED=$(awk -v f="${ARCHIVE}" '$2 == f { print $1 }' "${WORK_DIR}/checksums.txt")
   [ -n "$EXPECTED" ] || die "No checksum entry found for ${ARCHIVE} in checksums.txt"
   ACTUAL=$(sha256sum "${WORK_DIR}/${ARCHIVE}" | awk '{print $1}')
   [ "$ACTUAL" = "$EXPECTED" ] || \
@@ -95,13 +97,19 @@ main() {
   "${INSTALL_DIR}/agent-receipts-daemon" --version >/dev/null 2>&1 || \
     die "Installed binary failed to run — check glibc compatibility or open an issue"
 
-  # Key init — skip if key already exists (idempotent on upgrades)
-  if [ -f "$KEY_FILE" ]; then
-    echo "    signing key already present — skipping -init"
-  else
-    step "Generating signing key..."
-    "${INSTALL_DIR}/agent-receipts-daemon" -init
+  # Key init — try -init and handle both outcomes.
+  # Attempting unconditionally (rather than pre-checking KEY_FILE) ensures
+  # correctness when XDG_DATA_HOME overrides the default key location: if the
+  # key already exists at a non-default path, -init exits non-zero, and the
+  # fallback check at the default path distinguishes "already present" from a
+  # real failure.
+  step "Generating signing key..."
+  if "${INSTALL_DIR}/agent-receipts-daemon" -init 2>"${WORK_DIR}/init.err"; then
     echo "    key: ${KEY_FILE}"
+  elif [ -f "$KEY_FILE" ]; then
+    echo "    signing key already present — skipping"
+  else
+    die "-init failed: $(head -1 "${WORK_DIR}/init.err")"
   fi
 
   # Install systemd user unit.
@@ -117,7 +125,7 @@ Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
 Type=simple
 # %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
 # socket path is correct even when the service starts outside a PAM session.
-ExecStartPre=/bin/sh -c 'test -f %h/.local/share/agent-receipts/signing.key || %h/.local/bin/agent-receipts-daemon -init'
+ExecStartPre=/bin/sh -c 'test -f "%h/.local/share/agent-receipts/signing.key" || "%h/.local/bin/agent-receipts-daemon" -init'
 ExecStart=%h/.local/bin/agent-receipts-daemon \
   -socket %t/agentreceipts/events.sock
 Restart=on-failure
@@ -139,15 +147,24 @@ UNIT_EOF
   export XDG_RUNTIME_DIR
   SYSTEMCTL_ERR="${WORK_DIR}/systemctl.err"
   if systemctl --user daemon-reload 2>"$SYSTEMCTL_ERR"; then
-    systemctl --user enable --now agent-receipts-daemon
-    STARTED=1
-    echo "    Service running."
+    if systemctl --user enable --now agent-receipts-daemon 2>>"$SYSTEMCTL_ERR"; then
+      STARTED=1
+      echo "    Service running."
+    else
+      printf '    Service enabled but failed to start.\n'
+      printf '    Diagnose with:\n'
+      printf '      systemctl --user status agent-receipts-daemon\n'
+      printf '      journalctl --user -u agent-receipts-daemon -n 20\n'
+      if [ -s "$SYSTEMCTL_ERR" ]; then
+        printf '    systemctl error: %s\n' "$(head -1 "$SYSTEMCTL_ERR")"
+      fi
+    fi
   else
     printf '    No active systemd user session'
     if [ -s "$SYSTEMCTL_ERR" ]; then
       printf ' (%s)' "$(head -1 "$SYSTEMCTL_ERR")"
     fi
-    printf '\n'
+    printf '.\n'
     printf '    After enabling linger (see below) and logging back in, run:\n'
     printf '      systemctl --user daemon-reload\n'
     printf '      systemctl --user enable --now agent-receipts-daemon\n'
@@ -182,7 +199,7 @@ UNIT_EOF
   printf '\n'
   printf 'One root step required — enables the user session to persist across logouts:\n'
   printf '\n'
-  printf '    sudo loginctl enable-linger %s\n' "$USER"
+  printf '    sudo loginctl enable-linger %s\n' "$(id -un)"
   printf '\n'
   if [ "$STARTED" = "1" ]; then
     printf 'The service is already running. Enable linger so it survives future logouts.\n'

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -4,6 +4,10 @@
 #
 # Installs to ~/.local/bin, sets up the systemd user unit, and generates the
 # signing key if one does not already exist. Safe to re-run for upgrades.
+#
+# Wrapping everything in main() guards against partial execution when the
+# download is truncated mid-stream while piped to sh.
+
 set -eu
 
 REPO="agent-receipts/ar"
@@ -13,65 +17,98 @@ UNIT_DIR="${HOME}/.config/systemd/user"
 UNIT_NAME="agent-receipts-daemon.service"
 BASHRC="${HOME}/.bashrc"
 
+# Set at the top so the EXIT trap is always safe to evaluate.
+WORK_DIR=""
+STARTED=0
+trap '[ -n "$WORK_DIR" ] && rm -rf -- "$WORK_DIR"' EXIT
+
 step() { printf '\n==> %s\n' "$*"; }
 die()  { printf '\nerror: %s\n' "$*" >&2; exit 1; }
 
-# Linux only
-[ "$(uname -s)" = "Linux" ] || die "Linux only. For macOS: brew install agent-receipts/tap/agent-receipts-daemon"
+main() {
+  # Linux only
+  [ "$(uname -s)" = "Linux" ] || \
+    die "Linux only. For macOS: brew install agent-receipts/tap/agent-receipts-daemon"
 
-# Require systemd
-command -v systemctl >/dev/null 2>&1 || die "systemctl not found — this installer requires systemd"
+  # Require systemd
+  command -v systemctl >/dev/null 2>&1 || \
+    die "systemctl not found — this installer requires systemd"
 
-# Map uname -m to GoReleaser arch labels
-case "$(uname -m)" in
-  x86_64)        GOARCH=amd64 ;;
-  aarch64|arm64) GOARCH=arm64 ;;
-  *)             die "Unsupported architecture: $(uname -m)" ;;
-esac
+  # sha256sum for checksum verification (part of coreutils, present on all mainstream distros)
+  command -v sha256sum >/dev/null 2>&1 || \
+    die "sha256sum not found — install coreutils and retry"
 
-# Resolve latest daemon release from the GitHub releases API.
-# The repo contains multiple components with distinct tag prefixes (sdk/go/v*,
-# mcp-proxy/v*, daemon/v*) so we filter specifically for daemon tags rather
-# than relying on the repo-wide "latest" release pointer.
-step "Resolving latest release..."
-VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
-  | grep '"tag_name"' \
-  | grep '"daemon/v' \
-  | head -1 \
-  | sed 's/.*"daemon\/v\([^"]*\)".*/\1/')
-[ -n "$VERSION" ] || die "Could not resolve latest daemon version from GitHub API"
-echo "    version: ${VERSION}"
+  # Map uname -m to GoReleaser arch labels
+  case "$(uname -m)" in
+    x86_64)        GOARCH=amd64 ;;
+    aarch64|arm64) GOARCH=arm64 ;;
+    *)             die "Unsupported architecture: $(uname -m)" ;;
+  esac
 
-# Download
-ARCHIVE="daemon_${VERSION}_linux_${GOARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/daemon/v${VERSION}/${ARCHIVE}"
+  # Resolve latest stable daemon release.
+  # The repo has multiple component release trains (sdk/go/v*, mcp-proxy/v*,
+  # daemon/v*) so we filter by tag prefix and skip pre-releases explicitly —
+  # the repo-wide "latest" pointer is not reliable here.
+  step "Resolving latest release..."
+  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" | \
+    awk '
+      /"tag_name":.*"daemon\/v/ {
+        match($0, /"daemon\/v[^"]+/)
+        tag = substr($0, RSTART + 9, RLENGTH - 9)
+      }
+      tag != "" && /"prerelease": false/ { print tag; exit }
+      /"prerelease": true/ { tag = "" }
+    ')
+  [ -n "$VERSION" ] || die "Could not resolve latest stable daemon version from GitHub API"
+  echo "    version: ${VERSION}"
 
-step "Downloading ${ARCHIVE}..."
-WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
-curl -fsSL -o "${WORK_DIR}/${ARCHIVE}" "$URL"
+  # Download
+  ARCHIVE="daemon_${VERSION}_linux_${GOARCH}.tar.gz"
+  RELEASE_BASE="https://github.com/${REPO}/releases/download/daemon/v${VERSION}"
 
-# Install binaries
-step "Installing binaries to ${INSTALL_DIR}..."
-mkdir -p "$INSTALL_DIR"
-mkdir -p "${WORK_DIR}/extract"
-# Tarballs have a top-level directory (e.g. daemon_0.8.0_linux_amd64/); strip it.
-tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
-install -m 0755 "${WORK_DIR}/extract/agent-receipts-daemon" "${INSTALL_DIR}/"
-install -m 0755 "${WORK_DIR}/extract/agent-receipts"        "${INSTALL_DIR}/"
+  step "Downloading ${ARCHIVE}..."
+  WORK_DIR=$(mktemp -d)
+  curl -fsSL -o "${WORK_DIR}/${ARCHIVE}" "${RELEASE_BASE}/${ARCHIVE}"
 
-# Key init — skip if key already exists (idempotent on upgrades)
-if [ -f "$KEY_FILE" ]; then
-  echo "    signing key already present — skipping -init"
-else
-  step "Generating signing key..."
-  "${INSTALL_DIR}/agent-receipts-daemon" -init
-fi
+  # Verify checksum before writing anything to the filesystem.
+  # This is a cryptographic signing daemon — supply chain integrity matters.
+  step "Verifying checksum..."
+  curl -fsSL -o "${WORK_DIR}/checksums.txt" "${RELEASE_BASE}/checksums.txt"
+  EXPECTED=$(grep "  ${ARCHIVE}$" "${WORK_DIR}/checksums.txt" | awk '{print $1}')
+  [ -n "$EXPECTED" ] || die "No checksum entry found for ${ARCHIVE} in checksums.txt"
+  ACTUAL=$(sha256sum "${WORK_DIR}/${ARCHIVE}" | awk '{print $1}')
+  [ "$ACTUAL" = "$EXPECTED" ] || \
+    die "Checksum mismatch for ${ARCHIVE} — download may be corrupted or tampered with"
+  echo "    OK: ${EXPECTED}"
 
-# Install systemd user unit
-step "Installing systemd user unit to ${UNIT_DIR}..."
-mkdir -p "$UNIT_DIR"
-cat > "${UNIT_DIR}/${UNIT_NAME}" << 'UNIT_EOF'
+  # Install binaries
+  step "Installing binaries to ${INSTALL_DIR}..."
+  mkdir -p "$INSTALL_DIR"
+  mkdir -p "${WORK_DIR}/extract"
+  # Tarballs have a top-level directory (e.g. daemon_0.8.0_linux_amd64/); strip it.
+  tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
+  install -m 0755 "${WORK_DIR}/extract/agent-receipts-daemon" "${INSTALL_DIR}/"
+  install -m 0755 "${WORK_DIR}/extract/agent-receipts"        "${INSTALL_DIR}/"
+
+  # Smoke-test the binary on this host before proceeding.
+  # Catches glibc mismatches, bad architectures, or corrupt archives early.
+  "${INSTALL_DIR}/agent-receipts-daemon" --version >/dev/null 2>&1 || \
+    die "Installed binary failed to run — check glibc compatibility or open an issue"
+
+  # Key init — skip if key already exists (idempotent on upgrades)
+  if [ -f "$KEY_FILE" ]; then
+    echo "    signing key already present — skipping -init"
+  else
+    step "Generating signing key..."
+    "${INSTALL_DIR}/agent-receipts-daemon" -init
+    echo "    key: ${KEY_FILE}"
+  fi
+
+  # Install systemd user unit.
+  # The embedded unit is kept in sync with daemon/packaging/linux/agent-receipts-daemon.service.
+  step "Installing systemd user unit to ${UNIT_DIR}..."
+  mkdir -p "$UNIT_DIR"
+  cat > "${UNIT_DIR}/${UNIT_NAME}" << 'UNIT_EOF'
 [Unit]
 Description=Agent Receipts signing daemon
 Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
@@ -94,47 +131,69 @@ RuntimeDirectoryMode=0700
 WantedBy=default.target
 UNIT_EOF
 
-# Enable and start (or restart on upgrade).
-# systemctl --user requires an active user session (XDG_RUNTIME_DIR set and
-# /run/user/<uid>/systemd/private reachable). Ensure the variable is set so
-# that installs over SSH without linger still attempt the enable step.
-step "Enabling agent-receipts-daemon..."
-XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-export XDG_RUNTIME_DIR
-if systemctl --user daemon-reload 2>/dev/null; then
-  systemctl --user enable agent-receipts-daemon
-  systemctl --user restart agent-receipts-daemon
-  echo "    Service running."
-else
-  printf '    No active systemd user session detected.\n'
-  printf '    After enabling linger (see below) and logging back in, run:\n'
-  printf '      systemctl --user daemon-reload\n'
-  printf '      systemctl --user enable --now agent-receipts-daemon\n'
-fi
+  # Enable and start (or restart on upgrade).
+  # systemctl --user needs an active user session. Pre-set XDG_RUNTIME_DIR so
+  # installs over SSH without linger still attempt the enable step.
+  step "Enabling agent-receipts-daemon..."
+  XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  export XDG_RUNTIME_DIR
+  SYSTEMCTL_ERR="${WORK_DIR}/systemctl.err"
+  if systemctl --user daemon-reload 2>"$SYSTEMCTL_ERR"; then
+    systemctl --user enable --now agent-receipts-daemon
+    STARTED=1
+    echo "    Service running."
+  else
+    printf '    No active systemd user session'
+    if [ -s "$SYSTEMCTL_ERR" ]; then
+      printf ' (%s)' "$(head -1 "$SYSTEMCTL_ERR")"
+    fi
+    printf '\n'
+    printf '    After enabling linger (see below) and logging back in, run:\n'
+    printf '      systemctl --user daemon-reload\n'
+    printf '      systemctl --user enable --now agent-receipts-daemon\n'
+  fi
 
-# Add XDG_RUNTIME_DIR export to ~/.bashrc so that SSH sessions without a full
-# PAM login still have the variable set for user-service socket discovery.
-if grep -qF 'XDG_RUNTIME_DIR' "$BASHRC" 2>/dev/null; then
-  echo "    XDG_RUNTIME_DIR already in ${BASHRC} — skipping"
-else
-  step "Adding XDG_RUNTIME_DIR to ${BASHRC}..."
-  printf '\n# Required for systemd user services in SSH sessions (added by agent-receipts install.sh)\n' >> "$BASHRC"
-  # SC2016: single quotes are intentional — $(id -u) must expand at shell
-  # startup when .bashrc is sourced, not here during install.
-  # shellcheck disable=SC2016
-  printf 'export XDG_RUNTIME_DIR=/run/user/$(id -u)\n' >> "$BASHRC"
-fi
+  # Add XDG_RUNTIME_DIR export to ~/.bashrc so SSH sessions have it set.
+  # Only edits the file if it already exists (non-bash users: add manually
+  # to your shell rc file). Uses a marker comment for idempotency.
+  if [ ! -f "$BASHRC" ]; then
+    echo "    ~/.bashrc not found — skipping (add manually to your shell rc file if needed)"
+  elif grep -qF '# agent-receipts: XDG_RUNTIME_DIR' "$BASHRC"; then
+    echo "    XDG_RUNTIME_DIR already in ${BASHRC} — skipping"
+  else
+    step "Adding XDG_RUNTIME_DIR to ${BASHRC}..."
+    printf '\n# agent-receipts: XDG_RUNTIME_DIR — needed for systemd user services in SSH sessions\n' >> "$BASHRC"
+    # SC2016: $(id -u) must expand when .bashrc is sourced, not now.
+    # shellcheck disable=SC2016
+    printf 'export XDG_RUNTIME_DIR=/run/user/$(id -u)\n' >> "$BASHRC"
+  fi
 
-# Done
-printf '\nagent-receipts-daemon v%s installed to %s.\n' "$VERSION" "$INSTALL_DIR"
-printf '\n'
-printf 'One root step required — enables the user session to persist across logouts:\n'
-printf '\n'
-printf '    sudo loginctl enable-linger %s\n' "$USER"
-printf '\n'
-printf 'Without linger, the daemon stops when you log out. After running the command\n'
-printf 'above, log out and back in (or open a new SSH session) to activate it.\n'
-printf '\n'
-printf 'Note: MCP emitters running as system services need this in their unit file:\n'
-printf '    Environment=XDG_RUNTIME_DIR=/run/user/<uid>\n'
-printf 'See: https://github.com/agent-receipts/ar/tree/main/daemon/packaging/linux\n'
+  # Warn if ~/.local/bin is not in PATH so binaries are findable right away.
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) printf '\nNote: %s is not in your PATH.\n' "$INSTALL_DIR"
+       # SC2016: $PATH is literal text for the user to copy — must not expand here.
+       # shellcheck disable=SC2016
+       printf 'Add to your shell rc file:\n  export PATH="%s:$PATH"\n' "$INSTALL_DIR" ;;
+  esac
+
+  # Summary
+  printf '\nagent-receipts-daemon v%s installed to %s.\n' "$VERSION" "$INSTALL_DIR"
+  printf '\n'
+  printf 'One root step required — enables the user session to persist across logouts:\n'
+  printf '\n'
+  printf '    sudo loginctl enable-linger %s\n' "$USER"
+  printf '\n'
+  if [ "$STARTED" = "1" ]; then
+    printf 'The service is already running. Enable linger so it survives future logouts.\n'
+  else
+    printf 'Without linger, the daemon cannot start. After running the command above,\n'
+    printf 'log out and back in (or open a new SSH session) to activate it.\n'
+  fi
+  printf '\n'
+  printf 'Note: MCP emitters running as system services need this in their unit file:\n'
+  printf '    Environment=XDG_RUNTIME_DIR=/run/user/<uid>\n'
+  printf 'See: https://github.com/agent-receipts/ar/tree/main/daemon/packaging/linux\n'
+}
+
+main "$@"

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -19,7 +19,7 @@ Runs as the logged-in user. No root or dedicated system user needed. Data lives 
 curl -fsSL https://github.com/agent-receipts/ar/releases/latest/download/install.sh | sh
 ```
 
-Handles binary download, key generation, unit install, and service start in one step. See `install.sh` in this directory for details.
+Handles binary download, key generation, unit install, and service start in one step. See [`daemon/install.sh`](../../install.sh) for details.
 
 ### Manual install
 

--- a/daemon/packaging/linux/README.md
+++ b/daemon/packaging/linux/README.md
@@ -13,7 +13,19 @@ Two unit files are provided:
 
 Runs as the logged-in user. No root or dedicated system user needed. Data lives in the user's home directory.
 
-### Prerequisites
+### Quick install (Linux only)
+
+```sh
+curl -fsSL https://github.com/agent-receipts/ar/releases/latest/download/install.sh | sh
+```
+
+Handles binary download, key generation, unit install, and service start in one step. See `install.sh` in this directory for details.
+
+### Manual install
+
+Use this path if you built from source or need a custom configuration.
+
+#### Prerequisites
 
 Install the binary (pick one):
 
@@ -26,18 +38,22 @@ go build -o ~/.local/bin/agent-receipts-daemon ./cmd/agent-receipts-daemon
 
 The unit file assumes `~/.local/bin/agent-receipts-daemon` (`%h/.local/bin/…`). If the binary is elsewhere, edit `ExecStart` before installing the unit.
 
-### 1 — Generate the signing key (once)
+#### 1 — Generate the signing key (once, optional)
+
+The unit's `ExecStartPre` generates the key automatically on first start if it
+does not already exist, so this step is optional for most installs.
+
+To generate it manually before enabling the service:
 
 ```sh
 agent-receipts-daemon -init
 ```
 
 This creates `~/.local/share/agent-receipts/signing.key` (0600) and
-`~/.local/share/agent-receipts/signing.key.pub` (0644). The daemon refuses to
-start without a key. Run `-init` only once — if the key files already exist,
-`-init` will fail with an error rather than overwrite them. To rotate keys,
-remove the existing key files first, then re-run `-init` (this invalidates the
-existing receipt chain).
+`~/.local/share/agent-receipts/signing.key.pub` (0644). Run `-init` only once — if
+the key files already exist, `-init` fails with an error rather than overwrite them.
+To rotate keys, remove the existing key files first, then re-run `-init` (this
+invalidates the existing receipt chain).
 
 > **Note:** the default key and database paths have recently moved to
 > `~/.local/share/agent-receipts/` (XDG Base Directory). If you ran an earlier
@@ -45,7 +61,7 @@ existing receipt chain).
 > corresponding environment variables to point the daemon at the old paths, or
 > move the files to the new location.
 
-### 2 — Install and start the unit
+#### 2 — Install and start the unit
 
 ```sh
 mkdir -p ~/.config/systemd/user
@@ -55,14 +71,14 @@ systemctl --user daemon-reload
 systemctl --user enable --now agent-receipts-daemon
 ```
 
-### 3 — Check status and logs
+#### 3 — Check status and logs
 
 ```sh
 systemctl --user status agent-receipts-daemon
 journalctl --user -u agent-receipts-daemon -f
 ```
 
-### Stopping / disabling
+#### Stopping / disabling
 
 ```sh
 systemctl --user stop agent-receipts-daemon

--- a/daemon/packaging/linux/agent-receipts-daemon.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
 Type=simple
 # %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
 # socket path is correct even when the service starts outside a PAM session.
-ExecStartPre=/bin/sh -c 'test -f %h/.local/share/agent-receipts/signing.key || %h/.local/bin/agent-receipts-daemon -init'
+ExecStartPre=/bin/sh -c 'test -f "%h/.local/share/agent-receipts/signing.key" || "%h/.local/bin/agent-receipts-daemon" -init'
 ExecStart=%h/.local/bin/agent-receipts-daemon \
   -socket %t/agentreceipts/events.sock
 Restart=on-failure

--- a/daemon/packaging/linux/agent-receipts-daemon.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.service
@@ -4,15 +4,9 @@ Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
 
 [Service]
 Type=simple
-# Adjust ExecStart to wherever the binary is installed.
-# Common locations: %h/.local/bin/agent-receipts-daemon (per-user install)
-#                   /usr/local/bin/agent-receipts-daemon (system-wide install)
-#
-# Run once before enabling to generate the signing key:
-#   agent-receipts-daemon -init
-#
-# %t expands to $XDG_RUNTIME_DIR, ensuring the socket path is correct even when
-# the service is started outside a PAM session (where XDG_RUNTIME_DIR may be unset).
+# %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
+# socket path is correct even when the service starts outside a PAM session.
+ExecStartPre=/bin/sh -c 'test -f %h/.local/share/agent-receipts/signing.key || %h/.local/bin/agent-receipts-daemon -init'
 ExecStart=%h/.local/bin/agent-receipts-daemon \
   -socket %t/agentreceipts/events.sock
 Restart=on-failure

--- a/daemon/packaging/linux/agent-receipts-daemon.service
+++ b/daemon/packaging/linux/agent-receipts-daemon.service
@@ -6,7 +6,18 @@ Documentation=https://github.com/agent-receipts/ar/tree/main/daemon
 Type=simple
 # %h is the user's home directory; %t expands to $XDG_RUNTIME_DIR, ensuring the
 # socket path is correct even when the service starts outside a PAM session.
-ExecStartPre=/bin/sh -c 'test -f "%h/.local/share/agent-receipts/signing.key" || "%h/.local/bin/agent-receipts-daemon" -init'
+# If ExecStart is changed to a different binary location, update the path in
+# ExecStartPre to match, or put the change in a drop-in override file.
+#
+# ExecStartPre: key is generated only on a truly fresh install (no receipts.db).
+# If the key is missing but a database exists, the service fails loudly so the
+# operator can recover the key rather than silently creating a new signing identity
+# (which would orphan the existing receipt chain — see daemon/daemon.go:148-151).
+ExecStartPre=/bin/sh -c '\
+  if test -f "%h/.local/share/agent-receipts/signing.key"; then exit 0;\
+  elif test -f "%h/.local/share/agent-receipts/receipts.db"; then\
+    printf "signing key missing but receipts.db exists -- recover the key before restarting\n" >&2; exit 1;\
+  else exec "%h/.local/bin/agent-receipts-daemon" -init; fi'
 ExecStart=%h/.local/bin/agent-receipts-daemon \
   -socket %t/agentreceipts/events.sock
 Restart=on-failure

--- a/daemon/tests_concurrent_mcp_proxy_test.go
+++ b/daemon/tests_concurrent_mcp_proxy_test.go
@@ -87,7 +87,7 @@ func TestTwoMCPProxySessionsConcurrent(t *testing.T) {
 		}
 	}
 
-	receipts := fix.WaitForReceiptCount(t, total, 45*time.Second)
+	receipts := fix.WaitForReceiptCount(t, total, 120*time.Second)
 
 	sort.Slice(receipts, func(i, j int) bool {
 		return receipts[i].CredentialSubject.Chain.Sequence <

--- a/daemon/tests_concurrent_test.go
+++ b/daemon/tests_concurrent_test.go
@@ -67,10 +67,10 @@ func TestConcurrentSDKEmitters(t *testing.T) {
 		t.Fatalf("emitter failed: %v", err)
 	}
 
-	// Wait for all receipts (30 total). 30 s gives macOS CI runners (which are
-	// slower than Linux) enough headroom; the poll exits as soon as all receipts
-	// arrive so the happy path is unaffected.
-	receipts := f.WaitForReceiptCount(t, totalFrames, 30*time.Second)
+	// Wait for all receipts (30 total). 60 s gives macOS CI runners (which are
+	// significantly slower than Linux) enough headroom; the poll exits as soon
+	// as all receipts arrive so the happy path is unaffected.
+	receipts := f.WaitForReceiptCount(t, totalFrames, 60*time.Second)
 
 	// store.GetChain orders by insert id, which under concurrent emitters does
 	// not necessarily match Chain.Sequence (frame-receive order vs.

--- a/daemon/tests_concurrent_test.go
+++ b/daemon/tests_concurrent_test.go
@@ -67,10 +67,10 @@ func TestConcurrentSDKEmitters(t *testing.T) {
 		t.Fatalf("emitter failed: %v", err)
 	}
 
-	// Wait for all receipts (30 total). 60 s gives macOS CI runners (which are
+	// Wait for all receipts (30 total). 120 s gives macOS CI runners (which are
 	// significantly slower than Linux) enough headroom; the poll exits as soon
 	// as all receipts arrive so the happy path is unaffected.
-	receipts := f.WaitForReceiptCount(t, totalFrames, 60*time.Second)
+	receipts := f.WaitForReceiptCount(t, totalFrames, 120*time.Second)
 
 	// store.GetChain orders by insert id, which under concurrent emitters does
 	// not necessarily match Chain.Sequence (frame-receive order vs.


### PR DESCRIPTION
## What

Adds `daemon/install.sh` — a self-contained shell script that reduces the Linux daemon install to a single command:

```sh
curl -fsSL https://github.com/agent-receipts/ar/releases/latest/download/install.sh | sh
```

Also adds a guarded `ExecStartPre` to the systemd user unit for automatic first-start key initialisation.

> **Note:** `install.sh` must be uploaded as a release asset by the daemon release workflow before the above URL works. That CI change is tracked as a follow-up.

## Why

Installing the daemon on Linux previously required several manual steps with non-obvious gotchas (strip-components, XDG_RUNTIME_DIR, linger). Closes #380.

## What the script does

1. Checks Linux/arch (amd64/arm64); bails with a brew hint on macOS
2. Detects legacy `~/.agent-receipts/` key path and aborts with migration instructions (key + `receipts.db`) before making any changes
3. Fetches the latest **stable** daemon version from the GitHub releases API (filters `daemon/v*` tags, skips pre-releases, uses `?per_page=100`)
4. Downloads `daemon_{version}_linux_{arch}.tar.gz` using `%2F`-encoded tag URL (matches Homebrew formula pattern)
5. Verifies SHA-256 checksum against `checksums.txt` before touching the filesystem
6. Smoke-tests the extracted binary in the temp dir **before** overwriting any installed version
7. Installs `agent-receipts-daemon` and `agent-receipts` to `~/.local/bin`
8. Generates the signing key (`-init`) on fresh installs; warns (does not abort) if `-init` exits non-zero and the key isn't at the default path
9. Writes the user unit to `~/.config/systemd/user/` — customisations belong in a drop-in override file, not the base unit
10. Runs `systemctl --user enable && restart`; exits 1 on real start failures, degrades gracefully when no user session is active (SSH without linger)
11. Adds `export XDG_RUNTIME_DIR=/run/user/$(id -u)` to `~/.bashrc` if not already present (skipped if file absent or export already exists)
12. Warns if `~/.local/bin` is not in `$PATH`
13. Prints the one root step: `sudo loginctl enable-linger <user>`

Safe to re-run for upgrades. Wraps all logic in `main()` to guard against truncated `curl | sh` downloads.

## ExecStartPre key guard

The user unit now includes an `ExecStartPre` that:
- Does nothing if the signing key already exists
- Runs `-init` on a truly fresh install (no key **and** no `receipts.db`)
- Fails loudly if the key is missing but a database exists — operator must recover the key rather than silently creating a new signing identity (see `daemon/daemon.go:148-151`)

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`shellcheck` via lefthook)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed) — n/a
- [x] AGENTS.md updated (if project structure changed) — n/a
- [x] Spec changes have been reviewed by a maintainer (if applicable) — n/a