### PR TITLE
chore: add security checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,12 @@ Motivation — what problem does this solve?
 - [ ] AGENTS.md updated (if project structure changed)
 - [ ] Spec changes have been reviewed by a maintainer (if applicable)
 
+## Security
+
+- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)
+- [ ] Primitives and parameters have been reviewed
+- [ ] All inputs are validated at trust boundaries
+- [ ] Edge cases are tested (nil, empty, corrupted, concurrent)
+
 > [!TIP]
 > Request a Copilot review for automated checks against project conventions.


### PR DESCRIPTION
## What

Add a Security section to the PR template with a short checklist for changes that touch crypto, auth, or secrets handling.

## Why

Closes #60. The project is a cryptographic protocol — reviewers need a consistent prompt to check primitives, trust-boundary validation, and edge-case test coverage whenever a PR touches security-sensitive code. The checklist is gated behind a first item ("if no, skip remaining items") so it adds no friction for non-security PRs.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)
