### PR TITLE
chore(release): v0.8.0 CHANGELOG entries and SDK version bumps

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-05-10
+
+### Added
+
+- **Phase 2 integration tests**: concurrent mcp-proxy sessions, RFC8785-canonical
+  hash verification, socket handler coverage improved from 50.9% to 81.1%
+  ([#362](https://github.com/agent-receipts/ar/issues/362),
+  [#365](https://github.com/agent-receipts/ar/issues/365)).
+- **macOS `brew services` integration**: `brew services start agent-receipts-daemon`
+  now works — `service do` block added to the Homebrew formula via GoReleaser
+  template ([#375](https://github.com/agent-receipts/ar/issues/375)).
+- **Binary release pipeline**: GoReleaser-backed CI workflow publishes signed
+  archives and updates the Homebrew tap on each `daemon/v*` tag.
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.2` to `v0.8.0`.
+
 ## [0.8.0-alpha.2] - 2026-05-10
 
 ### Added

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -89,5 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive suite of integration tests covering socket communication,
   chain continuity, key generation, and verification workflows.
 
-[0.8.0-alpha.2]: https://github.com/agent-receipts/ar/releases/tag/daemon/v0.8.0-alpha.2
-[0.8.0-alpha.1]: https://github.com/agent-receipts/ar/releases/tag/daemon/v0.8.0-alpha.1
+[0.8.0]: https://github.com/agent-receipts/ar/releases/tag/daemon%2Fv0.8.0
+[0.8.0-alpha.2]: https://github.com/agent-receipts/ar/releases/tag/daemon%2Fv0.8.0-alpha.2
+[0.8.0-alpha.1]: https://github.com/agent-receipts/ar/releases/tag/daemon%2Fv0.8.0-alpha.1

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2026-05-10
+## [0.8.0] - 2026-05-15
 
 ### Added
 

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -9,6 +9,24 @@ This file starts at 0.6.2; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0] - 2026-05-15
+
+### Tests
+
+- Improved proxy test coverage from 32.7% to 69.1% and socket handler coverage
+  from 50.9% to 81.1%; fixed concurrent test timeout flakiness
+  ([#376](https://github.com/agent-receipts/ar/issues/376)).
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.2` to `v0.8.0`.
+
+## [0.8.0-alpha.2] - 2026-05-10
+
+### Dependencies
+
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.1` to `v0.8.0-alpha.2`.
+
 ## [0.8.0-alpha.1] - 2026-05-09
 
 ### Dependencies

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -19,13 +19,7 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ### Dependencies
 
-- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.2` to `v0.8.0`.
-
-## [0.8.0-alpha.2] - 2026-05-10
-
-### Dependencies
-
-- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.1` to `v0.8.0-alpha.2`.
+- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.8.0-alpha.1` to `v0.8.0`.
 
 ## [0.8.0-alpha.1] - 2026-05-09
 
@@ -102,6 +96,5 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
   [#262](https://github.com/agent-receipts/ar/issues/262).
 
 [0.8.0]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0
-[0.8.0-alpha.2]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0-alpha.2
 [0.8.0-alpha.1]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0-alpha.1
 [0.6.2]: https://github.com/agent-receipts/ar/compare/mcp-proxy/v0.6.1...mcp-proxy/v0.6.2

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -101,4 +101,7 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
   (disable) as remediations, then exits non-zero. Closes
   [#262](https://github.com/agent-receipts/ar/issues/262).
 
+[0.8.0]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0
+[0.8.0-alpha.2]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0-alpha.2
+[0.8.0-alpha.1]: https://github.com/agent-receipts/ar/releases/tag/mcp-proxy%2Fv0.8.0-alpha.1
 [0.6.2]: https://github.com/agent-receipts/ar/compare/mcp-proxy/v0.6.1...mcp-proxy/v0.6.2

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -9,6 +9,12 @@ This file starts at 0.6.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0] - 2026-05-15
+
+### Changed
+
+- No SDK code changes. Version bump to maintain lockstep with the coordinated v0.8.0 release.
+
 ## [0.8.0-alpha.2] - 2026-05-10
 
 ### Changed

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,12 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0] - 2026-05-15
+
+### Changed
+
+- No SDK code changes. Version bump to maintain lockstep with the coordinated v0.8.0 release.
+
 ## [0.8.0a2] - 2026-05-10
 
 ### Changed

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.8.0a2"
+version = "0.8.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.8.0a2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,6 +9,12 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.8.0] - 2026-05-15
+
+### Changed
+
+- No SDK code changes. Version bump to maintain lockstep with the coordinated v0.8.0 release.
+
 ## [0.8.0-alpha.2] - 2026-05-10
 
 ### Changed

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.8.0-alpha.2",
+	"version": "0.8.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Pre-tagging housekeeping for the coordinated v0.8.0 release.

## Changes

- **daemon**: add missing `[0.8.0]` entry (Phase 2 integration tests, brew services, release pipeline)
- **mcp-proxy**: add `[0.8.0]` entry (test coverage improvements, dep bump alpha.1 → v0.8.0); the alpha.2 tag was cut without updating `go.mod` so there is no alpha.2 CHANGELOG entry
- **sdk/go, sdk/ts, sdk/py**: add `[0.8.0]` lockstep bump entries
- **sdk/ts** `package.json`: `0.8.0-alpha.2` → `0.8.0`
- **sdk/py** `pyproject.toml`: `0.8.0a2` → `0.8.0`

All tests pass (237 TS, 257 Python).

Part of #367 — coordinated pre-release tags (2a).