### PR TITLE
chore(release): CHANGELOG for daemon/v0.9.0 and hook/v0.9.0

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-16
+
+### Changed
+
+- **`agent-receipts-hook` extracted into its own module** ([#405](https://github.com/agent-receipts/ar/issues/405),
+  [#407](https://github.com/agent-receipts/ar/pull/407)):
+  The hook binary is no longer bundled in this formula or release tarball.
+  Install it separately: `brew install agent-receipts/tap/agent-receipts-hook`
+  or `go install github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook@latest`.
+
 ## [0.8.1] - 2026-05-15
 
 ### Added

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Changelog
 
-## Unreleased
+All notable changes to `agent-receipts-hook` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.0] - 2026-05-16
 
 ### Changed
 
-- Extracted `agent-receipts-hook` from the `daemon` module into its own Go module (`github.com/agent-receipts/ar/hook`). The `go install` path is now `github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook@latest`. Homebrew install path changes to `brew install agent-receipts/tap/agent-receipts-hook`.
+- **Extracted into its own Go module** ([#405](https://github.com/agent-receipts/ar/issues/405),
+  [#407](https://github.com/agent-receipts/ar/pull/407)):
+  `agent-receipts-hook` now lives at `github.com/agent-receipts/ar/hook` and is
+  released independently of the daemon. Install path:
+  `brew install agent-receipts/tap/agent-receipts-hook` or
+  `go install github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook@latest`.


### PR DESCRIPTION
## What

CHANGELOG entries for the upcoming `daemon/v0.9.0` and `hook/v0.9.0` releases.

## Why

- `daemon/v0.9.0` — minor bump because `agent-receipts-hook` is removed from the Homebrew formula (breaking for existing users)
- `hook/v0.9.0` — inaugural standalone release of the extracted hook module

## Checklist

- [x] Tests pass for all changed components (docs only)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests not affected