### PR TITLE
docs(site): SDK and ecosystem nits — DATA_ACTIONS, ReceiptStore, VERSION, quick-start caveat (issue #291 Track 3)

### DIFF
--- a/site/src/content/docs/ecosystem/index.mdx
+++ b/site/src/content/docs/ecosystem/index.mdx
@@ -99,6 +99,8 @@ Multiple projects have independently converged on the same cryptographic and pro
 | **OWASP Agentic AI Top 10** | Microsoft AGT, Pipelock, mcp-firewall (ressl) |
 | **YAML policy config** | All projects |
 
+Agent Receipts (this project) sits outside the enforcement tools in the table above — it is an audit trail, not a policy engine. Its trust model: signing keys live in a separate `agent-receipts-daemon` process (not in the agent, proxy, or SDK), so the audit trail is independent of the component being audited.
+
 ---
 
 ## Gap Analysis

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -5,6 +5,10 @@ description: Create, sign, and verify your first Agent Receipt.
 
 This guide walks you through creating, signing, and verifying an Agent Receipt using either the TypeScript or Python SDK.
 
+:::note[In-process API — standalone and testing use]
+The examples below use the direct SDK signing API, where the calling process holds the private key. This is the legacy in-process pattern that ADR-0010 deprecates in favour of the `agent-receipts-daemon`. For production deployments, the daemon owns the key and emitters send events over a socket — see [Daemon Setup](/getting-started/daemon-setup/).
+:::
+
 ## TypeScript
 
 ### 1. Install

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -286,6 +286,16 @@ func LoadTaxonomyConfig(path string) ([]TaxonomyMapping, error)
 
 Load taxonomy mappings from a JSON file. Validates that no duplicate tool names exist.
 
+### Variables
+
+```go
+var FilesystemActions []ActionTypeEntry  // 7 filesystem action types
+var SystemActions     []ActionTypeEntry  // 7 system action types
+var DataActions       []ActionTypeEntry  // 3 data/API action types
+```
+
+Pre-populated slices of action type entries by category. Use `AllActions()` to get all categories combined.
+
 ### Types
 
 ```go

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -256,7 +256,7 @@ OutcomeStatus = Literal["success", "failure", "pending"]
 CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
 RECEIPT_VERSION: str        # "0.2.0" (receipt schema)
-VERSION: str                # "0.5.0" (package version)
+VERSION: str                # current package version
 ```
 
 ---
@@ -404,6 +404,7 @@ class ClassificationResult:
 ```python
 FILESYSTEM_ACTIONS: list[ActionTypeEntry]  # 7 types
 SYSTEM_ACTIONS: list[ActionTypeEntry]      # 7 types
+DATA_ACTIONS: list[ActionTypeEntry]        # 3 data/API types
 ALL_ACTIONS: list[ActionTypeEntry]         # all + unknown
 UNKNOWN_ACTION: ActionTypeEntry
 ```

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -404,9 +404,14 @@ class ClassificationResult:
 ```python
 FILESYSTEM_ACTIONS: list[ActionTypeEntry]  # 7 types
 SYSTEM_ACTIONS: list[ActionTypeEntry]      # 7 types
-DATA_ACTIONS: list[ActionTypeEntry]        # 3 data/API types
 ALL_ACTIONS: list[ActionTypeEntry]         # all + unknown
 UNKNOWN_ACTION: ActionTypeEntry
+```
+
+`DATA_ACTIONS` (3 data/API types) is exported from the `taxonomy` submodule, not the package root:
+
+```python
+from agent_receipts.taxonomy import DATA_ACTIONS
 ```
 
 ### Backwards compatibility aliases

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -408,7 +408,12 @@ interface ClassificationResult {
 ```typescript
 const FILESYSTEM_ACTIONS: readonly ActionTypeEntry[]  // 7 types
 const SYSTEM_ACTIONS: readonly ActionTypeEntry[]       // 7 types
-const DATA_ACTIONS: readonly ActionTypeEntry[]          // 3 data/API types
 const ALL_ACTIONS: readonly ActionTypeEntry[]           // all + unknown
 const UNKNOWN_ACTION: ActionTypeEntry
+```
+
+`DATA_ACTIONS` (3 data/API types) is exported from the `taxonomy` subpath, not the package root:
+
+```typescript
+import { DATA_ACTIONS } from "@agnt-rcpt/sdk-ts/taxonomy";
 ```

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -292,6 +292,8 @@ Load a chain from the store and verify its integrity.
 
 ### `ReceiptStore`
 
+Use `openStore(dbPath)` to create a store — the class constructor is an implementation detail. `openStore` is the stable public factory.
+
 ```typescript
 class ReceiptStore {
   constructor(dbPath: string);
@@ -406,6 +408,7 @@ interface ClassificationResult {
 ```typescript
 const FILESYSTEM_ACTIONS: readonly ActionTypeEntry[]  // 7 types
 const SYSTEM_ACTIONS: readonly ActionTypeEntry[]       // 7 types
+const DATA_ACTIONS: readonly ActionTypeEntry[]          // 3 data/API types
 const ALL_ACTIONS: readonly ActionTypeEntry[]           // all + unknown
 const UNKNOWN_ACTION: ActionTypeEntry
 ```


### PR DESCRIPTION
## What

Final Track 3 PR from issue #291 — SDK API reference nits and quick-start caveat across five pages.

## Why

These were the remaining N-class (nit) and one D-class finding from the site audit, all small and mechanical. The D14 quick-start caveat is newly relevant now that ADR-0010 shipped in v0.8.0 and the in-process API is officially deprecated.

## Changes

**getting-started/quick-start.mdx**
- D14: `:::note` admonition added — the examples use the in-process/legacy signing API (caller holds the key); daemon-backed approach is recommended for production; link to Daemon Setup

**sdk-go/api-reference.mdx**
- N3: `Variables` section added to the `taxonomy` package documenting the exported `FilesystemActions`, `SystemActions`, and `DataActions` slices

**sdk-ts/api-reference.mdx**
- N4: `DATA_ACTIONS` (3 data/API types) added to the built-in action registries block
- N5: note added above the `ReceiptStore` class that `openStore()` is the stable public factory; the class constructor is an implementation detail

**sdk-py/api-reference.mdx**
- D36: `VERSION` comment stripped of hardcoded version string (`"0.5.0"`) which drifts with every release; changed to `# current package version`
- N6: `DATA_ACTIONS` (3 data/API types) added to the built-in action registries block

**ecosystem/index.mdx**
- N7: paragraph added after the Key Primitives table characterising Agent Receipts' trust model (daemon-isolated keys) and distinguishing it from the enforcement tools in the comparison tables

## Checklist

- [x] Tests pass for all changed components (site-only content change, no code)
- [x] Linter passes (no applicable linters for MDX)
- [x] No real keys or secrets in the diff
