### PR TITLE
fix(daemon): redact bare JWT tokens in receipts

### DIFF
--- a/daemon/internal/pipeline/redact.go
+++ b/daemon/internal/pipeline/redact.go
@@ -87,6 +87,16 @@ var builtinPatterns = []namedPattern{
 		re:   regexp.MustCompile(`Bearer\s+[A-Za-z0-9._\-/+=]{20,}`),
 	},
 	{
+		// JWT: three base64url segments separated by dots. Both the header
+		// and payload are base64url-encoded JSON objects, which always begin
+		// with `eyJ` (the encoding of `{"`). Anchoring both of the first two
+		// segments to `eyJ` keeps the pattern specific to JWTs and avoids
+		// matching arbitrary dotted base64 strings. The signature segment may
+		// be empty for unsigned (alg=none) JWTs.
+		name: "jwt",
+		re:   regexp.MustCompile(`eyJ[A-Za-z0-9_=\-]+\.eyJ[A-Za-z0-9_=\-]+\.[A-Za-z0-9_=\-]*`),
+	},
+	{
 		name: "slack-token",
 		re:   regexp.MustCompile(`xox[bpras]-[A-Za-z0-9\-]+`),
 	},

--- a/daemon/internal/pipeline/redact_test.go
+++ b/daemon/internal/pipeline/redact_test.go
@@ -61,6 +61,22 @@ func TestRedactor_BuiltinPatternsRedactKnownSecretShapes(t *testing.T) {
 			input: "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAA\n-----END RSA PRIVATE KEY-----",
 			want:  "MIIBogIBAA",
 		},
+		{
+			name:  "jwt-bare",
+			input: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJBbGljZSJ9.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+			want:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+		},
+		{
+			name:  "jwt-in-npmrc",
+			input: "//registry.npmjs.org/:_authToken=eyJ2ZXIiOjEsImlzdSI6MzQ1Njc4OTB9.eyJzdWIiOiJucG0tdXNlciIsImlhdCI6MTYwMDAwMDAwMH0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			want:  "eyJ2ZXIiOjEsImlzdSI6MzQ1Njc4OTB9",
+			keep:  "//registry.npmjs.org/:_authToken=",
+		},
+		{
+			name:  "jwt-unsigned",
+			input: "token: eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4In0.",
+			want:  "eyJhbGciOiJub25lIn0",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #450.

## Summary

The daemon's redaction pipeline missed bare JWTs — tokens not prefixed with `Bearer ` and not embedded in a URL query string. Concretely, `cat ~/.npmrc` from a Claude Code `Bash` tool call produced a receipt with the npm `_authToken=eyJ…` value in cleartext.

## Fix

One new entry in `builtinPatterns` (`daemon/internal/pipeline/redact.go`):

```go
{
    name: "jwt",
    re:   regexp.MustCompile(`eyJ[A-Za-z0-9_=\-]+\.eyJ[A-Za-z0-9_=\-]+\.[A-Za-z0-9_=\-]*`),
},
```

Anchoring both the header and payload segments on `eyJ` (the base64url encoding of `{"`) keeps the pattern specific to real JWTs and avoids matching arbitrary dotted base64 strings. The signature segment may be empty, which covers unsigned (`alg=none`) tokens.

Placement is between `bearer-token` (so `Bearer eyJ…` is still caught by the more contextual rule first) and `url-param-token` (so `?token=eyJ…` gets its value redacted to `[REDACTED]` before the URL-param rule runs).

Idempotency is preserved — the placeholder `[REDACTED]` does not start with `eyJ`, so re-running `Redact` is still a fixpoint.

## Tests

Three new sub-cases in `TestRedactor_BuiltinPatternsRedactKnownSecretShapes`:

- `jwt-bare` — well-formed HS256 JWT.
- `jwt-in-npmrc` — `//registry.npmjs.org/:_authToken=eyJ…` line; asserts the surrounding context (`//registry.npmjs.org/:_authToken=`) survives.
- `jwt-unsigned` — empty signature segment (`alg=none`).

`go vet ./...` clean. All daemon tests pass.

## Known gaps (deliberately left for follow-up)

- **JWEs** (5-segment JSON Web Encryption tokens) are not matched — only the header starts with `eyJ`, not subsequent segments. Rare in practice but worth a separate ticket if it comes up.
- **Opaque non-JWT npm tokens** (legacy `npm_*` prefixed values) still leak. Modern npm tokens are JWTs so are now covered.
- **`mcp-proxy/internal/audit`** has its own parallel redaction list; this PR does not touch it. Worth auditing for the same gap.

## Test plan

- [x] `go vet ./...` from `daemon/`
- [x] `go test ./...` from `daemon/`
- [x] New sub-tests pass and existing redactor sub-tests still pass
- [ ] CI green