### PR TITLE
docs(site): mcp-proxy positioning pass — daemon architecture, CC-1/2/7 (issue #291 Track 3)

### DIFF
--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -3,7 +3,7 @@ title: Approval Server
 description: HTTP endpoints that gate paused tool calls, how to approve or deny them, and how to auto-start an approver.
 ---
 
-The Approval Server is a proxy-layer feature — it gates tool calls at the MCP boundary and is separate from the Agent Receipts audit protocol. All calls (approved, denied, or timed out) are recorded as receipts regardless of outcome.
+The Approval Server is a proxy-layer feature — it gates tool calls at the MCP boundary and is separate from the Agent Receipts audit protocol. All calls (approved, denied, or timed out) are recorded in the audit log regardless of outcome.
 
 **Approvals are off by default.** To turn them on, pass `-http 127.0.0.1:<port>` to `mcp-proxy`. Without that flag the listener never starts, and any tool call that matches a `pause` rule fails immediately with JSON-RPC code `-32003` (`no approver configured`) instead of waiting for an approver that isn't there. With the listener up, a paused call blocks forwarding until something POSTs an approve or deny decision; if no approver responds within `-approval-timeout` (default 60s), the call fails with code `-32002` (`tool call approval timed out…`).
 

--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -3,6 +3,8 @@ title: Approval Server
 description: HTTP endpoints that gate paused tool calls, how to approve or deny them, and how to auto-start an approver.
 ---
 
+The Approval Server is a proxy-layer feature — it gates tool calls at the MCP boundary and is separate from the Agent Receipts audit protocol. All calls (approved, denied, or timed out) are recorded as receipts regardless of outcome.
+
 **Approvals are off by default.** To turn them on, pass `-http 127.0.0.1:<port>` to `mcp-proxy`. Without that flag the listener never starts, and any tool call that matches a `pause` rule fails immediately with JSON-RPC code `-32003` (`no approver configured`) instead of waiting for an approver that isn't there. With the listener up, a paused call blocks forwarding until something POSTs an approve or deny decision; if no approver responds within `-approval-timeout` (default 60s), the call fails with code `-32002` (`tool call approval timed out…`).
 
 The built-in defaults include a `pause_high_risk` rule (`min_risk_score: 50`). A call only pauses when its score actually reaches 50. Base by operation: read 0, write 20, execute 30, delete 40, unknown 10. Modifiers: +30 for sensitive keywords in the tool name (`auth`/`credential`/`password`/`token`/`secret`/`key`), +30 for SQL mutations in arguments missing `WHERE`, +20 for `config`/`setting` substrings, +15 for `send_*`/`post_*` prefixes. So `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), and `exec_sql` with an unparenthesised `DELETE` (60) all pause. But plain `update_config` (40), plain `delete_branch` (40), and sensitive-keyword *reads* like `get_token` (30) stay below the threshold — as do ordinary writes like `create_pull_request` (20) and `push_files` (20).

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -61,6 +61,8 @@ rules:
 
 ### Actions
 
+`pass` and `flag` are audit-only — they record the call and forward it. `pause` and `block` are proxy-layer enforcement features; the Agent Receipts protocol itself is audit-only and does not block or modify tool calls.
+
 | Action | Behavior |
 |--------|----------|
 | `pass` | Log only, forward normally |

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -49,7 +49,7 @@ Wrap any MCP server by passing its command as arguments. For a quick smoke test,
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
-The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. When the `agent-receipts` daemon is running, it forwards audit events there for signing and storage. Without the daemon (or if `AGENTRECEIPTS_SOCKET` is unset), it falls back to an ephemeral Ed25519 key pair for standalone use. Press `Ctrl-C` to stop.
+The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. It always signs receipts locally — with `-key` if provided, or an ephemeral Ed25519 key pair otherwise. Separately, daemon forwarding sends a copy of each event to `agent-receipts-daemon` via the `--socket` flag (defaults to the platform socket path; set `--socket=""` to disable). Press `Ctrl-C` to stop.
 
 For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), or [Codex](/mcp-proxy/codex/).
 
@@ -67,7 +67,7 @@ Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores
 
 ## Standalone signing key
 
-For production use, key management is handled by the `agent-receipts` daemon — see [Daemon Setup](/getting-started/daemon-setup/). The instructions below are for standalone use (no daemon), where the proxy holds the signing key directly.
+For production use, key management is handled by `agent-receipts-daemon` — see [Daemon Setup](/getting-started/daemon-setup/). The instructions below are for standalone use (no daemon), where the proxy holds the signing key directly.
 
 `mcp-proxy init` does everything in one step: creates `~/.agent-receipts/`, generates an Ed25519 keypair with correct permissions, initialises the receipt database, and prints a ready-to-paste `claude_desktop_config.json` snippet:
 

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -49,7 +49,7 @@ Wrap any MCP server by passing its command as arguments. For a quick smoke test,
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
-The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. By default it generates an ephemeral Ed25519 key pair for signing receipts. Press `Ctrl-C` to stop.
+The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. When the `agent-receipts` daemon is running, it forwards audit events there for signing and storage. Without the daemon (or if `AGENTRECEIPTS_SOCKET` is unset), it falls back to an ephemeral Ed25519 key pair for standalone use. Press `Ctrl-C` to stop.
 
 For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), or [Codex](/mcp-proxy/codex/).
 
@@ -65,7 +65,9 @@ Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores
 
 **Seeing `-32002` on a tool that shouldn't pause?** It's most likely client-side denial by the MCP client (e.g. Claude Code), not the proxy. See the [`-32002` troubleshooting entry](/mcp-proxy/configuration/#-32002-errors-on-tool-calls) for how to distinguish the two sources.
 
-## Persistent signing key
+## Standalone signing key
+
+For production use, key management is handled by the `agent-receipts` daemon — see [Daemon Setup](/getting-started/daemon-setup/). The instructions below are for standalone use (no daemon), where the proxy holds the signing key directly.
 
 `mcp-proxy init` does everything in one step: creates `~/.agent-receipts/`, generates an Ed25519 keypair with correct permissions, initialises the receipt database, and prints a ready-to-paste `claude_desktop_config.json` snippet:
 

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: MCP Proxy
-description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, and forwards audit events to the agent-receipts daemon for signing and storage.
+description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, signs receipts locally, and forwards events to agent-receipts-daemon when configured.
 ---
 
-The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, applies proxy-layer policy rules, redacts sensitive data, then forwards an audit event to the `agent-receipts` daemon for signing and tamper-evident storage — without modifying the server or client.
+The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, applies proxy-layer policy rules, redacts sensitive data, and signs and stores an Ed25519 receipt locally. When `agent-receipts-daemon` is configured via `--socket`, it also forwards events to the daemon for an independently signed and stored chain — without modifying the server or client.
 
 **Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
 
@@ -21,7 +21,7 @@ Scores that cross 50: `create_token` (write 20 + sensitive 30 = 50), `update_aut
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy rules** (proxy layer) -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** (proxy layer) -- HTTP endpoints for async approval of paused operations
-- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, signed and hash-chained by the `agent-receipts` daemon
+- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, hash-chained per session; events are also forwarded to `agent-receipts-daemon` when `--socket` is configured
 - **Issuer identity** -- receipts identify the AI agent, model, and operator via CLI flags
 - **Intent tracking** -- groups related tool calls by temporal proximity
 - **Data redaction** -- JSON-aware and pattern-based redaction of secrets before storage
@@ -38,14 +38,14 @@ MCP Client (Claude Desktop / Claude Code)
     |  - classify operation
     |  - score risk
     |  - evaluate policy rules
-    |  - redact sensitive data
-    |  - forward event (Unix socket) ──> agent-receipts daemon
-    v                                        - sign receipt (Ed25519)
- MCP Server (any)                            - append to chain
-                                             - write to SQLite
+    |  - redact sensitive data (local storage)
+    |  - sign receipt (Ed25519) → local SQLite
+    |  - forward event (--socket) ─────────────> agent-receipts-daemon
+    v                                                 - sign independently
+ MCP Server (any)                                     - append to daemon chain
 ```
 
-The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call generates a signed Agent Receipt — signing and storage are handled by the `agent-receipts` daemon, which hash-chains receipts into a tamper-evident audit log.
+The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call produces a locally signed Agent Receipt. When `--socket` points to a running `agent-receipts-daemon`, events are also forwarded for an independently signed chain.
 
 ## Quick start
 
@@ -58,8 +58,8 @@ brew install agent-receipts/tap/mcp-proxy
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 
 # With configuration (example: GitHub's official MCP server — brew install github-mcp-server)
-# -key is the standalone signing path; with the daemon running, omit -key and
-# set AGENTRECEIPTS_SOCKET instead — see Daemon Setup.
+# -key sets the local signing key (omit for an ephemeral key).
+# Daemon forwarding is a separate path configured via --socket — see Daemon Setup.
 mcp-proxy \
   -name github \
   -key private.pem \

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: MCP Proxy
-description: Transparent audit proxy for MCP servers with receipt signing, policy enforcement, and risk scoring.
+description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, and forwards audit events to the agent-receipts daemon for signing and storage.
 ---
 
-The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call and provides cryptographic audit trails, risk scoring, and policy enforcement -- without modifying the server or client.
+The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, applies proxy-layer policy rules, redacts sensitive data, then forwards an audit event to the `agent-receipts` daemon for signing and tamper-evident storage — without modifying the server or client.
 
 **Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
 
@@ -19,9 +19,9 @@ Scores that cross 50: `create_token` (write 20 + sensitive 30 = 50), `update_aut
 - **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
 - **Action taxonomy** -- classifies tool calls using configurable taxonomy mappings; GitHub and Atlassian MCP servers are covered by bundled taxonomies out of the box
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
-- **Policy enforcement** -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
-- **Approval workflows** -- HTTP endpoints for async approval of paused operations
-- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, hash-chained per session
+- **Policy rules** (proxy layer) -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
+- **Approval workflows** (proxy layer) -- HTTP endpoints for async approval of paused operations
+- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, signed and hash-chained by the `agent-receipts` daemon
 - **Issuer identity** -- receipts identify the AI agent, model, and operator via CLI flags
 - **Intent tracking** -- groups related tool calls by temporal proximity
 - **Data redaction** -- JSON-aware and pattern-based redaction of secrets before storage
@@ -39,13 +39,13 @@ MCP Client (Claude Desktop / Claude Code)
     |  - score risk
     |  - evaluate policy rules
     |  - redact sensitive data
-    |  - sign receipt
-    |  - log to SQLite
-    v
- MCP Server (any)
+    |  - forward event (Unix socket) ──> agent-receipts daemon
+    v                                        - sign receipt (Ed25519)
+ MCP Server (any)                            - append to chain
+                                             - write to SQLite
 ```
 
-The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call generates a signed Agent Receipt that is hash-chained into a tamper-evident audit log.
+The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call generates a signed Agent Receipt — signing and storage are handled by the `agent-receipts` daemon, which hash-chains receipts into a tamper-evident audit log.
 
 ## Quick start
 
@@ -58,6 +58,8 @@ brew install agent-receipts/tap/mcp-proxy
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 
 # With configuration (example: GitHub's official MCP server — brew install github-mcp-server)
+# -key is the standalone signing path; with the daemon running, omit -key and
+# set AGENTRECEIPTS_SOCKET instead — see Daemon Setup.
 mcp-proxy \
   -name github \
   -key private.pem \


### PR DESCRIPTION
## What

mcp-proxy pages positioning cleanup — second Track 3 PR from issue #291, unblocked by the v0.8.0 daemon release. Four pages: `overview`, `installation`, `configuration`, `approval-ui`.

## Why

The mcp-proxy pages described signing and storage as happening inside the proxy, and framed policy enforcement as a core Agent Receipts protocol feature. Both are now wrong or misleading: the daemon handles signing/storage, and CC-1 (Track 1 decision) settled on a "split story" where block/pause/approval are proxy-layer features distinct from the audit-only protocol.

## Changes

**overview.mdx**
- D8 (CC-1/7): description and opening rewritten — daemon handles signing/storage; "policy enforcement" removed as a primary descriptor
- D9/D10 (CC-1): "Policy enforcement" and "Approval workflows" bullets labelled as `(proxy layer)`
- D11/D12 (CC-2): "Cryptographic receipts" bullet notes the daemon does the signing; opening paragraph names the daemon
- B2: ASCII architecture diagram updated — `sign receipt / log to SQLite` inside mcp-proxy replaced with `forward event (Unix socket) → agent-receipts daemon` which handles signing, chaining, and storage
- D13: comment on the `-key` quick-start example noting it is the standalone path; `AGENTRECEIPTS_SOCKET` / daemon path called out

**installation.mdx**
- D23: "By default generates an ephemeral key pair" updated — daemon path noted when `AGENTRECEIPTS_SOCKET` is set; ephemeral key is the standalone fallback
- D24: "Persistent signing key" renamed to "Standalone signing key"; daemon-setup link added as the production path before the `mcp-proxy init` instructions

**configuration.mdx**
- D25: note added above the actions table — `pass`/`flag` are audit-only; `pause`/`block` are proxy-layer enforcement, separate from the Agent Receipts protocol

**approval-ui.mdx**
- D26: framing sentence added — Approval Server is a proxy-layer feature, separate from the audit protocol; all outcomes are recorded as receipts regardless

## Checklist

- [x] Tests pass for all changed components (site-only content change, no code)
- [x] Linter passes (no applicable linters for MDX)
- [x] No real keys or secrets in the diff
