### PR TITLE
docs(site): document --parameter-disclosure flag in daemon setup guide

### DIFF
--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -48,6 +48,7 @@ func main() {
 		ChainID:              envOrDefault("AGENTRECEIPTS_CHAIN_ID", "default"),
 		IssuerID:             envOrDefault("AGENTRECEIPTS_ISSUER_ID", "did:agent-receipts-daemon:local"),
 		VerificationMethodID: envOrDefault("AGENTRECEIPTS_VERIFICATION_METHOD", "did:agent-receipts-daemon:local#k1"),
+		ParameterDisclosure:  os.Getenv("AGENTRECEIPTS_PARAMETER_DISCLOSURE") == "1",
 	}
 
 	initKeys := flag.Bool("init", false, "Generate a new signing key pair and exit (must not exist)")
@@ -59,6 +60,7 @@ func main() {
 	flag.StringVar(&cfg.ChainID, "chain-id", cfg.ChainID, "Chain id to write under (env: AGENTRECEIPTS_CHAIN_ID)")
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
+	flag.BoolVar(&cfg.ParameterDisclosure, "parameter-disclosure", cfg.ParameterDisclosure, "Include plaintext tool input/output in parameters_disclosure (WARNING: stores unredacted payloads; see issue #280) (env: AGENTRECEIPTS_PARAMETER_DISCLOSURE)")
 	flag.Parse()
 
 	if *showVersion {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -59,6 +59,12 @@ type Config struct {
 	// When nil, tracing is silent. Tests can pass a buffer to inspect
 	// what frames were received, receipts signed, etc.
 	TraceLog io.Writer
+
+	// ParameterDisclosure controls whether plaintext tool input and output are
+	// included in the parameters_disclosure receipt field. Disabled by default.
+	// WARNING: stores unredacted payloads — see issue #280 for the encrypted
+	// design that supersedes this flag.
+	ParameterDisclosure bool
 }
 
 // DefaultSocketPath returns the per-OS default socket path. Phase 1 resolves
@@ -315,9 +321,17 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	cfg.Logger.Printf("loaded chain %s, next seq=%d", cfg.ChainID, state.NextSeq())
 
+	if cfg.ParameterDisclosure {
+		cfg.Logger.Printf("WARNING: --parameter-disclosure is enabled.")
+		cfg.Logger.Printf("WARNING: Plaintext tool input and output will be stored in receipts.")
+		cfg.Logger.Printf("WARNING: This is a temporary opt-in pending encrypted disclosure (issue #280).")
+		cfg.Logger.Printf("WARNING: Ensure receipts.db is protected and does not contain secrets you cannot afford to expose.")
+	}
+
 	pp := pipeline.New(state, ks, st, cfg.IssuerID)
 	pp.TraceLog = cfg.TraceLog
 	pp.ErrorLog = cfg.Logger.Printf
+	pp.ParameterDisclosure = cfg.ParameterDisclosure
 
 	ln, err := socket.Listen(socket.Options{
 		Path:     cfg.SocketPath,

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -82,6 +82,12 @@ type Pipeline struct {
 	TraceLog io.Writer              // Optional trace log for testing; nil = silent
 	ErrorLog func(string, ...any)   // Optional error logger; nil = silent
 
+	// ParameterDisclosure, when true, includes plaintext tool input and output
+	// in the parameters_disclosure receipt field. Disabled by default.
+	// WARNING: stores unredacted payloads — see issue #280 for the encrypted
+	// design that supersedes this flag.
+	ParameterDisclosure bool
+
 	// traceMu serialises writes to TraceLog. Process is invoked concurrently
 	// from the listener accept loop, so unguarded fmt.Fprintf calls would
 	// interleave bytes from different frames in the buffer (and race the
@@ -400,6 +406,17 @@ func (p *Pipeline) buildAndSign(
 			return receipt.AgentReceipt{}, "", fmt.Errorf("hash input: %w", err)
 		}
 		action.ParametersHash = hash
+	}
+
+	// Populate plaintext disclosure after hashing so the hash always covers the
+	// raw bytes, not any string conversion. Only runs when explicitly opted in.
+	if p.ParameterDisclosure {
+		if hasJSONPayload(f.Input) {
+			disclosure["input"] = string(f.Input)
+		}
+		if hasJSONPayload(f.Output) {
+			disclosure["output"] = string(f.Output)
+		}
 	}
 
 	outcome := receipt.Outcome{

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -374,8 +374,13 @@ func (p *Pipeline) buildAndSign(
 	// ts_emit is dropped (it is untrusted self-report and would not add audit
 	// value); the daemon's authoritative receive-time is the `now` value
 	// already stamped into action.timestamp, issuanceDate, and proof.created.
-	// Mirroring any of these into parameters_disclosure could accidentally
-	// persist PII pulled from emitter-controlled bytes, so we don't.
+	//
+	// Exception: when the operator explicitly enables ParameterDisclosure, the
+	// emitter-controlled input/output bytes are intentionally added below.
+	// That opt-in is for full-fidelity audit trails where the operator has
+	// already accepted the trade-off. PII exposure and the absence of a
+	// redaction mechanism are tracked in issue #423 — operators should not
+	// enable this option until that is resolved.
 	disclosure := map[string]string{
 		"peer.platform": peer.Platform,
 		"peer.pid":      strconv.FormatInt(int64(peer.PID), 10),

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -814,6 +814,97 @@ func TestProcess_DropCountChainContinues(t *testing.T) {
 	}
 }
 
+// TestProcess_ParameterDisclosureEnabled verifies that when ParameterDisclosure
+// is true, plaintext input and output are recorded in parameters_disclosure under
+// the "input" and "output" keys. The hash fields must still be present because
+// hashing runs before the disclosure block.
+func TestProcess_ParameterDisclosureEnabled(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+	p.ParameterDisclosure = true
+
+	inputJSON := json.RawMessage(`{"path":"/tmp/file","mode":"r"}`)
+	outputJSON := json.RawMessage(`{"bytes":42}`)
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Input:     inputJSON,
+		Output:    outputJSON,
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := receipts[0]
+	pd := r.CredentialSubject.Action.ParametersDisclosure
+
+	if got := pd["input"]; got != string(inputJSON) {
+		t.Errorf("parameters_disclosure[input] = %q, want %q", got, string(inputJSON))
+	}
+	if got := pd["output"]; got != string(outputJSON) {
+		t.Errorf("parameters_disclosure[output] = %q, want %q", got, string(outputJSON))
+	}
+	// Hashes must still be present — disclosure doesn't replace hashing.
+	if r.CredentialSubject.Action.ParametersHash == "" {
+		t.Error("parameters_hash must be present when input is set, even with disclosure enabled")
+	}
+	if r.CredentialSubject.Outcome.ResponseHash == "" {
+		t.Error("response_hash must be present when output is set, even with disclosure enabled")
+	}
+}
+
+// TestProcess_ParameterDisclosureDisabled verifies that when ParameterDisclosure
+// is false (the default), the "input" and "output" keys are absent from
+// parameters_disclosure even when the frame carries non-null input and output.
+func TestProcess_ParameterDisclosureDisabled(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+	// ParameterDisclosure defaults to false; no assignment needed.
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "fs.read"},
+		Input:     json.RawMessage(`{"path":"/tmp/file","mode":"r"}`),
+		Output:    json.RawMessage(`{"bytes":42}`),
+		Decision:  "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
+
+	if _, ok := pd["input"]; ok {
+		t.Errorf("parameters_disclosure must not contain \"input\" when ParameterDisclosure is false, got %q", pd["input"])
+	}
+	if _, ok := pd["output"]; ok {
+		t.Errorf("parameters_disclosure must not contain \"output\" when ParameterDisclosure is false, got %q", pd["output"])
+	}
+}
+
 // failOnNthInsert wraps a ReceiptStore and returns an error on the Nth Insert.
 type failOnNthInsert struct {
 	store.ReceiptStore

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -180,6 +180,37 @@ AGENTRECEIPTS_SOCKET=/path/to/events.sock mcp-proxy npx -y @modelcontextprotocol
 
 See the [OpenClaw installation guide](/openclaw/installation) for daemon forwarding configuration.
 
+## Payload disclosure
+
+By default the daemon stores only a cryptographic hash of each tool call's input and output (`parameters_hash` / `response_hash`). This is privacy-preserving — the receipt proves what happened without retaining the raw payload.
+
+### Opt-in plaintext disclosure
+
+You can instruct the daemon to also store the plaintext input and output in the `parameters_disclosure` receipt field:
+
+```bash
+agent-receipts-daemon --parameter-disclosure
+# or via environment variable
+AGENTRECEIPTS_PARAMETER_DISCLOSURE=1 agent-receipts-daemon
+```
+
+When this flag is enabled, the daemon logs a warning block at startup:
+
+```
+WARNING: --parameter-disclosure is enabled.
+Plaintext tool input and output will be stored in receipts.
+This is a temporary opt-in pending encrypted disclosure (issue #280).
+Ensure receipts.db is protected and does not contain secrets you cannot afford to expose.
+```
+
+:::danger
+`--parameter-disclosure` stores **unredacted** tool payloads in `receipts.db`. Tool call arguments routinely contain file paths, file contents, API tokens, and other sensitive data. Do not enable this flag until daemon-side redaction ([issue #423](https://github.com/agent-receipts/ar/issues/423)) has landed, unless you have verified that your workload does not produce sensitive payloads.
+:::
+
+### Future: encrypted disclosure
+
+The plaintext opt-in is a temporary bridge. The target design ([ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md), [issue #280](https://github.com/agent-receipts/ar/issues/280)) uses asymmetric encryption so the daemon stores ciphertext — recoverable only by the holder of a forensic private key, not by the daemon process itself. This allows full forensic capability without the daemon being able to read its own past disclosures. The `--parameter-disclosure` flag will be superseded by that design when it ships.
+
 ## Verify your chain
 
 `agent-receipts verify` reads the database directly — the daemon does not need to be running:


### PR DESCRIPTION
Adds a Payload disclosure section to the daemon setup guide covering:

- The default hash-only behaviour
- The `--parameter-disclosure` flag and `AGENTRECEIPTS_PARAMETER_DISCLOSURE=1` env var
- A danger callout linking to #423 (redaction not yet in daemon)
- A forward pointer to the encrypted design in ADR-0012 / #280

Follows the code change landed in #427.