### PR TITLE
docs(site): openclaw Track 4 — daemon trust model, daemonForwarding, key isolation (issue #291)

### DIFF
--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -141,7 +141,7 @@ Receipt 2: sequence=2, previous_receipt_hash=sha256:<hash of receipt 1>
 Receipt 3: sequence=3, previous_receipt_hash=sha256:<hash of receipt 2>
 ```
 
-To tamper with the chain, you'd need to modify a receipt, recompute all subsequent hashes, and re-sign every receipt with the private key. Without the key, the chain is tamper-evident: any modification breaks verification at the point of change, and any gap in sequence numbers is immediately visible. In the default configuration the signing key lives on disk at `~/.openclaw/agent-receipts/keys.json` — accessible to the agent process itself. For stronger isolation, set `daemonForwarding: true` to move signing into `agent-receipts-daemon`, which runs as a separate process and holds the key outside the agent's reach.
+To tamper with the chain, you'd need to modify a receipt, recompute all subsequent hashes, and re-sign every receipt with the private key. Without the key, the chain is tamper-evident: any modification breaks verification at the point of change, and any gap in sequence numbers is immediately visible. In the default configuration the signing key lives on disk at `~/.openclaw/agent-receipts/keys.json` — accessible to the agent process itself. Set `daemonForwarding: true` to move key material into `agent-receipts-daemon`: the agent can no longer read the key or rewrite already-signed receipts. The daemon listens on a local Unix socket, so a compromised agent running as the same OS user can still connect and emit new events for signing; preventing that requires the daemon to run as a dedicated OS user.
 
 The `export` command produces the full credential for independent verification:
 

--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -141,7 +141,7 @@ Receipt 2: sequence=2, previous_receipt_hash=sha256:<hash of receipt 1>
 Receipt 3: sequence=3, previous_receipt_hash=sha256:<hash of receipt 2>
 ```
 
-To tamper with the chain, you'd need to modify a receipt, recompute all subsequent hashes, and re-sign every receipt with the private key. Without the key, the chain is tamper-evident: any modification breaks verification at the point of change, and any gap in sequence numbers is immediately visible.
+To tamper with the chain, you'd need to modify a receipt, recompute all subsequent hashes, and re-sign every receipt with the private key. Without the key, the chain is tamper-evident: any modification breaks verification at the point of change, and any gap in sequence numbers is immediately visible. In the default configuration the signing key lives on disk at `~/.openclaw/agent-receipts/keys.json` — accessible to the agent process itself. For stronger isolation, set `daemonForwarding: true` to move signing into `agent-receipts-daemon`, which runs as a separate process and holds the key outside the agent's reach.
 
 The `export` command produces the full credential for independent verification:
 

--- a/site/src/content/docs/openclaw/agent-tools.mdx
+++ b/site/src/content/docs/openclaw/agent-tools.mdx
@@ -87,7 +87,7 @@ Tamper detected! The following receipts have issues:
 ```
 
 :::caution[A broken chain means receipts at or after the reported position cannot be trusted]
-A valid chain guarantees that no receipt was altered, inserted, or deleted after signing. The strength of that guarantee depends on where the signing key lives: in the default in-process configuration the key is stored on disk alongside the agent, so a compromised agent process could in principle forge receipts. With `daemonForwarding: true` the key lives in `agent-receipts-daemon` — a separate process the agent cannot access — which restores the full tamper-evidence property. If the chain is broken, treat all receipts from the reported position onward as potentially compromised and investigate before relying on them.
+A valid chain guarantees that no receipt was altered, inserted, or deleted after signing. The strength of that guarantee depends on where the signing key lives: in the default in-process configuration the key is stored on disk alongside the agent, so a compromised agent process could read the key and forge receipts. With `daemonForwarding: true` the key lives in `agent-receipts-daemon` — the agent process cannot read the key material or rewrite already-signed receipts. Note that the daemon listens on a local Unix socket: any process running as the same OS user can still connect and emit new events; preventing that requires the daemon to run as a dedicated OS user (the production deployment). If the chain is broken, treat all receipts from the reported position onward as potentially compromised and investigate before relying on them.
 :::
 
 ---

--- a/site/src/content/docs/openclaw/agent-tools.mdx
+++ b/site/src/content/docs/openclaw/agent-tools.mdx
@@ -87,7 +87,7 @@ Tamper detected! The following receipts have issues:
 ```
 
 :::caution[A broken chain means receipts at or after the reported position cannot be trusted]
-A valid chain guarantees that no receipt was altered, inserted, or deleted after it was written. If the chain is broken, treat all receipts from the reported position onward as potentially compromised and investigate before relying on them.
+A valid chain guarantees that no receipt was altered, inserted, or deleted after signing. The strength of that guarantee depends on where the signing key lives: in the default in-process configuration the key is stored on disk alongside the agent, so a compromised agent process could in principle forge receipts. With `daemonForwarding: true` the key lives in `agent-receipts-daemon` — a separate process the agent cannot access — which restores the full tamper-evidence property. If the chain is broken, treat all receipts from the reported position onward as potentially compromised and investigate before relying on them.
 :::
 
 ---

--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -68,15 +68,18 @@ All configuration is optional. Defaults are shown below:
         "config": {
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
-          "keyPath": "~/.openclaw/agent-receipts/keys.json",
+          "keyPath": "~/.openclaw/agent-receipts/keys.json",  // in-process signing key; not used when daemonForwarding is true
           // "taxonomyPath": "/path/to/custom-taxonomy.json",  // optional — overrides bundled taxonomy
-          "parameterDisclosure": false    // false | true | "high" | string[]
+          "parameterDisclosure": false,   // false | true | "high" | string[]
+          "daemonForwarding": false       // set true to forward events to agent-receipts-daemon instead of signing in-process
         }
       }
     }
   }
 }
 ```
+
+`keyPath` holds the Ed25519 signing key used for in-process receipt signing (the default). When `daemonForwarding: true`, signing is delegated to `agent-receipts-daemon` and `keyPath` is not used — see [Daemon Setup](/getting-started/daemon-setup/) for daemon installation. Daemon forwarding is opt-in because it sends raw tool I/O across a process boundary; see the [openclaw README](https://github.com/agent-receipts/openclaw#daemon-forwarding) for trust-boundary details.
 
 ## Parameter disclosure
 

--- a/site/src/content/docs/openclaw/overview.mdx
+++ b/site/src/content/docs/openclaw/overview.mdx
@@ -13,10 +13,10 @@ The `@agnt-rcpt/openclaw` plugin integrates the Agent Receipt Protocol with Open
 
 - Intercepts every tool call routed through OpenClaw via lifecycle hooks
 - Classifies each call using the bundled action taxonomy (filesystem, system, browser, and more)
-- Signs a W3C Verifiable Credential receipt with an Ed25519 key
+- Signs a W3C Verifiable Credential receipt with an Ed25519 key (in-process by default; set `daemonForwarding: true` to move signing to `agent-receipts-daemon`)
 - Hash-chains receipts into a tamper-evident sequence per session
 - Stores receipts in a local SQLite database
-- Exposes two agent tools (`ar_query_receipts`, `ar_verify_chain`) so the agent can query and verify its own audit trail
+- Exposes two agent tools (`ar_query_receipts`, `ar_verify_chain`) for querying and verifying the local audit trail
 
 See [Installation](/openclaw/installation/) to get started.
 
@@ -36,7 +36,7 @@ OpenClaw agent makes a tool call
     v
  after_tool_call hook
     |  - record outcome (success / failure)
-    |  - sign receipt (Ed25519)
+    |  - sign receipt (Ed25519, using keyPath key — or forward to agent-receipts-daemon if daemonForwarding: true)
     |  - chain to previous receipt (SHA-256 hash link)
     |  - store in SQLite
     v


### PR DESCRIPTION
## What

Track 4 items from issue #291 — previously blocked on ADR-0010 shipping and the openclaw repo being public. Both gates are now cleared: v0.8.0 shipped the daemon and `agent-receipts/openclaw` / `@agnt-rcpt/openclaw` are publicly accessible.

## Why

The openclaw docs and blog post described the tamper-evidence guarantee without qualifying that the default configuration holds the signing key in-process (accessible to the agent). The stronger guarantee only holds with `daemonForwarding: true`. Now that the daemon is real, the pages can accurately describe both paths.

## Changes

**openclaw/overview.mdx**
- B5: "Signs a W3C Verifiable Credential receipt" bullet notes in-process is the default; `daemonForwarding: true` moves signing to `agent-receipts-daemon`
- B15: repo and package are now verifiably public — no text change needed
- Diagram signing step updated to mention daemon forwarding alternative
- D15: "so the agent can query and verify its own audit trail" → "for querying and verifying the local audit trail" (avoids implying independent audit of self)

**openclaw/installation.mdx**
- D29: `keyPath` annotated as the in-process signing key (not used when `daemonForwarding: true`); `daemonForwarding` config option added to the default config block; explanatory paragraph added linking to Daemon Setup

**openclaw/agent-tools.mdx**
- B12: caution block expanded — the "valid chain" guarantee now explains that strength depends on key location; in-process default vs. daemon; `daemonForwarding: true` restores full tamper-evidence

**blog/openclaw-plugin-deep-dive.mdx**
- B10: "Without the key, the chain is tamper-evident" — caveat added: default config stores the key on disk accessible to the agent process; `daemonForwarding` moves it to a separate process outside the agent's reach

## Checklist

- [x] Tests pass for all changed components (site-only content change, no code)
- [x] Linter passes (no applicable linters for MDX)
- [x] No real keys or secrets in the diff
