### PR TITLE
fix(hook): detect Claude Code from hook_event_name in JSON payload

### DIFF
--- a/hook/cmd/agent-receipts-hook/main.go
+++ b/hook/cmd/agent-receipts-hook/main.go
@@ -29,19 +29,19 @@ var formats = map[string]reader{
 // environment. An empty string means no format could be auto-detected; the
 // caller should fall back to the --format flag or exit silently.
 //
-// Claude Code sets CLAUDE_SESSION_ID in the environment for older versions and
-// always includes hook_event_name in the stdin JSON payload. We check both so
-// either signal suffices.
+// Claude Code does not set CLAUDE_SESSION_ID as an environment variable; it
+// passes hook_event_name:"PostToolUse" in the stdin JSON payload instead. We
+// check both signals so the binary works with runtimes that take either
+// approach. Only PostToolUse is accepted from stdin to avoid misidentifying
+// PreToolUse or other hook event payloads as PostToolUse frames.
 func detect(stdin []byte, env func(string) string) string {
 	if env("CLAUDE_SESSION_ID") != "" {
 		return "claude-code"
 	}
-	// Claude Code passes hook_event_name in the JSON payload rather than via
-	// an environment variable. Detect by probing the payload directly.
 	var probe struct {
 		HookEventName string `json:"hook_event_name"`
 	}
-	if json.Unmarshal(stdin, &probe) == nil && probe.HookEventName != "" {
+	if json.Unmarshal(stdin, &probe) == nil && probe.HookEventName == "PostToolUse" {
 		return "claude-code"
 	}
 	return ""

--- a/hook/cmd/agent-receipts-hook/main.go
+++ b/hook/cmd/agent-receipts-hook/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"io"
 	"log/slog"
@@ -24,11 +25,23 @@ var formats = map[string]reader{
 	"claude-code": readClaudeCode,
 }
 
-// detect returns the format name inferred from environment variables. An empty
-// string means no format could be auto-detected; the caller should fall back
-// to the --format flag or exit silently.
-func detect(env func(string) string) string {
+// detect returns the format name inferred from the stdin payload and
+// environment. An empty string means no format could be auto-detected; the
+// caller should fall back to the --format flag or exit silently.
+//
+// Claude Code sets CLAUDE_SESSION_ID in the environment for older versions and
+// always includes hook_event_name in the stdin JSON payload. We check both so
+// either signal suffices.
+func detect(stdin []byte, env func(string) string) string {
 	if env("CLAUDE_SESSION_ID") != "" {
+		return "claude-code"
+	}
+	// Claude Code passes hook_event_name in the JSON payload rather than via
+	// an environment variable. Detect by probing the payload directly.
+	var probe struct {
+		HookEventName string `json:"hook_event_name"`
+	}
+	if json.Unmarshal(stdin, &probe) == nil && probe.HookEventName != "" {
 		return "claude-code"
 	}
 	return ""
@@ -53,7 +66,7 @@ func main() {
 
 	format := *formatFlag
 	if format == "" {
-		format = detect(env)
+		format = detect(stdin, env)
 	}
 	if format == "" {
 		// Unknown runtime — nothing to record.

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -204,6 +204,12 @@ func TestDetect(t *testing.T) {
 			want:  "",
 		},
 		{
+			name:  "non-PostToolUse hook_event_name is not detected",
+			stdin: `{"hook_event_name":"PreToolUse","session_id":"s","tool_name":"Bash","tool_input":{}}`,
+			env:   map[string]string{},
+			want:  "",
+		},
+		{
 			name: "no known env vars and empty stdin",
 			env:  map[string]string{},
 			want: "",
@@ -226,15 +232,9 @@ func TestDetect(t *testing.T) {
 		},
 	}
 
-	noEnv := func(k string) string { return "" }
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env := noEnv
-			if tt.env != nil {
-				env = func(k string) string { return tt.env[k] }
-			}
-			got := detect([]byte(tt.stdin), env)
+			got := detect([]byte(tt.stdin), func(k string) string { return tt.env[k] })
 			if got != tt.want {
 				t.Errorf("detect() = %q; want %q", got, tt.want)
 			}

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -175,17 +175,36 @@ func TestReadClaudeCode_InputOutputAreValidJSON(t *testing.T) {
 
 func TestDetect(t *testing.T) {
 	tests := []struct {
-		name string
-		env  map[string]string
-		want string
+		name  string
+		stdin string
+		env   map[string]string
+		want  string
 	}{
 		{
-			name: "CLAUDE_SESSION_ID set",
+			name: "CLAUDE_SESSION_ID env var set",
 			env:  map[string]string{"CLAUDE_SESSION_ID": "abc"},
 			want: "claude-code",
 		},
 		{
-			name: "no known env vars",
+			name:  "hook_event_name in stdin (no env var)",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Bash","tool_input":{},"tool_response":{}}`,
+			env:   map[string]string{},
+			want:  "claude-code",
+		},
+		{
+			name:  "hook_event_name takes precedence over missing env var",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Read"}`,
+			env:   map[string]string{"CLAUDE_SESSION_ID": ""},
+			want:  "claude-code",
+		},
+		{
+			name:  "no env var and no hook_event_name in stdin",
+			stdin: `{"session_id":"s","tool_name":"Bash"}`,
+			env:   map[string]string{},
+			want:  "",
+		},
+		{
+			name: "no known env vars and empty stdin",
 			env:  map[string]string{},
 			want: "",
 		},
@@ -199,11 +218,23 @@ func TestDetect(t *testing.T) {
 			env:  map[string]string{"CLAUDE_SESSION_ID": ""},
 			want: "",
 		},
+		{
+			name:  "malformed stdin does not panic",
+			stdin: `not json`,
+			env:   map[string]string{},
+			want:  "",
+		},
 	}
+
+	noEnv := func(k string) string { return "" }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detect(func(k string) string { return tt.env[k] })
+			env := noEnv
+			if tt.env != nil {
+				env = func(k string) string { return tt.env[k] }
+			}
+			got := detect([]byte(tt.stdin), env)
 			if got != tt.want {
 				t.Errorf("detect() = %q; want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Problem

Claude Code does not set `CLAUDE_SESSION_ID` as an environment variable when invoking PostToolUse hooks. It passes the session identifier inside the JSON stdin payload alongside `hook_event_name`. The previous `detect()` checked only the env var, so every hook invocation exited silently as an "unknown runtime" — no receipts were captured for Claude Code tool calls.

Confirmed via a debug wrapper that showed the actual stdin payload Claude Code delivers:
```json
{
  "hook_event_name": "PostToolUse",
  "session_id": "...",
  "tool_name": "Bash",
  ...
}
```
with `CLAUDE_SESSION_ID` empty in the environment.

## Fix

Update `detect(stdin []byte, env func(string) string)` to also probe the stdin JSON for `hook_event_name`. Either signal now suffices for detection, keeping the env-var path for forward compatibility with runtimes that may set it in future.

## Changes

- `daemon/cmd/agent-receipts-hook/main.go` — update `detect()` signature and add JSON probe
- `daemon/cmd/agent-receipts-hook/main_test.go` — update all `detect()` call sites; add cases for stdin-based detection, no-env-var path, malformed stdin

## Test plan

- [ ] All existing hook tests pass: `go test ./daemon/cmd/agent-receipts-hook/...`
- [ ] New `TestDetect` cases cover: env var path, `hook_event_name` path, neither, malformed stdin
- [ ] Manually verified: after installing the fixed binary, `echo "hook test trigger"` produced a new receipt in `~/.local/share/agent-receipts/receipts.db`