### PR TITLE
docs(blog): update daemon process separation publish date to 2026-05-18

### DIFF
--- a/site/src/content/docs/blog/daemon-process-separation.mdx
+++ b/site/src/content/docs/blog/daemon-process-separation.mdx
@@ -3,7 +3,7 @@ title: "The audit boundary belongs outside the agent"
 description: "The architectural problem with in-process receipt signing, and how daemon process separation restores the audit property."
 ---
 
-_Published 2026-05-17_ · **Series: Auditing AI Agents** · Part 1 of 3
+_Published 2026-05-18_ · **Series: Auditing AI Agents** · Part 1 of 3
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the published date in `site/src/content/docs/blog/daemon-process-separation.mdx` from `2026-05-17` to `2026-05-18`.

## Test plan
- [ ] Verify the rendered blog post on the docs site shows `Published 2026-05-18`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm2HsfAmuGKBqoYTvUHh2s)_