### PR TITLE
feat(hook): fail hard on errors; add PreToolUse support; emitter strict mode

### DIFF
--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -8,17 +8,28 @@ import (
 )
 
 // claudeCodeFrame is the JSON envelope Claude Code sends on stdin for
-// PostToolUse hooks.
+// PostToolUse and PreToolUse hooks.
 type claudeCodeFrame struct {
-	SessionID    string          `json:"session_id"`
-	ToolName     string          `json:"tool_name"`
-	ToolInput    json.RawMessage `json:"tool_input"`
-	ToolResponse json.RawMessage `json:"tool_response"`
+	HookEventName string          `json:"hook_event_name"`
+	SessionID     string          `json:"session_id"`
+	ToolUseID     string          `json:"tool_use_id"`
+	ToolName      string          `json:"tool_name"`
+	ToolInput     json.RawMessage `json:"tool_input"`
+	ToolResponse  json.RawMessage `json:"tool_response"`
 }
 
-// readClaudeCode parses a Claude Code PostToolUse stdin frame and maps it to
-// an emitter.Event. The returned sessionID is the host-supplied session
-// identifier from the frame; it is the empty string when absent.
+// readClaudeCode parses a Claude Code PostToolUse or PreToolUse stdin frame
+// and maps it to an emitter.Event. The decision is derived from the
+// hook_event_name field:
+//   - "PostToolUse" → "allowed" (tool ran successfully)
+//   - "PreToolUse"  → "pending" (tool is about to run; outcome not yet known)
+//
+// The returned sessionID is the host-supplied session identifier from the
+// frame; it is the empty string when absent.
+//
+// Note: tool_use_id is parsed but not forwarded — emitter.Event has no
+// correlation-ID field. A follow-up can add one to the wire format once
+// ADR-0010 is amended.
 func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string, error) {
 	if len(stdin) == 0 {
 		return emitter.Event{}, "", errors.New("empty stdin")
@@ -31,10 +42,23 @@ func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string,
 		return emitter.Event{}, "", errors.New("missing tool_name")
 	}
 
+	var decision string
+	switch f.HookEventName {
+	case "PostToolUse":
+		decision = "allowed"
+	case "PreToolUse":
+		decision = "pending"
+	default:
+		// hook_event_name absent or unrecognised — fall back to "allowed" for
+		// backward compatibility with payloads that omit the field (e.g. runtimes
+		// that set CLAUDE_SESSION_ID but do not include hook_event_name).
+		decision = "allowed"
+	}
+
 	ev := emitter.Event{
 		Channel:  "claude-code",
 		Tool:     emitter.Tool{Name: f.ToolName},
-		Decision: "allowed", // PostToolUse fires after the tool ran successfully
+		Decision: decision,
 	}
 	// Only set Input/Output when non-empty; the emitter rejects non-nil empty
 	// slices and the daemon expects nil to mean "no payload".

--- a/hook/cmd/agent-receipts-hook/integration_test.go
+++ b/hook/cmd/agent-receipts-hook/integration_test.go
@@ -205,15 +205,18 @@ func TestIntegration_ClaudeCodeFrame(t *testing.T) {
 	}
 }
 
-// TestIntegration_DaemonDown verifies the hook exits silently (no panic, no
-// error returned) when the daemon socket is unreachable. This is the
-// fire-and-forget contract: a missing daemon must never block the agent.
-func TestIntegration_DaemonDown(t *testing.T) {
+// TestIntegration_DaemonDown_StrictErrors verifies that with WithStrictErrors()
+// (the mode the hook uses), Emit returns an error when the daemon socket is
+// unreachable. The hook then exits non-zero to surface the failure to the agent
+// runtime. Latency must still be bounded by the dial timeout so the agent is
+// not blocked indefinitely.
+func TestIntegration_DaemonDown_StrictErrors(t *testing.T) {
 	dir := shortSocketDir(t)
 	// No listener started — socket path doesn't exist.
 	socketPath := filepath.Join(dir, "missing.sock")
 
 	stdin := `{
+		"hook_event_name": "PostToolUse",
 		"session_id": "no-daemon",
 		"tool_name": "Read",
 		"tool_input": {"file_path":"/tmp/test.txt"},
@@ -229,6 +232,55 @@ func TestIntegration_DaemonDown(t *testing.T) {
 		emitter.WithSocketPath(socketPath),
 		emitter.WithSessionID(sid),
 		emitter.WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+		emitter.WithStrictErrors(),
+	)
+	if err != nil {
+		t.Fatalf("emitter.New: %v", err)
+	}
+	defer em.Close()
+
+	start := time.Now()
+	emitErr := em.Emit(context.Background(), ev)
+	elapsed := time.Since(start)
+
+	// With strict errors, a missing daemon must surface as an error.
+	if emitErr == nil {
+		t.Error("Emit returned nil; want error when daemon is unreachable (strict mode)")
+	}
+
+	// Latency must still be bounded: dial timeout (25ms) is the dominant cost.
+	// Allow 2x for slow CI.
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("Emit took %s; want <250ms even in strict mode", elapsed)
+	}
+}
+
+// TestIntegration_DaemonDown_FireAndForget verifies that without WithStrictErrors,
+// the default fire-and-forget behaviour is preserved: Emit returns nil quickly
+// when the daemon socket is unreachable.
+func TestIntegration_DaemonDown_FireAndForget(t *testing.T) {
+	dir := shortSocketDir(t)
+	// No listener started — socket path doesn't exist.
+	socketPath := filepath.Join(dir, "missing.sock")
+
+	stdin := `{
+		"hook_event_name": "PostToolUse",
+		"session_id": "no-daemon-faf",
+		"tool_name": "Read",
+		"tool_input": {"file_path":"/tmp/test.txt"},
+		"tool_response": {"content":"hello"}
+	}`
+
+	ev, sid, err := readClaudeCode([]byte(stdin), func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+
+	em, err := emitter.New(
+		emitter.WithSocketPath(socketPath),
+		emitter.WithSessionID(sid),
+		emitter.WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+		// no WithStrictErrors — fire-and-forget mode
 	)
 	if err != nil {
 		t.Fatalf("emitter.New: %v", err)

--- a/hook/cmd/agent-receipts-hook/main.go
+++ b/hook/cmd/agent-receipts-hook/main.go
@@ -1,14 +1,21 @@
 // Command agent-receipts-hook is a short-lived hook binary invoked by agent
-// runtimes (Claude Code, Codex, …) on PostToolUse events. It reads a JSON
-// frame from stdin, maps it to an emitter.Event, and forwards it to the
-// agent-receipts-daemon over a Unix-domain socket. The binary always exits 0
-// so it never blocks the agent, consistent with ADR-0010 §"Failure model".
+// runtimes (Claude Code, Codex, …) on PostToolUse and PreToolUse events. It
+// reads a JSON frame from stdin, maps it to an emitter.Event, and forwards it
+// to the agent-receipts-daemon over a Unix-domain socket.
+//
+// Exit behaviour:
+//   - stdin unreadable or runtime not recognised → silent exit 0 (not our concern)
+//   - runtime identified, any subsequent failure → exit 1 + message to stderr
+//
+// The strict-error exit-1 behaviour is intentional: once we know which runtime
+// is calling us, a failure to record the receipt is a signal worth surfacing.
 package main
 
 import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -30,10 +37,9 @@ var formats = map[string]reader{
 // caller should fall back to the --format flag or exit silently.
 //
 // Claude Code does not set CLAUDE_SESSION_ID as an environment variable; it
-// passes hook_event_name:"PostToolUse" in the stdin JSON payload instead. We
-// check both signals so the binary works with runtimes that take either
-// approach. Only PostToolUse is accepted from stdin to avoid misidentifying
-// PreToolUse or other hook event payloads as PostToolUse frames.
+// passes hook_event_name in the stdin JSON payload instead. We check both
+// signals so the binary works with runtimes that take either approach.
+// Both "PostToolUse" and "PreToolUse" are accepted from stdin.
 func detect(stdin []byte, env func(string) string) string {
 	if env("CLAUDE_SESSION_ID") != "" {
 		return "claude-code"
@@ -41,8 +47,11 @@ func detect(stdin []byte, env func(string) string) string {
 	var probe struct {
 		HookEventName string `json:"hook_event_name"`
 	}
-	if json.Unmarshal(stdin, &probe) == nil && probe.HookEventName == "PostToolUse" {
-		return "claude-code"
+	if json.Unmarshal(stdin, &probe) == nil {
+		switch probe.HookEventName {
+		case "PostToolUse", "PreToolUse":
+			return "claude-code"
+		}
 	}
 	return ""
 }
@@ -73,20 +82,24 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Runtime identified. From this point, failures exit 1 with a message so
+	// the agent runtime can surface the problem.
+
 	read, ok := formats[format]
 	if !ok {
-		// Unsupported format — drop silently.
-		os.Exit(0)
+		fmt.Fprintf(os.Stderr, "agent-receipts-hook: unsupported format %q\n", format)
+		os.Exit(1)
 	}
 
 	ev, sessionID, err := read(stdin, env)
 	if err != nil {
-		// Malformed or unrecognisable frame — drop silently.
-		os.Exit(0)
+		fmt.Fprintf(os.Stderr, "agent-receipts-hook: cannot parse %s payload: %v\n", format, err)
+		os.Exit(1)
 	}
 
 	opts := []emitter.Option{
 		emitter.WithLogger(logger),
+		emitter.WithStrictErrors(),
 	}
 	if sessionID != "" {
 		opts = append(opts, emitter.WithSessionID(sessionID))
@@ -94,11 +107,14 @@ func main() {
 
 	em, err := emitter.New(opts...)
 	if err != nil {
-		// No socket path available for this platform — drop silently.
-		os.Exit(0)
+		fmt.Fprintf(os.Stderr, "agent-receipts-hook: cannot create emitter: %v\n", err)
+		os.Exit(1)
 	}
 	defer em.Close()
 
-	_ = em.Emit(context.Background(), ev)
+	if err := em.Emit(context.Background(), ev); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-receipts-hook: emit failed: %v\n", err)
+		os.Exit(1)
+	}
 	os.Exit(0)
 }

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -12,62 +12,100 @@ import (
 
 func TestReadClaudeCode(t *testing.T) {
 	tests := []struct {
-		name      string
-		stdin     string
-		wantErr   bool
-		wantTool  string
-		wantSID   string
-		wantInput bool
-		wantOut   bool
+		name         string
+		stdin        string
+		wantErr      bool
+		wantTool     string
+		wantSID      string
+		wantDecision string
+		wantInput    bool
+		wantOut      bool
 	}{
 		{
-			name: "full frame",
+			name: "PostToolUse full frame",
 			stdin: `{
+				"hook_event_name": "PostToolUse",
 				"session_id": "sess-abc",
 				"tool_name": "Bash",
 				"tool_input": {"command":"go test ./..."},
 				"tool_response": {"output":"ok","exit_code":0}
 			}`,
-			wantTool:  "Bash",
-			wantSID:   "sess-abc",
-			wantInput: true,
-			wantOut:   true,
+			wantTool:     "Bash",
+			wantSID:      "sess-abc",
+			wantDecision: "allowed",
+			wantInput:    true,
+			wantOut:      true,
+		},
+		{
+			name: "PreToolUse frame",
+			stdin: `{
+				"hook_event_name": "PreToolUse",
+				"session_id": "sess-pre",
+				"tool_use_id": "tu-001",
+				"tool_name": "Bash",
+				"tool_input": {"command":"rm -rf /"}
+			}`,
+			wantTool:     "Bash",
+			wantSID:      "sess-pre",
+			wantDecision: "pending",
+			wantInput:    true,
+			wantOut:      false,
+		},
+		{
+			name: "legacy frame without hook_event_name falls back to allowed",
+			stdin: `{
+				"session_id": "sess-legacy",
+				"tool_name": "Bash",
+				"tool_input": {"command":"go test ./..."},
+				"tool_response": {"output":"ok","exit_code":0}
+			}`,
+			wantTool:     "Bash",
+			wantSID:      "sess-legacy",
+			wantDecision: "allowed",
+			wantInput:    true,
+			wantOut:      true,
 		},
 		{
 			name: "no session_id",
 			stdin: `{
+				"hook_event_name": "PostToolUse",
 				"tool_name": "Read",
 				"tool_input": {"file_path":"/etc/hosts"},
 				"tool_response": {"content":"127.0.0.1 localhost"}
 			}`,
-			wantTool:  "Read",
-			wantSID:   "",
-			wantInput: true,
-			wantOut:   true,
+			wantTool:     "Read",
+			wantSID:      "",
+			wantDecision: "allowed",
+			wantInput:    true,
+			wantOut:      true,
 		},
 		{
 			name: "no tool_input",
 			stdin: `{
+				"hook_event_name": "PostToolUse",
 				"session_id": "s1",
 				"tool_name": "WebSearch",
 				"tool_response": {"results":[]}
 			}`,
-			wantTool:  "WebSearch",
-			wantSID:   "s1",
-			wantInput: false,
-			wantOut:   true,
+			wantTool:     "WebSearch",
+			wantSID:      "s1",
+			wantDecision: "allowed",
+			wantInput:    false,
+			wantOut:      true,
 		},
 		{
 			name: "no tool_response",
 			stdin: `{
+				"hook_event_name": "PostToolUse",
 				"session_id": "s2",
 				"tool_name": "Write",
 				"tool_input": {"file_path":"x.go","content":"package main"}
 			}`,
-			wantTool:  "Write",
-			wantSID:   "s2",
-			wantInput: true,
-			wantOut:   false,
+			wantTool:     "Write",
+			wantSID:      "s2",
+			wantDecision: "allowed",
+			wantInput:    true,
+			wantOut:      false,
 		},
 		{
 			name:    "missing tool_name",
@@ -90,18 +128,20 @@ func TestReadClaudeCode(t *testing.T) {
 				// Build a frame with a large but valid JSON input.
 				val := strings.Repeat("x", 100)
 				f := map[string]any{
-					"session_id":    "big",
-					"tool_name":     "Bash",
-					"tool_input":    map[string]string{"command": val},
-					"tool_response": map[string]string{"output": val},
+					"hook_event_name": "PostToolUse",
+					"session_id":      "big",
+					"tool_name":       "Bash",
+					"tool_input":      map[string]string{"command": val},
+					"tool_response":   map[string]string{"output": val},
 				}
 				b, _ := json.Marshal(f)
 				return string(b)
 			}(),
-			wantTool:  "Bash",
-			wantSID:   "big",
-			wantInput: true,
-			wantOut:   true,
+			wantTool:     "Bash",
+			wantSID:      "big",
+			wantDecision: "allowed",
+			wantInput:    true,
+			wantOut:      true,
 		},
 	}
 
@@ -128,8 +168,12 @@ func TestReadClaudeCode(t *testing.T) {
 			if ev.Tool.Server != "" {
 				t.Errorf("Tool.Server = %q; want empty", ev.Tool.Server)
 			}
-			if ev.Decision != "allowed" {
-				t.Errorf("Decision = %q; want allowed", ev.Decision)
+			wantDecision := tt.wantDecision
+			if wantDecision == "" {
+				wantDecision = "allowed"
+			}
+			if ev.Decision != wantDecision {
+				t.Errorf("Decision = %q; want %q", ev.Decision, wantDecision)
 			}
 			if sid != tt.wantSID {
 				t.Errorf("sessionID = %q; want %q", sid, tt.wantSID)
@@ -204,8 +248,14 @@ func TestDetect(t *testing.T) {
 			want:  "",
 		},
 		{
-			name:  "non-PostToolUse hook_event_name is not detected",
+			name:  "PreToolUse hook_event_name is detected as claude-code",
 			stdin: `{"hook_event_name":"PreToolUse","session_id":"s","tool_name":"Bash","tool_input":{}}`,
+			env:   map[string]string{},
+			want:  "claude-code",
+		},
+		{
+			name:  "unrecognised hook_event_name is not detected",
+			stdin: `{"hook_event_name":"StopHook","session_id":"s"}`,
 			env:   map[string]string{},
 			want:  "",
 		},
@@ -244,23 +294,11 @@ func TestDetect(t *testing.T) {
 
 // --- emitter.Event compatibility tests ---
 
-// TestReadClaudeCode_EventAcceptedByEmitter verifies that the emitter.Event
-// produced by readClaudeCode satisfies the emitter's validation rules (channel,
-// tool.name, decision, valid JSON). This catches mismatches before the emitter
-// rejects the frame at emit time.
-func TestReadClaudeCode_EventAcceptedByEmitter(t *testing.T) {
-	stdin := `{
-		"session_id": "compat-test",
-		"tool_name": "Bash",
-		"tool_input": {"command":"echo hello"},
-		"tool_response": {"output":"hello\n","exit_code":0}
-	}`
-	ev, _, err := readClaudeCode([]byte(stdin), func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("readClaudeCode: %v", err)
-	}
-
-	// Replicate the emitter's validation rules without dialling a socket.
+// checkEventAcceptedByEmitter replicates the emitter's validation rules without
+// dialling a socket. Used by TestReadClaudeCode_EventAcceptedByEmitter and
+// TestReadClaudeCode_PreToolUseAcceptedByEmitter.
+func checkEventAcceptedByEmitter(t *testing.T, ev emitter.Event) {
+	t.Helper()
 	if ev.Channel == "" {
 		t.Error("Channel is empty; emitter would reject")
 	}
@@ -284,7 +322,49 @@ func TestReadClaudeCode_EventAcceptedByEmitter(t *testing.T) {
 	if ev.Output != nil && !json.Valid(ev.Output) {
 		t.Errorf("Output is not valid JSON: %s", ev.Output)
 	}
-
 	// Sanity-check emitter.Tool type is used (compile-time check embedded here).
 	var _ emitter.Tool = ev.Tool
+}
+
+// TestReadClaudeCode_EventAcceptedByEmitter verifies that the emitter.Event
+// produced by readClaudeCode for a PostToolUse frame satisfies the emitter's
+// validation rules. This catches mismatches before the emitter rejects the
+// frame at emit time.
+func TestReadClaudeCode_EventAcceptedByEmitter(t *testing.T) {
+	stdin := `{
+		"hook_event_name": "PostToolUse",
+		"session_id": "compat-test",
+		"tool_name": "Bash",
+		"tool_input": {"command":"echo hello"},
+		"tool_response": {"output":"hello\n","exit_code":0}
+	}`
+	ev, _, err := readClaudeCode([]byte(stdin), func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+	if ev.Decision != "allowed" {
+		t.Errorf("PostToolUse decision = %q; want allowed", ev.Decision)
+	}
+	checkEventAcceptedByEmitter(t, ev)
+}
+
+// TestReadClaudeCode_PreToolUseAcceptedByEmitter verifies that the emitter.Event
+// produced by readClaudeCode for a PreToolUse frame satisfies the emitter's
+// validation rules, with decision="pending".
+func TestReadClaudeCode_PreToolUseAcceptedByEmitter(t *testing.T) {
+	stdin := `{
+		"hook_event_name": "PreToolUse",
+		"session_id": "pre-compat-test",
+		"tool_use_id": "tu-abc",
+		"tool_name": "Write",
+		"tool_input": {"file_path":"x.go","content":"package main"}
+	}`
+	ev, _, err := readClaudeCode([]byte(stdin), func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+	if ev.Decision != "pending" {
+		t.Errorf("PreToolUse decision = %q; want pending", ev.Decision)
+	}
+	checkEventAcceptedByEmitter(t, ev)
 }

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -95,9 +95,10 @@ type Event struct {
 type Option func(*config)
 
 type config struct {
-	socketPath string
-	sessionID  string
-	logger     *slog.Logger
+	socketPath   string
+	sessionID    string
+	logger       *slog.Logger
+	strictErrors bool
 }
 
 // WithSocketPath overrides the daemon socket path. When unset, the path
@@ -130,6 +131,18 @@ func WithLogger(l *slog.Logger) Option {
 	return func(c *config) { c.logger = l }
 }
 
+// WithStrictErrors makes Emit return dial and write failures as errors
+// instead of silently dropping them. The default fire-and-forget behaviour
+// (returning nil on transient I/O failures) is preserved for all callers
+// that do not pass this option, so it is a non-breaking addition.
+//
+// Use this option when the caller must know whether the event reached the
+// daemon — for example, a hook binary that should exit non-zero when the
+// daemon is unreachable so the agent runtime surfaces the failure.
+func WithStrictErrors() Option {
+	return func(c *config) { c.strictErrors = true }
+}
+
 // Emitter is the daemon-socket client. Construct with New, fire events
 // with Emit, release the socket with Close. Safe for concurrent Emit.
 type Emitter struct {
@@ -139,9 +152,10 @@ type Emitter struct {
 	// Uses atomic.Int64 so concurrent logDrop calls never corrupt state.
 	dropCount atomic.Int64
 
-	socketPath string
-	sessionID  string
-	logger     *slog.Logger
+	socketPath   string
+	sessionID    string
+	logger       *slog.Logger
+	strictErrors bool
 
 	mu     sync.Mutex
 	conn   net.Conn
@@ -174,9 +188,10 @@ func New(opts ...Option) (*Emitter, error) {
 		cfg.logger = slog.Default()
 	}
 	return &Emitter{
-		socketPath: cfg.socketPath,
-		sessionID:  cfg.sessionID,
-		logger:     cfg.logger,
+		socketPath:   cfg.socketPath,
+		sessionID:    cfg.sessionID,
+		logger:       cfg.logger,
+		strictErrors: cfg.strictErrors,
 	}, nil
 }
 
@@ -311,6 +326,9 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 			}
 			e.dropCount.Add(pendingDrops)
 			e.logDrop(ctx, "dial", err)
+			if e.strictErrors {
+				return fmt.Errorf("emitter: dial %s: %w", e.socketPath, err)
+			}
 			return nil
 		}
 		// Install with a check-and-set: if a sibling Emit dialled and
@@ -358,7 +376,11 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		// Emit re-establish.
 		e.mu.Unlock()
 		e.dropCount.Add(pendingDrops)
-		e.logDrop(ctx, "write", errors.New("connection reset by sibling Emit"))
+		siblingErr := errors.New("connection reset by sibling Emit")
+		e.logDrop(ctx, "write", siblingErr)
+		if e.strictErrors {
+			return fmt.Errorf("emitter: write: %w", siblingErr)
+		}
 		return nil
 	}
 	if err := e.writeFrame(ctx, conn, body); err != nil {
@@ -375,6 +397,9 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		e.dropCount.Add(pendingDrops)
 		e.logDrop(ctx, "write", err)
 		_ = conn.Close()
+		if e.strictErrors {
+			return fmt.Errorf("emitter: write frame: %w", err)
+		}
 		return nil
 	}
 	e.mu.Unlock()

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -887,6 +887,96 @@ func TestEmit_DropCounterRestoredOnWriteFailure(t *testing.T) {
 	}
 }
 
+// TestEmit_StrictErrors_DialFailure asserts that WithStrictErrors() causes
+// Emit to return an error when the daemon socket is missing, rather than
+// silently returning nil (the default fire-and-forget behaviour).
+func TestEmit_StrictErrors_DialFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+	em, err := New(
+		WithSocketPath(filepath.Join(dir, "missing.sock")),
+		WithLogger(silentLogger()),
+		WithStrictErrors(),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	err = em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "noop"},
+		Decision: "allowed",
+	})
+	if err == nil {
+		t.Error("Emit with strict errors returned nil; want error on dial failure")
+	}
+}
+
+// TestEmit_StrictErrors_WriteFailure asserts that WithStrictErrors() causes
+// Emit to return an error when the write fails (listener closed mid-stream),
+// rather than silently returning nil.
+func TestEmit_StrictErrors_WriteFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	em, err := New(
+		WithSocketPath(rl.path),
+		WithLogger(silentLogger()),
+		WithStrictErrors(),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	// Establish the connection via a successful emit.
+	if err := em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "first"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Fatalf("first Emit: %v", err)
+	}
+	rl.waitForFrames(t, 1, 2*time.Second)
+
+	// Stop listener and remove socket so the next write fails.
+	rl.Stop()
+	_ = os.Remove(rl.path)
+	time.Sleep(50 * time.Millisecond)
+
+	err = em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "failing"},
+		Decision: "allowed",
+	})
+	if err == nil {
+		t.Error("Emit with strict errors returned nil; want error on write failure")
+	}
+}
+
+// TestEmit_NoStrictErrors_DialFailure confirms that without WithStrictErrors
+// the default fire-and-forget behaviour is preserved: dial failure returns nil.
+func TestEmit_NoStrictErrors_DialFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+	em, err := New(
+		WithSocketPath(filepath.Join(dir, "missing.sock")),
+		WithLogger(silentLogger()),
+		// no WithStrictErrors
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	if err := em.Emit(context.Background(), Event{
+		Channel:  "mcp",
+		Tool:     Tool{Name: "noop"},
+		Decision: "allowed",
+	}); err != nil {
+		t.Errorf("Emit without strict errors returned error %v; want nil (fire-and-forget)", err)
+	}
+}
+
 func TestEmit_ConcurrentCallsAreSerialised(t *testing.T) {
 	dir := shortSocketDir(t)
 	rl := newRecordingListener(t, dir)


### PR DESCRIPTION
## What

Three related changes to make the `agent-receipts-hook` binary behave correctly in production:

1. **`sdk/go/emitter`: `WithStrictErrors()` option** — new `Option` that makes `Emit` return dial/write failures as errors instead of silently dropping them. The existing fire-and-forget behaviour is unchanged for all callers that don't opt in (MCP proxy, etc.).

2. **`hook/claude_code.go`: PreToolUse support** — extends the frame parser to handle both `PostToolUse` (decision=`"allowed"`) and `PreToolUse` (decision=`"pending"`). Frames without `hook_event_name` fall back to `"allowed"` for backward compatibility. The `tool_use_id` field is parsed but not yet forwarded (no correlation-ID field exists on `emitter.Event`; tracked as follow-up once ADR-0010 is amended — see below).

3. **`hook/main.go`: fail hard once runtime is identified** — changes all error paths after format detection to exit 1 + stderr message instead of silent exit 0. The only remaining silent exit 0 paths are: stdin unreadable (before detection) and unknown runtime (not our concern). `detect()` is updated to accept `"PreToolUse"` alongside `"PostToolUse"`.

## Why

Closes #412.

Currently the hook exits 0 on every failure, even when the daemon is down or the payload is malformed. This makes it impossible for an operator to know whether receipts are actually being recorded — the hook appears to succeed even when nothing happened.

Once the runtime is identified, a failure to emit a receipt is a signal worth surfacing. Claude Code and other runtimes can display hook exit codes in their UI; a non-zero exit makes the gap visible.

The `WithStrictErrors()` option keeps the emitter's published API non-breaking: the MCP proxy and any other callers continue to get fire-and-forget semantics.

## ADR-0010 note

`tool_use_id` forwarding requires adding a correlation-ID field to the wire format, which is a spec change. That amendment is tracked separately and is explicitly out of scope for this PR per the issue instructions.

## Test plan

- [x] `go test ./sdk/go/emitter/...` — 3 new tests: `TestEmit_StrictErrors_DialFailure`, `TestEmit_StrictErrors_WriteFailure`, `TestEmit_NoStrictErrors_DialFailure`
- [x] `go test ./hook/...` — updated `TestIntegration_DaemonDown` split into `TestIntegration_DaemonDown_StrictErrors` (asserts error returned) and `TestIntegration_DaemonDown_FireAndForget` (asserts nil returned without option); new `TestReadClaudeCode_PreToolUseAcceptedByEmitter`; `TestDetect` now includes PreToolUse detection cases
- [x] `go vet ./sdk/go/... ./hook/...` — clean
- [x] All 35 tests pass