### PR TITLE
docs(site): Track 5 existing-diagram fixes — Gap 2.2, 7.1 (issue #291)

### DIFF
--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -55,7 +55,7 @@ sequenceDiagram
 
 `before_tool_call` runs at priority 100 — earlier than most hooks — to capture timing accurately before the tool call starts. It stashes the parameters hash (SHA-256 of the [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON of the arguments) and the start timestamp.
 
-Receipt creation happens in `after_tool_call`. The default path signs in-process and writes to the local SQLite database. With `daemonForwarding: true`, the plugin forwards the event to `agent-receipts-daemon` instead — the daemon signs and stores the receipt; in-process signing is skipped. If receipt creation fails for any reason — signing error, DB write error — the plugin logs a warning and returns cleanly. The agent session continues; the receipt is lost but the tool call is not blocked.
+Receipt creation happens in `after_tool_call`. The default path signs in-process and writes to the local SQLite database. With `daemonForwarding: true`, the plugin forwards the event to `agent-receipts-daemon` instead — the daemon signs and stores the receipt; in-process signing is skipped. In the default in-process path, signing or DB write failures are caught by the plugin, which logs a warning and returns cleanly. In the daemon-forwarding path, forwarding is fire-and-forget — daemon-side failures are not reported back to the plugin. In both cases the agent session continues; the receipt may be lost but the tool call is not blocked.
 
 ---
 

--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -35,6 +35,7 @@ sequenceDiagram
     participant Plugin as agent-receipts plugin
     participant Tool
     participant DB as SQLite
+    participant Daemon as agent-receipts-daemon
 
     Agent->>OpenClaw: tool call
     OpenClaw->>Plugin: before_tool_call (priority 100)
@@ -42,14 +43,15 @@ sequenceDiagram
     OpenClaw->>Tool: execute
     Tool-->>OpenClaw: result / error
     OpenClaw->>Plugin: after_tool_call
-    Note over Plugin: classify action + risk<br/>build receipt<br/>sign Ed25519<br/>hash + chain to previous
+    Note over Plugin: classify action + risk<br/>build receipt<br/>sign Ed25519 (in-process, default)
     Plugin->>DB: insert receipt
+    Plugin-->>Daemon: forward event [if daemonForwarding: true]
     OpenClaw-->>Agent: tool result
 ```
 
 `before_tool_call` runs at priority 100 — earlier than most hooks — to capture timing accurately before the tool call starts. It stashes the parameters hash (SHA-256 of the [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON of the arguments) and the start timestamp.
 
-Receipt creation happens in `after_tool_call`. If receipt creation fails for any reason — signing error, DB write error — the plugin logs a warning and returns cleanly. The agent session continues; the receipt is lost but the tool call is not blocked.
+Receipt creation happens in `after_tool_call`. The default path signs in-process and writes to the local SQLite database. With `daemonForwarding: true`, the plugin also forwards the event to `agent-receipts-daemon` over a Unix socket; the daemon signs and stores an independent receipt. If receipt creation fails for any reason — signing error, DB write error — the plugin logs a warning and returns cleanly. The agent session continues; the receipt is lost but the tool call is not blocked.
 
 ---
 

--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -43,9 +43,13 @@ sequenceDiagram
     OpenClaw->>Tool: execute
     Tool-->>OpenClaw: result / error
     OpenClaw->>Plugin: after_tool_call
-    Note over Plugin: classify action + risk<br/>build receipt<br/>sign Ed25519 (in-process, default)
-    Plugin->>DB: insert receipt
-    Plugin-->>Daemon: forward event [if daemonForwarding: true]
+    Note over Plugin: classify action + risk<br/>build receipt
+    alt daemonForwarding: false (default)
+      Note over Plugin: sign Ed25519 in-process
+      Plugin->>DB: insert receipt
+    else daemonForwarding: true
+      Plugin-->>Daemon: forward event [fire-and-forget]
+    end
     OpenClaw-->>Agent: tool result
 ```
 

--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -55,7 +55,7 @@ sequenceDiagram
 
 `before_tool_call` runs at priority 100 — earlier than most hooks — to capture timing accurately before the tool call starts. It stashes the parameters hash (SHA-256 of the [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON of the arguments) and the start timestamp.
 
-Receipt creation happens in `after_tool_call`. The default path signs in-process and writes to the local SQLite database. With `daemonForwarding: true`, the plugin also forwards the event to `agent-receipts-daemon` over a Unix socket; the daemon signs and stores an independent receipt. If receipt creation fails for any reason — signing error, DB write error — the plugin logs a warning and returns cleanly. The agent session continues; the receipt is lost but the tool call is not blocked.
+Receipt creation happens in `after_tool_call`. The default path signs in-process and writes to the local SQLite database. With `daemonForwarding: true`, the plugin forwards the event to `agent-receipts-daemon` instead — the daemon signs and stores the receipt; in-process signing is skipped. If receipt creation fails for any reason — signing error, DB write error — the plugin logs a warning and returns cleanly. The agent session continues; the receipt is lost but the tool call is not blocked.
 
 ---
 

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -83,6 +83,8 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 </svg>
 </div>
 
+*All steps above are performed by `agent-receipts-daemon`. The emitter sends the raw receipt fields; the daemon owns the key and produces the signed receipt.*
+
 1. Start with the receipt fields (everything except `proof`)
 2. Serialize to **RFC 8785** canonical JSON — deterministic byte ordering
 3. Sign the canonical bytes with the issuer's **Ed25519** private key

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -83,7 +83,7 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 </svg>
 </div>
 
-*Steps 2–4 (canonicalization, signing, storage) are performed by `agent-receipts-daemon` in the reference implementation. The emitter supplies the receipt fields (step 1) and sends them over a Unix socket; the daemon owns the key.*
+*Steps 2–4 (canonicalization, signing, and signature encoding) are performed by `agent-receipts-daemon` in the reference implementation. The emitter supplies the receipt fields (step 1) and sends them over a Unix socket; the daemon owns the key and stores the result.*
 
 1. Start with the receipt fields (everything except `proof`)
 2. Serialize to **RFC 8785** canonical JSON — deterministic byte ordering

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -83,7 +83,7 @@ Before a receipt can be trusted, it needs a cryptographic signature proving the 
 </svg>
 </div>
 
-*All steps above are performed by `agent-receipts-daemon`. The emitter sends the raw receipt fields; the daemon owns the key and produces the signed receipt.*
+*Steps 2–4 (canonicalization, signing, storage) are performed by `agent-receipts-daemon` in the reference implementation. The emitter supplies the receipt fields (step 1) and sends them over a Unix socket; the daemon owns the key.*
 
 1. Start with the receipt fields (everything except `proof`)
 2. Serialize to **RFC 8785** canonical JSON — deterministic byte ordering


### PR DESCRIPTION
## What

Existing-diagram fixes for Track 5 of issue #291. Two files updated; two gaps already resolved by earlier PRs.

## Why

The signing SVG in `how-it-works.mdx` showed no process boundary (who holds the key). The blog Mermaid showed pure in-process signing, which conflicts with the daemon architecture now that ADR-0010 shipped.

## Changes

**specification/how-it-works.mdx — Gap 2.2**
Italic caption added below the signing pipeline SVG: clarifies that RFC 8785 canonicalization, Ed25519 signing, and storage are all performed by `agent-receipts-daemon`; the emitter sends raw fields and never touches the key.

**blog/openclaw-plugin-deep-dive.mdx — Gap 7.1**
Hook pipeline Mermaid updated:
- `agent-receipts-daemon` added as a participant
- `Note over Plugin` for `after_tool_call` updated from "sign Ed25519 / hash + chain to previous" (pure in-process) to "sign Ed25519 (in-process, default)"
- Optional forwarding arrow to daemon added (`[if daemonForwarding: true]`)
- Prose paragraph below updated to describe both paths (default in-process + daemon forwarding)

**Already handled:**
- Gap 1.2 (homepage SVG): labelled as conceptual overview in PR #392
- Gap 6.1 (openclaw ASCII art): updated with `daemonForwarding` caveat in PR #397

## Checklist

- [x] Tests pass (site-only content change)
- [x] No real keys or secrets in the diff
