### PR TITLE
docs(blog): remove broken forward links and add publish dates

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -157,12 +157,12 @@ export default defineConfig({
           items: [
             { label: "All Posts", slug: "blog" },
             {
-              label: "Why Your Agent Can't Audit Itself",
-              slug: "blog/daemon-process-separation",
-            },
-            {
               label: "OpenClaw Plugin: How It Works",
               slug: "blog/openclaw-plugin-deep-dive",
+            },
+            {
+              label: "The audit boundary belongs outside the agent",
+              slug: "blog/daemon-process-separation",
             },
           ],
         },

--- a/site/src/content/docs/blog/daemon-process-separation.mdx
+++ b/site/src/content/docs/blog/daemon-process-separation.mdx
@@ -3,7 +3,7 @@ title: "The audit boundary belongs outside the agent"
 description: "The architectural problem with in-process receipt signing, and how daemon process separation restores the audit property."
 ---
 
-**Series: Auditing AI Agents** · Part 1 of 3 · Next: [One Chain, Two Channels, Zero Secrets →](/blog/unified-chain-redaction-demo/)
+_Published 2026-05-17_ · **Series: Auditing AI Agents** · Part 1 of 3
 
 ---
 
@@ -113,5 +113,3 @@ That signing key — `did:agent-receipts-daemon:local#k1` — lives only in the 
 ## What comes next
 
 The daemon is the trust anchor for everything that follows: secret redaction before storage (already shipped), asymmetric payload encryption so only a forensic key holder can read stored inputs, centralised storage for cross-machine audit trails. All of it depends on having one trusted process that owns the keys and the chain.
-
-The next post is the demo — the unified chain and secret redaction working end to end, on real receipts.

--- a/site/src/content/docs/blog/index.mdx
+++ b/site/src/content/docs/blog/index.mdx
@@ -7,4 +7,5 @@ Updates, deep dives, and field notes from building the Agent Receipt Protocol.
 
 ## Posts
 
-- [OpenClaw Plugin: How It Works](/blog/openclaw-plugin-deep-dive/) — Plugin architecture, receipt anatomy, self-verification, and how the OpenClaw integration differs from the MCP Proxy.
+- **2026-05-17** — [The audit boundary belongs outside the agent](/blog/daemon-process-separation/) — The architectural problem with in-process receipt signing, and how daemon process separation restores the audit property.
+- **2026-04-27** — [OpenClaw Plugin: How It Works](/blog/openclaw-plugin-deep-dive/) — Plugin architecture, receipt anatomy, self-verification, and how the OpenClaw integration differs from the MCP Proxy.

--- a/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
+++ b/site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx
@@ -3,6 +3,8 @@ title: "OpenClaw Plugin: How It Works"
 description: "Plugin architecture, receipt anatomy, self-verification, and how the OpenClaw integration differs from the MCP Proxy."
 ---
 
+_Published 2026-04-27_
+
 The OpenClaw plugin is the second way to generate Agent Receipts — the first being the [MCP Proxy](/mcp-proxy/overview/). Both produce the same W3C Verifiable Credentials with Ed25519 signatures and hash-chained sequences. They differ in where they sit and what context they have access to.
 
 This post covers the plugin's internal mechanics, using real receipts from the first end-to-end trial.


### PR DESCRIPTION
## Summary

PR #443 shipped the daemon-process-separation post before posts 2 and 3 in the series, leaving two broken forward references on the live site. This PR removes them; they'll be restored when posts 2 (#442) and 3 (#444) ship.

Bundled blog housekeeping while here:

- **Publish dates** added inline to both existing posts (plain text, no schema changes). OpenClaw back-filled from first-commit date (2026-04-27).
- **Sidebar order** in `astro.config.mjs` flipped so OpenClaw (older) appears before the daemon post.
- **Sidebar label** for the daemon post updated to match the retitled article ("The audit boundary belongs outside the agent").
- **`blog/index.mdx`** now lists the daemon post in date order.

## Files changed

- `site/src/content/docs/blog/daemon-process-separation.mdx` — strip "Next:" link from series header, drop closing "next post" line, add publish date
- `site/src/content/docs/blog/openclaw-plugin-deep-dive.mdx` — add publish date
- `site/src/content/docs/blog/index.mdx` — add daemon post, prefix both with date
- `site/astro.config.mjs` — reorder Blog sidebar items, fix daemon-post label

## Test plan

- [ ] `pnpm build` in `site/` passes
- [ ] Visual check on `/blog/` index, daemon post, and sidebar order after deploy
