### PR TITLE
fix(sdk/ts): chain invariants + expectedFinalHash error message (#274, #276)

### DIFF
--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -420,6 +420,42 @@ describe("verifyChain", () => {
 		expect(chain.at(-1)?.credentialSubject.chain.terminal).toBe(true);
 	});
 
+	it("hash compute error is preserved through terminal early return", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const terminalChain = buildTerminalChain(2, privateKey);
+		const terminalReceipt = terminalChain.at(-1);
+		const terminalHash =
+			terminalReceipt != null ? hashReceipt(terminalReceipt) : "";
+		const extra = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:test" },
+			action: { type: "filesystem.file.read", risk_level: "low" },
+			outcome: { status: "success" },
+			chain: {
+				sequence: 3,
+				previous_receipt_hash: terminalHash,
+				chain_id: "chain_test",
+			},
+		});
+		const extraSigned = signReceipt(extra, privateKey, "did:agent:test#key-1");
+		const chain = [...terminalChain, extraSigned];
+		const targetId = chain[0]?.id;
+
+		const original = hashModule.hashReceipt;
+		const spy = vi.spyOn(hashModule, "hashReceipt").mockImplementation((r) => {
+			if (r.id === targetId) throw new Error("synthetic hash failure");
+			return original(r);
+		});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(/hash compute failed at index 0/);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	it("compute error is preserved when terminal violation also present", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 		const terminalChain = buildTerminalChain(2, privateKey);

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -127,12 +127,56 @@ describe("verifyChain", () => {
 			const result = verifyChain(chain, publicKey);
 			expect(result.valid).toBe(false);
 			expect(result.brokenAt).toBe(1);
+			expect(result.receipts).toHaveLength(2);
 			expect(result.error).toMatch(/^hash compute failed at index 0:/);
 			expect(result.error).toContain("synthetic canonicalize failure");
 			expect(result.receipts[1]?.hashLinkValid).toBe(false);
 		} finally {
 			spy.mockRestore();
 		}
+	});
+
+	it("hash compute error mid-chain: all receipts present (invariant)", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const chain = buildChain(5, privateKey);
+		const targetId = chain[0]?.id;
+
+		const original = hashModule.hashReceipt;
+		const spy = vi.spyOn(hashModule, "hashReceipt").mockImplementation((r) => {
+			if (r.id === targetId) {
+				throw new Error("synthetic failure");
+			}
+			return original(r);
+		});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.brokenAt).toBe(1);
+			expect(result.length).toBe(5);
+			expect(result.receipts).toHaveLength(5);
+			// Only receipt[1]'s hash link is broken; later ones resolve normally.
+			expect(result.receipts[1]?.hashLinkValid).toBe(false);
+			expect(result.receipts[2]?.hashLinkValid).toBe(true);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("expectedFinalHash mismatch error includes expected and computed hashes", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const chain = buildChain(3, privateKey);
+		const realFinalHash = hashReceipt(chain[2]!);
+		const wrongHash = `sha256:${"0".repeat(64)}`;
+
+		const result = verifyChain(chain, publicKey, {
+			expectedFinalHash: wrongHash,
+		});
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toMatch(/final receipt hash mismatch at index 2/);
+		expect(result.error).toContain(wrongHash);
+		expect(result.error).toContain(realFinalHash);
 	});
 
 	it("surfaces verifyReceipt errors via the error field", () => {

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -420,6 +420,44 @@ describe("verifyChain", () => {
 		expect(chain.at(-1)?.credentialSubject.chain.terminal).toBe(true);
 	});
 
+	it("compute error is preserved when terminal violation also present", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const terminalChain = buildTerminalChain(2, privateKey);
+		const terminalReceipt = terminalChain.at(-1);
+		const terminalHash =
+			terminalReceipt != null ? hashReceipt(terminalReceipt) : "";
+		const extra = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:test" },
+			action: { type: "filesystem.file.read", risk_level: "low" },
+			outcome: { status: "success" },
+			chain: {
+				sequence: 3,
+				previous_receipt_hash: terminalHash,
+				chain_id: "chain_test",
+			},
+		});
+		const extraSigned = signReceipt(extra, privateKey, "did:agent:test#key-1");
+		const chain = [...terminalChain, extraSigned];
+		const targetId = chain[0]?.id;
+
+		const original = signingModule.verifyReceipt;
+		const spy = vi
+			.spyOn(signingModule, "verifyReceipt")
+			.mockImplementation((r, key) => {
+				if (r.id === targetId) throw new Error("synthetic sig failure");
+				return original(r, key);
+			});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(/signature compute failed at index 0/);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	it("receipt after terminal is always invalid", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 		const terminalChain = buildTerminalChain(3, privateKey);

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -166,7 +166,8 @@ describe("verifyChain", () => {
 	it("expectedFinalHash mismatch error includes expected and computed hashes", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 		const chain = buildChain(3, privateKey);
-		const realFinalHash = hashReceipt(chain[2]!);
+		const last = chain.at(-1);
+		const realFinalHash = last != null ? hashReceipt(last) : "";
 		const wrongHash = `sha256:${"0".repeat(64)}`;
 
 		const result = verifyChain(chain, publicKey, {

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -163,6 +163,38 @@ describe("verifyChain", () => {
 		}
 	});
 
+	it("dual error: sig-compute takes precedence over hash-compute in error field", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const chain = buildChain(3, privateKey);
+		const targetId = chain[0]?.id;
+
+		const originalHash = hashModule.hashReceipt;
+		const originalVerify = signingModule.verifyReceipt;
+
+		const hashSpy = vi
+			.spyOn(hashModule, "hashReceipt")
+			.mockImplementation((r) => {
+				if (r.id === targetId) throw new Error("synthetic hash failure");
+				return originalHash(r);
+			});
+		const verifySpy = vi
+			.spyOn(signingModule, "verifyReceipt")
+			.mockImplementation((r, key) => {
+				if (r.id === targetId) throw new Error("synthetic sig failure");
+				return originalVerify(r, key);
+			});
+
+		try {
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(/signature compute failed at index 0/);
+			expect(result.error).not.toMatch(/hash compute/);
+		} finally {
+			hashSpy.mockRestore();
+			verifySpy.mockRestore();
+		}
+	});
+
 	it("expectedFinalHash mismatch error includes expected and computed hashes", () => {
 		const { publicKey, privateKey } = generateKeyPair();
 		const chain = buildChain(3, privateKey);

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -106,6 +106,7 @@ export function verifyChain(
 	let brokenAt = -1;
 	let previous: AgentReceipt | undefined;
 	let signatureError: string | undefined;
+	let hashComputeError: string | undefined;
 
 	for (let i = 0; i < receipts.length; i++) {
 		const receipt = receipts[i];
@@ -127,33 +128,18 @@ export function verifyChain(
 		if (previous === undefined) {
 			hashLinkValid = chain.previous_receipt_hash === null;
 		} else {
-			let previousHash: string;
+			let previousHash: string | undefined;
 			try {
 				previousHash = hashReceipt(previous);
 			} catch (e) {
 				const reason = e instanceof Error ? e.message : String(e);
-				const prevSeq = previous.credentialSubject.chain.sequence;
-				const curSeq = chain.sequence;
-				const seqValid =
-					Number.isSafeInteger(curSeq) &&
-					Number.isSafeInteger(prevSeq) &&
-					curSeq === prevSeq + 1;
-				results.push({
-					index: i,
-					receiptId: receipt.id,
-					signatureValid,
-					hashLinkValid: false,
-					sequenceValid: seqValid,
-				});
-				return {
-					valid: false,
-					length: receipts.length,
-					receipts: results,
-					brokenAt: i,
-					error: `hash compute failed at index ${i - 1}: ${reason}`,
-				};
+				if (hashComputeError === undefined) {
+					hashComputeError = `hash compute failed at index ${i - 1}: ${reason}`;
+				}
 			}
-			hashLinkValid = chain.previous_receipt_hash === previousHash;
+			hashLinkValid =
+				previousHash !== undefined &&
+				chain.previous_receipt_hash === previousHash;
 		}
 
 		let sequenceValid: boolean;
@@ -210,8 +196,11 @@ export function verifyChain(
 		receipts: results,
 		brokenAt,
 	};
+	// Sig errors take precedence over hash-compute errors.
 	if (signatureError !== undefined) {
 		cv.error = signatureError;
+	} else if (hashComputeError !== undefined) {
+		cv.error = hashComputeError;
 	}
 
 	// Response-hash verification (spec §4.3.2).
@@ -282,7 +271,7 @@ export function verifyChain(
 				...cv,
 				valid: false,
 				brokenAt: receipts.length - 1,
-				error: "final receipt hash does not match expected value",
+				error: `final receipt hash mismatch at index ${receipts.length - 1}: expected ${options.expectedFinalHash}, got ${lastHash}`,
 			};
 		}
 	}

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -173,6 +173,11 @@ export function verifyChain(
 		previous = receipt;
 	}
 
+	// Sig errors take precedence over hash-compute errors; when both are present
+	// the hash-compute error is discarded (a single error field can only surface one).
+	// Compute this before the terminal check so early returns preserve it.
+	const loopError = signatureError ?? hashComputeError;
+
 	// Receipt-after-terminal integrity check (unconditional — spec §7.3.2).
 	for (let i = 0; i < receipts.length - 1; i++) {
 		const r = receipts[i];
@@ -185,7 +190,7 @@ export function verifyChain(
 				receipts: results,
 				brokenAt,
 				responseHashNote: undefined,
-				error: signatureError,
+				error: loopError,
 			};
 		}
 	}
@@ -196,12 +201,8 @@ export function verifyChain(
 		receipts: results,
 		brokenAt,
 	};
-	// Sig errors take precedence over hash-compute errors; when both are present
-	// the hash-compute error is discarded (a single error field can only surface one).
-	if (signatureError !== undefined) {
-		cv.error = signatureError;
-	} else if (hashComputeError !== undefined) {
-		cv.error = hashComputeError;
+	if (loopError !== undefined) {
+		cv.error = loopError;
 	}
 
 	// Response-hash verification (spec §4.3.2).

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -196,7 +196,8 @@ export function verifyChain(
 		receipts: results,
 		brokenAt,
 	};
-	// Sig errors take precedence over hash-compute errors.
+	// Sig errors take precedence over hash-compute errors; when both are present
+	// the hash-compute error is discarded (a single error field can only surface one).
 	if (signatureError !== undefined) {
 		cv.error = signatureError;
 	} else if (hashComputeError !== undefined) {


### PR DESCRIPTION
## What

Fix the hash-compute error early-return in `verifyChain` that violated the documented `ChainVerification` invariants, and enrich the `expectedFinalHash` mismatch error message with the expected and computed hashes.

Closes #274 (TypeScript SDK). Closes #276 (TypeScript SDK).

## Why

**Invariants (#274):** The hash-compute error path returned early when `hashReceipt` threw mid-loop, leaving `receipts.length < length` and violating the documented `ChainVerification` contract. The path now continues iterating: every receipt gets a per-receipt entry, `brokenAt` is the first broken index, and `length` always equals `receipts.length`. Signature-compute errors already continued correctly; `hashComputeError` is now tracked alongside `signatureError` and applied with the same precedence (sig > hash) to `cv.error` after the loop.

**Error message (#276):** The `expectedFinalHash` mismatch previously emitted a generic `"final receipt hash does not match expected value"`. The new message follows the existing `response_hash` mismatch shape:

```
final receipt hash mismatch at index N: expected <expected>, got <computed>
```

## Changes

- `sdk/ts/src/receipt/chain.ts` — replace hash-compute early return with tracked error + continue; apply `hashComputeError` after loop alongside `signatureError`; fix `expectedFinalHash` error message
- `sdk/ts/src/receipt/chain.test.ts` — add receipt count assertion to existing hash-error test; add `hash compute error mid-chain: all receipts present (invariant)` and `expectedFinalHash mismatch error includes expected and computed hashes`

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`biome`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [ ] AGENTS.md updated (if project structure changed)
- [ ] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)