### PR TITLE
docs(blog): Native Tool Calls in the Audit Trail

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -168,6 +168,10 @@ export default defineConfig({
               label: "The audit boundary belongs outside the agent",
               slug: "blog/daemon-process-separation",
             },
+            {
+              label: "Native Tool Calls in the Audit Trail",
+              slug: "blog/hooks-native-tool-audit",
+            },
           ],
         },
       ],

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -1,0 +1,29 @@
+---
+title: "Native Tool Calls in the Audit Trail"
+description: "How the Claude Code hook captures Bash, Read, Write, Edit and other native tools — and why this matters for a complete agent audit."
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<!-- DRAFT — stub for third blog post in the series -->
+
+<!-- Story arc:
+  - MCP proxy covers MCP tool calls. But Claude Code's native tools (Bash, Read,
+    Write, Edit, WebFetch, WebSearch) don't go through any MCP server — they're
+    built into Claude Code itself. Without the hook, those calls are invisible
+    to the audit trail.
+  - The gap: a receipt chain that captures every GitHub API call but misses every
+    file write is not a complete audit.
+  - The hook: agent-receipts-hook is a PostToolUse hook binary. Claude Code calls
+    it after every tool completes, passing a JSON payload describing the call.
+    The hook forwards to the daemon — same socket, same chain, same receipts.
+  - Installation is one settings.json change. No proxy to configure, no MCP
+    server to wrap.
+  - Show a real Bash receipt from this session. Compare it to the side-by-side
+    MCP + hook receipt pair (the pull_request_read demo) to show how they land
+    in the same chain.
+  - Note: hook is PostToolUse only today. PreToolUse (policy/blocking) is on the
+    roadmap. The current hook is audit-only.
+  - Close: with the hook in place, the daemon chain has every tool call from a
+    Claude Code session — native and MCP — in one verifiable sequence.
+-->

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -113,7 +113,7 @@ Here's a real `Bash` receipt from a Claude Code session, captured while running 
     "type": "claude-code.Bash",
     "tool_name": "Bash",
     "risk_level": "medium",
-    "parameters_hash": "sha256:dc143db4ad2fd5df10685749c688e018610dfb254bd75bbf753ed3ddd84d97a2",
+    "parameters_hash": "sha256:dc143db4ad...",
     "parameters_disclosure": {
       "input": "{\"command\":\"echo \\\"Connecting with api_key=[REDACTED] to service\\\"\"}",
       "output": "{\"stdout\":\"Connecting with api_key=[REDACTED] to service\",\"stderr\":\"\"}",
@@ -122,10 +122,14 @@ Here's a real `Bash` receipt from a Claude Code session, captured while running 
       "peer.pid": "74389"
     }
   },
-  "outcome": { "status": "success" },
-  "chain": {
-    "sequence": 2051,
-    "chain_id": "default"
+  "credentialSubject": {
+    "outcome": { "status": "success" },
+    "chain": { "sequence": 2051, "chain_id": "default" }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "verificationMethod": "did:agent-receipts-daemon:local#k1",
+    "proofValue": "uZ8bqK5Zgr..."
   }
 }
 ```

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -161,20 +161,22 @@ This is a deliberate design choice. Silent drops mean invisible audit gaps. A vi
 
 ---
 
-## Why PostToolUse and not PreToolUse?
+## Why PostToolUse and not the other ~20 hook events?
 
-This is the first question people ask. The short answer: audit first, policy second — and for good reason.
+Claude Code's [hooks system](https://code.claude.com/docs/en/hooks) has grown to around 20 lifecycle events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `PreCompact`, `Notification`, `WorktreeCreate`, `WorktreeRemove`, and more. Each represents a different moment in the agent's lifecycle.
 
-`PreToolUse` hooks fire *before* the tool runs. Exiting non-zero blocks the call. That sounds powerful, but it changes the contract: you're no longer just observing, you're in the critical path. If the hook is slow, the agent is slow. If the hook crashes, the tool call fails — even for calls that should succeed. If the hook blocks something it shouldn't, the agent is broken in a way that's hard to debug.
+Agent Receipts currently handles `PostToolUse` only. That's deliberate.
 
-`PostToolUse` has none of these failure modes. The tool has already run. The hook fires after the fact. If it crashes or times out, the agent doesn't notice — the call completed, Claude Code continues. The audit trail has a gap, not a breakage.
+**Audit first, policy second.** `PreToolUse` can block a tool call by exiting non-zero — which puts the hook in the critical path. If it's slow, the agent is slow. If it crashes, the tool call fails. If it incorrectly blocks something, the agent breaks in ways that are hard to debug. `PostToolUse` has none of these failure modes: the tool has already run, the hook fires after the fact, and if it fails the agent doesn't notice. The audit trail has a gap, not a breakage.
 
-There's also an information argument. A `PostToolUse` hook sees the *output* — what the tool actually returned. A `PreToolUse` hook only sees the *intent* — what the agent asked for. For forensics and breach investigation, the output is often the more interesting half.
+**The output is more interesting than the intent.** A `PostToolUse` hook sees what the tool *returned*. A `PreToolUse` hook only sees what the agent *asked for*. For forensics and breach investigation, the output — what actually came back — is often the more useful half of the record.
 
-The current approach is deliberate: ship the audit foundation with the lowest possible blast radius, get it running in production, then add policy enforcement once the system is trusted. The MCP proxy already does `PreToolUse`-equivalent blocking for MCP calls. The hook will follow the same path once the audit baseline is solid.
+**Expanding deliberately.** `SessionStart`, `UserPromptSubmit`, and `Stop` are natural next candidates: they'd let the daemon chain record session boundaries and the prompts that triggered tool use, not just the tool calls themselves. But each new event type adds surface area — and there's a technical complication specific to short-lived hook processes (each hook invocation is a fresh process, so the ADR-0010 drop-counter mechanism needs adapting before expanding coverage).
+
+The MCP proxy already does `PreToolUse`-equivalent blocking for MCP calls. The hook will follow the same path — audit baseline first, then policy enforcement once it's proven in production.
 
 <Aside type="note">
-There's also a technical complication specific to short-lived hook processes: the drop-counter mechanism that makes backpressure visible in the chain doesn't work naturally when the emitter process exits after every call. That design question is being resolved before `PreToolUse` lands, so new event types don't inherit the silent-drop gap.
+The drop-counter mechanism that makes backpressure visible in the chain doesn't work naturally when the emitter process exits after every call. That design question is being resolved before new event types are added, so they don't inherit the silent-drop gap.
 </Aside>
 
 ---

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -5,7 +5,7 @@ description: "How the Claude Code hook captures Bash, Read, Write, Edit and othe
 
 import { Aside } from '@astrojs/starlight/components';
 
-**Series: Auditing AI Agents** · Part 3 of 3 · [← One Chain, Two Channels, Zero Secrets](/blog/unified-chain-redaction-demo/)
+_Published 2026-05-28_ · **Series: Auditing AI Agents** · Part 3 of 3 · [← One Chain, Two Channels, Zero Secrets](/blog/unified-chain-redaction-demo/)
 
 ---
 
@@ -207,4 +207,4 @@ With both the MCP proxy and the hook in place, a Claude Code session produces on
 - Every native tool call — captured and receipted by the hook
 - All in one hash-chained sequence, signed by the daemon
 
-An agent that could previously obscure its activity by choosing native tools over MCP calls no longer has that option. The chain is complete.
+Without the hook, a Claude Code session's audit trail skips over whatever happened through native tools — file writes, shell commands, web fetches. With both in place, every tool call from the session lands in one signed, hash-chained sequence.

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -140,7 +140,7 @@ A few things worth noting:
 
 When the hook and the MCP proxy both fire for the same underlying call (an MCP tool call triggers both a proxy intercept and a PostToolUse event), you get two consecutive receipts in the chain:
 
-| seq | channel | action.type | parameters_hash |
+| seq | emitter | action.type | parameters_hash |
 |-----|---------|-------------|-----------------|
 | 2046 | mcp-proxy | `mcp.github.pull_request_read` | `sha256:2f9911...` |
 | 2047 | hook | `claude-code.mcp__github-audited__pull_request_read` | `sha256:2f9911...` |
@@ -155,28 +155,28 @@ The two receipts carry different `session_id` values — the hook forwards Claud
 
 ## Fail-hard, not silent
 
-When the daemon is unreachable, the hook exits non-zero. Claude Code surfaces this as a visible non-blocking error in the session — the tool call still completes, but the gap is visible rather than silent.
+When the daemon is unreachable, the hook exits non-zero. Claude Code surfaces this as a non-blocking error in the session — the tool call still completes, but the missing receipt is reported rather than swallowed.
 
 This is a deliberate design choice. Silent drops mean invisible audit gaps. A visible error means an operator knows to investigate whether the daemon is down.
 
 ---
 
-## Why PostToolUse and not the other ~20 hook events?
+## Why PostToolUse and not the other hook events?
 
-Claude Code's [hooks system](https://code.claude.com/docs/en/hooks) has grown to around 20 lifecycle events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `PreCompact`, `Notification`, `WorktreeCreate`, `WorktreeRemove`, and more. Each represents a different moment in the agent's lifecycle.
+Claude Code's [hooks system](https://code.claude.com/docs/en/hooks) now exposes close to 30 lifecycle events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `PreCompact`, `Notification`, `WorktreeCreate`, `WorktreeRemove`, and many more. Each represents a different moment in the agent's lifecycle.
 
-Agent Receipts currently handles `PostToolUse` only. That's deliberate.
+The recommended Agent Receipts configuration wires up `PostToolUse` only. That's deliberate.
 
-**Audit first, policy second.** `PreToolUse` can block a tool call by exiting non-zero — which puts the hook in the critical path. If it's slow, the agent is slow. If it crashes, the tool call fails. If it incorrectly blocks something, the agent breaks in ways that are hard to debug. `PostToolUse` has none of these failure modes: the tool has already run, the hook fires after the fact, and if it fails the agent doesn't notice. The audit trail has a gap, not a breakage.
+**Audit first, policy second.** `PreToolUse` can block a tool call by exiting non-zero — which puts the hook in the critical path. If it's slow, the agent is slow. If it crashes, the tool call fails. If it incorrectly blocks something, the agent breaks in ways that are hard to debug. `PostToolUse` has none of these failure modes: the tool has already run, the hook fires after the fact, and a failure to record surfaces as a non-blocking error rather than a broken tool call. The audit trail has a gap, not a breakage.
 
 **The output is more interesting than the intent.** A `PostToolUse` hook sees what the tool *returned*. A `PreToolUse` hook only sees what the agent *asked for*. For forensics and breach investigation, the output — what actually came back — is often the more useful half of the record.
 
-**Expanding deliberately.** `SessionStart`, `UserPromptSubmit`, and `Stop` are natural next candidates: they'd let the daemon chain record session boundaries and the prompts that triggered tool use, not just the tool calls themselves. But each new event type adds surface area — and there's a technical complication specific to short-lived hook processes (each hook invocation is a fresh process, so the ADR-0010 drop-counter mechanism needs adapting before expanding coverage).
+**Expanding deliberately.** `SessionStart`, `UserPromptSubmit`, and `Stop` are natural next candidates: they would let the chain record session boundaries and the prompts that triggered tool use, not just the tool calls themselves. Each new event type adds surface area, and there's a wire-format question to resolve first — see the note below.
 
 The MCP proxy already does `PreToolUse`-equivalent blocking for MCP calls. The hook will follow the same path — audit baseline first, then policy enforcement once it's proven in production.
 
 <Aside type="note">
-The drop-counter mechanism that makes backpressure visible in the chain doesn't work naturally when the emitter process exits after every call. That design question is being resolved before new event types are added, so they don't inherit the silent-drop gap.
+ADR-0010's drop-counter relies on a long-lived emitter to count and report frames the daemon couldn't ingest. A short-lived hook process has nowhere to keep that count between invocations. Resolving this is a prerequisite for broader event coverage, so new event types don't inherit a silent-drop gap.
 </Aside>
 
 ---
@@ -187,11 +187,13 @@ Rust would produce a smaller, faster binary with compile-time memory safety guar
 
 The honest answer is that the emitter is designed to be so thin that language choice barely matters. Its entire job is: read stdin, open a Unix socket, write a length-prefixed frame, close. The 25ms dial timeout and 100ms write timeout are the latency budget — not the language runtime. A Rust binary would hit those same wall-clock limits. The bottleneck is IPC, not CPU or memory.
 
-The safety argument for Rust is real but narrow here. There's no complex memory management in the emitter, no pointer arithmetic, no unsafe operations the Go runtime can't handle safely. The Go emitter has been running in production without memory-safety incidents because it genuinely doesn't do anything that requires Rust's guarantees.
+The safety argument for Rust is real but narrow here. The emitter does no manual memory management, no pointer arithmetic, no unsafe operations — nothing that exercises the failure modes Rust's borrow checker is designed to prevent. Go's runtime covers what little surface there is.
 
 There's also a practical argument: the hook binary uses the Go emitter package directly, sharing code with the daemon, the SDK, and the proxy. Rust would mean a separate implementation of the IPC framing, the frame schema, and the timeout logic — more surface area for drift between the hook and every other emitter in the system.
 
 If the emitter ever needs to do heavy local processing before forwarding — structured field extraction, client-side pattern matching, local buffering for offline operation — that calculus changes. For fire-and-forget over a Unix socket, Go is more than adequate.
+
+---
 
 ## The complete picture
 

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -181,6 +181,18 @@ The drop-counter mechanism that makes backpressure visible in the chain doesn't 
 
 ---
 
+## Why Go and not Rust?
+
+Rust would produce a smaller, faster binary with compile-time memory safety guarantees. It's a reasonable question.
+
+The honest answer is that the emitter is designed to be so thin that language choice barely matters. Its entire job is: read stdin, open a Unix socket, write a length-prefixed frame, close. The 25ms dial timeout and 100ms write timeout are the latency budget — not the language runtime. A Rust binary would hit those same wall-clock limits. The bottleneck is IPC, not CPU or memory.
+
+The safety argument for Rust is real but narrow here. There's no complex memory management in the emitter, no pointer arithmetic, no unsafe operations the Go runtime can't handle safely. The Go emitter has been running in production without memory-safety incidents because it genuinely doesn't do anything that requires Rust's guarantees.
+
+There's also a practical argument: the hook binary uses the Go emitter package directly, sharing code with the daemon, the SDK, and the proxy. Rust would mean a separate implementation of the IPC framing, the frame schema, and the timeout logic — more surface area for drift between the hook and every other emitter in the system.
+
+If the emitter ever needs to do heavy local processing before forwarding — structured field extraction, client-side pattern matching, local buffering for offline operation — that calculus changes. For fire-and-forget over a Unix socket, Go is more than adequate.
+
 ## The complete picture
 
 With both the MCP proxy and the hook in place, a Claude Code session produces one chain covering everything:

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -161,13 +161,21 @@ This is a deliberate design choice. Silent drops mean invisible audit gaps. A vi
 
 ---
 
-## Current scope and roadmap
+## Why PostToolUse and not PreToolUse?
 
-The hook today handles `PostToolUse` only — it fires after a tool has already run. This makes it audit-only: it records what happened but cannot influence what runs.
+This is the first question people ask. The short answer: audit first, policy second — and for good reason.
 
-`PreToolUse` hooks (which fire before the tool runs and can block it by exiting non-zero) are on the roadmap. That opens the door to policy enforcement at the native tool level — the same pattern the MCP proxy uses today for MCP calls. Once both `Pre` and `PostToolUse` are covered, the hook becomes a full policy + audit layer for native tools.
+`PreToolUse` hooks fire *before* the tool runs. Exiting non-zero blocks the call. That sounds powerful, but it changes the contract: you're no longer just observing, you're in the critical path. If the hook is slow, the agent is slow. If the hook crashes, the tool call fails — even for calls that should succeed. If the hook blocks something it shouldn't, the agent is broken in a way that's hard to debug.
 
-Until then: install the hook, get the audit trail, know what your agent ran.
+`PostToolUse` has none of these failure modes. The tool has already run. The hook fires after the fact. If it crashes or times out, the agent doesn't notice — the call completed, Claude Code continues. The audit trail has a gap, not a breakage.
+
+There's also an information argument. A `PostToolUse` hook sees the *output* — what the tool actually returned. A `PreToolUse` hook only sees the *intent* — what the agent asked for. For forensics and breach investigation, the output is often the more interesting half.
+
+The current approach is deliberate: ship the audit foundation with the lowest possible blast radius, get it running in production, then add policy enforcement once the system is trusted. The MCP proxy already does `PreToolUse`-equivalent blocking for MCP calls. The hook will follow the same path once the audit baseline is solid.
+
+<Aside type="note">
+There's also a technical complication specific to short-lived hook processes: the drop-counter mechanism that makes backpressure visible in the chain doesn't work naturally when the emitter process exits after every call. That design question is being resolved before `PreToolUse` lands, so new event types don't inherit the silent-drop gap.
+</Aside>
 
 ---
 

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -5,6 +5,10 @@ description: "How the Claude Code hook captures Bash, Read, Write, Edit and othe
 
 import { Aside } from '@astrojs/starlight/components';
 
+**Series: Auditing AI Agents** · Part 3 of 3 · [← One Chain, Two Channels, Zero Secrets](/blog/unified-chain-redaction-demo/)
+
+---
+
 The MCP proxy covers MCP tool calls. Everything that flows through an MCP server — GitHub API calls, database queries, Atlassian writes — is intercepted, receipted, and hash-chained. But Claude Code has another class of tools that never touch an MCP server at all.
 
 `Bash`. `Read`. `Write`. `Edit`. `WebFetch`. `WebSearch`.

--- a/site/src/content/docs/blog/hooks-native-tool-audit.mdx
+++ b/site/src/content/docs/blog/hooks-native-tool-audit.mdx
@@ -1,29 +1,182 @@
 ---
 title: "Native Tool Calls in the Audit Trail"
-description: "How the Claude Code hook captures Bash, Read, Write, Edit and other native tools — and why this matters for a complete agent audit."
+description: "How the Claude Code hook captures Bash, Read, Write, Edit and other native tools — closing the gap the MCP proxy leaves open."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<!-- DRAFT — stub for third blog post in the series -->
+The MCP proxy covers MCP tool calls. Everything that flows through an MCP server — GitHub API calls, database queries, Atlassian writes — is intercepted, receipted, and hash-chained. But Claude Code has another class of tools that never touch an MCP server at all.
 
-<!-- Story arc:
-  - MCP proxy covers MCP tool calls. But Claude Code's native tools (Bash, Read,
-    Write, Edit, WebFetch, WebSearch) don't go through any MCP server — they're
-    built into Claude Code itself. Without the hook, those calls are invisible
-    to the audit trail.
-  - The gap: a receipt chain that captures every GitHub API call but misses every
-    file write is not a complete audit.
-  - The hook: agent-receipts-hook is a PostToolUse hook binary. Claude Code calls
-    it after every tool completes, passing a JSON payload describing the call.
-    The hook forwards to the daemon — same socket, same chain, same receipts.
-  - Installation is one settings.json change. No proxy to configure, no MCP
-    server to wrap.
-  - Show a real Bash receipt from this session. Compare it to the side-by-side
-    MCP + hook receipt pair (the pull_request_read demo) to show how they land
-    in the same chain.
-  - Note: hook is PostToolUse only today. PreToolUse (policy/blocking) is on the
-    roadmap. The current hook is audit-only.
-  - Close: with the hook in place, the daemon chain has every tool call from a
-    Claude Code session — native and MCP — in one verifiable sequence.
--->
+`Bash`. `Read`. `Write`. `Edit`. `WebFetch`. `WebSearch`.
+
+These are native tools — built into Claude Code itself. They run locally, directly, with no proxy in between. Without additional instrumentation, they're invisible to the audit trail. A receipt chain that captures every GitHub API call but misses every file write isn't a complete audit.
+
+---
+
+## The gap
+
+Here's what a typical Claude Code session looks like without the hook:
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant MP as mcp-proxy
+    participant MS as MCP Server
+    participant D as agent-receipts-daemon
+
+    CC->>MP: mcp tool call (stdio)
+    MP->>MS: forward
+    MS-->>MP: response
+    MP-->>CC: response
+    MP--)D: receipt ✓
+
+    CC->>CC: Bash / Read / Write / Edit
+    Note over D: no receipt ✗
+```
+
+The daemon chain has gaps wherever native tools ran. An auditor sees the MCP calls but not the file system activity, shell commands, or web fetches that happened between them.
+
+---
+
+## The hook
+
+Claude Code exposes a `PostToolUse` hook — a shell command it calls after every tool completes, passing a JSON payload describing the call. The `agent-receipts-hook` binary reads that payload and forwards it to the daemon over the same Unix socket the MCP proxy uses.
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant MP as mcp-proxy
+    participant MS as MCP Server
+    participant Hook as agent-receipts-hook
+    participant D as agent-receipts-daemon
+
+    CC->>MP: mcp tool call (stdio)
+    MP->>MS: forward
+    MS-->>MP: response
+    MP-->>CC: response
+    MP--)D: emit · channel: mcp ✓
+    CC--)Hook: PostToolUse event
+    Hook--)D: emit · channel: claude-code ✓
+
+    CC->>CC: Bash / Read / Write
+    CC--)Hook: PostToolUse event
+    Hook--)D: emit · channel: claude-code ✓
+```
+
+All emitters — the proxy and the hook — fire to the same daemon socket. The daemon assigns consecutive sequence numbers. One chain, all channels.
+
+---
+
+## Installation
+
+One entry in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agent-receipts-hook"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The empty `matcher` means the hook fires for every tool. The `agent-receipts-hook` binary needs to be on `$PATH` — install it via Homebrew:
+
+```sh
+brew install agent-receipts/tap/agent-receipts-hook
+```
+
+That's it. No MCP server to wrap, no proxy config to write. The next tool call you make will land a receipt.
+
+---
+
+## What a native tool receipt looks like
+
+Here's a real `Bash` receipt from a Claude Code session, captured while running a shell command that included a fake API key:
+
+```json
+{
+  "action": {
+    "type": "claude-code.Bash",
+    "tool_name": "Bash",
+    "risk_level": "medium",
+    "parameters_hash": "sha256:dc143db4ad2fd5df10685749c688e018610dfb254bd75bbf753ed3ddd84d97a2",
+    "parameters_disclosure": {
+      "input": "{\"command\":\"echo \\\"Connecting with api_key=[REDACTED] to service\\\"\"}",
+      "output": "{\"stdout\":\"Connecting with api_key=[REDACTED] to service\",\"stderr\":\"\"}",
+      "peer.platform": "darwin",
+      "peer.uid": "501",
+      "peer.pid": "74389"
+    }
+  },
+  "outcome": { "status": "success" },
+  "chain": {
+    "sequence": 2051,
+    "chain_id": "default"
+  }
+}
+```
+
+A few things worth noting:
+
+**`action.type` prefix is `claude-code.`** — every hook-sourced receipt carries this prefix, so you can filter by channel at query time.
+
+**Secrets are redacted** — the `api_key=sk-...` value was caught by the daemon's built-in redaction patterns before the receipt was stored. The `parameters_hash` still commits to the original unredacted input, so the call is verifiable without the secret being retained.
+
+**Peer credentials** — the daemon captured the hook process's uid, pid, and platform at socket connect time, independent of anything the hook claims about itself.
+
+---
+
+## Side by side with an MCP call
+
+When the hook and the MCP proxy both fire for the same underlying call (an MCP tool call triggers both a proxy intercept and a PostToolUse event), you get two consecutive receipts in the chain:
+
+| seq | channel | action.type | parameters_hash |
+|-----|---------|-------------|-----------------|
+| 2046 | mcp-proxy | `mcp.github.pull_request_read` | `sha256:2f9911...` |
+| 2047 | hook | `claude-code.mcp__github-audited__pull_request_read` | `sha256:2f9911...` |
+
+The identical `parameters_hash` correlates the two receipts to the same underlying call. An auditor can verify from either receipt that the same input was processed.
+
+<Aside type="note">
+The two receipts carry different `session_id` values — the hook forwards Claude Code's session ID while the proxy generates its own per-process UUID. Cross-channel correlation by `parameters_hash` is the reliable key today.
+</Aside>
+
+---
+
+## Fail-hard, not silent
+
+When the daemon is unreachable, the hook exits non-zero. Claude Code surfaces this as a visible non-blocking error in the session — the tool call still completes, but the gap is visible rather than silent.
+
+This is a deliberate design choice. Silent drops mean invisible audit gaps. A visible error means an operator knows to investigate whether the daemon is down.
+
+---
+
+## Current scope and roadmap
+
+The hook today handles `PostToolUse` only — it fires after a tool has already run. This makes it audit-only: it records what happened but cannot influence what runs.
+
+`PreToolUse` hooks (which fire before the tool runs and can block it by exiting non-zero) are on the roadmap. That opens the door to policy enforcement at the native tool level — the same pattern the MCP proxy uses today for MCP calls. Once both `Pre` and `PostToolUse` are covered, the hook becomes a full policy + audit layer for native tools.
+
+Until then: install the hook, get the audit trail, know what your agent ran.
+
+---
+
+## The complete picture
+
+With both the MCP proxy and the hook in place, a Claude Code session produces one chain covering everything:
+
+- Every MCP tool call — intercepted and receipted by the proxy
+- Every native tool call — captured and receipted by the hook
+- All in one hash-chained sequence, signed by the daemon
+
+An agent that could previously obscure its activity by choosing native tools over MCP calls no longer has that option. The chain is complete.

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -247,7 +247,7 @@ agent-receipts-hook [--format=<name>]
 |---|---|
 | `--format` | Force a specific input format (default: auto-detected from environment variables). Currently supported: `claude-code`. |
 
-**Exit behaviour:** Always exits 0. Emit failures (daemon not running, socket missing, malformed frame) are dropped silently — the hook never blocks the agent.
+**Exit behaviour:** The hook never blocks the agent — the tool call has already completed by the time `PostToolUse` fires. Stdin/format issues exit 0 silently (unreadable stdin, unrecognised runtime). Emit failures (daemon unreachable, parse error, socket write timeout) exit 1 with a message on stderr so the operator can surface a missing-receipt event out-of-band. The in-chain audit gap from a daemon-down event is still silent by design — see [ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md) — but the hook itself is loud about its own failures.
 
 **Auto-detection:** When `--format` is omitted, the binary inspects environment variables to identify the calling runtime. `CLAUDE_SESSION_ID` set → `claude-code` format.
 


### PR DESCRIPTION
Stub for the third post in the series. Outline is in the file as comments.

**Publishing order:**
1. #443 — Daemon re-architecture ("Why Your Agent Can't Audit Itself")
2. #442 — Disclosure + redaction ("One Chain, Two Channels, Zero Secrets")
3. This — Hooks ("Native Tool Calls in the Audit Trail")

Content to write: the gap MCP proxy leaves (native tools invisible), how the hook fills it, installation (one settings.json change), real Bash receipt, PostToolUse-only today with PreToolUse on the roadmap.