### PR TITLE
docs(site): update hook install docs for standalone hook/ module

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -174,7 +174,7 @@ AGENTRECEIPTS_SOCKET=/path/to/events.sock mcp-proxy npx -y @modelcontextprotocol
 
 ### agent-receipts-hook
 
-`agent-receipts-hook` is a short-lived hook binary that captures native agent tool calls (Bash, Write, Edit, Read, …) that bypass `mcp-proxy`. Install it from the same release tarball as the daemon, then [wire it up as a PostToolUse hook](/hook/claude-code/) in your agent runtime. The hook uses the same socket-path resolution as the other emitters — no extra socket configuration needed.
+`agent-receipts-hook` is a short-lived hook binary that captures native agent tool calls (Bash, Write, Edit, Read, …) that bypass `mcp-proxy`. Install it separately (see [Hook Installation](/hook/installation/)), then [wire it up as a PostToolUse hook](/hook/claude-code/) in your agent runtime. The hook uses the same socket-path resolution as the other emitters — no extra socket configuration needed.
 
 ### OpenClaw
 

--- a/site/src/content/docs/hook/claude-code.mdx
+++ b/site/src/content/docs/hook/claude-code.mdx
@@ -39,13 +39,11 @@ Add to `~/.claude/settings.json` to capture tool calls across all projects. Use 
 
 ## Verify receipts appear
 
-After running any Claude Code tool (e.g. a `Bash` command), query the daemon receipt store:
+After running any Claude Code tool (e.g. a `Bash` command), check the dashboard or openclaw — receipts with `channel: claude-code` should appear alongside any MCP receipts from `mcp-proxy`.
 
-```bash
-agent-receipts list
-```
-
-You should see receipts with `channel: claude-code` alongside any MCP receipts from `mcp-proxy`.
+:::note
+`agent-receipts list` is not yet implemented ([#410](https://github.com/agent-receipts/ar/issues/410)). Use the dashboard or openclaw to inspect receipts in the interim.
+:::
 
 ## What Claude Code sends
 
@@ -74,7 +72,7 @@ Claude Code serialises each PostToolUse event as a JSON object on stdin:
 
 ## MCP tool overlap
 
-The empty matcher captures `mcp__*` tools too, which `mcp-proxy` already covers. This produces a second receipt per MCP call — one at `channel: "mcp"` from the proxy, one at `channel: "claude-code"` from the hook. They are distinguishable in `agent-receipts list` output. If you want to exclude MCP tools from the hook, add a non-empty matcher or restrict the hook to specific tool names. See the [overview](/hook/overview/#mcp-tool-overlap) for more detail.
+The empty matcher captures `mcp__*` tools too, which `mcp-proxy` already covers. This produces a second receipt per MCP call — one at `channel: "mcp"` from the proxy, one at `channel: "claude-code"` from the hook. Both share the same `session_id` and are distinguishable by their `channel` field. If you want to exclude MCP tools from the hook, add a non-empty matcher or restrict the hook to specific tool names. See the [overview](/hook/overview/#mcp-tool-overlap) for more detail.
 
 ## Session correlation
 
@@ -84,6 +82,6 @@ Claude Code passes the same `session_id` across all tool calls in a session. Bot
 
 | Flag | Description |
 |---|---|
-| `--format` | Force a specific input format. Defaults to auto-detection via environment variables. Currently supported: `claude-code`. |
+| `--format` | Force a specific input format. Defaults to auto-detection via `hook_event_name` in the stdin payload or the `CLAUDE_SESSION_ID` environment variable. Currently supported: `claude-code`. |
 
 The `--format` flag is intended for testing and future runtime support. In normal Claude Code usage, auto-detection is sufficient.

--- a/site/src/content/docs/hook/claude-code.mdx
+++ b/site/src/content/docs/hook/claude-code.mdx
@@ -39,10 +39,10 @@ Add to `~/.claude/settings.json` to capture tool calls across all projects. Use 
 
 ## Verify receipts appear
 
-After running any Claude Code tool (e.g. a `Bash` command), check the dashboard or openclaw — receipts with `channel: claude-code` should appear alongside any MCP receipts from `mcp-proxy`.
+After running any Claude Code tool (e.g. a `Bash` command), check the dashboard — receipts with `channel: claude-code` should appear alongside any MCP receipts from `mcp-proxy`.
 
 :::note
-`agent-receipts list` is not yet implemented ([#410](https://github.com/agent-receipts/ar/issues/410)). Use the dashboard or openclaw to inspect receipts in the interim.
+`agent-receipts list` is not yet implemented ([#410](https://github.com/agent-receipts/ar/issues/410)). Use the dashboard to inspect receipts in the interim.
 :::
 
 ## What Claude Code sends

--- a/site/src/content/docs/hook/claude-code.mdx
+++ b/site/src/content/docs/hook/claude-code.mdx
@@ -51,6 +51,7 @@ Claude Code serialises each PostToolUse event as a JSON object on stdin:
 
 ```json
 {
+  "hook_event_name": "PostToolUse",
   "session_id": "<current session ID>",
   "tool_name": "Bash",
   "tool_input": { "command": "go test ./..." },
@@ -72,7 +73,7 @@ Claude Code serialises each PostToolUse event as a JSON object on stdin:
 
 ## MCP tool overlap
 
-The empty matcher captures `mcp__*` tools too, which `mcp-proxy` already covers. This produces a second receipt per MCP call — one at `channel: "mcp"` from the proxy, one at `channel: "claude-code"` from the hook. Both share the same `session_id` and are distinguishable by their `channel` field. If you want to exclude MCP tools from the hook, add a non-empty matcher or restrict the hook to specific tool names. See the [overview](/hook/overview/#mcp-tool-overlap) for more detail.
+The empty matcher captures `mcp__*` tools too, which `mcp-proxy` already covers. This produces a second receipt per MCP call — one at `channel: "mcp"` from the proxy, one at `channel: "claude-code"` from the hook. They are distinguishable by their `channel` field. If you want to exclude MCP tools from the hook, add a non-empty matcher or restrict the hook to specific tool names. See the [overview](/hook/overview/#mcp-tool-overlap) for more detail.
 
 ## Session correlation
 

--- a/site/src/content/docs/hook/installation.mdx
+++ b/site/src/content/docs/hook/installation.mdx
@@ -3,7 +3,7 @@ title: Hook Installation
 description: Install the agent-receipts-hook binary and verify it is on your PATH.
 ---
 
-`agent-receipts-hook` ships in the same release tarball as `agent-receipts-daemon` and `agent-receipts`.
+`agent-receipts-hook` is released independently of the daemon — it has its own Homebrew formula and Go module path.
 
 ## Prerequisites
 
@@ -14,19 +14,17 @@ description: Install the agent-receipts-hook binary and verify it is on your PAT
 ### Homebrew (macOS, Linux)
 
 ```bash
-brew install agent-receipts/tap/agent-receipts-daemon
+brew install agent-receipts/tap/agent-receipts-hook
 ```
-
-This installs `agent-receipts-daemon`, `agent-receipts`, and `agent-receipts-hook` from a single tarball.
 
 ### Prebuilt binaries
 
-Download a tarball for your platform (darwin/linux, amd64/arm64) from the [releases page](https://github.com/agent-receipts/ar/releases?q=daemon) and move `agent-receipts-hook` onto your `$PATH`.
+Download a tarball for your platform (darwin/linux, amd64/arm64) from the [releases page](https://github.com/agent-receipts/ar/releases?q=hook) and move `agent-receipts-hook` onto your `$PATH`.
 
 ### From source
 
 ```bash
-go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-hook@latest
+go install github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook@latest
 ```
 
 Requires Go 1.26+.


### PR DESCRIPTION
## What

After #407 extracted `agent-receipts-hook` into its own `hook/` Go module, the site docs still described the hook as bundled with the daemon. This fixes two files:

| File | Change |
|---|---|
| `site/src/content/docs/hook/installation.mdx` | Homebrew formula → `agent-receipts/tap/agent-receipts-hook`; releases link → `?q=hook`; `go install` path → `github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook@latest`; opening sentence updated |
| `site/src/content/docs/getting-started/daemon-setup.mdx` | Hook section no longer says "install from the same tarball as the daemon" — links to Hook Installation page instead |

## Why

Spotted during pre-release E2E validation (#238).