### PR TITLE
feat(cli): implement agent-receipts list command

### DIFF
--- a/daemon/cmd/agent-receipts/main.go
+++ b/daemon/cmd/agent-receipts/main.go
@@ -1,19 +1,20 @@
-// Command agent-receipts is the daemon's read-side companion CLI. The first
-// subcommand is `verify`, which validates the chain in a daemon-written
-// SQLite store using the daemon-published public key. Logic lives in
-// internal/verifycli so it can be tested without shelling out to the binary.
+// Command agent-receipts is the daemon's read-side companion CLI. Logic lives
+// in internal/verifycli and internal/listcli so subcommands can be tested
+// without shelling out to the binary.
 package main
 
 import (
 	"fmt"
 	"os"
 
+	"github.com/agent-receipts/ar/daemon/internal/listcli"
 	"github.com/agent-receipts/ar/daemon/internal/verifycli"
 )
 
 const usage = `Usage: agent-receipts <command> [flags]
 
 Commands:
+  list     List recent receipts from the store.
   verify   Verify a stored chain's signatures and hash links.
 
 Run 'agent-receipts <command> -h' for command-specific flags.
@@ -25,6 +26,8 @@ func main() {
 		os.Exit(verifycli.ExitUsageError)
 	}
 	switch os.Args[1] {
+	case "list":
+		os.Exit(listcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
 	case "verify":
 		os.Exit(verifycli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
 	case "-h", "--help", "help":

--- a/daemon/internal/listcli/list.go
+++ b/daemon/internal/listcli/list.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"text/tabwriter"
 
 	"github.com/agent-receipts/ar/daemon"
@@ -133,6 +134,9 @@ func writeTabular(stdout io.Writer, receipts []receipt.AgentReceipt) int {
 
 func exitFromFlush(w *tabwriter.Writer) int {
 	if err := w.Flush(); err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			return ExitOK
+		}
 		return ExitUsageError
 	}
 	return ExitOK

--- a/daemon/internal/listcli/list.go
+++ b/daemon/internal/listcli/list.go
@@ -1,0 +1,139 @@
+// Package listcli implements the `agent-receipts list` subcommand:
+// query recent receipts from a daemon-written SQLite store and print them in
+// tabular or JSON form. It opens the database read-only so it is safe to run
+// while the daemon is the active writer.
+//
+// Logic lives here, away from cmd/agent-receipts/main.go, so tests can drive
+// the subcommand directly with arbitrary args / captured I/O without shelling
+// out to a built binary.
+package listcli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+const (
+	ExitOK         = 0
+	ExitUsageError = 2
+)
+
+const defaultLimit = 50
+
+// Run executes the list subcommand with the given args (sans the program name
+// and "list" subcommand token), writing output to stdout and diagnostics to
+// stderr. Returns one of the Exit* constants.
+//
+// envLookup is split out so tests can inject a deterministic environment
+// without touching the real process env. Pass os.Getenv for the production
+// caller.
+func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string) int {
+	if envLookup == nil {
+		envLookup = os.Getenv
+	}
+	envOr := func(key, fallback string) string {
+		if v := envLookup(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
+	asJSON := fs.Bool("json", false, "Output raw JSON array instead of tabular text")
+	limit := fs.Int("limit", defaultLimit, "Maximum number of receipts to return")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitUsageError
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "agent-receipts list: unexpected positional argument(s): %v\n", fs.Args())
+		return ExitUsageError
+	}
+	if *dbPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts list: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		return ExitUsageError
+	}
+	if *limit <= 0 {
+		fmt.Fprintln(stderr, "agent-receipts list: --limit must be a positive integer")
+		return ExitUsageError
+	}
+
+	s, err := store.OpenReadOnly(*dbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts list: open store: %v\n", err)
+		return ExitUsageError
+	}
+	defer s.Close()
+
+	lim := *limit
+	receipts, err := s.QueryReceipts(store.Query{
+		Limit:       &lim,
+		NewestFirst: true,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts list: query: %v\n", err)
+		return ExitUsageError
+	}
+
+	if *asJSON {
+		return writeJSON(stdout, stderr, receipts)
+	}
+	return writeTabular(stdout, receipts)
+}
+
+func writeJSON(stdout, stderr io.Writer, receipts []receipt.AgentReceipt) int {
+	if receipts == nil {
+		receipts = []receipt.AgentReceipt{}
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(receipts); err != nil {
+		fmt.Fprintf(stderr, "agent-receipts list: encode JSON: %v\n", err)
+		return ExitUsageError
+	}
+	return ExitOK
+}
+
+func writeTabular(stdout io.Writer, receipts []receipt.AgentReceipt) int {
+	if len(receipts) == 0 {
+		fmt.Fprintln(stdout, "no receipts found")
+		return ExitOK
+	}
+
+	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SEQ\tTIMESTAMP\tCHAIN\tTOOL / ACTION TYPE")
+	for _, r := range receipts {
+		subj := r.CredentialSubject
+		tool := subj.Action.ToolName
+		if tool == "" {
+			tool = subj.Action.Type
+		}
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n",
+			subj.Chain.Sequence,
+			subj.Action.Timestamp,
+			subj.Chain.ChainID,
+			tool,
+		)
+	}
+	return exitFromFlush(w)
+}
+
+func exitFromFlush(w *tabwriter.Writer) int {
+	if err := w.Flush(); err != nil {
+		return ExitUsageError
+	}
+	return ExitOK
+}

--- a/daemon/internal/listcli/list_test.go
+++ b/daemon/internal/listcli/list_test.go
@@ -1,0 +1,235 @@
+package listcli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// fixtureDB writes a DB at dir/receipts.db with `count` receipts on chainID.
+func fixtureDB(t *testing.T, dir, chainID string, count int) string {
+	t.Helper()
+
+	dbPath := filepath.Join(dir, "receipts.db")
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var prevHash *string
+	for i := 1; i <= count; i++ {
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				Type:      "filesystem.file.read",
+				ToolName:  "Read",
+				RiskLevel: receipt.RiskLow,
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: chainID},
+		})
+		signed, err := receipt.Sign(unsigned, privPEM, "did:test#k1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := receipt.HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+	return dbPath
+}
+
+func runOnce(t *testing.T, args []string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code = Run(args, &out, &errb, func(string) string { return "" })
+	return code, out.String(), errb.String()
+}
+
+func TestRun_TabularOutputShowsReceipts(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 3)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	if !strings.Contains(stdout, "Read") {
+		t.Errorf("stdout = %q, expected tool name 'Read'", stdout)
+	}
+	if !strings.Contains(stdout, "SEQ") {
+		t.Errorf("stdout = %q, expected header with SEQ", stdout)
+	}
+}
+
+func TestRun_JSONOutputIsValidArray(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 2)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath, "--json"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	var receipts []receipt.AgentReceipt
+	if err := json.Unmarshal([]byte(stdout), &receipts); err != nil {
+		t.Fatalf("JSON output not parseable: %v (stdout=%q)", err, stdout)
+	}
+	if len(receipts) != 2 {
+		t.Errorf("got %d receipts, want 2", len(receipts))
+	}
+}
+
+func TestRun_LimitCapsResults(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 5)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath, "--json", "--limit", "2"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	var receipts []receipt.AgentReceipt
+	if err := json.Unmarshal([]byte(stdout), &receipts); err != nil {
+		t.Fatalf("JSON output not parseable: %v", err)
+	}
+	if len(receipts) != 2 {
+		t.Errorf("got %d receipts, want 2", len(receipts))
+	}
+}
+
+func TestRun_NewestFirstOrdering(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 3)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath, "--json"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	var receipts []receipt.AgentReceipt
+	if err := json.Unmarshal([]byte(stdout), &receipts); err != nil {
+		t.Fatalf("JSON output not parseable: %v", err)
+	}
+	for i := 1; i < len(receipts); i++ {
+		prev := receipts[i-1].CredentialSubject.Chain.Sequence
+		curr := receipts[i].CredentialSubject.Chain.Sequence
+		if prev < curr {
+			t.Errorf("receipts[%d].Sequence=%d < receipts[%d].Sequence=%d — not newest-first", i-1, prev, i, curr)
+		}
+	}
+}
+
+func TestRun_EmptyStoreProducesEmptyJSON(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 0)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath, "--json"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	if strings.TrimSpace(stdout) != "[]" {
+		t.Errorf("stdout = %q, want []", stdout)
+	}
+}
+
+func TestRun_EmptyStoreTabularSaysNoReceipts(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 0)
+
+	code, stdout, stderr := runOnce(t, []string{"--db", dbPath})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	if !strings.Contains(stdout, "no receipts") {
+		t.Errorf("stdout = %q, expected 'no receipts'", stdout)
+	}
+}
+
+func TestRun_MissingDBIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+
+	code, _, stderr := runOnce(t, []string{"--db", filepath.Join(dir, "no-such.db")})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "open store") {
+		t.Errorf("stderr = %q, expected 'open store' diagnostic", stderr)
+	}
+}
+
+func TestRun_BadFlagIsUsageError(t *testing.T) {
+	code, _, _ := runOnce(t, []string{"--bogus"})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+}
+
+func TestRun_HelpFlagExitsCleanly(t *testing.T) {
+	code, _, stderr := runOnce(t, []string{"-h"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (asking for help is not an error)", code, ExitOK)
+	}
+	if !strings.Contains(stderr, "--db") && !strings.Contains(stderr, "-db") {
+		t.Errorf("stderr should mention --db; got %q", stderr)
+	}
+}
+
+func TestRun_InvalidLimitIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 1)
+
+	code, _, stderr := runOnce(t, []string{"--db", dbPath, "--limit", "0"})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "--limit") {
+		t.Errorf("stderr = %q, expected '--limit' diagnostic", stderr)
+	}
+}
+
+func TestRun_EnvVarDBPath(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := fixtureDB(t, dir, "chain-1", 1)
+
+	var out, errb bytes.Buffer
+	code := Run([]string{"--json"}, &out, &errb, func(key string) string {
+		if key == "AGENTRECEIPTS_DB" {
+			return dbPath
+		}
+		return ""
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, errb.String())
+	}
+	var receipts []receipt.AgentReceipt
+	if err := json.Unmarshal([]byte(out.String()), &receipts); err != nil {
+		t.Fatalf("JSON output not parseable: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Errorf("got %d receipts, want 1", len(receipts))
+	}
+}

--- a/daemon/internal/listcli/list_test.go
+++ b/daemon/internal/listcli/list_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -45,6 +46,9 @@ func fixtureDB(t *testing.T, dir, chainID string, count int) string {
 				Type:      "filesystem.file.read",
 				ToolName:  "Read",
 				RiskLevel: receipt.RiskLow,
+				// Explicit strictly-increasing timestamps avoid non-deterministic
+				// ordering when multiple receipts share the same wall-clock second.
+				Timestamp: fmt.Sprintf("2024-01-01T%02d:00:00Z", i),
 			},
 			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
 			Chain:   receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: chainID},


### PR DESCRIPTION
## What

Adds the `agent-receipts list` subcommand to the companion CLI binary.

- `agent-receipts list` — tabular output (SEQ, TIMESTAMP, CHAIN, TOOL / ACTION TYPE), newest-first, default limit 50
- `agent-receipts list --json` — raw JSON array suitable for piping to `jq`
- `--limit N` — cap result count
- `--db PATH` / `AGENTRECEIPTS_DB` — same wiring as `verify`

Logic lives in `daemon/internal/listcli/` mirroring `verifycli/`. Tests are written first and cover tabular output, JSON output, limit capping, newest-first ordering, empty store, missing DB, bad flags, env var wiring, and help flag.

Closes #410.

## Why

Users and scripts need a way to inspect recent receipts without reading the raw SQLite file. The `list` subcommand gives a human-readable overview and a `--json` mode for automated processing.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet ./...` clean)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (no receipt format changes)
- [x] AGENTS.md updated (no structural change)
- [x] Spec changes have been reviewed by a maintainer (not applicable)