### PR TITLE
feat(store): DESC ordering and remove silent 10k limit cap

### DIFF
--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -64,7 +64,9 @@ type Query struct {
 	Status     *receipt.OutcomeStatus
 	After      *string // ISO 8601 timestamp
 	Before     *string // ISO 8601 timestamp
-	Limit      *int    // Default 10000
+	// Limit caps the number of returned receipts. When nil, all matching rows
+	// are returned (no default cap is applied).
+	Limit *int
 	// NewestFirst reverses the default ascending-timestamp ordering so the
 	// most recent receipts are returned first. Default is false (ascending)
 	// to preserve historical behavior.
@@ -305,9 +307,9 @@ func (s *Store) MaxRowID() (int64, error) {
 // is the largest rowid in the result set, or afterRowID when no rows match —
 // callers feed it back in to poll for subsequent inserts.
 //
-// NewestFirst is ignored (follow-mode rows are always chronological). Limit
-// defaults to 10000 like QueryReceipts but is typically set much lower when
-// polling.
+// NewestFirst is ignored (follow-mode rows are always chronological). When
+// Limit is nil all matching rows are returned; callers polling in follow mode
+// typically set an explicit small limit to bound per-poll latency.
 //
 // Callers that want to bound query latency (e.g. so Ctrl-C in follow mode
 // stops a busy/locked query promptly) should use QueryAfterRowIDContext.
@@ -409,19 +411,23 @@ func buildQueryReceiptsSQL(q Query) (string, []any) {
 		where = "WHERE " + strings.Join(conds, " AND ")
 	}
 
-	limit := 10000
-	if q.Limit != nil {
-		limit = *q.Limit
-	}
 	order := "ASC"
 	if q.NewestFirst {
 		order = "DESC"
 	}
+	orderClause := fmt.Sprintf("ORDER BY timestamp %s, sequence %s", order, order)
+	if q.Limit != nil {
+		query := fmt.Sprintf(
+			"SELECT receipt_json FROM receipts %s %s LIMIT ?",
+			where, orderClause,
+		)
+		args = append(args, *q.Limit)
+		return query, args
+	}
 	query := fmt.Sprintf(
-		"SELECT receipt_json FROM receipts %s ORDER BY timestamp %s LIMIT ?",
-		where, order,
+		"SELECT receipt_json FROM receipts %s %s",
+		where, orderClause,
 	)
-	args = append(args, limit)
 	return query, args
 }
 
@@ -455,14 +461,16 @@ func buildQueryAfterRowIDSQL(q Query, afterRowID int64) (string, []any) {
 		args = append(args, *q.Before)
 	}
 
-	limit := 10000
 	if q.Limit != nil {
-		limit = *q.Limit
+		args = append(args, *q.Limit)
+		query := fmt.Sprintf(
+			"SELECT rowid, receipt_json FROM receipts WHERE %s ORDER BY rowid ASC LIMIT ?",
+			strings.Join(conds, " AND "),
+		)
+		return query, args
 	}
-	args = append(args, limit)
-
 	query := fmt.Sprintf(
-		"SELECT rowid, receipt_json FROM receipts WHERE %s ORDER BY rowid ASC LIMIT ?",
+		"SELECT rowid, receipt_json FROM receipts WHERE %s ORDER BY rowid ASC",
 		strings.Join(conds, " AND "),
 	)
 	return query, args

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -415,7 +415,7 @@ func buildQueryReceiptsSQL(q Query) (string, []any) {
 	if q.NewestFirst {
 		order = "DESC"
 	}
-	orderClause := fmt.Sprintf("ORDER BY timestamp %s, sequence %s", order, order)
+	orderClause := fmt.Sprintf("ORDER BY timestamp %s, sequence %s, rowid %s", order, order, order)
 	if q.Limit != nil {
 		query := fmt.Sprintf(
 			"SELECT receipt_json FROM receipts %s %s LIMIT ?",

--- a/sdk/go/store/store_sql_test.go
+++ b/sdk/go/store/store_sql_test.go
@@ -1,0 +1,39 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildQueryReceiptsSQLNoLimit verifies that nil Limit omits the LIMIT
+// clause entirely. Five rows would still pass with a 10,000-row cap, so this
+// white-box check is the real regression guard for the removed cap.
+func TestBuildQueryReceiptsSQLNoLimit(t *testing.T) {
+	sql, _ := buildQueryReceiptsSQL(Query{})
+	if strings.Contains(sql, "LIMIT") {
+		t.Errorf("expected no LIMIT clause when Limit is nil, got: %s", sql)
+	}
+}
+
+// TestBuildQueryReceiptsSQLWithLimit verifies that an explicit Limit adds the
+// LIMIT clause.
+func TestBuildQueryReceiptsSQLWithLimit(t *testing.T) {
+	lim := 50
+	sql, _ := buildQueryReceiptsSQL(Query{Limit: &lim})
+	if !strings.Contains(sql, "LIMIT") {
+		t.Errorf("expected LIMIT clause when Limit is set, got: %s", sql)
+	}
+}
+
+// TestBuildQueryReceiptsSQLOrderClause verifies rowid is the final tiebreaker.
+func TestBuildQueryReceiptsSQLOrderClause(t *testing.T) {
+	asc, _ := buildQueryReceiptsSQL(Query{})
+	if !strings.Contains(asc, "timestamp ASC, sequence ASC, rowid ASC") {
+		t.Errorf("ASC order clause missing rowid tiebreaker: %s", asc)
+	}
+
+	desc, _ := buildQueryReceiptsSQL(Query{NewestFirst: true})
+	if !strings.Contains(desc, "timestamp DESC, sequence DESC, rowid DESC") {
+		t.Errorf("DESC order clause missing rowid tiebreaker: %s", desc)
+	}
+}

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -637,6 +637,37 @@ func TestQueryAfterRowIDAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestQueryAfterRowIDNilLimitReturnsAllRows(t *testing.T) {
+	s := setupStore(t)
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 5
+	var prevHash *string
+	for i := 1; i <= n; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-nil-limit", prevHash)
+		h, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(r, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	// nil Limit must return all rows above rowid 0.
+	results, _, err := s.QueryAfterRowID(Query{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != n {
+		t.Errorf("QueryAfterRowID with nil Limit: got %d rows, want %d", len(results), n)
+	}
+}
+
 func TestCloseMultipleTimes(t *testing.T) {
 	s, err := Open(":memory:")
 	if err != nil {

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -349,9 +349,9 @@ func TestQueryReceiptsNoDefaultLimit(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()
 
-	// Insert more than 10000 rows to prove the cap is gone. Inserting 10001
-	// would be slow; instead we insert a small batch and confirm that nil Limit
-	// returns all of them without any cap applied.
+	// A small batch here proves the integration path; the real regression guard
+	// for the removed 10k cap is TestBuildQueryReceiptsSQLNoLimit in
+	// store_sql_test.go (white-box SQL assertion in the store package).
 	const n = 5
 	for i := 1; i <= n; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", nil)

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -345,6 +345,86 @@ func TestQueryReceiptsOrdering(t *testing.T) {
 	}
 }
 
+func TestQueryReceiptsNoDefaultLimit(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	// Insert more than 10000 rows to prove the cap is gone. Inserting 10001
+	// would be slow; instead we insert a small batch and confirm that nil Limit
+	// returns all of them without any cap applied.
+	const n = 5
+	for i := 1; i <= n; i++ {
+		r := makeSignedReceipt(t, kp, i, "chain-1", nil)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	// nil Limit must return all rows.
+	results, err := s.QueryReceipts(Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != n {
+		t.Errorf("expected %d results with no limit, got %d", n, len(results))
+	}
+
+	// Explicit Limit still works.
+	lim := 3
+	limited, err := s.QueryReceipts(Query{Limit: &lim})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(limited) != lim {
+		t.Errorf("expected %d results with explicit limit, got %d", lim, len(limited))
+	}
+}
+
+func TestQueryReceiptsDescSequenceTiebreaker(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	// Two receipts share the same timestamp but differ in sequence.
+	// With NewestFirst the one with the higher sequence must come first.
+	sharedTS := "2024-06-01T12:00:00Z"
+	for _, seq := range []int{1, 2} {
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:agent:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				Timestamp: sharedTS,
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: seq, ChainID: "chain-tie"},
+		})
+		signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, _ := receipt.HashReceipt(signed)
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	desc, err := s.QueryReceipts(Query{NewestFirst: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(desc) != 2 {
+		t.Fatalf("expected 2 receipts, got %d", len(desc))
+	}
+	if got := desc[0].CredentialSubject.Chain.Sequence; got != 2 {
+		t.Errorf("tiebreaker: expected sequence 2 first, got %d", got)
+	}
+	if got := desc[1].CredentialSubject.Chain.Sequence; got != 1 {
+		t.Errorf("tiebreaker: expected sequence 1 second, got %d", got)
+	}
+}
+
 func TestQueryReceiptsCombinedFilters(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -425,6 +425,48 @@ func TestQueryReceiptsDescSequenceTiebreaker(t *testing.T) {
 	}
 }
 
+func TestQueryReceiptsAscSequenceTiebreaker(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+
+	sharedTS := "2024-06-01T12:00:00Z"
+	for _, seq := range []int{2, 1} { // insert in reverse to confirm ordering is by SQL not insertion
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:agent:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				Timestamp: sharedTS,
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: seq, ChainID: "chain-asc-tie"},
+		})
+		signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, _ := receipt.HashReceipt(signed)
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	asc, err := s.QueryReceipts(Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(asc) != 2 {
+		t.Fatalf("expected 2 receipts, got %d", len(asc))
+	}
+	if got := asc[0].CredentialSubject.Chain.Sequence; got != 1 {
+		t.Errorf("ASC tiebreaker: expected sequence 1 first, got %d", got)
+	}
+	if got := asc[1].CredentialSubject.Chain.Sequence; got != 2 {
+		t.Errorf("ASC tiebreaker: expected sequence 2 second, got %d", got)
+	}
+}
+
 func TestQueryReceiptsCombinedFilters(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -707,6 +708,13 @@ func TestQueryAfterRowIDNilLimitReturnsAllRows(t *testing.T) {
 	}
 	if len(results) != n {
 		t.Errorf("QueryAfterRowID with nil Limit: got %d rows, want %d", len(results), n)
+	}
+}
+
+func TestBuildQueryAfterRowIDSQLNilLimitOmitsLIMIT(t *testing.T) {
+	sql, _ := buildQueryAfterRowIDSQL(Query{}, 0)
+	if strings.Contains(sql, "LIMIT") {
+		t.Errorf("buildQueryAfterRowIDSQL with nil Limit must not contain LIMIT, got: %s", sql)
 	}
 }
 

--- a/sdk/py/src/agent_receipts/store/store.py
+++ b/sdk/py/src/agent_receipts/store/store.py
@@ -181,7 +181,7 @@ class ReceiptStore:
 
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
         dir_ = "DESC" if filters.newest_first else "ASC"
-        order_clause = f"ORDER BY timestamp {dir_}, sequence {dir_}"
+        order_clause = f"ORDER BY timestamp {dir_}, sequence {dir_}, rowid {dir_}"
         if filters.limit is not None:
             params.append(filters.limit)
             sql = f"SELECT receipt_json FROM receipts{where} {order_clause} LIMIT ?"  # noqa: S608

--- a/sdk/py/src/agent_receipts/store/store.py
+++ b/sdk/py/src/agent_receipts/store/store.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agent_receipts.receipt.types import AgentReceipt
 
-DEFAULT_QUERY_LIMIT = 10_000
-
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS receipts (
   id TEXT PRIMARY KEY,
@@ -47,7 +45,12 @@ class ReceiptQuery:
     status: str | None = None
     after: str | None = None
     before: str | None = None
+    # When None, all matching rows are returned (no default cap).
     limit: int | None = None
+    # When True, results are ordered newest-first (timestamp DESC, sequence
+    # DESC). Ties on timestamp are broken by sequence descending. Default is
+    # False (ascending) to preserve historical behavior.
+    newest_first: bool = False
 
 
 @dataclass
@@ -177,10 +180,13 @@ class ReceiptStore:
             params.append(filters.before)
 
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-        limit = filters.limit if filters.limit is not None else DEFAULT_QUERY_LIMIT
-        params.append(limit)
-
-        sql = f"SELECT receipt_json FROM receipts{where} ORDER BY timestamp LIMIT ?"  # noqa: S608
+        dir_ = "DESC" if filters.newest_first else "ASC"
+        order_clause = f"ORDER BY timestamp {dir_}, sequence {dir_}"
+        if filters.limit is not None:
+            params.append(filters.limit)
+            sql = f"SELECT receipt_json FROM receipts{where} {order_clause} LIMIT ?"  # noqa: S608
+        else:
+            sql = f"SELECT receipt_json FROM receipts{where} {order_clause}"  # noqa: S608
         rows = self._conn.execute(sql, params).fetchall()
         return [_parse_receipt(r["receipt_json"]) for r in rows]
 

--- a/sdk/py/tests/store/test_store.py
+++ b/sdk/py/tests/store/test_store.py
@@ -190,14 +190,47 @@ def test_query_explicit_limit_respected() -> None:
 
 
 def test_query_no_default_limit() -> None:
-    """No limit set means all rows are returned — no silent cap."""
-    store = open_store(":memory:")
-    for i in range(5):
-        r = make_receipt(id=f"urn:receipt:nl{i}", sequence=i + 1)
-        store.insert(r, hash_receipt(r))
+    """No limit set means all rows are returned — no silent cap.
 
+    Batch-inserts 15 000 rows via raw SQL to prove the LIMIT clause is absent.
+    This would fail with the old DEFAULT_QUERY_LIMIT = 10_000 because only
+    10 000 rows would be returned.
+    """
+    store = open_store(":memory:")
+    n = 15_000
+    # Generate one valid receipt JSON and reuse it for all rows (table id is
+    # unique per row; receipt_json content only needs to be deserializable).
+    base_receipt = make_receipt(id="urn:receipt:bulk-base", sequence=1)
+    base_json = base_receipt.model_dump_json()
+    rows = [
+        (
+            f"urn:receipt:bulk-{i}",
+            "chain-bulk",
+            i,
+            "filesystem.file.read",
+            "Read",
+            "low",
+            "success",
+            f"2024-01-01T{i // 3600:02d}:{(i % 3600) // 60:02d}:{i % 60:02d}Z",
+            "did:issuer",
+            "did:user",
+            base_json,
+            f"sha256:bulk{i}",
+            None,
+        )
+        for i in range(1, n + 1)
+    ]
+    store._conn.executemany(  # noqa: SLF001
+        """INSERT INTO receipts
+           (id, chain_id, sequence, action_type, tool_name, risk_level, status,
+            timestamp, issuer_id, principal_id, receipt_json, receipt_hash,
+            previous_receipt_hash)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        rows,
+    )
+    store._conn.commit()  # noqa: SLF001
     results = store.query(ReceiptQuery())
-    assert len(results) == 5
+    assert len(results) == n
     store.close()
 
 

--- a/sdk/py/tests/store/test_store.py
+++ b/sdk/py/tests/store/test_store.py
@@ -177,6 +177,18 @@ def test_query_no_filters() -> None:
     store.close()
 
 
+def test_query_explicit_limit_respected() -> None:
+    """An explicit limit still caps results after the cap removal."""
+    store = open_store(":memory:")
+    for i in range(5):
+        r = make_receipt(id=f"urn:receipt:el{i}", sequence=i + 1)
+        store.insert(r, hash_receipt(r))
+
+    results = store.query(ReceiptQuery(limit=3))
+    assert len(results) == 3
+    store.close()
+
+
 def test_query_no_default_limit() -> None:
     """No limit set means all rows are returned — no silent cap."""
     store = open_store(":memory:")

--- a/sdk/py/tests/store/test_store.py
+++ b/sdk/py/tests/store/test_store.py
@@ -277,6 +277,29 @@ def test_query_desc_sequence_tiebreaker() -> None:
     store.close()
 
 
+def test_query_asc_sequence_tiebreaker() -> None:
+    """When timestamps are equal, lower sequence comes first in ASC order."""
+    store = open_store(":memory:")
+    shared_ts = "2026-06-01T12:00:00Z"
+    r1 = make_receipt(
+        id="urn:receipt:asctie1", timestamp=shared_ts, chain_id="casctie", sequence=1
+    )
+    r2 = make_receipt(
+        id="urn:receipt:asctie2",
+        timestamp=shared_ts,
+        chain_id="casctie",
+        sequence=2,
+        previous_hash=hash_receipt(r1),
+    )
+    store.insert(r2, hash_receipt(r2))  # insert higher sequence first
+    store.insert(r1, hash_receipt(r1))
+
+    results = store.query(ReceiptQuery())
+    ids = [r.id for r in results]
+    assert ids.index("urn:receipt:asctie1") < ids.index("urn:receipt:asctie2")
+    store.close()
+
+
 def test_stats() -> None:
     store = open_store(":memory:")
     r1 = make_receipt(

--- a/sdk/py/tests/store/test_store.py
+++ b/sdk/py/tests/store/test_store.py
@@ -177,6 +177,94 @@ def test_query_no_filters() -> None:
     store.close()
 
 
+def test_query_no_default_limit() -> None:
+    """No limit set means all rows are returned — no silent cap."""
+    store = open_store(":memory:")
+    for i in range(5):
+        r = make_receipt(id=f"urn:receipt:nl{i}", sequence=i + 1)
+        store.insert(r, hash_receipt(r))
+
+    results = store.query(ReceiptQuery())
+    assert len(results) == 5
+    store.close()
+
+
+def test_query_order_asc_default() -> None:
+    """Default ordering is ascending by timestamp (oldest first)."""
+    store = open_store(":memory:")
+    r1 = make_receipt(
+        id="urn:receipt:ord1",
+        timestamp="2026-01-01T00:00:00Z",
+        chain_id="cord",
+        sequence=1,
+    )
+    r2 = make_receipt(
+        id="urn:receipt:ord2",
+        timestamp="2026-06-01T00:00:00Z",
+        chain_id="cord",
+        sequence=2,
+        previous_hash=hash_receipt(r1),
+    )
+    store.insert(r1, hash_receipt(r1))
+    store.insert(r2, hash_receipt(r2))
+
+    results = store.query(ReceiptQuery())
+    assert results[0].id == "urn:receipt:ord1"
+    assert results[1].id == "urn:receipt:ord2"
+    store.close()
+
+
+def test_query_order_desc() -> None:
+    """newest_first=True returns most recent receipts first."""
+    store = open_store(":memory:")
+    r1 = make_receipt(
+        id="urn:receipt:desc1",
+        timestamp="2026-01-01T00:00:00Z",
+        chain_id="cdesc",
+        sequence=1,
+    )
+    r2 = make_receipt(
+        id="urn:receipt:desc2",
+        timestamp="2026-06-01T00:00:00Z",
+        chain_id="cdesc",
+        sequence=2,
+        previous_hash=hash_receipt(r1),
+    )
+    store.insert(r1, hash_receipt(r1))
+    store.insert(r2, hash_receipt(r2))
+
+    results = store.query(ReceiptQuery(newest_first=True))
+    assert results[0].id == "urn:receipt:desc2"
+    assert results[1].id == "urn:receipt:desc1"
+    store.close()
+
+
+def test_query_desc_sequence_tiebreaker() -> None:
+    """When timestamps are equal, higher sequence comes first in DESC order."""
+    store = open_store(":memory:")
+    shared_ts = "2026-06-01T12:00:00Z"
+    r1 = make_receipt(
+        id="urn:receipt:tie1",
+        timestamp=shared_ts,
+        chain_id="ctie",
+        sequence=1,
+    )
+    r2 = make_receipt(
+        id="urn:receipt:tie2",
+        timestamp=shared_ts,
+        chain_id="ctie",
+        sequence=2,
+        previous_hash=hash_receipt(r1),
+    )
+    store.insert(r1, hash_receipt(r1))
+    store.insert(r2, hash_receipt(r2))
+
+    results = store.query(ReceiptQuery(newest_first=True))
+    assert results[0].id == "urn:receipt:tie2"
+    assert results[1].id == "urn:receipt:tie1"
+    store.close()
+
+
 def test_stats() -> None:
     store = open_store(":memory:")
     r1 = make_receipt(

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -177,6 +177,60 @@ describe("ReceiptStore", () => {
 			});
 			expect(results).toHaveLength(2);
 		});
+
+		it("returns all rows ascending by default (no implicit cap)", () => {
+			// The three rows were inserted in beforeEach; no limit means all 3.
+			const results = store.query({});
+			expect(results).toHaveLength(3);
+			// Default order is ascending by timestamp.
+			expect(results[0]?.id).toBe("urn:receipt:1");
+			expect(results[2]?.id).toBe("urn:receipt:3");
+		});
+
+		it("returns rows in DESC order when order is 'desc'", () => {
+			const results = store.query({ order: "desc" });
+			expect(results).toHaveLength(3);
+			expect(results[0]?.id).toBe("urn:receipt:3");
+			expect(results[2]?.id).toBe("urn:receipt:1");
+		});
+
+		it("returns rows in ASC order when order is 'asc' (explicit)", () => {
+			const results = store.query({ order: "asc" });
+			expect(results).toHaveLength(3);
+			expect(results[0]?.id).toBe("urn:receipt:1");
+		});
+
+		it("desc order with sequence tiebreaker when timestamps are equal", () => {
+			// Insert two extra receipts with the same timestamp but different sequences.
+			store.insert(
+				makeReceipt({
+					id: "urn:receipt:tie-1",
+					sequence: 10,
+					actionType: "filesystem.file.read",
+					riskLevel: "low",
+					status: "success",
+					timestamp: "2026-03-29T13:00:00Z",
+				}),
+				"sha256:tie1",
+			);
+			store.insert(
+				makeReceipt({
+					id: "urn:receipt:tie-2",
+					sequence: 11,
+					actionType: "filesystem.file.read",
+					riskLevel: "low",
+					status: "success",
+					timestamp: "2026-03-29T13:00:00Z",
+				}),
+				"sha256:tie2",
+			);
+
+			const results = store.query({ order: "desc" });
+			// The two tied rows should come first (most recent timestamp),
+			// with the higher sequence preceding the lower.
+			expect(results[0]?.id).toBe("urn:receipt:tie-2");
+			expect(results[1]?.id).toBe("urn:receipt:tie-1");
+		});
 	});
 
 	describe("corrupt receipt validation", () => {

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -276,7 +276,6 @@ describe("ReceiptStore", () => {
 			// absent when limit is undefined. This would fail with the old
 			// DEFAULT_QUERY_LIMIT = 10000 because only 10000 rows would be returned.
 			const freshStore = openStore(":memory:");
-			// @ts-expect-error reaches into private db for batch insert performance
 			const db: DatabaseSync = (freshStore as unknown as { db: DatabaseSync })
 				.db;
 			const stmt = db.prepare(

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -200,6 +200,41 @@ describe("ReceiptStore", () => {
 			expect(results[0]?.id).toBe("urn:receipt:1");
 		});
 
+		it("asc order with sequence tiebreaker when timestamps are equal", () => {
+			store.insert(
+				makeReceipt({
+					id: "urn:receipt:asc-tie-1",
+					sequence: 5,
+					actionType: "filesystem.file.read",
+					riskLevel: "low",
+					status: "success",
+					timestamp: "2026-01-01T00:00:00Z",
+				}),
+				"sha256:asctie1",
+			);
+			store.insert(
+				makeReceipt({
+					id: "urn:receipt:asc-tie-2",
+					sequence: 6,
+					actionType: "filesystem.file.read",
+					riskLevel: "low",
+					status: "success",
+					timestamp: "2026-01-01T00:00:00Z",
+				}),
+				"sha256:asctie2",
+			);
+
+			const results = store.query({ order: "asc" });
+			// Among the tied rows, lower sequence comes first.
+			const tieIdx1 = results.findIndex(
+				(r) => r.id === "urn:receipt:asc-tie-1",
+			);
+			const tieIdx2 = results.findIndex(
+				(r) => r.id === "urn:receipt:asc-tie-2",
+			);
+			expect(tieIdx1).toBeLessThan(tieIdx2);
+		});
+
 		it("desc order with sequence tiebreaker when timestamps are equal", () => {
 			// Insert two extra receipts with the same timestamp but different sequences.
 			store.insert(

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -232,6 +232,8 @@ describe("ReceiptStore", () => {
 			const tieIdx2 = results.findIndex(
 				(r) => r.id === "urn:receipt:asc-tie-2",
 			);
+			expect(tieIdx1).toBeGreaterThanOrEqual(0);
+			expect(tieIdx2).toBeGreaterThanOrEqual(0);
 			expect(tieIdx1).toBeLessThan(tieIdx2);
 		});
 
@@ -265,6 +267,79 @@ describe("ReceiptStore", () => {
 			// with the higher sequence preceding the lower.
 			expect(results[0]?.id).toBe("urn:receipt:tie-2");
 			expect(results[1]?.id).toBe("urn:receipt:tie-1");
+		});
+	});
+
+	describe("no implicit 10k cap (regression guard)", () => {
+		it("returns all rows when limit is omitted, even beyond the former 10k cap", () => {
+			// Batch-insert 15000 rows via raw SQL to prove the LIMIT clause is
+			// absent when limit is undefined. This would fail with the old
+			// DEFAULT_QUERY_LIMIT = 10000 because only 10000 rows would be returned.
+			const freshStore = openStore(":memory:");
+			// @ts-expect-error reaches into private db for batch insert performance
+			const db: DatabaseSync = (freshStore as unknown as { db: DatabaseSync })
+				.db;
+			const stmt = db.prepare(
+				`INSERT INTO receipts
+				 (id, chain_id, sequence, action_type, tool_name, risk_level, status,
+				  timestamp, issuer_id, principal_id, receipt_json, receipt_hash)
+				 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+			);
+			// Minimal valid AgentReceipt JSON the SDK can deserialize.
+			const baseJson = JSON.stringify({
+				id: "urn:receipt:bulk-base",
+				"@context": [
+					"https://www.w3.org/ns/credentials/v2",
+					"https://agentreceipts.ai/context/v1",
+				],
+				type: ["VerifiableCredential", "AgentReceipt"],
+				version: "0.2.0",
+				issuer: { id: "did:issuer" },
+				issuanceDate: "2024-01-01T00:00:00Z",
+				credentialSubject: {
+					principal: { id: "did:user" },
+					action: {
+						id: "act_0",
+						type: "filesystem.file.read",
+						tool_name: "Read",
+						risk_level: "low",
+						timestamp: "2024-01-01T00:00:00Z",
+					},
+					outcome: { status: "success" },
+					chain: {
+						sequence: 1,
+						chain_id: "chain-bulk",
+						previous_receipt_hash: null,
+					},
+				},
+				proof: {
+					type: "Ed25519Signature2020",
+					created: "2024-01-01T00:00:00Z",
+					verificationMethod: "did:issuer#k1",
+					proofPurpose: "assertionMethod",
+					proofValue: "u" + "A".repeat(86),
+				},
+			});
+			const n = 15_000;
+			for (let i = 1; i <= n; i++) {
+				stmt.run(
+					`urn:receipt:bulk-${i}`,
+					"chain-bulk",
+					i,
+					"filesystem.file.read",
+					"Read",
+					"low",
+					"success",
+					new Date(i * 1000).toISOString(),
+					"did:issuer",
+					"did:user",
+					baseJson,
+					`sha256:bulk${i}`,
+				);
+			}
+			const results = freshStore.query({});
+			expect(results).toHaveLength(n);
+			freshStore.close();
 		});
 	});
 

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -317,7 +317,7 @@ describe("ReceiptStore", () => {
 					created: "2024-01-01T00:00:00Z",
 					verificationMethod: "did:issuer#k1",
 					proofPurpose: "assertionMethod",
-					proofValue: "u" + "A".repeat(86),
+					proofValue: `u${"A".repeat(86)}`,
 				},
 			});
 			const n = 15_000;

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -43,8 +43,17 @@ export interface ReceiptQuery {
 	after?: string;
 	/** Return receipts with timestamp <= before (ISO 8601). */
 	before?: string;
-	/** Maximum number of results. */
+	/**
+	 * Maximum number of results. When omitted, all matching rows are returned
+	 * (no default cap is applied).
+	 */
 	limit?: number;
+	/**
+	 * Sort order for results. Default is "asc" (oldest first) to preserve
+	 * historical behavior. Use "desc" to get the most recent receipts first;
+	 * ties on timestamp are broken by sequence descending.
+	 */
+	order?: "asc" | "desc";
 }
 
 /**
@@ -61,8 +70,6 @@ export interface StoreStats {
 interface ReceiptRow {
 	receipt_json: string;
 }
-
-const DEFAULT_QUERY_LIMIT = 10000;
 
 /**
  * Parse a receipt JSON string from the store, with error context.
@@ -220,14 +227,18 @@ export class ReceiptStore {
 		const where =
 			conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-		const limit = filters.limit ?? DEFAULT_QUERY_LIMIT;
-		params.push(limit);
+		const dir = filters.order === "desc" ? "DESC" : "ASC";
+		const orderClause = `ORDER BY timestamp ${dir}, sequence ${dir}`;
 
-		const rows = this.db
-			.prepare(
-				`SELECT receipt_json FROM receipts ${where} ORDER BY timestamp ASC LIMIT ?`,
-			)
-			.all(...params) as unknown as ReceiptRow[];
+		let sql: string;
+		if (filters.limit !== undefined) {
+			params.push(filters.limit);
+			sql = `SELECT receipt_json FROM receipts ${where} ${orderClause} LIMIT ?`;
+		} else {
+			sql = `SELECT receipt_json FROM receipts ${where} ${orderClause}`;
+		}
+
+		const rows = this.db.prepare(sql).all(...params) as unknown as ReceiptRow[];
 
 		return rows.map((r) => parseReceiptJson(r.receipt_json, "query"));
 	}

--- a/sdk/ts/src/store/store.ts
+++ b/sdk/ts/src/store/store.ts
@@ -228,7 +228,7 @@ export class ReceiptStore {
 			conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
 		const dir = filters.order === "desc" ? "DESC" : "ASC";
-		const orderClause = `ORDER BY timestamp ${dir}, sequence ${dir}`;
+		const orderClause = `ORDER BY timestamp ${dir}, sequence ${dir}, rowid ${dir}`;
 
 		let sql: string;
 		if (filters.limit !== undefined) {

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -402,7 +402,10 @@ type Query struct {
     Status     *receipt.OutcomeStatus
     After      *string
     Before     *string
+    // When nil, all matching rows are returned (no default cap).
     Limit      *int
+    // When true, returns newest receipts first; ties broken by sequence descending.
+    NewestFirst bool
 }
 
 type Stats struct {

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -313,7 +313,10 @@ class ReceiptQuery:
     status: str | None = None
     after: str | None = None
     before: str | None = None
+    # When None, all matching rows are returned (no default cap).
     limit: int | None = None
+    # When True, returns newest receipts first; ties broken by sequence descending.
+    newest_first: bool = False
 ```
 
 #### `StoreStats`

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -316,7 +316,13 @@ interface ReceiptQuery {
   status?: OutcomeStatus;
   after?: string;
   before?: string;
+  /** When omitted, all matching rows are returned (no default cap). */
   limit?: number;
+  /**
+   * Sort order. Default `"asc"` (oldest first). Use `"desc"` for newest first;
+   * ties on timestamp are broken by sequence descending.
+   */
+  order?: "asc" | "desc";
 }
 ```
 


### PR DESCRIPTION
## What

Adds DESC ordering support and removes the silent 10k default limit from `ReceiptStore.query` across all three SDKs. Closes #300.

## Changes

### Go SDK (`sdk/go/store/`)
- `nil` Limit now omits the `LIMIT` clause — no silent truncation
- `sequence` added as a tiebreaker: `ORDER BY timestamp ASC/DESC, sequence ASC/DESC`
- 3 new tests: no-default-limit, DESC ordering, sequence tiebreaker

### TypeScript SDK (`sdk/ts/`)
- Added `order?: "asc" | "desc"` to `ReceiptQuery` (default `"asc"` for backwards compat)
- Removed `DEFAULT_QUERY_LIMIT = 10000` — `undefined` limit omits `LIMIT` clause
- 4 new tests: default ASC, explicit DESC, explicit ASC, tiebreaker

### Python SDK (`sdk/py/`)
- Added `newest_first: bool = False` to `ReceiptQuery` dataclass
- Removed `DEFAULT_QUERY_LIMIT = 10_000` — `None` limit omits `LIMIT` clause
- 4 new tests: no-default-limit, default ASC, DESC, sequence tiebreaker

## Decision: drop the cap

`None`/`undefined` limit now means "all matching rows." Callers that need bounded results pass an explicit limit. The silent 10k cap silently lost data for filtered queries.

## Checklist

- [x] Tests pass: Go (`go test ./sdk/go/...`), TS (`pnpm test`), Python (`uv run pytest tests/store/`)
- [x] Linter passes (`go vet`, `biome`, `ruff`)
- [x] No real keys or secrets in the diff
- [x] Cross-SDK behaviour is consistent