### PR TITLE
fix(sdk/go): chain invariants + expectedFinalHash error message (#274, #276)

### DIFF
--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -180,7 +180,8 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		Receipts: results,
 		BrokenAt: brokenAt,
 	}
-	// Sig errors take precedence over hash-compute errors.
+	// Sig errors take precedence over hash-compute errors; when both are present
+	// the hash-compute error is discarded (a single Error field can only surface one).
 	switch {
 	case firstSigErr != "":
 		cv.Error = firstSigErr

--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -105,7 +105,9 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 	results := make([]ReceiptVerification, 0, len(receipts))
 	brokenAt := -1
 	var firstSigErr string
+	var firstSigErrAt int = -1
 	var firstHashComputeErr string
+	var firstHashComputeErrAt int = -1
 
 	for i, r := range receipts {
 		chain := r.CredentialSubject.Chain
@@ -115,6 +117,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 			sigValid = false
 			if firstSigErr == "" {
 				firstSigErr = "signature compute failed at index " + strconv.Itoa(i) + ": " + sigErr.Error()
+				firstSigErrAt = i
 			}
 		}
 
@@ -126,6 +129,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 			if err != nil {
 				if firstHashComputeErr == "" {
 					firstHashComputeErr = "hash compute failed at index " + strconv.Itoa(i-1) + ": " + err.Error()
+					firstHashComputeErrAt = i
 				}
 				hashValid = false
 			} else {
@@ -153,15 +157,22 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		}
 	}
 
-	// Sig errors take precedence over hash-compute errors; when both are present
-	// the hash-compute error is discarded (a single Error field can only surface one).
+	// Pick whichever compute error occurred first in the chain. When both appear
+	// at the same index (same receipt), the sig error takes precedence.
 	// Compute this before the terminal check so early returns preserve it.
 	var loopErr string
+	var loopErrAt int = -1
 	switch {
+	case firstSigErr != "" && firstHashComputeErr != "":
+		if firstSigErrAt <= firstHashComputeErrAt {
+			loopErr, loopErrAt = firstSigErr, firstSigErrAt
+		} else {
+			loopErr, loopErrAt = firstHashComputeErr, firstHashComputeErrAt
+		}
 	case firstSigErr != "":
-		loopErr = firstSigErr
+		loopErr, loopErrAt = firstSigErr, firstSigErrAt
 	case firstHashComputeErr != "":
-		loopErr = firstHashComputeErr
+		loopErr, loopErrAt = firstHashComputeErr, firstHashComputeErrAt
 	}
 
 	// Receipt-after-terminal integrity check (unconditional — spec §7.3.2).
@@ -171,12 +182,14 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		ch := r.CredentialSubject.Chain
 		if ch.Terminal != nil && *ch.Terminal {
 			if i < len(receipts)-1 {
-				if brokenAt == -1 {
-					brokenAt = i + 1
+				terminalViolationAt := i + 1
+				if brokenAt == -1 || terminalViolationAt < brokenAt {
+					brokenAt = terminalViolationAt
 				}
-				// Compute errors take precedence; fall back to the terminal violation message.
+				// Use compute error only if it occurred at or before the terminal
+				// violation; otherwise the terminal violation message takes precedence.
 				errMsg := loopErr
-				if errMsg == "" {
+				if loopErrAt == -1 || loopErrAt > terminalViolationAt {
 					errMsg = "receipt after terminal: receipt at index " + strconv.Itoa(i+1) + " follows a terminal receipt at index " + strconv.Itoa(i)
 				}
 				return ChainVerification{

--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -153,6 +153,17 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		}
 	}
 
+	// Sig errors take precedence over hash-compute errors; when both are present
+	// the hash-compute error is discarded (a single Error field can only surface one).
+	// Compute this before the terminal check so early returns preserve it.
+	var loopErr string
+	switch {
+	case firstSigErr != "":
+		loopErr = firstSigErr
+	case firstHashComputeErr != "":
+		loopErr = firstHashComputeErr
+	}
+
 	// Receipt-after-terminal integrity check (unconditional — spec §7.3.2).
 	// If a receipt has terminal: true and is not the last receipt, that is a
 	// protocol violation: a receipt after a terminal predecessor exists.
@@ -163,12 +174,17 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 				if brokenAt == -1 {
 					brokenAt = i + 1
 				}
+				// Compute errors take precedence; fall back to the terminal violation message.
+				errMsg := loopErr
+				if errMsg == "" {
+					errMsg = "receipt after terminal: receipt at index " + strconv.Itoa(i+1) + " follows a terminal receipt at index " + strconv.Itoa(i)
+				}
 				return ChainVerification{
 					Valid:    false,
 					Length:   len(receipts),
 					Receipts: results,
 					BrokenAt: brokenAt,
-					Error:    "receipt after terminal: receipt at index " + strconv.Itoa(i+1) + " follows a terminal receipt at index " + strconv.Itoa(i),
+					Error:    errMsg,
 				}
 			}
 		}
@@ -179,14 +195,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		Length:   len(receipts),
 		Receipts: results,
 		BrokenAt: brokenAt,
-	}
-	// Sig errors take precedence over hash-compute errors; when both are present
-	// the hash-compute error is discarded (a single Error field can only surface one).
-	switch {
-	case firstSigErr != "":
-		cv.Error = firstSigErr
-	case firstHashComputeErr != "":
-		cv.Error = firstHashComputeErr
+		Error:    loopErr,
 	}
 
 	// Response-hash verification (spec §4.3.2).

--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -10,6 +10,10 @@ import (
 // be exercised. In production, this variable is left pointing at HashReceipt.
 var hashReceipt = HashReceipt
 
+// verifyReceipt is overridable in tests so the error-return path of Verify can
+// be exercised without a malformed key. In production this points at Verify.
+var verifyReceipt = Verify
+
 // ReceiptVerification holds the verification result for a single receipt in a chain.
 type ReceiptVerification struct {
 	Index          int    `json:"index"`
@@ -100,25 +104,17 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 
 	results := make([]ReceiptVerification, 0, len(receipts))
 	brokenAt := -1
+	var firstSigErr string
+	var firstHashComputeErr string
 
 	for i, r := range receipts {
 		chain := r.CredentialSubject.Chain
 
-		sigValid, sigErr := Verify(r, publicKeyPEM)
+		sigValid, sigErr := verifyReceipt(r, publicKeyPEM)
 		if sigErr != nil {
-			results = append(results, ReceiptVerification{
-				Index:          i,
-				ReceiptID:      r.ID,
-				SignatureValid: false,
-				HashLinkValid:  false,
-				SequenceValid:  false,
-			})
-			return ChainVerification{
-				Valid:    false,
-				Length:   len(receipts),
-				Receipts: results,
-				BrokenAt: i,
-				Error:    sigErr.Error(),
+			sigValid = false
+			if firstSigErr == "" {
+				firstSigErr = "signature compute failed at index " + strconv.Itoa(i) + ": " + sigErr.Error()
 			}
 		}
 
@@ -128,23 +124,13 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		} else {
 			prevHash, err := hashReceipt(receipts[i-1])
 			if err != nil {
-				seqValid := chain.Sequence == receipts[i-1].CredentialSubject.Chain.Sequence+1
-				results = append(results, ReceiptVerification{
-					Index:          i,
-					ReceiptID:      r.ID,
-					SignatureValid: sigValid,
-					HashLinkValid:  false,
-					SequenceValid:  seqValid,
-				})
-				return ChainVerification{
-					Valid:    false,
-					Length:   len(receipts),
-					Receipts: results,
-					BrokenAt: i,
-					Error:    "hash compute failed at index " + strconv.Itoa(i-1) + ": " + err.Error(),
+				if firstHashComputeErr == "" {
+					firstHashComputeErr = "hash compute failed at index " + strconv.Itoa(i-1) + ": " + err.Error()
 				}
+				hashValid = false
+			} else {
+				hashValid = chain.PreviousReceiptHash != nil && *chain.PreviousReceiptHash == prevHash
 			}
-			hashValid = chain.PreviousReceiptHash != nil && *chain.PreviousReceiptHash == prevHash
 		}
 
 		seqValid := true
@@ -193,6 +179,13 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		Length:   len(receipts),
 		Receipts: results,
 		BrokenAt: brokenAt,
+	}
+	// Sig errors take precedence over hash-compute errors.
+	switch {
+	case firstSigErr != "":
+		cv.Error = firstSigErr
+	case firstHashComputeErr != "":
+		cv.Error = firstHashComputeErr
 	}
 
 	// Response-hash verification (spec §4.3.2).
@@ -251,7 +244,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 			} else if lastHash != opt.ExpectedFinalHash {
 				cv.Valid = false
 				cv.BrokenAt = last
-				cv.Error = "final receipt hash does not match expected value"
+				cv.Error = "final receipt hash mismatch at index " + strconv.Itoa(last) + ": expected " + opt.ExpectedFinalHash + ", got " + lastHash
 			}
 		}
 

--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -219,6 +219,57 @@ func TestSigComputeErrorContinuesIteration(t *testing.T) {
 	if !strings.Contains(result.Error, "synthetic verify failure") {
 		t.Errorf("expected error to include cause, got: %s", result.Error)
 	}
+	// Non-target receipts must have their SignatureValid computed correctly.
+	if !result.Receipts[0].SignatureValid {
+		t.Error("expected Receipts[0].SignatureValid=true")
+	}
+	if result.Receipts[1].SignatureValid {
+		t.Error("expected Receipts[1].SignatureValid=false (injected error)")
+	}
+	for i := 2; i < 5; i++ {
+		if !result.Receipts[i].SignatureValid {
+			t.Errorf("expected Receipts[%d].SignatureValid=true", i)
+		}
+	}
+}
+
+// TestDualErrorSigTakesPrecedenceOverHashCompute verifies that when both a
+// signature-compute error and a hash-compute error occur in the same chain,
+// the signature error wins in ChainVerification.Error.
+func TestDualErrorSigTakesPrecedenceOverHashCompute(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChain(t, kp, 3)
+
+	targetID := chain[0].ID
+
+	origVerify := verifyReceipt
+	verifyReceipt = func(r AgentReceipt, key string) (bool, error) {
+		if r.ID == targetID {
+			return false, errors.New("synthetic sig failure")
+		}
+		return origVerify(r, key)
+	}
+	t.Cleanup(func() { verifyReceipt = origVerify })
+
+	origHash := hashReceipt
+	hashReceipt = func(r AgentReceipt) (string, error) {
+		if r.ID == targetID {
+			return "", errors.New("synthetic hash failure")
+		}
+		return origHash(r)
+	}
+	t.Cleanup(func() { hashReceipt = origHash })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if !strings.Contains(result.Error, "signature compute failed at index 0") {
+		t.Errorf("expected sig error to win, got: %s", result.Error)
+	}
+	if strings.Contains(result.Error, "hash compute") {
+		t.Errorf("hash-compute error must be suppressed when sig error present, got: %s", result.Error)
+	}
 }
 
 // TestExpectedFinalHashMismatchError verifies the enriched error message includes

--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -296,6 +296,47 @@ func TestExpectedFinalHashMismatchError(t *testing.T) {
 	}
 }
 
+// TestComputeErrorPreservedThroughTerminalCheck verifies that a sig-compute error
+// is still surfaced in ChainVerification.Error when the chain also has a
+// receipt-after-terminal violation (which previously returned early before the error
+// was applied).
+func TestComputeErrorPreservedThroughTerminalCheck(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	terminalChain := buildChainWithTerminal(t, kp, 2)
+
+	terminalHash, err := HashReceipt(terminalChain[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	extra := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 3, PreviousReceiptHash: &terminalHash, ChainID: "chain-1"},
+	})
+	extraSigned, _ := Sign(extra, kp.PrivateKey, "did:agent:test#key-1")
+	chain := append(terminalChain, extraSigned)
+
+	targetID := chain[0].ID
+	orig := verifyReceipt
+	verifyReceipt = func(r AgentReceipt, key string) (bool, error) {
+		if r.ID == targetID {
+			return false, errors.New("synthetic sig failure")
+		}
+		return orig(r, key)
+	}
+	t.Cleanup(func() { verifyReceipt = orig })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if !strings.Contains(result.Error, "signature compute failed at index 0") {
+		t.Errorf("compute error must surface through terminal check, got: %s", result.Error)
+	}
+}
+
 // --- ADR-0008 tests below ---
 
 // buildChainWithTerminal builds a chain of `count` receipts where the last

--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -132,11 +132,116 @@ func TestVerifyChainSurfacesHashError(t *testing.T) {
 	if result.BrokenAt != 1 {
 		t.Errorf("expected BrokenAt=1, got %d", result.BrokenAt)
 	}
+	if len(result.Receipts) != 3 {
+		t.Errorf("expected all 3 receipt entries, got %d", len(result.Receipts))
+	}
 	if !strings.Contains(result.Error, "hash compute failed at index 0") {
 		t.Errorf("expected error to contain 'hash compute failed at index 0', got: %s", result.Error)
 	}
 	if !strings.Contains(result.Error, "synthetic canonicalize failure") {
 		t.Errorf("expected error to contain 'synthetic canonicalize failure', got: %s", result.Error)
+	}
+}
+
+// TestHashComputeErrorAllReceiptsPresent verifies the length/brokenAt invariants
+// when hashReceipt fails mid-chain: all receipts must be in the result, and
+// brokenAt must point to the first broken index, not the early-exit point.
+func TestHashComputeErrorAllReceiptsPresent(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChain(t, kp, 5)
+
+	targetID := chain[0].ID
+	orig := hashReceipt
+	hashReceipt = func(r AgentReceipt) (string, error) {
+		if r.ID == targetID {
+			return "", errors.New("synthetic failure")
+		}
+		return orig(r)
+	}
+	t.Cleanup(func() { hashReceipt = orig })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if result.BrokenAt != 1 {
+		t.Errorf("expected BrokenAt=1 (first broken index), got %d", result.BrokenAt)
+	}
+	if result.Length != 5 {
+		t.Errorf("expected Length=5, got %d", result.Length)
+	}
+	if len(result.Receipts) != 5 {
+		t.Errorf("expected 5 per-receipt entries (invariant), got %d", len(result.Receipts))
+	}
+	// Only receipt[1]'s hash link is broken; later ones resolve normally.
+	if result.Receipts[1].HashLinkValid {
+		t.Error("expected Receipts[1].HashLinkValid=false")
+	}
+	if !result.Receipts[2].HashLinkValid {
+		t.Error("expected Receipts[2].HashLinkValid=true (hash of receipt[1] computes fine)")
+	}
+}
+
+// TestSigComputeErrorContinuesIteration verifies that a signature-compute error
+// (Verify returns a non-nil error) does not early-exit the loop: all receipts
+// must be present, brokenAt is the first index that failed, and the error message
+// names the failure site.
+func TestSigComputeErrorContinuesIteration(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChain(t, kp, 5)
+
+	targetID := chain[1].ID
+	orig := verifyReceipt
+	verifyReceipt = func(r AgentReceipt, key string) (bool, error) {
+		if r.ID == targetID {
+			return false, errors.New("synthetic verify failure")
+		}
+		return orig(r, key)
+	}
+	t.Cleanup(func() { verifyReceipt = orig })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if result.BrokenAt != 1 {
+		t.Errorf("expected BrokenAt=1, got %d", result.BrokenAt)
+	}
+	if result.Length != 5 {
+		t.Errorf("expected Length=5, got %d", result.Length)
+	}
+	if len(result.Receipts) != 5 {
+		t.Errorf("expected 5 per-receipt entries, got %d", len(result.Receipts))
+	}
+	if !strings.Contains(result.Error, "signature compute failed at index 1") {
+		t.Errorf("expected error to name failure site, got: %s", result.Error)
+	}
+	if !strings.Contains(result.Error, "synthetic verify failure") {
+		t.Errorf("expected error to include cause, got: %s", result.Error)
+	}
+}
+
+// TestExpectedFinalHashMismatchError verifies the enriched error message includes
+// both the expected and computed hashes.
+func TestExpectedFinalHashMismatchError(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChain(t, kp, 3)
+	realFinalHash, _ := HashReceipt(chain[2])
+
+	// Supply a deliberately wrong expected hash.
+	wrongHash := "sha256:" + strings.Repeat("0", 64)
+	result := VerifyChain(chain, kp.PublicKey, ChainVerifyOptions{ExpectedFinalHash: wrongHash})
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if !strings.Contains(result.Error, "final receipt hash mismatch at index 2") {
+		t.Errorf("expected index in error, got: %s", result.Error)
+	}
+	if !strings.Contains(result.Error, wrongHash) {
+		t.Errorf("expected expected-hash in error, got: %s", result.Error)
+	}
+	if !strings.Contains(result.Error, realFinalHash) {
+		t.Errorf("expected computed-hash in error, got: %s", result.Error)
 	}
 }
 

--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -795,6 +795,75 @@ func TestResponseHashNoBodyInMap(t *testing.T) {
 	}
 }
 
+// TestTerminalViolationBeforeComputeError verifies that when a terminal violation
+// occurs at an earlier index than a hash-compute error, brokenAt reflects the
+// terminal violation index and the error message names the terminal violation.
+func TestTerminalViolationBeforeComputeError(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	// Build: receipt[0] is terminal, receipt[1..3] are normal — terminal violation
+	// at terminalViolationAt=1 (receipt[1] follows the terminal receipt[0]).
+	terminalChain := buildChainWithTerminal(t, kp, 1)
+
+	// Append three more receipts after the terminal one.
+	var prevHash *string
+	h, err := HashReceipt(terminalChain[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	prevHash = &h
+	extra := make([]AgentReceipt, 3)
+	for j := 0; j < 3; j++ {
+		seq := 2 + j
+		unsigned := Create(CreateInput{
+			Issuer:    Issuer{ID: "did:agent:test"},
+			Principal: Principal{ID: "did:user:test"},
+			Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+			Outcome:   Outcome{Status: StatusSuccess},
+			Chain:     Chain{Sequence: seq, PreviousReceiptHash: prevHash, ChainID: "chain-1"},
+		})
+		signed, signErr := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+		if signErr != nil {
+			t.Fatal(signErr)
+		}
+		extra[j] = signed
+		hh, hashErr := HashReceipt(signed)
+		if hashErr != nil {
+			t.Fatal(hashErr)
+		}
+		prevHash = &hh
+	}
+	chain := append(terminalChain, extra...)
+
+	// Inject a hash-compute error on receipt[2] — this fires when processing
+	// receipt[3] (i=3, computing hash of receipts[2]), so loopErrAt=3.
+	// Terminal violation is at terminalViolationAt=1 (receipt[0] is terminal).
+	// The bug: before the fix, brokenAt was left at loopErrAt=3 and the error
+	// message was the hash-compute error even though terminal violation came first.
+	targetID := chain[2].ID
+	orig := hashReceipt
+	hashReceipt = func(r AgentReceipt) (string, error) {
+		if r.ID == targetID {
+			return "", errors.New("synthetic hash failure")
+		}
+		return orig(r)
+	}
+	t.Cleanup(func() { hashReceipt = orig })
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if result.Valid {
+		t.Error("expected Valid: false")
+	}
+	if result.BrokenAt != 1 {
+		t.Errorf("expected BrokenAt=1 (terminal violation index), got %d", result.BrokenAt)
+	}
+	if !strings.Contains(result.Error, "receipt after terminal") {
+		t.Errorf("expected terminal violation error to win, got: %s", result.Error)
+	}
+	if strings.Contains(result.Error, "hash compute") {
+		t.Errorf("hash-compute error must not appear when terminal violation comes first, got: %s", result.Error)
+	}
+}
+
 func containsStr(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || findStr(s, sub))
 }


### PR DESCRIPTION
## What

Fix two early-return paths in `VerifyChain` that violated the documented `ChainVerification` invariants, and enrich the `expectedFinalHash` mismatch error message with the expected and computed hashes.

Closes #274 (Go SDK). Closes #276 (Go SDK).

## Why

**Invariants (#274):** `ChainVerification.Length` is documented as "number of receipts verified" and `BrokenAt` as "index of the **first** broken receipt". Both were violated on early-return paths:

- **Signature-compute errors** (`Verify` returns non-nil error): returned early with `len(Receipts) < Length` and an unformatted error string.
- **Hash-compute errors** (`hashReceipt` fails mid-loop): returned early with `len(Receipts) < Length` when the failure index was not the last receipt.

Both paths now continue iterating. Every receipt gets a per-receipt entry, `BrokenAt` is the first broken index, and `Length` always equals `len(receipts)`. Sig errors take precedence over hash-compute errors in the `Error` field.

**Error message (#276):** The `expectedFinalHash` mismatch previously emitted a generic `"final receipt hash does not match expected value"`. Auditors had to recompute the chain's final hash externally to diagnose whether the witness was stale, the chain was truncated, or storage was corrupt. The new message follows the existing `response_hash` mismatch shape:

```
final receipt hash mismatch at index N: expected <expected>, got <computed>
```

**New `verifyReceipt` hook:** Added a `verifyReceipt` indirection variable (mirrors the existing `hashReceipt` hook) so tests can inject signature-compute errors without a malformed key.

## Changes

- `sdk/go/receipt/chain.go` — remove both early-return paths, track first sig/hash errors, apply after loop; fix `expectedFinalHash` error message; add `verifyReceipt` hook
- `sdk/go/receipt/chain_test.go` — add invariant count assertion to existing hash-error test; add `TestHashComputeErrorAllReceiptsPresent`, `TestSigComputeErrorContinuesIteration`, `TestExpectedFinalHashMismatchError`

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [ ] AGENTS.md updated (if project structure changed)
- [ ] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)