### PR TITLE
chore(mcp-proxy): migrate data directory to ~/.local/share/agent-receipts/

### DIFF
--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -47,23 +47,6 @@ main() {
     *)             die "Unsupported architecture: $(uname -m)" ;;
   esac
 
-  # Detect legacy beta key path before downloading anything.
-  # Old installs wrote to ~/.agent-receipts/; the daemon now uses the XDG path.
-  # An upgrade from the old layout would otherwise look like a fresh install and
-  # silently create a new signing identity under the new path.
-  LEGACY_KEY="${HOME}/.agent-receipts/signing.key"
-  if [ -f "$LEGACY_KEY" ]; then
-    printf '\nLegacy signing key found at: %s\n' "$LEGACY_KEY"
-    printf 'The daemon now uses:         %s\n' "$KEY_FILE"
-    printf 'Move your data before continuing:\n'
-    printf '  mkdir -p "%s"\n' "$(dirname "$KEY_FILE")"
-    printf '  mv "%s" "%s"\n' "$LEGACY_KEY" "$KEY_FILE"
-    printf '  mv "%s.pub" "%s.pub"\n' "$LEGACY_KEY" "$KEY_FILE"
-    printf '  # Also move the receipt database (preserves chain history):\n'
-    printf '  mv "%s" "%s"\n' "${HOME}/.agent-receipts/receipts.db" "${HOME}/.local/share/agent-receipts/receipts.db"
-    die "Aborting — move legacy data and re-run the installer"
-  fi
-
   # Resolve latest stable daemon release.
   # The repo has multiple component release trains (sdk/go/v*, mcp-proxy/v*,
   # daemon/v*) so we filter by tag prefix and skip pre-releases explicitly —

--- a/mcp-proxy/cmd/mcp-proxy/cli.go
+++ b/mcp-proxy/cmd/mcp-proxy/cli.go
@@ -766,7 +766,7 @@ func cmdInit(args []string) {
 	force := fs.Bool("force", false, "Overwrite existing key files")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy init [-name <name>] [-force] [-no-approval] [-http-port <port>]\n\n")
-		fmt.Fprintf(os.Stderr, "  One-command setup: creates ~/.agent-receipts/, generates an Ed25519\n")
+		fmt.Fprintf(os.Stderr, "  One-command setup: creates ~/.local/share/agent-receipts/, generates an Ed25519\n")
 		fmt.Fprintf(os.Stderr, "  signing keypair with correct permissions, initialises the receipt\n")
 		fmt.Fprintf(os.Stderr, "  database, and prints a claude_desktop_config.json snippet to stdout.\n\n")
 		fmt.Fprintf(os.Stderr, "  Safe to re-run: warns and skips key generation if files already exist.\n\n")
@@ -783,11 +783,12 @@ func cmdInit(args []string) {
 		os.Exit(2)
 	}
 
-	home, err := userHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-proxy init: resolve home directory: %v\n", err)
+	dir := xdgDataHome()
+	if dir == "" {
+		fmt.Fprintf(os.Stderr, "mcp-proxy init: resolve data directory: home directory unavailable\n")
 		os.Exit(1)
 	}
+	dir = filepath.Join(dir, "agent-receipts")
 
 	binPath, err := os.Executable()
 	if err != nil {
@@ -795,7 +796,6 @@ func cmdInit(args []string) {
 		binPath = "mcp-proxy"
 	}
 
-	dir := filepath.Join(home, ".agent-receipts")
 	if err := runInit(dir, *name, *force, *noApproval, *httpPort, binPath, os.Stderr, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "mcp-proxy init: %v\n", err)
 		os.Exit(1)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -982,18 +982,40 @@ func recordRejectedToolCall(db *audit.Store, sessionID string, rc rejectedCall) 
 // os.UserHomeDir can still resolve via /etc/passwd).
 var userHomeDir = os.UserHomeDir
 
-// defaultDBPath returns an absolute path under the user's home directory
-// (`~/.agent-receipts/<name>`) for the given filename. MCP clients (Claude
-// Desktop, Claude Code, Codex) spawn the proxy with an unwritable cwd, so a
-// relative default would crash on first open. Falls back to the bare filename
-// only if the home directory cannot be resolved to an absolute path — callers
-// are expected to surface a clear error when that fallback is hit.
-func defaultDBPath(name string) string {
+// xdgDataHome returns the XDG_DATA_HOME directory or its default
+// ($HOME/.local/share). Returns "" when XDG_DATA_HOME is unset and the
+// user's home directory cannot be determined.
+//
+// Per the XDG Base Directory spec, $XDG_DATA_HOME must be an absolute path;
+// a relative value is treated as invalid and ignored, falling back to the
+// $HOME/.local/share default. This protects against a misconfigured
+// environment silently relocating the receipt store under the working
+// directory of whichever process happened to start the proxy.
+func xdgDataHome() string {
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome != "" && filepath.IsAbs(dataHome) {
+		return dataHome
+	}
 	home, err := userHomeDir()
 	if err != nil || home == "" || !filepath.IsAbs(home) {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share")
+}
+
+// defaultDBPath returns an absolute path under the XDG data directory
+// (`$XDG_DATA_HOME/agent-receipts/<name>`, defaulting to
+// `~/.local/share/agent-receipts/<name>`) for the given filename. MCP clients
+// (Claude Desktop, Claude Code, Codex) spawn the proxy with an unwritable
+// cwd, so a relative default would crash on first open. Falls back to the
+// bare filename only if the data home directory cannot be resolved — callers
+// are expected to surface a clear error when that fallback is hit.
+func defaultDBPath(name string) string {
+	dh := xdgDataHome()
+	if dh == "" {
 		return name
 	}
-	return filepath.Join(home, ".agent-receipts", name)
+	return filepath.Join(dh, "agent-receipts", name)
 }
 
 // ensureDir creates the parent directory of path at 0o700 permissions.

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -56,19 +56,63 @@ func withHomeDirResolver(t *testing.T, resolver func() (string, error)) {
 	t.Cleanup(func() { userHomeDir = prev })
 }
 
+// withXDGDataHome temporarily sets XDG_DATA_HOME to dir (or unsets it when dir
+// is empty) and restores the previous value on cleanup.
+func withXDGDataHome(t *testing.T, dir string) {
+	t.Helper()
+	prev, had := os.LookupEnv("XDG_DATA_HOME")
+	if dir == "" {
+		os.Unsetenv("XDG_DATA_HOME")
+	} else {
+		os.Setenv("XDG_DATA_HOME", dir)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("XDG_DATA_HOME", prev)
+		} else {
+			os.Unsetenv("XDG_DATA_HOME")
+		}
+	})
+}
+
 func TestDefaultDBPathUsesHomeDir(t *testing.T) {
 	home := t.TempDir()
 	withHomeDirResolver(t, func() (string, error) { return home, nil })
+	withXDGDataHome(t, "") // ensure XDG_DATA_HOME does not override
 
 	got := defaultDBPath("audit.db")
-	want := filepath.Join(home, ".agent-receipts", "audit.db")
+	want := filepath.Join(home, ".local", "share", "agent-receipts", "audit.db")
 	if got != want {
 		t.Fatalf("defaultDBPath(audit.db) = %q, want %q", got, want)
 	}
 }
 
+func TestDefaultDBPathRespectsXDGDataHome(t *testing.T) {
+	xdgDir := t.TempDir()
+	withXDGDataHome(t, xdgDir)
+
+	got := defaultDBPath("audit.db")
+	want := filepath.Join(xdgDir, "agent-receipts", "audit.db")
+	if got != want {
+		t.Fatalf("defaultDBPath(audit.db) = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDBPathIgnoresRelativeXDGDataHome(t *testing.T) {
+	home := t.TempDir()
+	withHomeDirResolver(t, func() (string, error) { return home, nil })
+	withXDGDataHome(t, "relative/xdg") // relative — must be ignored per XDG spec
+
+	got := defaultDBPath("audit.db")
+	want := filepath.Join(home, ".local", "share", "agent-receipts", "audit.db")
+	if got != want {
+		t.Fatalf("defaultDBPath(audit.db) = %q, want %q; expected relative XDG_DATA_HOME to be ignored", got, want)
+	}
+}
+
 func TestDefaultDBPathFallsBackOnResolverError(t *testing.T) {
 	withHomeDirResolver(t, func() (string, error) { return "", errors.New("no home") })
+	withXDGDataHome(t, "") // ensure XDG_DATA_HOME does not override
 
 	if got := defaultDBPath("audit.db"); got != "audit.db" {
 		t.Fatalf("expected fallback to bare filename, got %q", got)
@@ -77,6 +121,7 @@ func TestDefaultDBPathFallsBackOnResolverError(t *testing.T) {
 
 func TestDefaultDBPathFallsBackOnEmptyHome(t *testing.T) {
 	withHomeDirResolver(t, func() (string, error) { return "", nil })
+	withXDGDataHome(t, "") // ensure XDG_DATA_HOME does not override
 
 	if got := defaultDBPath("audit.db"); got != "audit.db" {
 		t.Fatalf("expected fallback for empty home, got %q", got)
@@ -85,6 +130,7 @@ func TestDefaultDBPathFallsBackOnEmptyHome(t *testing.T) {
 
 func TestDefaultDBPathRejectsRelativeHome(t *testing.T) {
 	withHomeDirResolver(t, func() (string, error) { return "relative/path", nil })
+	withXDGDataHome(t, "") // ensure XDG_DATA_HOME does not override
 
 	if got := defaultDBPath("audit.db"); got != "audit.db" {
 		t.Fatalf("expected fallback for non-absolute home, got %q", got)

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -56,23 +56,12 @@ func withHomeDirResolver(t *testing.T, resolver func() (string, error)) {
 	t.Cleanup(func() { userHomeDir = prev })
 }
 
-// withXDGDataHome temporarily sets XDG_DATA_HOME to dir (or unsets it when dir
-// is empty) and restores the previous value on cleanup.
+// withXDGDataHome temporarily sets XDG_DATA_HOME to dir and restores the
+// previous value on cleanup. Pass "" to disable XDG override (xdgDataHome
+// treats an empty value the same as unset).
 func withXDGDataHome(t *testing.T, dir string) {
 	t.Helper()
-	prev, had := os.LookupEnv("XDG_DATA_HOME")
-	if dir == "" {
-		os.Unsetenv("XDG_DATA_HOME")
-	} else {
-		os.Setenv("XDG_DATA_HOME", dir)
-	}
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("XDG_DATA_HOME", prev)
-		} else {
-			os.Unsetenv("XDG_DATA_HOME")
-		}
-	})
+	t.Setenv("XDG_DATA_HOME", dir)
 }
 
 func TestDefaultDBPathUsesHomeDir(t *testing.T) {

--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -29,7 +29,7 @@ make build
 
 ## Usage
 
-If you use the standard per-user path (`~/.agent-receipts/receipts.db`), no flags are needed:
+If you use the standard per-user path (`~/.local/share/agent-receipts/receipts.db`), no flags are needed:
 
 ```sh
 dashboard
@@ -41,7 +41,7 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `~/.agent-receipts/receipts.db` | Path to a receipt SQLite database |
+| `-db` | `~/.local/share/agent-receipts/receipts.db` | Path to a receipt SQLite database |
 | `-port` | `8080` | Port to serve on |
 
 ### Example

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -202,7 +202,7 @@ A successful run prints the chain length and confirms hash linkage and signature
 
 **Preserve old data offline if you need it.** Auditors who need long-term verification of pre-v0.8 receipts should archive the old SQLite databases and their corresponding public keys before uninstalling the previous tooling. Verification of those receipts continues to work using the archived files and a v0.7 (or compatible) `verify` binary.
 
-**New paths are separate.** The daemon writes to `$XDG_DATA_HOME/agent-receipts/` (falling back to `~/.local/share/agent-receipts/` when `$XDG_DATA_HOME` is unset or not an absolute path). The in-process SDKs typically wrote to `~/.agent-receipts/` or a path configured via `AGENTRECEIPTS_DB`. These directories are distinct — the daemon will not pick up old data.
+**New paths are separate.** The daemon, MCP proxy, and hook all write to `$XDG_DATA_HOME/agent-receipts/` (falling back to `~/.local/share/agent-receipts/` when `$XDG_DATA_HOME` is unset or not an absolute path). The in-process SDKs (pre-v0.8) typically wrote to `~/.agent-receipts/` or a path configured via `AGENTRECEIPTS_DB`. These directories are distinct — the current tooling will not pick up old data from the legacy path.
 
 ## Troubleshooting
 

--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -157,7 +157,7 @@ done < <(tail -f /path/to/proxy.stderr)
 For local testing only, auto-approve every paused call. This defeats the point of the pause rule — do not run it on anything you care about:
 
 ```bash
-sqlite3 ~/.agent-receipts/audit.db \
+sqlite3 ~/.local/share/agent-receipts/audit.db \
   "SELECT approval_id FROM tool_calls WHERE policy_action='pause' AND approved_by IS NULL;" |
 while read -r id; do
   curl -sX POST "http://127.0.0.1:8081/api/tool-calls/$id/approve" \

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -30,7 +30,7 @@ Both `claude mcp add-json` and `.mcp.json` persist their content as plaintext on
 
 ```bash
 mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
+# creates ~/.local/share/agent-receipts/github-proxy.pem (0600) and ~/.local/share/agent-receipts/github-proxy.pem.pub
 ```
 
 Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
@@ -46,7 +46,7 @@ The token needs to reach `mcp-proxy`'s environment **without being written into 
 Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
 
 ```ini
-# ~/.agent-receipts/mcp.env  (chmod 600)
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
 GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
 ```
 
@@ -61,11 +61,11 @@ JSON_BODY=$(cat <<JSON
   "command": "$(which op)",
   "args": [
     "run",
-    "--env-file=$HOME/.agent-receipts/mcp.env",
+    "--env-file=$HOME/.local/share/agent-receipts/mcp.env",
     "--",
     "$(which mcp-proxy)",
     "-name", "github",
-    "-key", "$HOME/.agent-receipts/github-proxy.pem",
+    "-key", "$HOME/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -84,8 +84,8 @@ claude mcp add-json github-audited --scope user "$JSON_BODY"
 set OP (which op)
 set MCP_PROXY (which mcp-proxy)
 set GITHUB_MCP (which github-mcp-server)
-set KEY $HOME/.agent-receipts/github-proxy.pem
-set ENV_FILE $HOME/.agent-receipts/mcp.env
+set KEY $HOME/.local/share/agent-receipts/github-proxy.pem
+set ENV_FILE $HOME/.local/share/agent-receipts/mcp.env
 
 set json (printf '{
   "command": "%s",
@@ -121,7 +121,7 @@ JSON_BODY=$(cat <<JSON
   "command": "$(which mcp-proxy)",
   "args": [
     "-name", "github",
-    "-key", "$HOME/.agent-receipts/github-proxy.pem",
+    "-key", "$HOME/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -142,7 +142,7 @@ claude mcp add-json github-audited --scope user "$JSON_BODY"
 ```fish
 set MCP_PROXY (which mcp-proxy)
 set GITHUB_MCP (which github-mcp-server)
-set KEY $HOME/.agent-receipts/github-proxy.pem
+set KEY $HOME/.local/share/agent-receipts/github-proxy.pem
 
 set json (printf '{
   "command": "%s",
@@ -182,13 +182,13 @@ Since `.mcp.json` is a static JSON file, print the absolute paths you need first
 
 ```bash
 echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
+echo "key:     $HOME/.local/share/agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
 ```
 
 ### Recommended: secret manager
 
-Point Claude Code at `op run`, same as the `claude mcp add-json` pattern above. Each developer needs `~/.agent-receipts/mcp.env` on their machine with their own `op://` reference (or whichever secret manager the team uses).
+Point Claude Code at `op run`, same as the `claude mcp add-json` pattern above. Each developer needs `~/.local/share/agent-receipts/mcp.env` on their machine with their own `op://` reference (or whichever secret manager the team uses).
 
 ```json
 {
@@ -197,11 +197,11 @@ Point Claude Code at `op run`, same as the `claude mcp add-json` pattern above. 
       "command": "/opt/homebrew/bin/op",
       "args": [
         "run",
-        "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -223,7 +223,7 @@ Claude Code expands `${VAR}` placeholders at server-launch time, so each develop
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -244,12 +244,12 @@ The proxy path and key path will need to be consistent across the team, or handl
 After making tool calls through Claude Code, inspect the receipt store from your terminal:
 
 ```bash
-# List all receipts (uses the default ~/.agent-receipts/receipts.db)
+# List all receipts (uses the default ~/.local/share/agent-receipts/receipts.db)
 mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy.pem.pub \
+  -key ~/.local/share/agent-receipts/github-proxy.pem.pub \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -29,7 +29,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
 ```bash
 mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
+# creates ~/.local/share/agent-receipts/github-proxy.pem (0600) and ~/.local/share/agent-receipts/github-proxy.pem.pub
 # prints a claude_desktop_config.json snippet — paste it as a starting point
 ```
 
@@ -43,7 +43,7 @@ Claude Desktop doesn't shell-expand config values, so paste absolute paths. On m
 
 ```bash
 echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
+echo "key:     $HOME/.local/share/agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
 ```
 
@@ -60,7 +60,7 @@ The token needs to reach the MCP server's environment **without being written in
 Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
 
 ```ini
-# ~/.agent-receipts/mcp.env  (chmod 600)
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
 GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
 ```
 
@@ -73,11 +73,11 @@ Point Claude Desktop at `op run` — it resolves the `op://` reference at exec t
       "command": "/opt/homebrew/bin/op",
       "args": [
         "run",
-        "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -103,7 +103,7 @@ security add-generic-password -s github-mcp -a "$USER" -w
 
 ```bash
 #!/usr/bin/env bash
-# ~/.agent-receipts/run-mcp-proxy-github.sh — chmod 700
+# ~/.local/share/agent-receipts/run-mcp-proxy-github.sh — chmod 700
 set -euo pipefail
 GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s github-mcp -a "$USER" -w)" \
   exec /Users/YOU/go/bin/mcp-proxy "$@"
@@ -117,10 +117,10 @@ Point Claude Desktop at the launcher — no `env` block, since the script sets i
 {
   "mcpServers": {
     "github-audited": {
-      "command": "/Users/YOU/.agent-receipts/run-mcp-proxy-github.sh",
+      "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -142,7 +142,7 @@ Useful for kicking the tyres against a throwaway PAT before wiring up secret man
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -165,12 +165,12 @@ Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — ever
 After making tool calls, inspect the receipt store from your terminal:
 
 ```bash
-# List all receipts (uses the default ~/.agent-receipts/receipts.db)
+# List all receipts (uses the default ~/.local/share/agent-receipts/receipts.db)
 mcp-proxy list
 
 # Verify chain integrity
 mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy.pem.pub \
+  -key ~/.local/share/agent-receipts/github-proxy.pem.pub \
   <chain-id>
 ```
 

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -7,8 +7,8 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `$HOME/.agent-receipts/audit.db` | SQLite audit database path. Parent directory is created on first run (mode 0700 on Unix). |
-| `-receipt-db` | `$HOME/.agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created on first run (mode 0700 on Unix). |
+| `-db` | `$HOME/.local/share/agent-receipts/audit.db` | SQLite audit database path. Parent directory is created on first run (mode 0700 on Unix). Respects `$XDG_DATA_HOME`. |
+| `-receipt-db` | `$HOME/.local/share/agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created on first run (mode 0700 on Unix). Respects `$XDG_DATA_HOME`. |
 | `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
 | `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification. Merged with bundled taxonomies; user mappings win on conflict. |
 | `-bundled-taxonomies` | `true` | Include bundled taxonomies (e.g. GitHub, Atlassian) embedded in the binary. Set to `false` to use only `-taxonomy`. |
@@ -169,7 +169,7 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 ```bash
 # Did the failing call reach the proxy at all?
 # Substitute the tool name you saw fail.
-sqlite3 ~/.agent-receipts/audit.db \
+sqlite3 ~/.local/share/agent-receipts/audit.db \
   "SELECT tool_name, policy_action, risk_score, approved_by, approval_wait_us, requested_at
    FROM tool_calls
    WHERE tool_name = 'create_pull_request'
@@ -199,7 +199,7 @@ An approver listener is running and either denied the call or didn't respond in 
 ps aux | grep mcp-proxy | grep -v grep
 
 # Check overall breakdown.
-sqlite3 ~/.agent-receipts/audit.db \
+sqlite3 ~/.local/share/agent-receipts/audit.db \
   "SELECT policy_action, COUNT(*) FROM tool_calls GROUP BY policy_action;"
 ```
 
@@ -228,4 +228,4 @@ mcp-proxy -name github -http 127.0.0.1:8082 ... /path/to/server
 
 `127.0.0.1:0` picks a random free port automatically — fine when the approver parses the stderr discovery event at startup.
 
-Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log. By default both point at `$HOME/.agent-receipts/`, so all clients share one audit log unless you override them.
+Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log. By default both point at `$HOME/.local/share/agent-receipts/` (respecting `$XDG_DATA_HOME`), so all clients share one audit log unless you override them.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -104,11 +104,11 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
       "command": "/opt/homebrew/bin/op",
       "args": [
         "run",
-        "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -130,7 +130,7 @@ claude mcp add-json github-audited --scope user '{
   "command": "/Users/YOU/go/bin/mcp-proxy",
   "args": [
     "-name", "github",
-    "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
+    "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -37,7 +37,7 @@ Remote MCP Server (e.g. mcp.atlassian.com/v1/mcp)
 
 ```bash
 mcp-proxy init --name atlassian-proxy
-# creates ~/.agent-receipts/atlassian-proxy.pem (0600) and ~/.agent-receipts/atlassian-proxy.pem.pub
+# creates ~/.local/share/agent-receipts/atlassian-proxy.pem (0600) and ~/.local/share/agent-receipts/atlassian-proxy.pem.pub
 ```
 
 :::tip[Reuse an existing key]
@@ -55,7 +55,7 @@ Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-r
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "atlassian",
-        "-key", "/Users/YOU/.agent-receipts/atlassian-proxy.pem",
+        "-key", "/Users/YOU/.local/share/agent-receipts/atlassian-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -74,7 +74,7 @@ claude mcp add-json atlassian-audited --scope user '{
   "command": "/Users/YOU/go/bin/mcp-proxy",
   "args": [
     "-name", "atlassian",
-    "-key", "'"$HOME"'/.agent-receipts/atlassian-proxy.pem",
+    "-key", "'"$HOME"'/.local/share/agent-receipts/atlassian-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -108,7 +108,7 @@ The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.co
 **Fix:** run the full proxy command directly in a terminal first, complete the browser OAuth, then Ctrl+C and reconnect via `/mcp`:
 
 ```bash
-$HOME/go/bin/mcp-proxy -name atlassian -key ~/.agent-receipts/atlassian-proxy.pem \
+$HOME/go/bin/mcp-proxy -name atlassian -key ~/.local/share/agent-receipts/atlassian-proxy.pem \
   npx --registry https://registry.npmjs.org -y mcp-remote https://mcp.atlassian.com/v1/mcp
 ```
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -40,7 +40,7 @@ mcp-proxy list --follow --interval 1s     # custom poll interval
 | `-json` | Output as JSON (NDJSON — one object per line — in `--follow` mode) |
 | `-follow`, `-f` | After the initial listing, keep polling and stream new receipts as they are inserted (`tail -f`-style). Exit with `Ctrl-C`. In `--follow` mode, the startup batch is printed in chronological order (oldest → newest) so it reads continuously with the streamed tail. |
 | `-interval` | Poll interval in `--follow` mode (default: `500ms`) |
-| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
 
 ### Example output
 
@@ -76,7 +76,7 @@ mcp-proxy inspect -key public.pem <receipt-id>   # verify signature
 | Flag | Description |
 |------|-------------|
 | `-key` | Public key PEM file to verify the receipt signature |
-| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
 
 ## `mcp-proxy verify`
 
@@ -89,7 +89,7 @@ mcp-proxy verify -key public.pem <chain-id>
 | Flag | Description |
 |------|-------------|
 | `-key` | Public key PEM file (required) |
-| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
 
 ## `mcp-proxy export`
 
@@ -102,7 +102,7 @@ mcp-proxy export <chain-id> > chain.json
 
 | Flag | Description |
 |------|-------------|
-| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
 
 ## `mcp-proxy stats`
 
@@ -116,7 +116,7 @@ mcp-proxy stats -json
 | Flag | Description |
 |------|-------------|
 | `-json` | Output as JSON |
-| `-receipt-db` | Receipt store path (default: `$HOME/.agent-receipts/receipts.db`) |
+| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
 
 ## `mcp-proxy timing`
 
@@ -131,7 +131,7 @@ mcp-proxy timing -limit 10                    # top 10 tools
 
 | Flag | Description |
 |------|-------------|
-| `-db` | Audit database path (default: `$HOME/.agent-receipts/audit.db`) |
+| `-db` | Audit database path (default: `$HOME/.local/share/agent-receipts/audit.db`) |
 | `-session` | Filter by session ID |
 | `-limit` | Maximum number of tools to show (default: `20`) |
 | `-json` | Output as JSON |
@@ -183,7 +183,7 @@ mcp-proxy doctor -json                              # JSON output
 
 ## `mcp-proxy init`
 
-One-command setup: creates `~/.agent-receipts/`, generates an Ed25519 signing keypair with correct permissions (private key `0600`, public key `0644`), initialises the receipt database, and prints a `claude_desktop_config.json` snippet to stdout.
+One-command setup: creates `~/.local/share/agent-receipts/`, generates an Ed25519 signing keypair with correct permissions (private key `0600`, public key `0644`), initialises the receipt database, and prints a `claude_desktop_config.json` snippet to stdout.
 
 Safe to re-run — warns and skips key generation if files already exist (use `-force` to overwrite).
 
@@ -216,7 +216,7 @@ mcp-proxy audit-secrets -db /path/to/audit.db                 # specify audit DB
 
 | Flag | Description |
 |------|-------------|
-| `-db` | Audit database path (default: `$HOME/.agent-receipts/audit.db`) |
+| `-db` | Audit database path (default: `$HOME/.local/share/agent-receipts/audit.db`) |
 | `-redact-patterns` | YAML file with additional patterns to scan for |
 
 If the database was encrypted at rest (proxy launched with `BEACON_ENCRYPTION_KEY`), set the same env var before running so the scanner can decrypt. Without the key, encrypted rows are reported as `encrypted-no-key` and counted as hits.


### PR DESCRIPTION
## What

Migrate the MCP proxy's default data directory from `~/.agent-receipts/` to `~/.local/share/agent-receipts/` (XDG), matching the daemon and hook. Fixes #413.

## Why

The daemon and hook already use `$XDG_DATA_HOME/agent-receipts/` (defaulting to `~/.local/share/agent-receipts/`). The MCP proxy still defaulted to `~/.agent-receipts/`, splitting receipts across two databases. Dashboards reading one path missed the other.

## Changes

**`mcp-proxy/cmd/mcp-proxy/main.go`**
- Add `xdgDataHome()` matching the daemon's exact XDG logic: respects `$XDG_DATA_HOME` when it is set to an absolute path, falls back to `$HOME/.local/share`. Relative `XDG_DATA_HOME` values are rejected per spec.
- `defaultDBPath` now resolves through `xdgDataHome` instead of joining directly from home.

**`mcp-proxy/cmd/mcp-proxy/cli.go`**
- `cmdInit` constructs the init directory via `xdgDataHome` instead of `filepath.Join(home, ".agent-receipts")`.
- Update help text to show new path.

**`mcp-proxy/cmd/mcp-proxy/main_test.go`**
- Update `TestDefaultDBPathUsesHomeDir` assertion to expect the new XDG path.
- Add `withXDGDataHome` helper to isolate `XDG_DATA_HOME` in tests.
- Add `TestDefaultDBPathRespectsXDGDataHome` — verify `$XDG_DATA_HOME` is honoured.
- Add `TestDefaultDBPathIgnoresRelativeXDGDataHome` — verify relative values are rejected.
- Add `withXDGDataHome(t, "")` guards to existing fallback tests so a set env var does not interfere.

**`daemon/install.sh`**
- Remove the legacy beta path check (`~/.agent-receipts/signing.key`). Pre-1.0, no backwards-compatibility shim is needed.

**Site docs** (`site/src/content/docs/`)
- Update all `~/.agent-receipts/` references to `~/.local/share/agent-receipts/` in: `mcp-proxy/configuration.mdx`, `mcp-proxy/approval-ui.mdx`, `mcp-proxy/overview.mdx`, `mcp-proxy/claude-desktop.mdx`, `mcp-proxy/claude-code.mdx`, `mcp-proxy/remote-servers.mdx`, `reference/cli-commands.mdx`, `dashboard/installation.mdx`, `getting-started/daemon-setup.mdx`.

**Out of scope:** the `openclaw` and `dashboard` repos also hard-code `~/.agent-receipts/` and need separate PRs.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `shellcheck`, `mcp-proxy-fmt` via lefthook)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, no protocol changes
- [x] AGENTS.md updated (if project structure changed) — N/A
- [x] Spec changes have been reviewed by a maintainer (if applicable) — N/A