### PR TITLE
docs(site): specification pages positioning pass — daemon context, caveats, missing fields (issue #291 Track 3)

### DIFF
--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -194,6 +194,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `reversal_method` | No | Machine-readable reversal method (e.g. `gmail:undo_send`). |
 | `reversal_window_seconds` | No | Seconds within which reversal is possible. |
 | `reversal_of` | No | `urn:receipt:<uuid>` of the original receipt this receipt reverses. Present only on reversal receipts. |
+| `response_hash` | No | `sha256:` prefixed hash of the tool's response (RFC 8785 canonical JSON). |
 | `state_change.before_hash` | Conditional | `sha256:` hash of state before. Required when `state_change` is present. |
 | `state_change.after_hash` | Conditional | `sha256:` hash of state after. Required when `state_change` is present. |
 
@@ -223,6 +224,7 @@ Present when this chain was spawned by delegation from another agent. All fields
 | `chain_id` | Yes | Opaque identifier grouping receipts into a chain. |
 | `sequence` | Yes | Monotonically increasing integer, starting at `1`. |
 | `previous_receipt_hash` | Yes | `sha256:` hash of previous receipt, or `null` for first in chain. |
+| `terminal` | No | `true` if this is the final receipt in the chain. Enables tail-truncation detection by verifiers — see [Receipt Chain Verification](/specification/receipt-chain-verification/#chain-integrity-verification). |
 
 ## Proof
 
@@ -230,7 +232,7 @@ Present when this chain was spawned by delegation from another agent. All fields
 |---|---|---|
 | `type` | Yes | Must be `"Ed25519Signature2020"`. |
 | `created` | Yes | ISO 8601 datetime when the proof was created. |
-| `verificationMethod` | Yes | DID URL of the signing key. |
+| `verificationMethod` | Yes | DID URL of the signing key. The `did:agent:` method used in examples is an illustrative placeholder — DID resolution is not specified in the current protocol (see ADR-0007). |
 | `proofPurpose` | Yes | Must be `"assertionMethod"`. |
 | `proofValue` | Yes | Multibase-encoded (`u`-prefixed base64url, no padding) Ed25519 signature. |
 

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -88,6 +88,8 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 3. Sign the canonical bytes with the issuer's **Ed25519** private key
 4. Encode the signature as **u-prefixed base64url** (no padding) and attach as `proof.proofValue`
 
+In the reference implementation, steps 2–4 are performed by the `agent-receipts` daemon. The emitter (agent, mcp-proxy, or SDK) sends the receipt fields over a Unix socket; the daemon canonicalizes, signs, and stores the result. The issuer process never holds the private key.
+
 The same canonical bytes are also SHA-256 hashed to produce the link for the *next* receipt in the chain.
 
 ## How receipts chain

--- a/site/src/content/docs/specification/overview.mdx
+++ b/site/src/content/docs/specification/overview.mdx
@@ -95,7 +95,7 @@ The human (or organization) on whose behalf the agent acted. Identified by a DID
 
 ### Issuer
 
-The agent (or agent platform) that performed the action and produced the receipt. The issuer signs the receipt with its private key.
+The agent (or agent platform) that performed the action and produced the receipt. The receipt is signed using the issuer's key — in the reference implementation the `agent-receipts` daemon holds that key and performs the signing; the issuer process sends the event fields and never touches the key directly.
 
 ## Relationship to existing work
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -48,7 +48,7 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 
 ## Canonical form
 
-For hashing and signing, receipts must be serialized using the **JSON Canonicalization Scheme (RFC 8785)** with the `proof` field removed before hashing. This approach aligns with the W3C Verifiable Credentials Data Integrity specification, though the signing procedure defined here is intentionally simplified.
+For hashing and signing, receipts must be serialized using the **JSON Canonicalization Scheme (RFC 8785)** with the `proof` field removed before hashing. This diverges from the W3C Verifiable Credentials Data Integrity default, which uses JSON-LD canonicalization (RDF Dataset Canonicalization). Implementations expecting JSON-LD processing will not be interoperable with Agent Receipt signatures — existing JSON-LD-based VC tooling cannot verify them without modification.
 
 ## Signing
 
@@ -60,13 +60,15 @@ To verify a receipt chain:
 
 1. Retrieve all receipts for the chain, ordered by `chain.sequence`. Let *n* be the number of receipts.
 2. For each receipt *R(i)* (0-based index):
-   - **a.** Verify the `proof` signature against the issuer's public key at `proof.verificationMethod`.
+   - **a.** Verify the `proof` signature against the issuer's public key at `proof.verificationMethod`. Note: resolution of `proof.verificationMethod` URLs (particularly `did:agent:` identifiers) is not specified in the current protocol — verifiers must obtain public keys through out-of-band means (e.g. the daemon's published `.pub` file).
    - **b.** Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of *R(i)* with the `proof` field removed.
    - **c.** If *i < n - 1*, confirm *R(i+1)*'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
 3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1.
 4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null`.
 
 If any step fails, the chain is broken at that point. Receipts before the break may still be individually valid; receipts after are suspect.
+
+**Truncation detection.** The algorithm above detects inserted, modified, or reordered receipts, but does not detect tail truncation — a chain that ends prematurely looks identical to a normally-terminated chain. When the final receipt carries `chain.terminal: true`, verifiers SHOULD treat any chain that ends without this flag as potentially truncated. Without a terminal receipt, silently dropping the most recent events is undetectable by this algorithm alone.
 
 ## Reversal receipts
 

--- a/site/src/content/docs/specification/risk-levels.mdx
+++ b/site/src/content/docs/specification/risk-levels.mdx
@@ -30,5 +30,5 @@ The no-downgrade rule ensures that risk levels serve as a reliable floor for com
 
 - **Filtering**: Show only `high` and `critical` actions in an audit dashboard
 - **Alerting**: Trigger real-time notifications for `critical` actions
-- **Authorization gates**: Require explicit user confirmation before executing `high` or `critical` actions
+- **Authorization gates**: Risk levels provide a basis for enforcement or approval tooling (such as the mcp-proxy `pause` rule or external policy engines) to require confirmation before executing `high` or `critical` actions
 - **Compliance reporting**: Generate reports filtered by risk level for regulatory requirements


### PR DESCRIPTION
## What

Specification pages positioning and accuracy cleanup — third Track 3 PR from issue #291. Five pages: `overview`, `how-it-works`, `receipt-chain-verification`, `agent-receipt-schema`, `risk-levels`.

## Why

The specification pages still described signing as happening inside the issuer process, understated the deviation from W3C VC Data Integrity, omitted the truncation-detection caveat and DID resolution gap, and were missing two fields added by ADR-0008. All are now addressed with the daemon having shipped in v0.8.0.

## Changes

**specification/overview.mdx**
- D27: Issuer definition updated — daemon holds the key and performs signing; issuer process sends event fields and never touches the key directly

**specification/how-it-works.mdx**
- D22: Added paragraph after signing steps noting steps 2–4 are performed by the `agent-receipts` daemon; emitter sends fields over Unix socket

**specification/receipt-chain-verification.mdx**
- D16: Canonical-form section rewritten — replaced "intentionally simplified" with accurate statement: RFC 8785 diverges from W3C VC Data Integrity's JSON-LD canonicalization; existing JSON-LD-based VC tooling cannot verify these signatures
- D17: Added truncation-detection caveat after the algorithm — algorithm detects gaps but not tail truncation; explains `chain.terminal` flag and how verifiers SHOULD use it
- D18 (CC-12): Step 2a expanded with DID resolution caveat — `did:agent:` identifiers have no resolver; verifiers must obtain keys out-of-band (e.g. the daemon's published `.pub` file)

**specification/agent-receipt-schema.mdx**
- D19 (partial): Added missing `response_hash` field to `outcome` section (ADR-0008); added missing `chain.terminal` field to `chain` section (ADR-0008)
- N1: `verificationMethod` description notes `did:agent:` is illustrative; DID resolution not specified (ADR-0007)

**specification/risk-levels.mdx**
- D30 (CC-1): "Authorization gates" use case reframed — risk levels provide a basis for external enforcement/approval tooling, not a built-in enforcement capability of the Agent Receipts protocol

## Checklist

- [x] Tests pass for all changed components (site-only content change, no code)
- [x] Linter passes (no applicable linters for MDX)
- [x] No real keys or secrets in the diff
