### PR TITLE
docs(site): Track 5 HIGH diagrams — Gap 1.1, 2.1, 3.1, 4.1 (issue #291)

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -119,7 +119,7 @@ AI agents are increasingly acting on behalf of humans — sending emails, modify
 
 ```mermaid
 graph LR
-  subgraph ap["Agent process"]
+  subgraph ap["Emitter process"]
     A["Agent / plugin / proxy"]
   end
   A -- "Unix socket" --> D

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -117,6 +117,20 @@ It sits in front of an MCP server you already use and gives you:
 
 AI agents are increasingly acting on behalf of humans — sending emails, modifying documents, making purchases, managing files. Observability platforms like LangSmith and Arize provide valuable operational telemetry but are designed for debugging and monitoring, not cryptographic proof of authorization or identity. Agent Receipts produces a tamper-evident record using the same Ed25519 and SHA-256 primitives the space already converged on, wrapped in the W3C Verifiable Credentials envelope — reusing standards, not authoring a new one. The EU AI Act mandates traceability for high-risk AI systems (Article 12); Agent Receipts produces a record that meets that bar.
 
+```mermaid
+graph LR
+  subgraph ap["Agent process"]
+    A["Agent / plugin / proxy"]
+  end
+  A -- "Unix socket" --> D
+  subgraph dp["agent-receipts-daemon"]
+    D[daemon]
+    D --> K[(Ed25519 key)]
+    D --> DB[(receipts.db)]
+  end
+  V["agent-receipts verify"] -- "read-only" --> DB
+```
+
 ## What is an Agent Receipt?
 
 An **Agent Receipt** is a cryptographically signed record of a single action taken by an AI agent on behalf of a human. Each receipt is structured as a [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) with type `AgentReceipt`, signed with Ed25519, and hash-chained into a tamper-evident log.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -49,8 +49,8 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```mermaid
 graph LR
-  C[MCP Client] --- |"stdio / JSON-RPC"| P[mcp-proxy]
-  P --- |"stdio / JSON-RPC"| S[MCP Server]
+  C[MCP Client] ---|"stdio / JSON-RPC"| P[mcp-proxy]
+  P ---|"stdio / JSON-RPC"| S[MCP Server]
   P -- "Unix socket" --> D[agent-receipts-daemon]
   D --> DB[(receipts.db)]
 ```

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -49,8 +49,8 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```mermaid
 graph LR
-  C[MCP Client] -- "stdio / JSON-RPC" --> P[mcp-proxy]
-  P -- "stdio / JSON-RPC" --> S[MCP Server]
+  C[MCP Client] <-- "stdio / JSON-RPC" --> P[mcp-proxy]
+  P <-- "stdio / JSON-RPC" --> S[MCP Server]
   P -- "Unix socket" --> D[agent-receipts-daemon]
   D --> DB[(receipts.db)]
 ```

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -49,8 +49,8 @@ The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, for
 
 ```mermaid
 graph LR
-  C[MCP Client] <-- "stdio / JSON-RPC" --> P[mcp-proxy]
-  P <-- "stdio / JSON-RPC" --> S[MCP Server]
+  C[MCP Client] --- |"stdio / JSON-RPC"| P[mcp-proxy]
+  P --- |"stdio / JSON-RPC"| S[MCP Server]
   P -- "Unix socket" --> D[agent-receipts-daemon]
   D --> DB[(receipts.db)]
 ```

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -47,6 +47,14 @@ MCP Client (Claude Desktop / Claude Code)
 
 The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call produces a locally signed Agent Receipt. When `--socket` points to a running `agent-receipts-daemon`, events are also forwarded for an independently signed chain.
 
+```mermaid
+graph LR
+  C[MCP Client] -- "stdio / JSON-RPC" --> P[mcp-proxy]
+  P -- "stdio / JSON-RPC" --> S[MCP Server]
+  P -- "Unix socket" --> D[agent-receipts-daemon]
+  D --> DB[(receipts.db)]
+```
+
 ## Quick start
 
 ```bash

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -98,8 +98,8 @@ sequenceDiagram
 
   E->>D: event(tool, session_id, input, output) [Unix socket]
   Note over D: capture peer creds (uid, pid, exe_path)
-  Note over D: RFC 8785 canonicalize<br/>hash input → parameters_hash<br/>hash output → response_hash<br/>(plaintext not stored)
-  Note over D: SHA-256 of this receipt → next receipt's prev_hash
+  Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
+  Note over D: SHA-256 of this receipt → next receipt's chain.previous_receipt_hash
   Note over D: Ed25519 sign
   D->>DB: insert signed receipt
 ```

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -96,10 +96,10 @@ sequenceDiagram
   participant D as agent-receipts-daemon
   participant DB as receipts.db
 
-  E->>D: event(tool, input, output, session_id) [Unix socket]
+  E->>D: event(tool, session_id, input, output) [Unix socket]
   Note over D: capture peer creds (uid, pid, exe_path)
-  Note over D: RFC 8785 canonicalize
-  Note over D: SHA-256 → chain link (prev_hash)
+  Note over D: RFC 8785 canonicalize<br/>hash input → parameters_hash<br/>hash output → response_hash<br/>(plaintext not stored)
+  Note over D: SHA-256 of this receipt → next receipt's prev_hash
   Note over D: Ed25519 sign
   D->>DB: insert signed receipt
 ```

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -88,7 +88,7 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 3. Sign the canonical bytes with the issuer's **Ed25519** private key
 4. Encode the signature as **u-prefixed base64url** (no padding) and attach as `proof.proofValue`
 
-In the reference implementation, steps 2–4 are performed by the `agent-receipts` daemon. The emitter (agent, mcp-proxy, or SDK) sends the receipt fields over a Unix socket; the daemon canonicalizes, signs, and stores the result. The issuer process never holds the private key.
+In the reference implementation, steps 2–4 are performed by the `agent-receipts` daemon. The emitter (agent, mcp-proxy, or SDK) sends an event frame over a Unix socket; the daemon builds the receipt fields from that frame, then canonicalizes, signs, and stores the result. The issuer process never holds the private key.
 
 ```mermaid
 sequenceDiagram

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -90,6 +90,20 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 
 In the reference implementation, steps 2–4 are performed by the `agent-receipts` daemon. The emitter (agent, mcp-proxy, or SDK) sends the receipt fields over a Unix socket; the daemon canonicalizes, signs, and stores the result. The issuer process never holds the private key.
 
+```mermaid
+sequenceDiagram
+  participant E as Emitter (plugin / proxy / SDK)
+  participant D as agent-receipts-daemon
+  participant DB as receipts.db
+
+  E->>D: event(tool, input, output, session_id) [Unix socket]
+  Note over D: capture peer creds (uid, pid, exe_path)
+  Note over D: RFC 8785 canonicalize
+  Note over D: SHA-256 → chain link (prev_hash)
+  Note over D: Ed25519 sign
+  D->>DB: insert signed receipt
+```
+
 The same canonical bytes are also SHA-256 hashed to produce the link for the *next* receipt in the chain.
 
 ## How receipts chain

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -96,7 +96,8 @@ sequenceDiagram
   participant D as agent-receipts-daemon
   participant DB as receipts.db
 
-  E->>D: event(tool, session_id, input, output) [Unix socket]
+  E->>D: emitter frame (tool, session_id, channel, decision, input?, output?) [Unix socket]
+  Note over D: daemon builds receipt fields from frame
   Note over D: capture peer creds (uid, pid, exe_path)
   Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
   Note over D: SHA-256 of this receipt → next receipt's chain.previous_receipt_hash

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -96,7 +96,7 @@ sequenceDiagram
   participant D as agent-receipts-daemon
   participant DB as receipts.db
 
-  E->>D: emitter frame (tool, session_id, channel, decision, input?, output?) [Unix socket]
+  E->>D: emitter frame (v, ts_emit, tool, session_id, channel, decision, input?, output?, error?) [Unix socket]
   Note over D: daemon builds receipt fields from frame
   Note over D: capture peer creds (uid, pid, exe_path)
   Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>hash output → outcome.response_hash<br/>(plaintext not stored)

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -62,7 +62,7 @@ flowchart TD
   F -->|pass| G[Check sequence increments by 1]
   G -->|fail| Z
   G -->|pass| B
-  E -->|no| H[Chain valid ✓]
+  E -->|no| H[Chain integrity verified ✓]
 ```
 
 ## Canonical form
@@ -83,7 +83,7 @@ To verify a receipt chain:
    - **b.** Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of *R(i)* with the `proof` field removed.
    - **c.** If *i < n - 1*, confirm *R(i+1)*'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
 3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1.
-4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null`.
+4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null` and `chain.sequence` is `1`.
 
 If any step fails, the chain is broken at that point. Receipts before the break may still be individually valid; receipts after are suspect.
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -48,12 +48,14 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 
 ```mermaid
 flowchart TD
-  A[Load chain ordered by sequence] --> B[For each receipt R_i]
+  A[Load chain ordered by sequence] --> A2{R_0.prev_hash is null?}
+  A2 -->|no| Z[Chain broken]
+  A2 -->|yes| B[For each receipt R_i]
   B --> C[Verify Ed25519 signature]
-  C -->|fail| Z[Chain broken at R_i]
+  C -->|fail| Z
   C -->|pass| D[SHA-256 canonical form]
   D --> E{Not last receipt?}
-  E -->|yes| F[Check R_i+1.prev_hash matches]
+  E -->|yes| F[Check R_i+1.prev_hash matches digest]
   F -->|fail| Z
   F -->|pass| G[Check sequence increments by 1]
   G -->|fail| Z

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -48,14 +48,14 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 
 ```mermaid
 flowchart TD
-  A[Load chain ordered by sequence] --> A2{R_0.prev_hash is null?}
+  A[Load chain ordered by sequence] --> A2{R_0.chain.previous_receipt_hash is null?}
   A2 -->|no| Z[Chain broken]
   A2 -->|yes| B[For each receipt R_i]
   B --> C[Verify Ed25519 signature]
   C -->|fail| Z
-  C -->|pass| D[SHA-256 canonical form]
+  C -->|pass| D[SHA-256 of canonical form — proof excluded]
   D --> E{Not last receipt?}
-  E -->|yes| F[Check R_i+1.prev_hash matches digest]
+  E -->|yes| F["Check R_i+1.chain.previous_receipt_hash == sha256:digest"]
   F -->|fail| Z
   F -->|pass| G[Check sequence increments by 1]
   G -->|fail| Z

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -50,7 +50,9 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 flowchart TD
   A[Load chain ordered by sequence] --> A2{R_0.chain.previous_receipt_hash is null?}
   A2 -->|no| Z[Chain broken]
-  A2 -->|yes| B[For each receipt R_i]
+  A2 -->|yes| A3{R_0.chain.sequence == 1?}
+  A3 -->|no| Z
+  A3 -->|yes| B[For each receipt R_i]
   B --> C[Verify Ed25519 signature]
   C -->|fail| Z
   C -->|pass| D[SHA-256 of canonical form — proof excluded]

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -46,6 +46,21 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 </svg>
 </div>
 
+```mermaid
+flowchart TD
+  A[Load chain ordered by sequence] --> B[For each receipt R_i]
+  B --> C[Verify Ed25519 signature]
+  C -->|fail| Z[Chain broken at R_i]
+  C -->|pass| D[SHA-256 canonical form]
+  D --> E{Not last receipt?}
+  E -->|yes| F[Check R_i+1.prev_hash matches]
+  F -->|fail| Z
+  F -->|pass| G[Check sequence increments by 1]
+  G -->|fail| Z
+  G -->|pass| B
+  E -->|no| H[Chain valid ✓]
+```
+
 ## Canonical form
 
 For hashing and signing, receipts must be serialized using the **JSON Canonicalization Scheme (RFC 8785)** with the `proof` field removed before hashing. This diverges from the W3C Verifiable Credentials Data Integrity default, which uses JSON-LD canonicalization (RDF Dataset Canonicalization). Implementations expecting JSON-LD processing will not be interoperable with Agent Receipt signatures — existing JSON-LD-based VC tooling cannot verify them without modification.


### PR DESCRIPTION
## What

Four new Mermaid diagrams for the HIGH-priority gaps in issue #291 Track 5, now that ADR-0010 shipped in v0.8.0 and the architecture is stable.

## Why

The site had no diagrams showing the daemon architecture — the central differentiator. Every architecture description was prose-only or SVG showing the old in-process model. These four diagrams cover the most important surfaces.

## Changes

**index.mdx — Gap 1.1** (component diagram)
Shows agent/plugin/proxy connecting to `agent-receipts-daemon` via Unix socket; daemon holds Ed25519 key and `receipts.db`; `agent-receipts verify` reads the DB read-only. Inserted after the value-prop paragraph, before "What is an Agent Receipt?".

**specification/how-it-works.mdx — Gap 2.1** (sequence diagram)
Full tool-call-to-receipt lifecycle: emitter sends event over Unix socket → daemon captures peer creds, RFC 8785 canonicalizes, computes SHA-256 chain link, Ed25519 signs → inserts signed receipt into `receipts.db`. Inserted after the signing-steps paragraph (which already described the daemon), before "How receipts chain".

**specification/receipt-chain-verification.mdx — Gap 3.1** (flowchart)
Chain verification algorithm as a flowchart: for each receipt, verify Ed25519 signature → recompute SHA-256 of canonical form → check `prev_hash` matches → check sequence increments by 1 → fail fast with break position on any failure. Inserted before "Canonical form".

**mcp-proxy/overview.mdx — Gap 4.1** (component diagram)
MCP proxy topology: MCP Client ↔ mcp-proxy ↔ MCP Server (stdio/JSON-RPC both ways) + mcp-proxy → `agent-receipts-daemon` (Unix socket, fire-and-forget) → `receipts.db`. Inserted after the prose paragraph, before "Quick start".

## Checklist

- [x] Tests pass (site-only content change)
- [x] No real keys or secrets in the diff
