### PR TITLE
chore(deps): bump sdk/go to v0.9.0 in hook and daemon

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/daemon
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.8.0
+	github.com/agent-receipts/ar/sdk/go v0.9.0
 	golang.org/x/sys v0.43.0
 )
 

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.8.0 h1:eslo3Zf9qoo+STBy/ge7ND8ZTGIMsOgfQGhZjo6hcWY=
-github.com/agent-receipts/ar/sdk/go v0.8.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
+github.com/agent-receipts/ar/sdk/go v0.9.0 h1:UfFy16p/zaIgS31kmvC+c9dDthaINnSqSkIvfSQjyg4=
+github.com/agent-receipts/ar/sdk/go v0.9.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,7 +2,7 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.8.0
+require github.com/agent-receipts/ar/sdk/go v0.9.0
 
 require (
 	// daemon is a test-only dep of sdk/go/emitter (integration build tag). Lazy loading

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -1,7 +1,7 @@
 github.com/agent-receipts/ar/daemon v0.8.1 h1:X0NgmM3Oir0c226b0LOeJBP2zOaBVA+Hudh6zTj4yhE=
 github.com/agent-receipts/ar/daemon v0.8.1/go.mod h1:d7p+vyoZlHSzae2rJnMetD7skqOAKNm1c2+bL5rgTOE=
-github.com/agent-receipts/ar/sdk/go v0.8.0 h1:eslo3Zf9qoo+STBy/ge7ND8ZTGIMsOgfQGhZjo6hcWY=
-github.com/agent-receipts/ar/sdk/go v0.8.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
+github.com/agent-receipts/ar/sdk/go v0.9.0 h1:UfFy16p/zaIgS31kmvC+c9dDthaINnSqSkIvfSQjyg4=
+github.com/agent-receipts/ar/sdk/go v0.9.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
Updates `hook/go.mod` and `daemon/go.mod` to reference the published `sdk/go v0.9.0` (adds `emitter.WithStrictErrors()`). Required before releasing hook v0.10.0 and daemon v0.9.1.