### PR TITLE
docs: add doc.go for pkg.go.dev (#73)

### DIFF
--- a/mcp-proxy/doc.go
+++ b/mcp-proxy/doc.go
@@ -1,0 +1,9 @@
+// Package mcpproxy is the Agent Receipts MCP proxy module.
+//
+// The mcp-proxy command (cmd/mcp-proxy) sits between MCP clients and upstream MCP
+// servers. It enforces policy, records audit events, and can require human approval
+// before forwarding tool calls.
+//
+// Implementation packages live under internal/ and are intended for use by this
+// module only.
+package mcpproxy

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -1,0 +1,9 @@
+// Package sdk provides the Go libraries for the Agent Receipts protocol.
+//
+// Subpackages:
+//
+//   - receipt — create, hash, sign, verify, and chain W3C Verifiable Credentials
+//   - store — SQLite-backed receipt persistence and verification
+//   - taxonomy — tool-name to action-type classification
+//   - emitter — fire-and-forget client for the local agent-receipts daemon
+package sdk


### PR DESCRIPTION
## Summary
- Add `mcp-proxy/doc.go` with module-level package documentation
- Add `sdk/go/doc.go` describing receipt, store, taxonomy, and emitter subpackages

## Test plan
- [x] `go build ./...` in `mcp-proxy` and `sdk/go`

Closes #73