### PR TITLE
chore: separate tag from release in release tooling

### DIFF
--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -1,0 +1,64 @@
+name: "Release: sdk-go"
+
+on:
+  push:
+    tags:
+      - "sdk/go/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release. Configure at:
+    # https://github.com/agent-receipts/ar/settings/environments
+    environment: release-sdk-go
+    defaults:
+      run:
+        working-directory: sdk/go
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/}"
+          echo "SDK_GO_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Reject local replace directives
+        run: |
+          go mod edit -json | python3 -c '
+          import json, re, sys
+          mod = json.load(sys.stdin)
+          for entry in mod.get("Replace") or []:
+              path = entry.get("New", {}).get("Path", "")
+              if (path in (".", "..") or path.startswith("./") or path.startswith("../")
+                  or path.startswith("/") or re.match(r"^[A-Za-z]:[\\\\/]", path)):
+                  print(f"::error::go.mod contains a local replace directive ({path}) — remove it before releasing")
+                  sys.exit(1)
+          '
+
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test ./...
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mark pre-release tags (e.g. v0.9.0-alpha.1) so they don't show
+          # up as "latest" on the GitHub Releases page.
+          PRERELEASE_ARG=()
+          if [[ "${SDK_GO_VERSION}" == *-* ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "sdk-go ${SDK_GO_VERSION}" \
+            --generate-notes \
+            "${PRERELEASE_ARG[@]}"

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -1,0 +1,68 @@
+name: "Release: sdk-py"
+
+on:
+  push:
+    tags:
+      - "sdk-py-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release. Configure at:
+    # https://github.com/agent-receipts/ar/settings/environments
+    environment: release-sdk-py
+    defaults:
+      run:
+        working-directory: sdk/py
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-py-v}"
+          echo "SDK_PY_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Verify release tag matches pyproject.toml version
+        run: |
+          PY_VERSION=$(uv run python -c "
+          import tomllib, pathlib
+          p = pathlib.Path('pyproject.toml')
+          print(tomllib.loads(p.read_text())['project']['version'])
+          ")
+          if [ "$PY_VERSION" != "$SDK_PY_VERSION" ]; then
+            echo "::error::Release tag sdk-py-v${SDK_PY_VERSION} does not match pyproject.toml version ${PY_VERSION}"
+            exit 1
+          fi
+
+      - run: uv sync --frozen --all-extras
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run pytest
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mark pre-release tags as GitHub pre-releases so they don't show
+          # up as "latest" on the GitHub Releases page.
+          # Covers SemVer pre-releases (e.g. v0.9.0-beta.1, *-*) and PEP 440
+          # pre-release suffixes (e.g. v0.9.0a1, v0.9.0rc1 — matched by [abc][0-9]).
+          # publish-py.yml (triggered on release publish) handles PyPI publication.
+          PRERELEASE_ARG=()
+          CORE="${SDK_PY_VERSION%%+*}"
+          if [[ "$CORE" == *-* ]] || [[ "$CORE" =~ [0-9]+(a|b|rc)[0-9]+$ ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "sdk-py ${SDK_PY_VERSION}" \
+            --generate-notes \
+            "${PRERELEASE_ARG[@]}"

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -1,0 +1,66 @@
+name: "Release: sdk-ts"
+
+on:
+  push:
+    tags:
+      - "sdk-ts-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release. Configure at:
+    # https://github.com/agent-receipts/ar/settings/environments
+    environment: release-sdk-ts
+    defaults:
+      run:
+        working-directory: sdk/ts
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: sdk/ts/pnpm-lock.yaml
+
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
+          echo "SDK_TS_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Verify release tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$SDK_TS_VERSION" ]; then
+            echo "::error::Release tag sdk-ts-v${SDK_TS_VERSION} does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run typecheck
+      - run: pnpm run lint
+      - run: pnpm run build
+      - run: pnpm run test
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mark pre-release tags (e.g. v0.9.0-alpha.1) so they don't show
+          # up as "latest" on the GitHub Releases page.
+          # publish-ts.yml (triggered on release publish) handles npm publication.
+          PRERELEASE_ARG=()
+          if [[ "${SDK_TS_VERSION}" == *-* ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "sdk-ts ${SDK_TS_VERSION}" \
+            --generate-notes \
+            "${PRERELEASE_ARG[@]}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,13 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [--dry-run] <module> <version>
 
-Create a GitHub Release for a module in this monorepo.
+Validate and push the git tag for a module in this monorepo.
+
+The script tags only. Each module has a dedicated per-module release
+workflow in .github/workflows/release-<module>.yml that triggers on the
+tag, runs CI tests in a clean environment, and creates the GitHub Release.
+For modules with binaries (hook, mcp-proxy, daemon) it also builds
+artifacts via GoReleaser and publishes a Homebrew formula.
 
 Modules:
   sdk-go       Go SDK                 (tag: sdk/go/vVERSION)
@@ -17,14 +23,12 @@ Modules:
 
 Flags:
   --dry-run    Validate everything and print the actions, but do not push
-               tags or create releases.
+               the tag.
 
 Notes:
-  - Pre-release versions (e.g. 0.8.0-alpha.1) are automatically marked
-    as GitHub pre-releases.
-  - mcp-proxy and daemon push the tag only and let release-mcp-proxy.yml /
-    release-daemon.yml build binaries and create the GitHub Release. Other
-    modules use 'gh release create' directly.
+  - Pre-release versions (e.g. 0.8.0-alpha.1) are flagged here for
+    display only; the release workflow handles --prerelease detection.
+  - PEP 440 pre-release form (e.g. 0.8.0a1) is accepted only for sdk-py.
 
 Examples:
   $(basename "$0") sdk-go 0.2.0
@@ -41,8 +45,6 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Preflight: ensure common tools are available
 command -v git >/dev/null 2>&1 || fail "git is not installed"
-command -v gh >/dev/null 2>&1 || fail "gh CLI is not installed — see https://cli.github.com"
-gh auth status >/dev/null 2>&1 || fail "gh is not authenticated — run gh auth login"
 
 DRY_RUN=false
 ARGS=()
@@ -215,51 +217,23 @@ if [[ "$CORE_VERSION" == *-* ]] || [[ "$CORE_VERSION" =~ [0-9]+(a|b|rc)[0-9]+$ ]
   PRERELEASE=true
 fi
 
-echo "Will create release:"
+echo "Will push tag:"
 echo "  Tag:         $TAG"
-echo "  Title:       $MODULE v$VERSION"
+echo "  Module:      $MODULE v$VERSION"
 [[ "$PRERELEASE" == "true" ]] && echo "  Pre-release: yes"
-if [[ "$MODULE" == "hook" ]]; then
-  echo "  Action:      push tag only; release-hook.yml builds binaries and creates the GitHub Release"
-elif [[ "$MODULE" == "mcp-proxy" ]]; then
-  echo "  Action:      push tag only; release-mcp-proxy.yml builds binaries and creates the GitHub Release"
-elif [[ "$MODULE" == "daemon" ]]; then
-  echo "  Action:      push tag only; release-daemon.yml builds binaries and creates the GitHub Release"
-else
-  echo "  Action:      gh release create"
-fi
+echo "  Action:      push tag; release-${MODULE}.yml creates the GitHub Release"
 echo ""
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "==> Dry run; not pushing tag or creating release."
+  echo "==> Dry run; not pushing tag."
   exit 0
 fi
 
 read -rp "Proceed? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
-REPO_URL=$(gh repo view --json url -q '.url')
-
-if [[ "$MODULE" == "hook" || "$MODULE" == "mcp-proxy" || "$MODULE" == "daemon" ]]; then
-  # release-hook.yml / release-mcp-proxy.yml / release-daemon.yml owns release
-  # creation; we only push the tag. Avoids "release already exists" conflict
-  # between this script and the workflow when both call gh release create.
-  case "$MODULE" in
-    hook)      WORKFLOW="release-hook.yml" ;;
-    mcp-proxy) WORKFLOW="release-mcp-proxy.yml" ;;
-    daemon)    WORKFLOW="release-daemon.yml" ;;
-  esac
-  git tag "$TAG"
-  git push origin "$TAG"
-  echo ""
-  echo "==> Pushed tag $TAG"
-  echo "    ${WORKFLOW} builds binaries and creates the GitHub Release."
-  echo "    ${REPO_URL}/actions/workflows/${WORKFLOW}"
-else
-  PRERELEASE_FLAG=()
-  [[ "$PRERELEASE" == "true" ]] && PRERELEASE_FLAG=("--prerelease")
-  gh release create "$TAG" --title "$MODULE v$VERSION" --generate-notes "${PRERELEASE_FLAG[@]+"${PRERELEASE_FLAG[@]}"}"
-  echo ""
-  echo "==> Released $MODULE v$VERSION"
-  echo "    ${REPO_URL}/releases/tag/$TAG"
-fi
+git tag "$TAG"
+git push origin "$TAG"
+echo ""
+echo "==> Pushed tag $TAG"
+echo "    release-${MODULE}.yml will run CI and create the GitHub Release."


### PR DESCRIPTION
## What

- `scripts/release.sh` is now tag-only: validates version, runs local preflight checks, pushes the git tag. All `gh release create` calls removed.
- Three new per-module release workflows: `release-sdk-go.yml`, `release-sdk-ts.yml`, `release-sdk-py.yml`. Each triggers on its tag prefix, runs the module's tests in CI, auto-detects pre-release from the tag, and creates the GitHub Release.
- Removes the `gh` CLI dependency from `release.sh` entirely (only `git` needed now).

## Why

Closes #341. `scripts/release.sh` was creating GitHub Releases for sdk-go, sdk-ts, and sdk-py, while the binary modules (hook, mcp-proxy, daemon) already had per-workflow release creation. This asymmetry was a bug surface — both the script and the workflow could race to create the same release. The fix: one rule everywhere: the script tags, the per-module workflow creates the release.

The new workflows follow the existing `release-hook.yml` / `release-mcp-proxy.yml` / `release-daemon.yml` pattern exactly, including pinned action SHAs, the deployment environment gate, and the pre-release detection idiom.

## Checklist

- [x] Tests pass for all changed components (shellcheck passes; no code logic changed in SDKs)
- [x] Linter passes (`shellcheck` via lefthook pre-commit ran clean)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (not applicable — no receipt format changes)
- [x] AGENTS.md updated (not applicable — no project structure change)
- [x] Spec changes have been reviewed by a maintainer (not applicable)