### PR TITLE
docs(daemon): add v0.10.1 CHANGELOG entry

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-05-18
+
+### Security
+
+- **Redact bare JWT tokens in receipts** ([#451](https://github.com/agent-receipts/ar/pull/451),
+  closes [#450](https://github.com/agent-receipts/ar/issues/450)):
+  The pipeline redactor missed JWTs that were not prefixed with `Bearer ` and
+  not embedded in a URL query string. Concretely, `cat ~/.npmrc` from a Claude
+  Code `Bash` tool call produced a receipt with the npm `_authToken=eyJ…` value
+  in cleartext. Added a `jwt` built-in pattern (`eyJ…\.eyJ…\.…`) anchored on
+  the base64url-encoded `{"` prefix of the header and payload segments, which
+  keeps the pattern specific to real JWTs and avoids matching arbitrary dotted
+  base64 strings. The signature segment may be empty (covers unsigned
+  `alg=none` tokens).
+
 ## [0.10.0] - 2026-05-17
 
 ### Added


### PR DESCRIPTION
Release-prep for daemon **v0.10.1**.

## What

Adds the `## [0.10.1] - 2026-05-18` entry to `daemon/CHANGELOG.md`. It covers the JWT redaction fix already on main from [#451](https://github.com/agent-receipts/ar/pull/451) (closes [#450](https://github.com/agent-receipts/ar/issues/450)).

## What's NOT in this PR

An earlier revision of this branch also mirrored the JWT pattern into `mcp-proxy/internal/audit/redact.go`. That fix was dropped after a closer look: mcp-proxy's parallel redactor exists only because mcp-proxy still has its own local `audit.db`, which the thin-emitter refactor in [#421](https://github.com/agent-receipts/ar/pull/421) was supposed to retire. Patching the duplicate redactor would have entrenched the duplication.

Tracked as a follow-up in [#453](https://github.com/agent-receipts/ar/issues/453) — remove `mcp-proxy/internal/audit/{store,redact,encrypt}.go` entirely so the daemon is the sole writer and the sole redactor.

Short-term residual risk: a JWT pasted into a tool input/output that's already going through the proxy still lands in the operator's *local* `~/.agent-receipts/audit.db` un-redacted, until #453 lands. The leak is local-file only; signed receipts (the daemon's store) are already covered by #451.

## Release plan (after merge)

```
git tag daemon/v0.10.1 <merge-sha>
git push origin daemon/v0.10.1
```

`release-daemon.yml` builds binaries, updates the Homebrew tap, and creates the GitHub release.

## Test plan

- [x] `go vet ./...` clean in `daemon/`
- [x] `go test ./...` clean in `daemon/` (no code changes; CHANGELOG only)
- [ ] CI green
