### PR TITLE
feat(sdk/go): drop counter + events_dropped synthetic receipt (#391)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -317,6 +317,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	pp := pipeline.New(state, ks, st, cfg.IssuerID)
 	pp.TraceLog = cfg.TraceLog
+	pp.ErrorLog = cfg.Logger.Printf
 
 	ln, err := socket.Listen(socket.Options{
 		Path:     cfg.SocketPath,

--- a/daemon/internal/chain/state.go
+++ b/daemon/internal/chain/state.go
@@ -187,6 +187,9 @@ func (s *State) AllocatePair() PairAlloc {
 // for the second slot. The mutex remains held. Must be called at most once and
 // only after the first receipt was inserted successfully.
 func (p PairAlloc) CommitFirst(firstHash string) Allocation {
+	if p.state == nil {
+		panic("chain.PairAlloc: CommitFirst on zero-value PairAlloc")
+	}
 	p.state.nextSeq = p.FirstSeq + 1
 	h := firstHash
 	p.state.prevHash = &h
@@ -202,5 +205,8 @@ func (p PairAlloc) CommitFirst(firstHash string) Allocation {
 // insert fails, or as a deferred panic-safety guard. No-op after CommitFirst
 // (the second Allocation's Rollback handles cleanup instead).
 func (p PairAlloc) Rollback() {
+	if p.state == nil {
+		panic("chain.PairAlloc: Rollback on zero-value PairAlloc")
+	}
 	p.release.Do(func() { p.state.mu.Unlock() })
 }

--- a/daemon/internal/chain/state.go
+++ b/daemon/internal/chain/state.go
@@ -144,19 +144,26 @@ func (a Allocation) Rollback() {
 // Usage:
 //
 //	pair := state.AllocatePair()
-//	// build and insert first receipt using pair.FirstAllocation()
+//	defer pair.Rollback() // panic-safety: releases lock if CommitFirst never called
+//	// build first receipt using pair.FirstSeq and pair.FirstPrev
 //	second := pair.CommitFirst(firstHash)  // advances seq, keeps lock held
-//	// build and insert second receipt using second
+//	defer second.Rollback()                // panic-safety: releases lock if Commit never called
+//	// build second receipt using second.Sequence and second.PrevHash
 //	second.Commit(secondHash)              // advances seq, releases lock
+//
+// FirstSeq and FirstPrev expose the first slot's chain position directly.
+// There is no Allocation for the first slot — using plain values prevents
+// callers from accidentally calling Rollback on the first slot (which would
+// release the mutex prematurely and leave the second slot unguarded).
 //
 // Call pair.Rollback() if the first insert fails (releases lock, no advance).
 // Call second.Rollback() if the second insert fails (releases lock; chain is
-// at firstSeq+1 since CommitFirst already advanced it).
+// at FirstSeq+1 since CommitFirst already advanced it).
 type PairAlloc struct {
-	state    *State
-	firstSeq int64
-	prevHash *string // prev_hash for the first slot
-	release  *sync.Once
+	state     *State
+	FirstSeq  int64   // sequence number for the first slot
+	FirstPrev *string // prev_hash for the first slot; nil for the chain's first receipt
+	release   *sync.Once
 }
 
 // AllocatePair atomically reserves two consecutive chain slots. The State
@@ -170,22 +177,9 @@ func (s *State) AllocatePair() PairAlloc {
 	}
 	return PairAlloc{
 		state:    s,
-		firstSeq: s.nextSeq,
-		prevHash: prev,
+		FirstSeq: s.nextSeq,
+		FirstPrev: prev,
 		release:  &sync.Once{},
-	}
-}
-
-// FirstAllocation returns the Allocation for the first slot. Its Commit and
-// Rollback are no-ops — use CommitFirst and Rollback on PairAlloc instead.
-func (p PairAlloc) FirstAllocation() Allocation {
-	exhausted := &sync.Once{}
-	exhausted.Do(func() {}) // mark as done so Commit/Rollback are no-ops
-	return Allocation{
-		state:    p.state,
-		Sequence: p.firstSeq,
-		PrevHash: p.prevHash,
-		release:  exhausted,
 	}
 }
 
@@ -193,20 +187,20 @@ func (p PairAlloc) FirstAllocation() Allocation {
 // for the second slot. The mutex remains held. Must be called at most once and
 // only after the first receipt was inserted successfully.
 func (p PairAlloc) CommitFirst(firstHash string) Allocation {
-	p.state.nextSeq = p.firstSeq + 1
+	p.state.nextSeq = p.FirstSeq + 1
 	h := firstHash
 	p.state.prevHash = &h
 	return Allocation{
 		state:    p.state,
-		Sequence: p.firstSeq + 1,
+		Sequence: p.FirstSeq + 1,
 		PrevHash: &h,
 		release:  p.release, // second Commit/Rollback releases the outer lock
 	}
 }
 
 // Rollback releases the mutex without advancing the chain. Use when the first
-// insert fails. No-op after CommitFirst (the second Allocation's Rollback
-// handles cleanup instead).
+// insert fails, or as a deferred panic-safety guard. No-op after CommitFirst
+// (the second Allocation's Rollback handles cleanup instead).
 func (p PairAlloc) Rollback() {
 	p.release.Do(func() { p.state.mu.Unlock() })
 }

--- a/daemon/internal/chain/state.go
+++ b/daemon/internal/chain/state.go
@@ -136,3 +136,77 @@ func (a Allocation) Rollback() {
 		a.state.mu.Unlock()
 	})
 }
+
+// PairAlloc reserves two consecutive chain slots under a single mutex
+// acquisition, guaranteeing the two receipts are adjacent in the chain even
+// when Process is called concurrently from multiple emitter connections.
+//
+// Usage:
+//
+//	pair := state.AllocatePair()
+//	// build and insert first receipt using pair.FirstAllocation()
+//	second := pair.CommitFirst(firstHash)  // advances seq, keeps lock held
+//	// build and insert second receipt using second
+//	second.Commit(secondHash)              // advances seq, releases lock
+//
+// Call pair.Rollback() if the first insert fails (releases lock, no advance).
+// Call second.Rollback() if the second insert fails (releases lock; chain is
+// at firstSeq+1 since CommitFirst already advanced it).
+type PairAlloc struct {
+	state    *State
+	firstSeq int64
+	prevHash *string // prev_hash for the first slot
+	release  *sync.Once
+}
+
+// AllocatePair atomically reserves two consecutive chain slots. The State
+// mutex is held until CommitFirst+second.Commit or Rollback is called.
+func (s *State) AllocatePair() PairAlloc {
+	s.mu.Lock()
+	var prev *string
+	if s.prevHash != nil {
+		v := *s.prevHash
+		prev = &v
+	}
+	return PairAlloc{
+		state:    s,
+		firstSeq: s.nextSeq,
+		prevHash: prev,
+		release:  &sync.Once{},
+	}
+}
+
+// FirstAllocation returns the Allocation for the first slot. Its Commit and
+// Rollback are no-ops — use CommitFirst and Rollback on PairAlloc instead.
+func (p PairAlloc) FirstAllocation() Allocation {
+	exhausted := &sync.Once{}
+	exhausted.Do(func() {}) // mark as done so Commit/Rollback are no-ops
+	return Allocation{
+		state:    p.state,
+		Sequence: p.firstSeq,
+		PrevHash: p.prevHash,
+		release:  exhausted,
+	}
+}
+
+// CommitFirst advances the chain past the first slot and returns an Allocation
+// for the second slot. The mutex remains held. Must be called at most once and
+// only after the first receipt was inserted successfully.
+func (p PairAlloc) CommitFirst(firstHash string) Allocation {
+	p.state.nextSeq = p.firstSeq + 1
+	h := firstHash
+	p.state.prevHash = &h
+	return Allocation{
+		state:    p.state,
+		Sequence: p.firstSeq + 1,
+		PrevHash: &h,
+		release:  p.release, // second Commit/Rollback releases the outer lock
+	}
+}
+
+// Rollback releases the mutex without advancing the chain. Use when the first
+// insert fails. No-op after CommitFirst (the second Allocation's Rollback
+// handles cleanup instead).
+func (p PairAlloc) Rollback() {
+	p.release.Do(func() { p.state.mu.Unlock() })
+}

--- a/daemon/internal/chain/state_test.go
+++ b/daemon/internal/chain/state_test.go
@@ -158,12 +158,11 @@ func TestAllocatePair_AdjacentSequences(t *testing.T) {
 	s := New("c")
 	pair := s.AllocatePair()
 
-	first := pair.FirstAllocation()
-	if first.Sequence != 1 {
-		t.Errorf("first.Sequence = %d, want 1", first.Sequence)
+	if pair.FirstSeq != 1 {
+		t.Errorf("FirstSeq = %d, want 1", pair.FirstSeq)
 	}
-	if first.PrevHash != nil {
-		t.Errorf("first.PrevHash = %v, want nil", first.PrevHash)
+	if pair.FirstPrev != nil {
+		t.Errorf("FirstPrev = %v, want nil", pair.FirstPrev)
 	}
 
 	second := pair.CommitFirst("hash-1")

--- a/daemon/internal/chain/state_test.go
+++ b/daemon/internal/chain/state_test.go
@@ -154,6 +154,105 @@ func TestCommitAfterRollbackIsNoOp(t *testing.T) {
 	}
 }
 
+func TestAllocatePair_AdjacentSequences(t *testing.T) {
+	s := New("c")
+	pair := s.AllocatePair()
+
+	first := pair.FirstAllocation()
+	if first.Sequence != 1 {
+		t.Errorf("first.Sequence = %d, want 1", first.Sequence)
+	}
+	if first.PrevHash != nil {
+		t.Errorf("first.PrevHash = %v, want nil", first.PrevHash)
+	}
+
+	second := pair.CommitFirst("hash-1")
+	if second.Sequence != 2 {
+		t.Errorf("second.Sequence = %d, want 2", second.Sequence)
+	}
+	if second.PrevHash == nil || *second.PrevHash != "hash-1" {
+		t.Errorf("second.PrevHash = %v, want hash-1", second.PrevHash)
+	}
+
+	second.Commit("hash-2")
+
+	// Next allocation must be at seq 3.
+	next := s.Allocate()
+	defer next.Rollback()
+	if next.Sequence != 3 {
+		t.Errorf("post-pair next.Sequence = %d, want 3", next.Sequence)
+	}
+	if next.PrevHash == nil || *next.PrevHash != "hash-2" {
+		t.Errorf("post-pair next.PrevHash = %v, want hash-2", next.PrevHash)
+	}
+}
+
+// TestAllocatePair_RollbackBeforeCommitFirst verifies that rolling back the
+// pair before CommitFirst is called leaves the chain unchanged.
+func TestAllocatePair_RollbackBeforeCommitFirst(t *testing.T) {
+	s := New("c")
+	pair := s.AllocatePair()
+	pair.Rollback()
+
+	// Chain must be unchanged: next Allocate should give seq 1.
+	a := s.Allocate()
+	defer a.Rollback()
+	if a.Sequence != 1 {
+		t.Errorf("after Rollback, seq = %d, want 1", a.Sequence)
+	}
+}
+
+// TestAllocatePair_RollbackAfterCommitFirst verifies that rolling back the
+// second allocation (after CommitFirst) leaves the chain at seq 2 (first slot
+// committed, second rolled back).
+func TestAllocatePair_RollbackAfterCommitFirst(t *testing.T) {
+	s := New("c")
+	pair := s.AllocatePair()
+	second := pair.CommitFirst("hash-1")
+	second.Rollback() // second slot not committed
+
+	// Chain is at seq 2 (first was committed by CommitFirst).
+	a := s.Allocate()
+	defer a.Rollback()
+	if a.Sequence != 2 {
+		t.Errorf("after CommitFirst+Rollback, seq = %d, want 2", a.Sequence)
+	}
+	if a.PrevHash == nil || *a.PrevHash != "hash-1" {
+		t.Errorf("after CommitFirst+Rollback, prev_hash = %v, want hash-1", a.PrevHash)
+	}
+}
+
+// TestAllocatePair_ConcurrentNoInterleave is the core regression: concurrent
+// Allocate calls must not interleave with an active AllocatePair.
+func TestAllocatePair_ConcurrentNoInterleave(t *testing.T) {
+	s := New("c")
+
+	// Hold a pair allocation and attempt concurrent Allocate from a goroutine.
+	pair := s.AllocatePair()
+
+	var goroutineSeq int64
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		a := s.Allocate() // must block until pair is fully committed
+		goroutineSeq = a.Sequence
+		a.Rollback()
+		close(done)
+	}()
+	<-started
+
+	// Complete the pair.
+	second := pair.CommitFirst("h1")
+	second.Commit("h2")
+
+	<-done
+	// Goroutine got seq 3 (after both pair slots committed).
+	if goroutineSeq != 3 {
+		t.Errorf("goroutine seq = %d, want 3 (pair held lock for both slots)", goroutineSeq)
+	}
+}
+
 func TestDoubleRollbackIsNoOp(t *testing.T) {
 	s := New("c")
 	a := s.Allocate()

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -105,19 +105,17 @@ func New(s *chain.State, ks keysource.KeySource, store store.ReceiptStore, issue
 }
 
 // Process is the daemon's per-frame entrypoint. It parses the frame, allocates
-// the next chain slot, builds and signs the AgentReceipt, persists it via
-// store.Insert, and Commits the chain allocation. Any error before Commit
-// triggers Rollback so the chain state is not advanced past a missing receipt.
+// the next chain slot(s), builds and signs the AgentReceipt(s), persists them
+// via store.Insert, and commits the chain allocation. A non-nil return always
+// means the live receipt was NOT persisted.
 //
-// When the frame carries a positive DropCount, Process first inserts a
-// synthetic events_dropped receipt (in its own allocation) that makes the gap
-// visible in the chain before the live receipt.
-//
-// Rollback is deferred — and chain.Allocation.Commit/Rollback are idempotent
-// via sync.Once — so the chain mutex is released even if buildAndSign or
-// Store.Insert panics. Without that guarantee, a single panicking frame would
-// orphan the lock and deadlock the daemon for every subsequent emitter on the
-// same socket.
+// When the frame carries a positive DropCount, Process uses chain.AllocatePair
+// to reserve two consecutive slots under one mutex acquisition, guaranteeing
+// the synthetic events_dropped receipt and the live receipt are adjacent in the
+// chain even under concurrent emitter connections. If the synthetic insert
+// fails, Process logs the error and falls back to a normal single-slot insert
+// for the live receipt — the gap becomes invisible in that edge case but the
+// live receipt is still preserved.
 func (p *Pipeline) Process(f socket.Frame) error {
 	var frame EmitterFrame
 	if err := json.Unmarshal(f.Payload, &frame); err != nil {
@@ -130,23 +128,67 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	p.trace("frame received: session=%s channel=%s tool=%s drop_count=%d",
 		frame.SessionID, frame.Channel, frame.Tool.Name, frame.DropCount)
 
-	// Attempt the synthetic events_dropped receipt first. On failure, log
-	// via ErrorLog and continue: the live receipt is more important than
-	// the gap notification, and the chain allocation is rolled back on
-	// failure so the live receipt still gets the correct sequence number.
-	// Process returns nil when the live receipt is committed — a non-nil
-	// return always means the live receipt was NOT persisted.
 	if frame.DropCount > 0 {
-		if err := p.insertDropReceipt(&frame, f.Peer); err != nil {
-			p.logError("insert events_dropped receipt (drop_count=%d session=%s): %v",
-				frame.DropCount, frame.SessionID, err)
-		}
+		return p.processWithDrop(&frame, f.Peer)
+	}
+	return p.processLive(&frame, f.Peer)
+}
+
+// processWithDrop inserts a synthetic events_dropped receipt immediately
+// followed by the live receipt, holding one AllocatePair lock across both
+// inserts so they are guaranteed adjacent. On synthetic failure it logs and
+// falls back to processLive for the live receipt alone.
+func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) error {
+	pair := p.State.AllocatePair()
+
+	synAlloc := pair.FirstAllocation()
+	synthetic, synHash, err := p.buildAndSignDropReceipt(frame.DropCount, frame.SessionID, peer, synAlloc)
+	if err != nil {
+		pair.Rollback()
+		p.logError("build events_dropped receipt (drop_count=%d session=%s): %v",
+			frame.DropCount, frame.SessionID, err)
+		return p.processLive(frame, peer)
+	}
+	p.trace("events_dropped receipt: session=%s drop_count=%d seq=%d",
+		frame.SessionID, frame.DropCount, synAlloc.Sequence)
+
+	if err := p.Store.Insert(synthetic, synHash); err != nil {
+		pair.Rollback()
+		p.logError("insert events_dropped receipt (drop_count=%d session=%s): %v",
+			frame.DropCount, frame.SessionID, err)
+		return p.processLive(frame, peer)
 	}
 
+	// CommitFirst advances the chain past the synthetic slot and returns the
+	// allocation for the live receipt. The mutex remains held so no other
+	// frame can interleave between the two receipts.
+	liveAlloc := pair.CommitFirst(synHash)
+
+	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc)
+	if err != nil {
+		liveAlloc.Rollback() // releases lock; chain is at synAlloc.Sequence+1
+		return err
+	}
+	p.trace("receipt signed: seq=%d hash=%s", liveAlloc.Sequence, liveHash)
+
+	if err := p.Store.Insert(live, liveHash); err != nil {
+		liveAlloc.Rollback()
+		return fmt.Errorf("insert receipt: %w", err)
+	}
+	p.trace("receipt stored: seq=%d", liveAlloc.Sequence)
+
+	liveAlloc.Commit(liveHash)
+	return nil
+}
+
+// processLive allocates one chain slot, builds, inserts, and commits the live
+// receipt. Used for frames with DropCount == 0 and as fallback when the
+// synthetic insert fails.
+func (p *Pipeline) processLive(frame *EmitterFrame, peer socket.PeerCred) error {
 	alloc := p.State.Allocate()
 	defer alloc.Rollback()
 
-	signed, hash, err := p.buildAndSign(&frame, f.Peer, alloc)
+	signed, hash, err := p.buildAndSign(frame, peer, alloc)
 	if err != nil {
 		return err
 	}
@@ -156,29 +198,6 @@ func (p *Pipeline) Process(f socket.Frame) error {
 		return fmt.Errorf("insert receipt: %w", err)
 	}
 	p.trace("receipt stored: seq=%d", alloc.Sequence)
-
-	alloc.Commit(hash)
-	return nil
-}
-
-// insertDropReceipt allocates a chain slot, builds a synthetic events_dropped
-// receipt encoding the emitter's drop count, and commits. Called by Process
-// before the live receipt when frame.DropCount > 0.
-func (p *Pipeline) insertDropReceipt(frame *EmitterFrame, peer socket.PeerCred) error {
-	alloc := p.State.Allocate()
-	defer alloc.Rollback()
-
-	p.trace("events_dropped receipt: session=%s drop_count=%d seq=%d",
-		frame.SessionID, frame.DropCount, alloc.Sequence)
-
-	signed, hash, err := p.buildAndSignDropReceipt(frame.DropCount, frame.SessionID, peer, alloc)
-	if err != nil {
-		return err
-	}
-
-	if err := p.Store.Insert(signed, hash); err != nil {
-		return fmt.Errorf("insert drop receipt: %w", err)
-	}
 
 	alloc.Commit(hash)
 	return nil
@@ -438,7 +457,7 @@ func (p *Pipeline) buildAndSignDropReceipt(
 			RiskLevel: receipt.RiskLow,
 			Timestamp: now,
 			ParametersDisclosure: map[string]string{
-				"drop_count":    strconv.FormatInt(dropCount, 10),
+				"emitter.drop_count": strconv.FormatInt(dropCount, 10),
 				"peer.platform": peer.Platform,
 				"peer.pid":      strconv.FormatInt(int64(peer.PID), 10),
 				"peer.uid":      strconv.FormatUint(uint64(peer.UID), 10),

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -169,7 +169,7 @@ func (p *Pipeline) insertDropReceipt(frame *EmitterFrame, peer socket.PeerCred) 
 	}
 
 	if err := p.Store.Insert(signed, hash); err != nil {
-		return fmt.Errorf("store insert: %w", err)
+		return fmt.Errorf("insert drop receipt: %w", err)
 	}
 
 	alloc.Commit(hash)

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -79,7 +79,8 @@ type Pipeline struct {
 	Store    store.ReceiptStore
 	IssuerID string // e.g. "did:agent-receipts-daemon:<host>"
 	Now      func() time.Time
-	TraceLog io.Writer // Optional trace log for testing; nil = silent
+	TraceLog io.Writer              // Optional trace log for testing; nil = silent
+	ErrorLog func(string, ...any)   // Optional error logger; nil = silent
 
 	// traceMu serialises writes to TraceLog. Process is invoked concurrently
 	// from the listener accept loop, so unguarded fmt.Fprintf calls would
@@ -129,15 +130,15 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	p.trace("frame received: session=%s channel=%s tool=%s drop_count=%d",
 		frame.SessionID, frame.Channel, frame.Tool.Name, frame.DropCount)
 
-	// Attempt the synthetic events_dropped receipt first. On failure, save
-	// the error but continue: the live receipt is more important than the
-	// gap notification, and the chain allocation is rolled back on failure
-	// so the live receipt still gets the correct sequence number. The
-	// synthetic error is returned at the end so the daemon log captures it.
-	var dropErr error
+	// Attempt the synthetic events_dropped receipt first. On failure, log
+	// via ErrorLog and continue: the live receipt is more important than
+	// the gap notification, and the chain allocation is rolled back on
+	// failure so the live receipt still gets the correct sequence number.
+	// Process returns nil when the live receipt is committed — a non-nil
+	// return always means the live receipt was NOT persisted.
 	if frame.DropCount > 0 {
 		if err := p.insertDropReceipt(&frame, f.Peer); err != nil {
-			dropErr = fmt.Errorf("insert events_dropped receipt (drop_count=%d session=%s): %w",
+			p.logError("insert events_dropped receipt (drop_count=%d session=%s): %v",
 				frame.DropCount, frame.SessionID, err)
 		}
 	}
@@ -157,7 +158,7 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	p.trace("receipt stored: seq=%d", alloc.Sequence)
 
 	alloc.Commit(hash)
-	return dropErr
+	return nil
 }
 
 // insertDropReceipt allocates a chain slot, builds a synthetic events_dropped
@@ -181,6 +182,16 @@ func (p *Pipeline) insertDropReceipt(frame *EmitterFrame, peer socket.PeerCred) 
 
 	alloc.Commit(hash)
 	return nil
+}
+
+// logError calls ErrorLog if it is set. Used for non-fatal conditions where
+// Process still returns nil (e.g., synthetic receipt failure with live receipt
+// committed). Callers hold no locks when calling this.
+func (p *Pipeline) logError(format string, args ...any) {
+	if p.ErrorLog == nil {
+		return
+	}
+	p.ErrorLog(format, args...)
 }
 
 // trace writes a trace line to TraceLog if it's not nil. Safe to call

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -32,6 +32,11 @@ const multibaseBase64URL = "u"
 // misinterpret future fields.
 const SupportedFrameVersion = "1"
 
+// actionTypeEventsDropped is the action type for the daemon-synthesised
+// events_dropped receipt. The "agent_receipts" namespace identifies the daemon
+// as the source rather than a user-facing tool channel.
+const actionTypeEventsDropped = "agent_receipts.events_dropped"
+
 // EmitterFrame is the JSON payload emitters send. Mirrors ADR-0010 §"Schema
 // split". Fields the emitter does not populate are zero/empty; the daemon
 // fills in the authoritative chain/peer/id/ts_recv before signing.
@@ -42,6 +47,11 @@ const SupportedFrameVersion = "1"
 // A literal JSON null (or omitted field) means "no payload" and produces no
 // hash — hashing the literal "null" would falsely commit the daemon to a
 // value the emitter did not send.
+//
+// DropCount, when > 0, records events the emitter dropped (connect/write
+// failures) before this successful send. The daemon inserts a synthetic
+// events_dropped receipt with this count before the live receipt so the gap
+// is visible in the chain.
 type EmitterFrame struct {
 	Version   string          `json:"v"`
 	TsEmit    string          `json:"ts_emit"`
@@ -52,6 +62,7 @@ type EmitterFrame struct {
 	Output    json.RawMessage `json:"output,omitempty"`
 	Error     string          `json:"error,omitempty"`
 	Decision  string          `json:"decision"`
+	DropCount int64           `json:"drop_count,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -97,6 +108,10 @@ func New(s *chain.State, ks keysource.KeySource, store store.ReceiptStore, issue
 // store.Insert, and Commits the chain allocation. Any error before Commit
 // triggers Rollback so the chain state is not advanced past a missing receipt.
 //
+// When the frame carries a positive DropCount, Process first inserts a
+// synthetic events_dropped receipt (in its own allocation) that makes the gap
+// visible in the chain before the live receipt.
+//
 // Rollback is deferred — and chain.Allocation.Commit/Rollback are idempotent
 // via sync.Once — so the chain mutex is released even if buildAndSign or
 // Store.Insert panics. Without that guarantee, a single panicking frame would
@@ -111,7 +126,14 @@ func (p *Pipeline) Process(f socket.Frame) error {
 		return fmt.Errorf("invalid emitter frame: %w", err)
 	}
 
-	p.trace("frame received: session=%s channel=%s tool=%s", frame.SessionID, frame.Channel, frame.Tool.Name)
+	p.trace("frame received: session=%s channel=%s tool=%s drop_count=%d",
+		frame.SessionID, frame.Channel, frame.Tool.Name, frame.DropCount)
+
+	if frame.DropCount > 0 {
+		if err := p.insertDropReceipt(&frame, f.Peer); err != nil {
+			return fmt.Errorf("insert events_dropped receipt: %w", err)
+		}
+	}
 
 	alloc := p.State.Allocate()
 	defer alloc.Rollback()
@@ -126,6 +148,29 @@ func (p *Pipeline) Process(f socket.Frame) error {
 		return fmt.Errorf("insert receipt: %w", err)
 	}
 	p.trace("receipt stored: seq=%d", alloc.Sequence)
+
+	alloc.Commit(hash)
+	return nil
+}
+
+// insertDropReceipt allocates a chain slot, builds a synthetic events_dropped
+// receipt encoding the emitter's drop count, and commits. Called by Process
+// before the live receipt when frame.DropCount > 0.
+func (p *Pipeline) insertDropReceipt(frame *EmitterFrame, peer socket.PeerCred) error {
+	alloc := p.State.Allocate()
+	defer alloc.Rollback()
+
+	p.trace("events_dropped receipt: session=%s drop_count=%d seq=%d",
+		frame.SessionID, frame.DropCount, alloc.Sequence)
+
+	signed, hash, err := p.buildAndSignDropReceipt(frame.DropCount, frame.SessionID, peer, alloc)
+	if err != nil {
+		return err
+	}
+
+	if err := p.Store.Insert(signed, hash); err != nil {
+		return fmt.Errorf("store insert: %w", err)
+	}
 
 	alloc.Commit(hash)
 	return nil
@@ -178,6 +223,9 @@ func validateFrame(f *EmitterFrame) error {
 		// ok
 	default:
 		return fmt.Errorf("unknown decision %q (want allowed|denied|pending)", f.Decision)
+	}
+	if f.DropCount < 0 {
+		return fmt.Errorf("drop_count %d is negative", f.DropCount)
 	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
@@ -327,7 +375,7 @@ func (p *Pipeline) buildAndSign(
 		outcome.ResponseHash = hash
 	}
 
-	unsigned := receipt.Create(receipt.CreateInput{
+	return p.signAndHash(receipt.CreateInput{
 		Issuer: receipt.Issuer{
 			ID:        p.IssuerID,
 			Type:      "AgentReceiptsDaemon",
@@ -341,7 +389,60 @@ func (p *Pipeline) buildAndSign(
 			PreviousReceiptHash: alloc.PrevHash,
 			ChainID:             p.State.ChainID(),
 		},
-	})
+	}, now)
+}
+
+// buildAndSignDropReceipt constructs a synthetic events_dropped receipt that
+// records the emitter's accumulated drop count in the chain. Called by
+// insertDropReceipt when frame.DropCount > 0.
+func (p *Pipeline) buildAndSignDropReceipt(
+	dropCount int64,
+	sessionID string,
+	peer socket.PeerCred,
+	alloc chain.Allocation,
+) (receipt.AgentReceipt, string, error) {
+	now := p.Now().Format(time.RFC3339)
+
+	if alloc.Sequence > int64(math.MaxInt) {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("chain sequence %d exceeds int range on this platform (max %d)", alloc.Sequence, math.MaxInt)
+	}
+
+	return p.signAndHash(receipt.CreateInput{
+		Issuer: receipt.Issuer{
+			ID:        p.IssuerID,
+			Type:      "AgentReceiptsDaemon",
+			SessionID: sessionID,
+		},
+		Principal: receipt.Principal{ID: "did:user:unknown"},
+		Action: receipt.Action{
+			Type:      actionTypeEventsDropped,
+			ToolName:  "events_dropped",
+			RiskLevel: receipt.RiskLow,
+			Timestamp: now,
+			ParametersDisclosure: map[string]string{
+				"drop_count":    strconv.FormatInt(dropCount, 10),
+				"peer.platform": peer.Platform,
+				"peer.pid":      strconv.FormatInt(int64(peer.PID), 10),
+				"peer.uid":      strconv.FormatUint(uint64(peer.UID), 10),
+				"peer.gid":      strconv.FormatUint(uint64(peer.GID), 10),
+				"peer.exe_path": peer.ExePath,
+			},
+		},
+		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain: receipt.Chain{
+			Sequence:            int(alloc.Sequence),
+			PreviousReceiptHash: alloc.PrevHash,
+			ChainID:             p.State.ChainID(),
+		},
+	}, now)
+}
+
+// signAndHash builds, signs, and hashes one receipt. It is the common tail
+// shared by buildAndSign and buildAndSignDropReceipt — both construct a
+// CreateInput, set the issuance timestamp, and then need identical
+// canonicalize → sign → hash steps.
+func (p *Pipeline) signAndHash(in receipt.CreateInput, now string) (receipt.AgentReceipt, string, error) {
+	unsigned := receipt.Create(in)
 	// receipt.Create stamps IssuanceDate from time.Now() internally. Replace it
 	// with our deterministic now so action.timestamp, issuanceDate, and
 	// proof.created all share a single value (and tests can override Now).

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -129,13 +129,15 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	p.trace("frame received: session=%s channel=%s tool=%s drop_count=%d",
 		frame.SessionID, frame.Channel, frame.Tool.Name, frame.DropCount)
 
+	// Attempt the synthetic events_dropped receipt first. On failure, save
+	// the error but continue: the live receipt is more important than the
+	// gap notification, and the chain allocation is rolled back on failure
+	// so the live receipt still gets the correct sequence number. The
+	// synthetic error is returned at the end so the daemon log captures it.
+	var dropErr error
 	if frame.DropCount > 0 {
 		if err := p.insertDropReceipt(&frame, f.Peer); err != nil {
-			// The synthetic receipt failed to persist; the emitter's counter
-			// was already reset, so these drops are now permanently invisible.
-			// Return the error so the socket listener logs it — the live
-			// receipt is still attempted on the next Emit from this emitter.
-			return fmt.Errorf("insert events_dropped receipt (drop_count=%d session=%s): %w",
+			dropErr = fmt.Errorf("insert events_dropped receipt (drop_count=%d session=%s): %w",
 				frame.DropCount, frame.SessionID, err)
 		}
 	}
@@ -155,7 +157,7 @@ func (p *Pipeline) Process(f socket.Frame) error {
 	p.trace("receipt stored: seq=%d", alloc.Sequence)
 
 	alloc.Commit(hash)
-	return nil
+	return dropErr
 }
 
 // insertDropReceipt allocates a chain slot, builds a synthetic events_dropped

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -131,7 +131,12 @@ func (p *Pipeline) Process(f socket.Frame) error {
 
 	if frame.DropCount > 0 {
 		if err := p.insertDropReceipt(&frame, f.Peer); err != nil {
-			return fmt.Errorf("insert events_dropped receipt: %w", err)
+			// The synthetic receipt failed to persist; the emitter's counter
+			// was already reset, so these drops are now permanently invisible.
+			// Return the error so the socket listener logs it — the live
+			// receipt is still attempted on the next Emit from this emitter.
+			return fmt.Errorf("insert events_dropped receipt (drop_count=%d session=%s): %w",
+				frame.DropCount, frame.SessionID, err)
 		}
 	}
 

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -138,11 +138,17 @@ func (p *Pipeline) Process(f socket.Frame) error {
 // followed by the live receipt, holding one AllocatePair lock across both
 // inserts so they are guaranteed adjacent. On synthetic failure it logs and
 // falls back to processLive for the live receipt alone.
+//
+// Panic safety: pair.Rollback() is deferred immediately after AllocatePair so
+// any panic before CommitFirst releases the mutex. After CommitFirst, the
+// returned liveAlloc shares the same release Once so deferring liveAlloc.Rollback()
+// covers panics in the second phase; pair.Rollback() becomes a no-op.
 func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) error {
 	pair := p.State.AllocatePair()
+	defer pair.Rollback() // panic-safety: no-op after CommitFirst
 
-	synAlloc := pair.FirstAllocation()
-	synthetic, synHash, err := p.buildAndSignDropReceipt(frame.DropCount, frame.SessionID, peer, synAlloc)
+	synthetic, synHash, err := p.buildAndSignDropReceipt(
+		frame.DropCount, frame.SessionID, peer, pair.FirstSeq, pair.FirstPrev)
 	if err != nil {
 		pair.Rollback()
 		p.logError("build events_dropped receipt (drop_count=%d session=%s): %v",
@@ -150,7 +156,7 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 		return p.processLive(frame, peer)
 	}
 	p.trace("events_dropped receipt: session=%s drop_count=%d seq=%d",
-		frame.SessionID, frame.DropCount, synAlloc.Sequence)
+		frame.SessionID, frame.DropCount, pair.FirstSeq)
 
 	if err := p.Store.Insert(synthetic, synHash); err != nil {
 		pair.Rollback()
@@ -163,10 +169,11 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 	// allocation for the live receipt. The mutex remains held so no other
 	// frame can interleave between the two receipts.
 	liveAlloc := pair.CommitFirst(synHash)
+	defer liveAlloc.Rollback() // panic-safety; pair.Rollback defer is now a no-op
 
 	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc)
 	if err != nil {
-		liveAlloc.Rollback() // releases lock; chain is at synAlloc.Sequence+1
+		liveAlloc.Rollback() // releases lock; chain is at pair.FirstSeq+1
 		return err
 	}
 	p.trace("receipt signed: seq=%d hash=%s", liveAlloc.Sequence, liveHash)
@@ -429,19 +436,21 @@ func (p *Pipeline) buildAndSign(
 	}, now)
 }
 
-// buildAndSignDropReceipt constructs a synthetic events_dropped receipt that
-// records the emitter's accumulated drop count in the chain. Called by
-// insertDropReceipt when frame.DropCount > 0.
+// buildAndSignDropReceipt constructs a synthetic events_dropped receipt.
+// seq and prevHash come directly from PairAlloc.FirstSeq/FirstPrev rather
+// than from a chain.Allocation, avoiding the ambiguous no-op Allocation that
+// would be needed to represent the first PairAlloc slot.
 func (p *Pipeline) buildAndSignDropReceipt(
 	dropCount int64,
 	sessionID string,
 	peer socket.PeerCred,
-	alloc chain.Allocation,
+	seq int64,
+	prevHash *string,
 ) (receipt.AgentReceipt, string, error) {
 	now := p.Now().Format(time.RFC3339)
 
-	if alloc.Sequence > int64(math.MaxInt) {
-		return receipt.AgentReceipt{}, "", fmt.Errorf("chain sequence %d exceeds int range on this platform (max %d)", alloc.Sequence, math.MaxInt)
+	if seq > int64(math.MaxInt) {
+		return receipt.AgentReceipt{}, "", fmt.Errorf("chain sequence %d exceeds int range on this platform (max %d)", seq, math.MaxInt)
 	}
 
 	return p.signAndHash(receipt.CreateInput{
@@ -458,17 +467,17 @@ func (p *Pipeline) buildAndSignDropReceipt(
 			Timestamp: now,
 			ParametersDisclosure: map[string]string{
 				"emitter.drop_count": strconv.FormatInt(dropCount, 10),
-				"peer.platform": peer.Platform,
-				"peer.pid":      strconv.FormatInt(int64(peer.PID), 10),
-				"peer.uid":      strconv.FormatUint(uint64(peer.UID), 10),
-				"peer.gid":      strconv.FormatUint(uint64(peer.GID), 10),
-				"peer.exe_path": peer.ExePath,
+				"peer.platform":      peer.Platform,
+				"peer.pid":           strconv.FormatInt(int64(peer.PID), 10),
+				"peer.uid":           strconv.FormatUint(uint64(peer.UID), 10),
+				"peer.gid":           strconv.FormatUint(uint64(peer.GID), 10),
+				"peer.exe_path":      peer.ExePath,
 			},
 		},
 		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
 		Chain: receipt.Chain{
-			Sequence:            int(alloc.Sequence),
-			PreviousReceiptHash: alloc.PrevHash,
+			Sequence:            int(seq),
+			PreviousReceiptHash: prevHash,
 			ChainID:             p.State.ChainID(),
 		},
 	}, now)

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -600,6 +600,7 @@ func TestProcess_RejectsMalformedFrames(t *testing.T) {
 		{"missing tool.name", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{},"decision":"allowed"}`},
 		{"missing decision", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"}}`},
 		{"unknown decision", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"maybe"}`},
+		{"negative drop_count", `{"v":"1",` + ok + `,"session_id":"s","channel":"sdk","tool":{"name":"t"},"decision":"allowed","drop_count":-1}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -615,5 +616,199 @@ func TestProcess_RejectsMalformedFrames(t *testing.T) {
 	defer a.Rollback()
 	if a.Sequence != 1 {
 		t.Errorf("after rejected frames, next seq = %d, want 1 (no advance)", a.Sequence)
+	}
+}
+
+func dropFrame(t *testing.T, dropCount int64) socket.Frame {
+	t.Helper()
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "sess-drop",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "op"},
+		Decision:  "allowed",
+		DropCount: dropCount,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return socket.Frame{
+		Payload: body,
+		Peer:    socket.PeerCred{Platform: "linux", PID: 99, UID: 1000, GID: 1000, ExePath: "/usr/bin/emitter"},
+	}
+}
+
+// TestProcess_DropCountZero verifies that when drop_count is absent (zero),
+// Process inserts exactly one receipt and the chain starts at sequence 1.
+func TestProcess_DropCountZero(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1 (no synthetic receipt for zero drop_count)", len(receipts))
+	}
+	if receipts[0].CredentialSubject.Chain.Sequence != 1 {
+		t.Errorf("seq = %d, want 1", receipts[0].CredentialSubject.Chain.Sequence)
+	}
+}
+
+// TestProcess_DropCountInsertsEventsDroppedReceipt verifies the core
+// events_dropped guarantee: when drop_count > 0 the daemon inserts a synthetic
+// receipt at the current chain slot before the live receipt, so the gap is
+// visible in the chain with no missing sequences.
+func TestProcess_DropCountInsertsEventsDroppedReceipt(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(dropFrame(t, 3)); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 2 {
+		t.Fatalf("got %d receipts, want 2 (synthetic + live)", len(receipts))
+	}
+
+	synthetic := receipts[0]
+	live := receipts[1]
+
+	// Synthetic receipt at seq 1.
+	if synthetic.CredentialSubject.Chain.Sequence != 1 {
+		t.Errorf("synthetic seq = %d, want 1", synthetic.CredentialSubject.Chain.Sequence)
+	}
+	if synthetic.CredentialSubject.Chain.PreviousReceiptHash != nil {
+		t.Errorf("synthetic first-in-chain: prev_hash should be nil")
+	}
+	if got := synthetic.CredentialSubject.Action.Type; got != actionTypeEventsDropped {
+		t.Errorf("synthetic action.type = %q, want %q", got, actionTypeEventsDropped)
+	}
+	if got := synthetic.CredentialSubject.Action.ToolName; got != "events_dropped" {
+		t.Errorf("synthetic tool_name = %q, want events_dropped", got)
+	}
+	if got := synthetic.CredentialSubject.Action.RiskLevel; got != "low" {
+		t.Errorf("synthetic risk_level = %q, want low", got)
+	}
+	if got := synthetic.CredentialSubject.Outcome.Status; got != "success" {
+		t.Errorf("synthetic outcome.status = %q, want success", got)
+	}
+	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["drop_count"]; got != "3" {
+		t.Errorf("synthetic drop_count disclosure = %q, want 3", got)
+	}
+	if got := synthetic.Issuer.SessionID; got != "sess-drop" {
+		t.Errorf("synthetic session_id = %q, want sess-drop", got)
+	}
+
+	// Live receipt at seq 2, prev_hash pointing to synthetic.
+	if live.CredentialSubject.Chain.Sequence != 2 {
+		t.Errorf("live seq = %d, want 2", live.CredentialSubject.Chain.Sequence)
+	}
+	wantPrev, err := receipt.HashReceipt(synthetic)
+	if err != nil {
+		t.Fatalf("hash synthetic: %v", err)
+	}
+	if live.CredentialSubject.Chain.PreviousReceiptHash == nil || *live.CredentialSubject.Chain.PreviousReceiptHash != wantPrev {
+		t.Errorf("live prev_hash = %v, want %s", live.CredentialSubject.Chain.PreviousReceiptHash, wantPrev)
+	}
+	if live.CredentialSubject.Action.Type != "sdk.op" {
+		t.Errorf("live action.type = %q, want sdk.op", live.CredentialSubject.Action.Type)
+	}
+
+	// Both receipts must be verifiable — the synthetic receipt uses the same
+	// signer as the live one.
+	pubPEM, err := ks.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, r := range receipts {
+		ok, err := receipt.Verify(r, pubPEM)
+		if err != nil || !ok {
+			t.Errorf("receipt[%d]: verify ok=%v err=%v", i, ok, err)
+		}
+	}
+}
+
+// TestProcess_DropCountPreservesPeerAttestationOnSynthetic verifies that the
+// peer cred from the emitter connection is recorded in the synthetic receipt's
+// parameters_disclosure, matching the live receipt's attribution source.
+func TestProcess_DropCountPreservesPeerAttestationOnSynthetic(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(dropFrame(t, 1)); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) < 1 {
+		t.Fatal("no receipts")
+	}
+	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
+	if pd["peer.platform"] != "linux" {
+		t.Errorf("peer.platform = %q, want linux", pd["peer.platform"])
+	}
+	if pd["peer.pid"] != "99" {
+		t.Errorf("peer.pid = %q, want 99", pd["peer.pid"])
+	}
+	if pd["peer.exe_path"] != "/usr/bin/emitter" {
+		t.Errorf("peer.exe_path = %q", pd["peer.exe_path"])
+	}
+}
+
+// TestProcess_DropCountChainContinues verifies that a frame with a drop_count
+// followed by a normal frame (no drops) produces a clean contiguous chain
+// with correct prev_hash links across all three receipts.
+func TestProcess_DropCountChainContinues(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(dropFrame(t, 2)); err != nil {
+		t.Fatalf("Process (drop frame): %v", err)
+	}
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatalf("Process (normal frame): %v", err)
+	}
+
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 3 {
+		t.Fatalf("got %d receipts, want 3 (synthetic + live + normal)", len(receipts))
+	}
+	for i, r := range receipts {
+		if r.CredentialSubject.Chain.Sequence != i+1 {
+			t.Errorf("receipts[%d].Sequence = %d, want %d", i, r.CredentialSubject.Chain.Sequence, i+1)
+		}
+	}
+	for i := 1; i < len(receipts); i++ {
+		want, err := receipt.HashReceipt(receipts[i-1])
+		if err != nil {
+			t.Fatalf("hash receipt %d: %v", i-1, err)
+		}
+		got := receipts[i].CredentialSubject.Chain.PreviousReceiptHash
+		if got == nil || *got != want {
+			t.Errorf("receipts[%d] prev_hash = %v, want %s", i, got, want)
+		}
 	}
 }

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -830,9 +830,10 @@ func (f *failOnNthInsert) Insert(r receipt.AgentReceipt, hash string) error {
 }
 
 // TestProcess_DropCountSyntheticFailureLiveReceiptPersists verifies that when
-// the synthetic events_dropped receipt fails to persist, the live receipt is
-// still written to the store. The synthetic insert error is returned by
-// Process so the socket listener can log it, but the live event is not lost.
+// the synthetic events_dropped receipt fails to persist, Process still returns
+// nil and the live receipt is written. The synthetic failure is routed to
+// ErrorLog rather than returned, keeping the return-value contract: a non-nil
+// return from Process always means the live receipt was NOT persisted.
 func TestProcess_DropCountSyntheticFailureLiveReceiptPersists(t *testing.T) {
 	ks := newTestKeySource(t)
 	underlying := newTestStore(t)
@@ -842,12 +843,19 @@ func TestProcess_DropCountSyntheticFailureLiveReceiptPersists(t *testing.T) {
 	state := chain.New("chain-1")
 	p := New(state, ks, st, "did:agent-receipts-daemon:test")
 
-	err := p.Process(dropFrame(t, 2))
-	if err == nil {
-		t.Error("expected error from synthetic insert failure, got nil")
+	var logged string
+	p.ErrorLog = func(format string, args ...any) {
+		logged = fmt.Sprintf(format, args...)
 	}
 
-	// Live receipt must still be in the store despite the synthetic failure.
+	if err := p.Process(dropFrame(t, 2)); err != nil {
+		t.Errorf("Process returned error %v; want nil (live receipt was persisted)", err)
+	}
+	if logged == "" {
+		t.Error("ErrorLog was not called; synthetic failure must be logged")
+	}
+
+	// Live receipt must be in the store.
 	receipts, getErr := underlying.GetChain("chain-1")
 	if getErr != nil {
 		t.Fatalf("GetChain: %v", getErr)
@@ -859,6 +867,6 @@ func TestProcess_DropCountSyntheticFailureLiveReceiptPersists(t *testing.T) {
 		t.Errorf("action.type = %q, want sdk.op", got)
 	}
 	if got := receipts[0].CredentialSubject.Chain.Sequence; got != 1 {
-		t.Errorf("seq = %d, want 1 (chain advanced past failed synthetic slot)", got)
+		t.Errorf("seq = %d, want 1", got)
 	}
 }

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -707,8 +707,8 @@ func TestProcess_DropCountInsertsEventsDroppedReceipt(t *testing.T) {
 	if got := synthetic.CredentialSubject.Outcome.Status; got != "success" {
 		t.Errorf("synthetic outcome.status = %q, want success", got)
 	}
-	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["drop_count"]; got != "3" {
-		t.Errorf("synthetic drop_count disclosure = %q, want 3", got)
+	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["emitter.drop_count"]; got != "3" {
+		t.Errorf("synthetic emitter.drop_count disclosure = %q, want 3", got)
 	}
 	if got := synthetic.Issuer.SessionID; got != "sess-drop" {
 		t.Errorf("synthetic session_id = %q, want sess-drop", got)

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -810,5 +811,54 @@ func TestProcess_DropCountChainContinues(t *testing.T) {
 		if got == nil || *got != want {
 			t.Errorf("receipts[%d] prev_hash = %v, want %s", i, got, want)
 		}
+	}
+}
+
+// failOnNthInsert wraps a ReceiptStore and returns an error on the Nth Insert.
+type failOnNthInsert struct {
+	store.ReceiptStore
+	n       int
+	callNum int
+}
+
+func (f *failOnNthInsert) Insert(r receipt.AgentReceipt, hash string) error {
+	f.callNum++
+	if f.callNum == f.n {
+		return fmt.Errorf("simulated store insert failure on call %d", f.n)
+	}
+	return f.ReceiptStore.Insert(r, hash)
+}
+
+// TestProcess_DropCountSyntheticFailureLiveReceiptPersists verifies that when
+// the synthetic events_dropped receipt fails to persist, the live receipt is
+// still written to the store. The synthetic insert error is returned by
+// Process so the socket listener can log it, but the live event is not lost.
+func TestProcess_DropCountSyntheticFailureLiveReceiptPersists(t *testing.T) {
+	ks := newTestKeySource(t)
+	underlying := newTestStore(t)
+	// Fail only the first Insert (the synthetic receipt); the second (live) must succeed.
+	st := &failOnNthInsert{ReceiptStore: underlying, n: 1}
+
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	err := p.Process(dropFrame(t, 2))
+	if err == nil {
+		t.Error("expected error from synthetic insert failure, got nil")
+	}
+
+	// Live receipt must still be in the store despite the synthetic failure.
+	receipts, getErr := underlying.GetChain("chain-1")
+	if getErr != nil {
+		t.Fatalf("GetChain: %v", getErr)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1 (live receipt must survive synthetic failure)", len(receipts))
+	}
+	if got := receipts[0].CredentialSubject.Action.Type; got != "sdk.op" {
+		t.Errorf("action.type = %q, want sdk.op", got)
+	}
+	if got := receipts[0].CredentialSubject.Chain.Sequence; got != 1 {
+		t.Errorf("seq = %d, want 1 (chain advanced past failed synthetic slot)", got)
 	}
 }

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -137,7 +137,7 @@ func TestDropCounterEndToEnd(t *testing.T) {
 	if got := synthetic.CredentialSubject.Action.Type; got != "agent_receipts.events_dropped" {
 		t.Errorf("synthetic action.type = %q, want agent_receipts.events_dropped", got)
 	}
-	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["drop_count"]; got != "3" {
+	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["emitter.drop_count"]; got != "3" {
 		t.Errorf("synthetic drop_count = %q, want 3", got)
 	}
 	if got := synthetic.Issuer.SessionID; got != "drop-e2e-session" {

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -1,0 +1,119 @@
+//go:build integration && (linux || darwin)
+
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/sdk/go/emitter"
+)
+
+// TestConcurrentDaemonStartSameSocket verifies that when two daemon instances
+// race to bind the same socket path, exactly one wins and the other returns a
+// clear error containing "another daemon is already listening". This is the
+// regression test for the "bind: address already in use" bug documented in
+// issue #236 comment 1, where the second instance would crash or leave the
+// socket in an inconsistent state.
+func TestConcurrentDaemonStartSameSocket(t *testing.T) {
+	fix := StartDaemon(t)
+
+	// Attempt to start a second daemon at the SAME socket path. Give it the
+	// same key (read-only reuse is fine — the second daemon will fail before
+	// it needs to sign anything) and a separate writable DB so the only point
+	// of contention is the socket.
+	//
+	// The second daemon MUST return a graceful error (not hang, not panic, not
+	// remove the first daemon's socket). The exact error message is a contract
+	// the socket package promises: "another daemon is already listening on …".
+	dataDir2 := t.TempDir()
+	cfg2 := fix.Config
+	cfg2.DBPath = dataDir2 + "/receipts2.db"
+	cfg2.PublicKeyPath = dataDir2 + "/signing.key.pub"
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	done2 := make(chan error, 1)
+	go func() { done2 <- Run(ctx2, cfg2) }()
+
+	select {
+	case err := <-done2:
+		if err == nil {
+			t.Fatal("second daemon started on an already-bound socket: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "another daemon is already listening") {
+			t.Errorf("unexpected error from second daemon: %v\n(want message containing 'another daemon is already listening')", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel2()
+		t.Fatal("second daemon did not exit within 5s; expected immediate error on duplicate socket bind")
+	}
+
+	// The first daemon must still be alive and serving.
+	em, err := emitter.New(
+		emitter.WithSocketPath(fix.Config.SocketPath),
+		emitter.WithLogger(slog.Default()),
+	)
+	if err != nil {
+		t.Fatalf("create emitter: %v", err)
+	}
+	defer em.Close()
+	if err := em.Emit(context.Background(), emitter.Event{
+		Channel:  "regression",
+		Tool:     emitter.Tool{Name: "port-collision-test"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("first daemon no longer accepting after second daemon exit: %v", err)
+	}
+	fix.WaitForReceiptCount(t, 1, 5*time.Second)
+}
+
+// TestSandboxedEmitterViaDaemonSocket verifies that an emitter succeeds even
+// when it has no write access to the canonical receipt-DB directory. This is
+// the regression test for the pre-ADR-0010 architecture where the emitter
+// wrote directly to SQLite: in a sandboxed process (read-only rootfs,
+// container with mounted read-only volumes) the emitter would fail with a
+// permission error when trying to create or open the database. After the
+// daemon separation, the emitter only writes to the daemon's Unix socket and
+// never touches the DB path itself.
+func TestSandboxedEmitterViaDaemonSocket(t *testing.T) {
+	fix := StartDaemon(t)
+
+	// The emitter is constructed with only a socket path — no DB path whatsoever.
+	// In the old architecture the emitter would have tried to open cfg.DBPath
+	// (or the default ~/.agent-receipts/receipts.db) for writing. Here we
+	// deliberately do NOT pass the DB path to the emitter; the emitter should
+	// not need it and must succeed purely via the socket.
+	em, err := emitter.New(
+		emitter.WithSocketPath(fix.Config.SocketPath),
+		emitter.WithSessionID("sandboxed-session"),
+		emitter.WithLogger(slog.Default()),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	defer em.Close()
+
+	if err := em.Emit(context.Background(), emitter.Event{
+		Channel:  "test",
+		Tool:     emitter.Tool{Name: "sandboxed-tool"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("Emit in read-only-DB scenario: %v (emitter should not need DB access)", err)
+	}
+
+	receipts := fix.WaitForReceiptCount(t, 1, 5*time.Second)
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	r := receipts[0]
+	if r.CredentialSubject.Action.Type != "test.sandboxed-tool" {
+		t.Errorf("action.type = %q, want test.sandboxed-tool", r.CredentialSubject.Action.Type)
+	}
+	if r.Issuer.SessionID != "sandboxed-session" {
+		t.Errorf("issuer.session_id = %q, want sandboxed-session", r.Issuer.SessionID)
+	}
+}

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -167,14 +169,30 @@ func TestDropCounterEndToEnd(t *testing.T) {
 	}
 }
 
-// TestEmitterRequiresOnlySocketPath pins the contract that the emitter's only
-// external dependency is the daemon socket. The emitter has no DB path, no key
-// path, and no filesystem writes — it only dials the socket and sends frames.
-// This is the ADR-0010 separation guarantee: a process that can reach the
-// daemon socket can emit receipts regardless of whether it can access the DB,
-// the key, or any other daemon-owned path.
+// TestEmitterRequiresOnlySocketPath verifies that the emitter succeeds even
+// when every default filesystem path the old in-process emitter would have
+// used (HOME, XDG_DATA_HOME, XDG_RUNTIME_DIR, TMPDIR) is read-only. This is
+// the ADR-0010 regression guard: if someone accidentally re-introduces DB or
+// key access into the emitter, those opens would return EACCES and surface as
+// an Emit error here.
 func TestEmitterRequiresOnlySocketPath(t *testing.T) {
 	fix := StartDaemon(t)
+
+	// Create a read-only sandbox directory and redirect all default path
+	// env vars into it. Any emitter code that tries os.Create/os.OpenFile
+	// under HOME, XDG_DATA_HOME, XDG_RUNTIME_DIR, or TMPDIR will get EACCES.
+	sandboxHome := t.TempDir()
+	if err := os.Chmod(sandboxHome, 0o555); err != nil {
+		t.Fatalf("chmod sandboxHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sandboxHome, 0o755) })
+	t.Setenv("HOME", sandboxHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(sandboxHome, ".local", "share"))
+	t.Setenv("XDG_RUNTIME_DIR", filepath.Join(sandboxHome, "run"))
+	t.Setenv("TMPDIR", filepath.Join(sandboxHome, "tmp")) // macOS default socket/DB base
+
+	// The daemon was started before the env vars were redirected and uses
+	// paths from its Config struct, so it is unaffected.
 
 	em, err := emitter.New(
 		emitter.WithSocketPath(fix.Config.SocketPath),
@@ -191,7 +209,7 @@ func TestEmitterRequiresOnlySocketPath(t *testing.T) {
 		Tool:     emitter.Tool{Name: "socket-only-tool"},
 		Decision: "allowed",
 	}); err != nil {
-		t.Fatalf("Emit: %v", err)
+		t.Fatalf("Emit in read-only-HOME sandbox: %v", err)
 	}
 
 	receipts := fix.WaitForReceiptCount(t, 1, 5*time.Second)

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -167,25 +167,18 @@ func TestDropCounterEndToEnd(t *testing.T) {
 	}
 }
 
-// TestSandboxedEmitterViaDaemonSocket verifies that an emitter succeeds even
-// when it has no write access to the canonical receipt-DB directory. This is
-// the regression test for the pre-ADR-0010 architecture where the emitter
-// wrote directly to SQLite: in a sandboxed process (read-only rootfs,
-// container with mounted read-only volumes) the emitter would fail with a
-// permission error when trying to create or open the database. After the
-// daemon separation, the emitter only writes to the daemon's Unix socket and
-// never touches the DB path itself.
-func TestSandboxedEmitterViaDaemonSocket(t *testing.T) {
+// TestEmitterRequiresOnlySocketPath pins the contract that the emitter's only
+// external dependency is the daemon socket. The emitter has no DB path, no key
+// path, and no filesystem writes — it only dials the socket and sends frames.
+// This is the ADR-0010 separation guarantee: a process that can reach the
+// daemon socket can emit receipts regardless of whether it can access the DB,
+// the key, or any other daemon-owned path.
+func TestEmitterRequiresOnlySocketPath(t *testing.T) {
 	fix := StartDaemon(t)
 
-	// The emitter is constructed with only a socket path — no DB path whatsoever.
-	// In the old architecture the emitter would have tried to open cfg.DBPath
-	// (or the default ~/.agent-receipts/receipts.db) for writing. Here we
-	// deliberately do NOT pass the DB path to the emitter; the emitter should
-	// not need it and must succeed purely via the socket.
 	em, err := emitter.New(
 		emitter.WithSocketPath(fix.Config.SocketPath),
-		emitter.WithSessionID("sandboxed-session"),
+		emitter.WithSessionID("socket-only-session"),
 		emitter.WithLogger(slog.Default()),
 	)
 	if err != nil {
@@ -195,10 +188,10 @@ func TestSandboxedEmitterViaDaemonSocket(t *testing.T) {
 
 	if err := em.Emit(context.Background(), emitter.Event{
 		Channel:  "test",
-		Tool:     emitter.Tool{Name: "sandboxed-tool"},
+		Tool:     emitter.Tool{Name: "socket-only-tool"},
 		Decision: "allowed",
 	}); err != nil {
-		t.Fatalf("Emit in read-only-DB scenario: %v (emitter should not need DB access)", err)
+		t.Fatalf("Emit: %v", err)
 	}
 
 	receipts := fix.WaitForReceiptCount(t, 1, 5*time.Second)
@@ -206,10 +199,10 @@ func TestSandboxedEmitterViaDaemonSocket(t *testing.T) {
 		t.Fatalf("got %d receipts, want 1", len(receipts))
 	}
 	r := receipts[0]
-	if r.CredentialSubject.Action.Type != "test.sandboxed-tool" {
-		t.Errorf("action.type = %q, want test.sandboxed-tool", r.CredentialSubject.Action.Type)
+	if r.CredentialSubject.Action.Type != "test.socket-only-tool" {
+		t.Errorf("action.type = %q, want test.socket-only-tool", r.CredentialSubject.Action.Type)
 	}
-	if r.Issuer.SessionID != "sandboxed-session" {
-		t.Errorf("issuer.session_id = %q, want sandboxed-session", r.Issuer.SessionID)
+	if r.Issuer.SessionID != "socket-only-session" {
+		t.Errorf("issuer.session_id = %q, want socket-only-session", r.Issuer.SessionID)
 	}
 }

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -4,12 +4,14 @@ package daemon
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 // TestConcurrentDaemonStartSameSocket verifies that when two daemon instances
@@ -69,6 +71,100 @@ func TestConcurrentDaemonStartSameSocket(t *testing.T) {
 		t.Fatalf("first daemon no longer accepting after second daemon exit: %v", err)
 	}
 	fix.WaitForReceiptCount(t, 1, 5*time.Second)
+}
+
+// TestDropCounterEndToEnd verifies the full drop-counter pipeline: emitter
+// drops accumulate while the daemon is down, the count is flushed on the first
+// successful send after restart, and the daemon inserts a synthetic
+// events_dropped receipt in the chain before the live receipt.
+func TestDropCounterEndToEnd(t *testing.T) {
+	fix1 := StartDaemon(t)
+	pubPEM := fix1.PublicKey
+	cfg := fix1.Config
+
+	// Stop the first daemon without emitting anything. The emitter will be
+	// created after stop so all initial sends hit a dead socket.
+	fix1.cancel()
+	select {
+	case <-fix1.done:
+		if fix1.daemonErr != nil {
+			t.Logf("first daemon: %v", fix1.daemonErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("first daemon did not stop within 3s")
+	}
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(cfg.SocketPath),
+		emitter.WithSessionID("drop-e2e-session"),
+		emitter.WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	defer em.Close()
+
+	ctx := context.Background()
+	// Three emits to the dead socket → three dial failures → drop_count = 3.
+	for i := 0; i < 3; i++ {
+		if err := em.Emit(ctx, emitter.Event{Channel: "test", Tool: emitter.Tool{Name: "dropped"}, Decision: "allowed"}); err != nil {
+			t.Fatalf("Emit %d: expected nil (fire-and-forget), got %v", i, err)
+		}
+	}
+
+	// Restart the daemon at the same socket/DB/key.
+	fix2 := StartDaemonFromConfig(t, cfg, pubPEM)
+
+	// First successful send to fix2 flushes drop_count = 3.
+	if err := em.Emit(ctx, emitter.Event{Channel: "test", Tool: emitter.Tool{Name: "live"}, Decision: "allowed"}); err != nil {
+		t.Fatalf("live Emit: %v", err)
+	}
+
+	// Expect two receipts: synthetic events_dropped (seq 1) + live (seq 2).
+	receipts := fix2.WaitForReceiptCount(t, 2, 10*time.Second)
+	if len(receipts) != 2 {
+		t.Fatalf("got %d receipts, want 2 (events_dropped + live)\ntrace:\n%s", len(receipts), fix2.Trace())
+	}
+
+	synthetic := receipts[0]
+	live := receipts[1]
+
+	if synthetic.CredentialSubject.Chain.Sequence != 1 {
+		t.Errorf("synthetic seq = %d, want 1", synthetic.CredentialSubject.Chain.Sequence)
+	}
+	if got := synthetic.CredentialSubject.Action.Type; got != "agent_receipts.events_dropped" {
+		t.Errorf("synthetic action.type = %q, want agent_receipts.events_dropped", got)
+	}
+	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["drop_count"]; got != "3" {
+		t.Errorf("synthetic drop_count = %q, want 3", got)
+	}
+	if got := synthetic.Issuer.SessionID; got != "drop-e2e-session" {
+		t.Errorf("synthetic session_id = %q, want drop-e2e-session", got)
+	}
+
+	if live.CredentialSubject.Chain.Sequence != 2 {
+		t.Errorf("live seq = %d, want 2", live.CredentialSubject.Chain.Sequence)
+	}
+	if got := live.CredentialSubject.Action.Type; got != "test.live" {
+		t.Errorf("live action.type = %q, want test.live", got)
+	}
+
+	// Verify prev_hash link: live must point to synthetic.
+	wantPrev, err := receipt.HashReceipt(synthetic)
+	if err != nil {
+		t.Fatalf("hash synthetic: %v", err)
+	}
+	if live.CredentialSubject.Chain.PreviousReceiptHash == nil || *live.CredentialSubject.Chain.PreviousReceiptHash != wantPrev {
+		t.Errorf("live prev_hash = %v, want %s", live.CredentialSubject.Chain.PreviousReceiptHash, wantPrev)
+	}
+
+	// Both receipts must verify under the daemon's public key.
+	for i, r := range receipts {
+		ok, err := receipt.Verify(r, pubPEM)
+		if err != nil || !ok {
+			t.Errorf("receipt[%d]: verify ok=%v err=%v", i, ok, err)
+		}
+	}
 }
 
 // TestSandboxedEmitterViaDaemonSocket verifies that an emitter succeeds even

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -381,7 +381,8 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 }
 
 // Close releases the underlying connection. After Close, subsequent Emit
-// calls return an error. Safe to call multiple times.
+// calls return an error. Safe to call multiple times. Any drop count
+// accumulated but not yet flushed to the daemon is abandoned on Close.
 func (e *Emitter) Close() error {
 	e.mu.Lock()
 	if e.closed {

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -460,8 +461,23 @@ func writeAll(w io.Writer, buf []byte) error {
 	return nil
 }
 
+// saturatingIncr increments c by 1, capping at math.MaxInt64 so the counter
+// never wraps negative. The daemon rejects frames with drop_count < 0, so an
+// overflowed counter would make all subsequent emits fail validation.
+func saturatingIncr(c *atomic.Int64) {
+	for {
+		v := c.Load()
+		if v == math.MaxInt64 {
+			return
+		}
+		if c.CompareAndSwap(v, v+1) {
+			return
+		}
+	}
+}
+
 func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
-	e.dropCount.Add(1)
+	saturatingIncr(&e.dropCount)
 	e.logger.LogAttrs(ctx, slog.LevelDebug, "agent-receipts emitter dropped event",
 		slog.String("stage", stage),
 		slog.String("socket", e.socketPath),

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -17,9 +17,15 @@
 // connection) Emit logs a debug-level drop via the configured slog.Logger
 // and returns nil within milliseconds. Per ADR-0010 §"Permissions and
 // trust", a drop with the daemon NOT running is silent by design — there
-// is no daemon to record the gap. The EAGAIN-driven local drop counter
-// described in the same section ships in a follow-up commit; for now,
-// every drop reason takes the same silent path.
+// is no daemon to record the gap.
+//
+// Drop counter: every failed send (dial timeout, write timeout, broken
+// connection) increments an atomic counter. On the next successful send the
+// accumulated count is included in the frame's drop_count field and reset to
+// zero, letting the daemon insert a synthetic events_dropped receipt that
+// makes the gap visible in the chain. Narrow loss window: if the emitter
+// process crashes after a drop but before a subsequent successful send, the
+// accumulated count is lost and the gap remains permanently invisible.
 package emitter
 
 import (
@@ -35,6 +41,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -125,6 +132,12 @@ func WithLogger(l *slog.Logger) Option {
 // Emitter is the daemon-socket client. Construct with New, fire events
 // with Emit, release the socket with Close. Safe for concurrent Emit.
 type Emitter struct {
+	// dropCount accumulates failed sends. Swapped to zero when a frame is
+	// successfully written; the captured value is embedded in that frame's
+	// drop_count field so the daemon can record the gap as a synthetic receipt.
+	// Uses atomic.Int64 so concurrent logDrop calls never corrupt state.
+	dropCount atomic.Int64
+
 	socketPath string
 	sessionID  string
 	logger     *slog.Logger
@@ -184,6 +197,7 @@ type frame struct {
 	Output    json.RawMessage `json:"output,omitempty"`
 	Error     string          `json:"error,omitempty"`
 	Decision  string          `json:"decision"`
+	DropCount int64           `json:"drop_count,omitempty"`
 }
 
 type frameTool struct {
@@ -242,6 +256,11 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		}
 	}
 
+	// Capture accumulated drops and reset the counter to zero. If this send
+	// succeeds the daemon receives the count; if it fails, pendingDrops is
+	// restored (see the failure paths below) so it isn't lost.
+	pendingDrops := e.dropCount.Swap(0)
+
 	body, err := json.Marshal(frame{
 		Version:   SupportedFrameVersion,
 		TsEmit:    time.Now().UTC().Format(time.RFC3339Nano),
@@ -252,14 +271,19 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		Output:    ev.Output,
 		Error:     ev.Error,
 		Decision:  ev.Decision,
+		DropCount: pendingDrops,
 	})
 	if err != nil {
+		// Marshal failure is a caller bug, not a transient outage. Restore
+		// the pending drops so they survive this call.
+		e.dropCount.Add(pendingDrops)
 		return fmt.Errorf("emitter: marshal frame: %w", err)
 	}
 	if len(body) > MaxFrameSize {
 		// Surface oversize as a returned error rather than silent drop:
 		// the daemon would reject the frame at read time too, so this
 		// is a logic bug in the caller, not a transient outage.
+		e.dropCount.Add(pendingDrops)
 		return fmt.Errorf("emitter: frame too large: %d bytes (max %d)", len(body), MaxFrameSize)
 	}
 
@@ -271,6 +295,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	e.mu.Lock()
 	if e.closed {
 		e.mu.Unlock()
+		e.dropCount.Add(pendingDrops)
 		return errors.New("emitter: closed")
 	}
 	needDial := e.conn == nil
@@ -280,8 +305,10 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		dialed, err := e.dial(ctx)
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
+				e.dropCount.Add(pendingDrops)
 				return ctxErr
 			}
+			e.dropCount.Add(pendingDrops)
 			e.logDrop(ctx, "dial", err)
 			return nil
 		}
@@ -296,6 +323,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		case e.closed:
 			e.mu.Unlock()
 			_ = dialed.Close()
+			e.dropCount.Add(pendingDrops)
 			return errors.New("emitter: closed")
 		case e.conn == nil:
 			e.conn = dialed
@@ -317,6 +345,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	e.mu.Lock()
 	if e.closed {
 		e.mu.Unlock()
+		e.dropCount.Add(pendingDrops)
 		return errors.New("emitter: closed")
 	}
 	conn := e.conn
@@ -327,6 +356,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		// (ADR-0010 prefers next-Emit re-dial); drop and let the next
 		// Emit re-establish.
 		e.mu.Unlock()
+		e.dropCount.Add(pendingDrops)
 		e.logDrop(ctx, "write", errors.New("connection reset by sibling Emit"))
 		return nil
 	}
@@ -341,6 +371,7 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		// on I/O — holding e.mu across them would stall sibling Emits).
 		e.conn = nil
 		e.mu.Unlock()
+		e.dropCount.Add(pendingDrops)
 		e.logDrop(ctx, "write", err)
 		_ = conn.Close()
 		return nil
@@ -429,6 +460,7 @@ func writeAll(w io.Writer, buf []byte) error {
 }
 
 func (e *Emitter) logDrop(ctx context.Context, stage string, err error) {
+	e.dropCount.Add(1)
 	e.logger.LogAttrs(ctx, slog.LevelDebug, "agent-receipts emitter dropped event",
 		slog.String("stage", stage),
 		slog.String("socket", e.socketPath),

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -417,10 +417,24 @@ func TestEmit_ReconnectAfterDaemonRestart(t *testing.T) {
 		receipts, getErr := s.GetChain(d2.cfg.ChainID)
 		s.Close()
 		if getErr == nil && len(receipts) >= 3 {
-			// Verify at least one post-restart receipt carries the
-			// emitter's stable session_id. This is the OQ4 property
-			// (session_id persists across daemon reconnects).
+			// Filter out daemon-synthesised events_dropped receipts: a
+			// positive drop counter on the first post-restart frame causes
+			// the daemon to prepend a synthetic receipt before the live one,
+			// so receipts[2:] may start with it.
+			var live []receipt.AgentReceipt
 			for _, r := range receipts[2:] {
+				if r.CredentialSubject.Action.Type != "agent_receipts.events_dropped" {
+					live = append(live, r)
+				}
+			}
+			if len(live) == 0 {
+				// Only the synthetic receipt has arrived yet; wait for the live one.
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			// Verify post-restart receipts carry the emitter's stable
+			// session_id (OQ4 property: persists across daemon reconnects).
+			for _, r := range live {
 				if r.Issuer.SessionID != wantSession {
 					t.Errorf("post-restart receipt session_id = %q, want %q", r.Issuer.SessionID, wantSession)
 				}

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -781,9 +781,13 @@ func TestEmit_DropCounterResetAfterFlush(t *testing.T) {
 	rl.path = missingPath
 
 	// First successful send flushes drop_count = 1.
-	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "flush"}, Decision: "allowed"})
+	if err := em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "flush"}, Decision: "allowed"}); err != nil {
+		t.Fatalf("flush Emit: %v", err)
+	}
 	// Second successful send should have drop_count = 0.
-	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "clean"}, Decision: "allowed"})
+	if err := em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "clean"}, Decision: "allowed"}); err != nil {
+		t.Fatalf("clean Emit: %v", err)
+	}
 
 	frames := rl.waitForFrames(t, 2, 2*time.Second)
 

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -731,7 +731,9 @@ func TestEmit_DropCounterIncrementsOnFailure(t *testing.T) {
 
 	// Now bring up a listener at the same path and emit once more.
 	rl := newRecordingListener(t, dir)
-	_ = os.Rename(rl.path, missingPath)
+	if err := os.Rename(rl.path, missingPath); err != nil {
+		t.Fatalf("rename listener socket: %v", err)
+	}
 	rl.path = missingPath
 
 	if err := em.Emit(context.Background(), Event{
@@ -773,7 +775,9 @@ func TestEmit_DropCounterResetAfterFlush(t *testing.T) {
 
 	// Bring up listener.
 	rl := newRecordingListener(t, dir)
-	_ = os.Rename(rl.path, missingPath)
+	if err := os.Rename(rl.path, missingPath); err != nil {
+		t.Fatalf("rename listener socket: %v", err)
+	}
 	rl.path = missingPath
 
 	// First successful send flushes drop_count = 1.
@@ -801,76 +805,79 @@ func TestEmit_DropCounterResetAfterFlush(t *testing.T) {
 
 // TestEmit_DropCounterRestoredOnWriteFailure verifies that when a send
 // attempt fails mid-write (writeFrame error), the pending drop count that was
-// optimistically consumed is added back to the counter so it is not lost.
+// optimistically consumed (via Swap) is added back so it is not lost.
+//
+// Uses in-package access to inject a known value (7) before the failure; the
+// first successful post-failure frame must carry at least 7+1 = 8 drops
+// (injected + the write failure itself). Any additional dial failures between
+// the stop and reconnect add to the count, hence ">= 8" not "== 8".
 func TestEmit_DropCounterRestoredOnWriteFailure(t *testing.T) {
 	dir := shortSocketDir(t)
 
-	// Bring up a real listener first so the emitter can connect.
 	rl1 := newRecordingListener(t, dir)
-	em, err := New(
-		WithSocketPath(rl1.path),
-		WithLogger(silentLogger()),
-	)
+	em, err := New(WithSocketPath(rl1.path), WithLogger(silentLogger()))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	defer em.Close()
 
-	// Establish connection with a normal emit.
+	// Establish the connection.
 	if err := em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "prime"}, Decision: "allowed"}); err != nil {
 		t.Fatalf("prime Emit: %v", err)
 	}
 	rl1.waitForFrames(t, 1, 2*time.Second)
 
-	// Simulate a drop BEFORE rl1 goes away: the emitter now has drop_count = 0.
-	// We need drop_count > 0 at the moment of the write failure so we can
-	// observe the restore. Inject it by stopping the listener while holding
-	// a non-zero drop count accumulated from a missing socket.
-	//
-	// Step 1: stop rl1 and let the emitter's connection die.
+	// Inject a known pending count before killing the listener.
+	const injected = 7
+	em.dropCount.Store(injected)
+
+	// Stop rl1 so the next write fails; give the OS time to propagate.
 	rl1.Stop()
 	_ = os.Remove(rl1.path)
 	time.Sleep(50 * time.Millisecond)
 
-	// Step 2: emit to the dead socket — this drops and increments the counter.
-	// We just need drop_count > 0; the exact value depends on OS timing (write
-	// fail on rl1's dead conn, then one or more dial fails), so don't pin it.
+	// This emit hits the dead connection: pendingDrops = 7, write fails,
+	// Add(7) restores, then logDrop adds 1 → dropCount = 8.
 	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "dead"}, Decision: "allowed"})
 
-	// Step 3: bring up rl2. The emitter will dial + write. Writes may fail
-	// once more (dial race window), but eventually should succeed with drop_count > 0.
+	// Start rl2 at rl1's path so the emitter can reconnect.
 	rl2 := newRecordingListener(t, dir)
-	_ = os.Rename(rl2.path, rl1.path)
+	if err := os.Rename(rl2.path, rl1.path); err != nil {
+		t.Fatalf("rename listener socket: %v", err)
+	}
 	rl2.path = rl1.path
 
-	// Emit until we receive a frame with drop_count > 0 or time out.
+	// Loop until the emitter delivers a frame; any intermediate dial
+	// failures only increase the count beyond the minimum.
 	deadline := time.Now().Add(3 * time.Second)
 	for {
-		_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "probe"}, Decision: "allowed"})
+		_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "flush"}, Decision: "allowed"})
 		for _, raw := range rl2.snapshot() {
 			var f frame
 			if err := json.Unmarshal(raw, &f); err != nil {
 				continue
 			}
-			if f.DropCount > 0 {
-				// Capture the count before emitting so the wait target is stable
-				// regardless of when the listener goroutine processes the next frame.
-				beforeCount := len(rl2.snapshot())
-				_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "after"}, Decision: "allowed"})
-				frames2 := rl2.waitForFrames(t, beforeCount+1, 2*time.Second)
-				last := frames2[len(frames2)-1]
-				var after frame
-				if err := json.Unmarshal(last, &after); err != nil {
-					t.Fatalf("unmarshal after frame: %v", err)
-				}
-				if after.DropCount != 0 {
-					t.Errorf("after flush, drop_count = %d; want 0", after.DropCount)
-				}
-				return
+			// Must carry at least injected+1 (the injected value was
+			// restored, and the write failure itself added 1 more).
+			if f.DropCount < injected+1 {
+				t.Errorf("drop_count = %d; want >= %d (injected=%d + write failure)",
+					f.DropCount, injected+1, injected)
 			}
+			// The counter must be zero on the immediately following frame.
+			beforeCount := len(rl2.snapshot())
+			_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "clean"}, Decision: "allowed"})
+			frames2 := rl2.waitForFrames(t, beforeCount+1, 2*time.Second)
+			var clean frame
+			if err := json.Unmarshal(frames2[len(frames2)-1], &clean); err != nil {
+				t.Fatalf("unmarshal clean frame: %v", err)
+			}
+			if clean.DropCount != 0 {
+				t.Errorf("clean frame drop_count = %d; want 0 (counter must reset after flush)", clean.DropCount)
+			}
+			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("never received a frame with drop_count > 0; snapshot: %v", rl2.snapshot())
+			t.Fatalf("never received a frame; drop_count must carry >= %d", injected+1)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -701,6 +701,181 @@ func TestEmit_WriteFailureResetsConn(t *testing.T) {
 	}
 }
 
+// TestEmit_DropCounterIncrementsOnFailure verifies that every failed send
+// (dial or write) increments the emitter's drop counter. The counter is
+// internal state, but its effect is observable via the drop_count field in the
+// first frame delivered to a recovered listener.
+func TestEmit_DropCounterIncrementsOnFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+	missingPath := filepath.Join(dir, "missing.sock")
+
+	em, err := New(
+		WithSocketPath(missingPath),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	// Three Emits to a missing socket → three dial failures → drop_count = 3.
+	for i := 0; i < 3; i++ {
+		if err := em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "noop"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit %d: expected nil (fire-and-forget), got %v", i, err)
+		}
+	}
+
+	// Now bring up a listener at the same path and emit once more.
+	rl := newRecordingListener(t, dir)
+	_ = os.Rename(rl.path, missingPath)
+	rl.path = missingPath
+
+	if err := em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "recovery"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("recovery Emit: %v", err)
+	}
+
+	frames := rl.waitForFrames(t, 1, 2*time.Second)
+	var got frame
+	if err := json.Unmarshal(frames[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.DropCount != 3 {
+		t.Errorf("drop_count = %d; want 3", got.DropCount)
+	}
+}
+
+// TestEmit_DropCounterResetAfterFlush verifies that after the drop count is
+// flushed in a successful send it is reset to zero, so the following frame
+// carries drop_count = 0 (omitted on wire, which is the same as zero).
+func TestEmit_DropCounterResetAfterFlush(t *testing.T) {
+	dir := shortSocketDir(t)
+	missingPath := filepath.Join(dir, "missing.sock")
+
+	em, err := New(
+		WithSocketPath(missingPath),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	// One drop.
+	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "n"}, Decision: "allowed"})
+
+	// Bring up listener.
+	rl := newRecordingListener(t, dir)
+	_ = os.Rename(rl.path, missingPath)
+	rl.path = missingPath
+
+	// First successful send flushes drop_count = 1.
+	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "flush"}, Decision: "allowed"})
+	// Second successful send should have drop_count = 0.
+	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "clean"}, Decision: "allowed"})
+
+	frames := rl.waitForFrames(t, 2, 2*time.Second)
+
+	var flush, clean frame
+	if err := json.Unmarshal(frames[0], &flush); err != nil {
+		t.Fatalf("unmarshal flush frame: %v", err)
+	}
+	if err := json.Unmarshal(frames[1], &clean); err != nil {
+		t.Fatalf("unmarshal clean frame: %v", err)
+	}
+
+	if flush.DropCount != 1 {
+		t.Errorf("flush frame drop_count = %d; want 1", flush.DropCount)
+	}
+	if clean.DropCount != 0 {
+		t.Errorf("clean frame drop_count = %d; want 0 (counter should be reset after flush)", clean.DropCount)
+	}
+}
+
+// TestEmit_DropCounterRestoredOnWriteFailure verifies that when a send
+// attempt fails mid-write (writeFrame error), the pending drop count that was
+// optimistically consumed is added back to the counter so it is not lost.
+func TestEmit_DropCounterRestoredOnWriteFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	// Bring up a real listener first so the emitter can connect.
+	rl1 := newRecordingListener(t, dir)
+	em, err := New(
+		WithSocketPath(rl1.path),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	// Establish connection with a normal emit.
+	if err := em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "prime"}, Decision: "allowed"}); err != nil {
+		t.Fatalf("prime Emit: %v", err)
+	}
+	rl1.waitForFrames(t, 1, 2*time.Second)
+
+	// Simulate a drop BEFORE rl1 goes away: the emitter now has drop_count = 0.
+	// We need drop_count > 0 at the moment of the write failure so we can
+	// observe the restore. Inject it by stopping the listener while holding
+	// a non-zero drop count accumulated from a missing socket.
+	//
+	// Step 1: stop rl1 and let the emitter's connection die.
+	rl1.Stop()
+	_ = os.Remove(rl1.path)
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 2: emit to the dead socket — this drops and increments the counter.
+	// We just need drop_count > 0; the exact value depends on OS timing (write
+	// fail on rl1's dead conn, then one or more dial fails), so don't pin it.
+	_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "dead"}, Decision: "allowed"})
+
+	// Step 3: bring up rl2. The emitter will dial + write. Writes may fail
+	// once more (dial race window), but eventually should succeed with drop_count > 0.
+	rl2 := newRecordingListener(t, dir)
+	_ = os.Rename(rl2.path, rl1.path)
+	rl2.path = rl1.path
+
+	// Emit until we receive a frame with drop_count > 0 or time out.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "probe"}, Decision: "allowed"})
+		for _, raw := range rl2.snapshot() {
+			var f frame
+			if err := json.Unmarshal(raw, &f); err != nil {
+				continue
+			}
+			if f.DropCount > 0 {
+				// Capture the count before emitting so the wait target is stable
+				// regardless of when the listener goroutine processes the next frame.
+				beforeCount := len(rl2.snapshot())
+				_ = em.Emit(context.Background(), Event{Channel: "mcp", Tool: Tool{Name: "after"}, Decision: "allowed"})
+				frames2 := rl2.waitForFrames(t, beforeCount+1, 2*time.Second)
+				last := frames2[len(frames2)-1]
+				var after frame
+				if err := json.Unmarshal(last, &after); err != nil {
+					t.Fatalf("unmarshal after frame: %v", err)
+				}
+				if after.DropCount != 0 {
+					t.Errorf("after flush, drop_count = %d; want 0", after.DropCount)
+				}
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("never received a frame with drop_count > 0; snapshot: %v", rl2.snapshot())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 func TestEmit_ConcurrentCallsAreSerialised(t *testing.T) {
 	dir := shortSocketDir(t)
 	rl := newRecordingListener(t, dir)


### PR DESCRIPTION
Closes #391 (partial — drop counter + regression tests; coordinated release remains).

## What this does

**Emitter-side drop counter** (`sdk/go/emitter/emitter.go`)

Every failed send (dial timeout, write timeout, sibling-conn-reset) increments an `atomic.Int64 dropCount` via `logDrop`. On the next successful `Emit`, the accumulated count is atomically swapped to zero and embedded in the frame's `drop_count` field. Every failure path restores via `Add` so no drops are silently discarded. `Close()` documents that any unflushed count is abandoned at shutdown.

**Daemon-side `events_dropped` synthetic receipt** (`daemon/internal/pipeline/build.go`)

- `EmitterFrame` gains `DropCount int64 \`json:"drop_count,omitempty"\`` — negative values rejected by `validateFrame`
- When `DropCount > 0`, `Process` calls `processWithDrop`, which uses `chain.AllocatePair` to reserve two consecutive chain slots under **one mutex acquisition**, guaranteeing the synthetic and live receipts are always adjacent even under concurrent emitter connections
- Synthetic receipt: action type `agent_receipts.events_dropped`, risk `low`, outcome `success`; drop count stored as `emitter.drop_count` in `parameters_disclosure` (namespaced to distinguish it from OS-attested `peer.*` fields)
- If the synthetic insert fails, `Pipeline.ErrorLog` receives the error and `processLive` proceeds for the live receipt — a non-nil return from `Process` always means the live receipt was not persisted
- `processWithDrop` defers both `pair.Rollback()` and `liveAlloc.Rollback()` as panic-safety guards; they share a `*sync.Once` so only the first to fire releases the mutex

**`chain.PairAlloc`** (`daemon/internal/chain/state.go`)

New type returned by `State.AllocatePair()`. Exposes `FirstSeq`/`FirstPrev` as plain values (no Allocation returned for the first slot — avoids the silent-no-op deadlock risk). `CommitFirst(hash)` advances the chain past slot N without releasing the mutex and returns a normal `Allocation` for slot N+1.

**`Pipeline.ErrorLog`** (`daemon/internal/pipeline/build.go`)

New `func(string, ...any)` field, wired to `cfg.Logger.Printf` in `daemon.Run`. Receives non-fatal errors (synthetic receipt failure) so they are visible in the production daemon log without breaking the `Process` return-value contract.

**Regression tests** (`daemon/tests_regressions_test.go`)

- `TestConcurrentDaemonStartSameSocket` — two daemons race the same socket; second returns a graceful error, first keeps serving (#236 regression)
- `TestEmitterRequiresOnlySocketPath` — emitter succeeds with HOME/XDG_DATA_HOME/XDG_RUNTIME_DIR/TMPDIR all pointing at a read-only sandbox dir; any regression that re-adds DB access to the emitter will fail with EACCES
- `TestDropCounterEndToEnd` — full path: daemon down → emitter drops → daemon restarts → `events_dropped` at seq 1, live receipt at seq 2, both verify

## Narrow loss window

Documented in the emitter package comment: if the emitter process crashes after a drop but before the next successful send, the accumulated count is lost and the gap is permanently invisible. Known-and-accepted per ADR-0010.

## Test coverage

| Package | New tests |
|---------|-----------|
| `daemon/internal/chain` | `AllocatePair_AdjacentSequences`, `_RollbackBeforeCommitFirst`, `_RollbackAfterCommitFirst`, `_ConcurrentNoInterleave` |
| `daemon/internal/pipeline` | `DropCountZero`, `InsertsEventsDroppedReceipt`, `PreservesPeerAttestationOnSynthetic`, `ChainContinues`, `SyntheticFailureLiveReceiptPersists`; `negative drop_count` in `RejectsMalformedFrames` |
| `sdk/go/emitter` | `DropCounterIncrementsOnFailure`, `ResetAfterFlush`, `RestoredOnWriteFailure` |
| `daemon` (integration) | `TestConcurrentDaemonStartSameSocket`, `TestEmitterRequiresOnlySocketPath`, `TestDropCounterEndToEnd` |

## What's not in this PR (remaining #391 items)

- Coordinated 0.x pre-release tags across `@agnt-rcpt/openclaw`, `mcp-proxy`, and all three SDKs
- Deprecation notice for in-process signing/storage at cutover