### PR TITLE
docs(adr): Accept ADRs 0007, 0012–0016; document implementation status

### DIFF
--- a/docs/adr/0007-did-method-strategy.md
+++ b/docs/adr/0007-did-method-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-12) — Phase A only. Phase B (`did:web` resolution) and the pluggable resolver interface are designed but not yet scheduled. See *Implementation phasing* below.
 
 ## Context
 
@@ -26,9 +26,7 @@ Related: #20 (parent issue), spec §9.6 (open question #6), ADR-0001 (key lifecy
 
 ## Decision
 
-*This ADR is in Proposed status. No decision has been made — community input is being sought.*
-
-The leading candidate is a tiered approach:
+A tiered approach:
 
 1. **`did:key` as the default.** All SDKs ship with built-in `did:key` generation and resolution. This is the zero-configuration path: generate an Ed25519 key pair, derive the `did:key` identifier, and start signing receipts. No external infrastructure required.
 
@@ -36,13 +34,19 @@ The leading candidate is a tiered approach:
 
 3. **Pluggable resolver interface for other methods.** SDKs expose a DID resolution interface that integrators can implement for any DID method. The protocol does not endorse or require any method beyond `did:key` and `did:web`, but does not prevent others.
 
-### Open questions for community input
+### Resolved questions
 
-- **Is `did:web` the right production-tier recommendation?** Its DNS dependency is a feature (organizational anchoring) and a liability (centralized trust anchor, domain expiry risk). Are there better options for agent identity specifically?
-- **Should the protocol mandate a minimum set of DID methods that conformant implementations must support?** Or is "must support `did:key`, should support `did:web`" sufficient?
-- **How should key rotation interact with receipt chains?** If an agent rotates its key, receipts signed with the old key must remain verifiable. `did:web` DID Documents can include historical keys, but the protocol needs to specify how verifiers handle key rotation during chain verification.
-- **Is `did:peer` useful for agent-to-agent delegation?** The delegation model (spec §7.6) links chains across agents. Could `did:peer` be appropriate for these pairwise relationships even if public-facing identity uses `did:key` or `did:web`?
-- **What about `did:tdw` (Trust DID Web)?** `did:tdw` adds a verifiable history to `did:web`, removing the "trust the web server" problem. Is the added complexity justified for agent audit trails?
+- **Production tier.** `did:web` is the recommended production method. Its DNS dependency is accepted as the cost of organizational anchoring; `did:tdw` is noted as a future upgrade path if the DNS-trust footprint becomes a blocker, but not adopted now (additional complexity, smaller adopter base).
+- **Conformance.** Conformant implementations MUST support `did:key` and SHOULD support `did:web`. Other methods are pluggable but not required for interop.
+- **Key rotation interaction.** Covered by [ADR-0015](./0015-key-rotation-byok-anchoring.md): `proof.verificationMethod` carries the issuer's stable DID URL across rotations; the rotation-event witness chain plus DID resolution together let verifiers recover the key valid at a receipt's `issuanceDate`. This ADR no longer holds the rotation-semantics question open.
+- **`did:peer` for delegation.** Deferred. The delegation model (spec §7.6) is not yet in scope for implementation; revisit when delegation lands.
+- **`did:tdw`.** Deferred as above — interesting if `did:web` trust assumptions prove inadequate in real deployments, not a v1 concern.
+
+## Implementation phasing
+
+- **Phase A (now).** All SDKs implement `did:key` generation and resolution as a built-in capability. Existing `did:agent:` / `did:user:` placeholders in examples and test vectors are replaced with `did:key` equivalents. The protocol's verification algorithm is updated to require `did:key` resolution as an explicit step.
+- **Phase B (deferred).** `did:web` resolution lands in all SDKs along with the pluggable resolver interface. Trigger conditions: (a) a production deployment needs organizational anchoring; (b) a verifier needs to validate receipts whose issuer has rotated keys (ADR-0015 Phase A reaches the daemon); (c) `did:web` is required for cross-org interoperability with a named consumer.
+- **Phase C (deferred).** Verifier-side DID Document caching/pinning, historical resolution for long-lived receipts, and `did:tdw` evaluation.
 
 ## Security Considerations
 

--- a/docs/adr/0007-did-method-strategy.md
+++ b/docs/adr/0007-did-method-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (2026-05-12) — Phase A only. Phase B (`did:web` resolution) and the pluggable resolver interface are designed but not yet scheduled. See *Implementation phasing* below.
+Accepted (2026-05-12) — **decision only**. Phase A (the work described in *Implementation phasing* below) is **scoped but not started**: `did:key` resolution is not implemented in any SDK and `did:agent:` / `did:user:` placeholders still appear in the spec, examples, and the daemon's `did:user:unknown` default (`daemon/internal/pipeline/build.go`). Phase B and Phase C are deferred behind Phase A.
 
 ## Context
 
@@ -44,7 +44,7 @@ A tiered approach:
 
 ## Implementation phasing
 
-- **Phase A (now).** All SDKs implement `did:key` generation and resolution as a built-in capability. Existing `did:agent:` / `did:user:` placeholders in examples and test vectors are replaced with `did:key` equivalents. The protocol's verification algorithm is updated to require `did:key` resolution as an explicit step.
+- **Phase A (scoped, not started).** All SDKs implement `did:key` generation and resolution as a built-in capability. Existing `did:agent:` / `did:user:` placeholders in examples and test vectors are replaced with `did:key` equivalents, and the daemon's hardcoded `did:user:unknown` default in `daemon/internal/pipeline/build.go` is removed. The protocol's verification algorithm is updated to require `did:key` resolution as an explicit step. Trigger to start: someone is in a position to do the SDK + spec + daemon work end-to-end; absent that, this remains a decision without an owner.
 - **Phase B (deferred).** `did:web` resolution lands in all SDKs along with the pluggable resolver interface. Trigger conditions: (a) a production deployment needs organizational anchoring; (b) a verifier needs to validate receipts whose issuer has rotated keys (ADR-0015 Phase A reaches the daemon); (c) `did:web` is required for cross-org interoperability with a named consumer.
 - **Phase C (deferred).** Verifier-side DID Document caching/pinning, historical resolution for long-lived receipts, and `did:tdw` evaluation.
 

--- a/docs/adr/0012-payload-disclosure-policy.md
+++ b/docs/adr/0012-payload-disclosure-policy.md
@@ -108,7 +108,8 @@ What has landed:
 
 - The field has been renamed across SDKs from `parameters_preview` to `parameters_disclosure` (TS SDK ≥0.6.0; Go and Python SDKs carry the renamed field).
 - The config knob is named `parameterDisclosure` and the existing OpenClaw value space (`false | true | "high" | string[]`) is honoured at the config layer.
-- The hash-only default holds: no channel populates `parameters_disclosure` by default.
+- The daemon ships a `--parameter-disclosure` opt-in flag (PRs #427, #429); when enabled, the receipt pipeline writes redacted plaintext to `parameters_disclosure["input"]` and `parameters_disclosure["output"]` (`daemon/internal/pipeline/build.go`). **This is the legacy plaintext-in-body shape, not the envelope this ADR commits to** — it ships now because the field has redaction in front of it, and ships behind an explicit operator opt-in so it cannot be enabled silently.
+- The hash-only default holds: no channel populates `parameters_disclosure` unless the operator opts in.
 
 What has **not** landed and is required before disclosure is enabled in any non-experimental channel:
 
@@ -116,7 +117,7 @@ What has **not** landed and is required before disclosure is enabled in any non-
 - The forensic key-pair lifecycle (auto-generation, on-disk layout next to the signing key, CLI for export/import).
 - Cross-SDK canonical-JSON equivalence tests for the envelope.
 
-Until those land, callers **MUST NOT** populate `parameters_disclosure` from raw tool arguments — the field exists as a forward-compatible placeholder, not a plaintext-payload channel. The "plaintext-in-body" mode of the legacy TS `parameters_preview` is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
+Until those land, the `--parameter-disclosure` daemon flag is the only sanctioned way to populate the field, and it does so with **redacted plaintext** as an explicit interim step — not the envelope this ADR specifies. Callers other than the daemon's opt-in pipeline **MUST NOT** populate `parameters_disclosure` directly from raw tool arguments; the field is otherwise a forward-compatible placeholder for the envelope. The "plaintext-in-body" mode of the legacy TS `parameters_preview` (as an SDK-public surface) is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
 
 This gap is tracked as the remainder of **Phase A**. Phase B and Phase C are unchanged and remain sequenced behind daemon work (ADR-0010) and enterprise pull respectively.
 

--- a/docs/adr/0012-payload-disclosure-policy.md
+++ b/docs/adr/0012-payload-disclosure-policy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-12). Implementation is partial — see *Implementation status* below.
 
 ## Context
 
@@ -101,6 +101,24 @@ This ADR's *architecture* is decided now (because the receipt format is permanen
 - **Phase C — Enterprise.** Multi-recipient HPKE, HSM / KMS adapters, pluggable remote stores, retention knobs, operator-facing key-management documentation.
 
 Phase A receipts are forward-compatible with Phase B and C — no re-encryption, no migration.
+
+### Implementation status (as of 2026-05-12)
+
+What has landed:
+
+- The field has been renamed across SDKs from `parameters_preview` to `parameters_disclosure` (TS SDK ≥0.6.0; Go and Python SDKs carry the renamed field).
+- The config knob is named `parameterDisclosure` and the existing OpenClaw value space (`false | true | "high" | string[]`) is honoured at the config layer.
+- The hash-only default holds: no channel populates `parameters_disclosure` by default.
+
+What has **not** landed and is required before disclosure is enabled in any non-experimental channel:
+
+- The asymmetric envelope (`v`, `alg`, `recipients`, `nonce`, `ct`). No SDK currently produces or consumes the structured envelope shape committed to in this ADR.
+- The forensic key-pair lifecycle (auto-generation, on-disk layout next to the signing key, CLI for export/import).
+- Cross-SDK canonical-JSON equivalence tests for the envelope.
+
+Until those land, callers **MUST NOT** populate `parameters_disclosure` from raw tool arguments — the field exists as a forward-compatible placeholder, not a plaintext-payload channel. The "plaintext-in-body" mode of the legacy TS `parameters_preview` is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
+
+This gap is tracked as the remainder of **Phase A**. Phase B and Phase C are unchanged and remain sequenced behind daemon work (ADR-0010) and enterprise pull respectively.
 
 ## Consequences
 

--- a/docs/adr/0012-payload-disclosure-policy.md
+++ b/docs/adr/0012-payload-disclosure-policy.md
@@ -108,8 +108,9 @@ What has landed:
 
 - The field has been renamed across SDKs from `parameters_preview` to `parameters_disclosure` (TS SDK ≥0.6.0; Go and Python SDKs carry the renamed field).
 - The config knob is named `parameterDisclosure` and the existing OpenClaw value space (`false | true | "high" | string[]`) is honoured at the config layer.
-- The daemon ships a `--parameter-disclosure` opt-in flag (PRs #427, #429); when enabled, the receipt pipeline writes redacted plaintext to `parameters_disclosure["input"]` and `parameters_disclosure["output"]` (`daemon/internal/pipeline/build.go`). **This is the legacy plaintext-in-body shape, not the envelope this ADR commits to** — it ships now because the field has redaction in front of it, and ships behind an explicit operator opt-in so it cannot be enabled silently.
-- The hash-only default holds: no channel populates `parameters_disclosure` unless the operator opts in.
+- The daemon already populates `parameters_disclosure` with daemon-attested metadata on every receipt: OS-attested peer credentials (`peer.platform`, `peer.pid`, `peer.uid`, `peer.gid`, `peer.exe_path`) on normal receipts and `emitter.drop_count` on `events_dropped` receipts (`daemon/internal/pipeline/build.go`). These are not plaintext tool payloads — they are operator-allowlisted additive metadata that the daemon vouches for, stashed in the existing field until ADR-0010's dedicated `peer` field lands (Phase 2).
+- The daemon ships a `--parameter-disclosure` opt-in flag (PRs #427, #429); when enabled, the receipt pipeline *additionally* writes redacted plaintext tool input/output to `parameters_disclosure["input"]` and `parameters_disclosure["output"]` on the same map. **This is the legacy plaintext-in-body shape, not the envelope this ADR commits to** — it ships behind an explicit operator opt-in so plaintext payload disclosure cannot be enabled silently. The peer/drop-count metadata above is unaffected by this flag.
+- The hash-only default for **tool input/output payloads** holds: no channel writes the plaintext input/output keys unless the operator opts in.
 
 What has **not** landed and is required before disclosure is enabled in any non-experimental channel:
 
@@ -117,7 +118,7 @@ What has **not** landed and is required before disclosure is enabled in any non-
 - The forensic key-pair lifecycle (auto-generation, on-disk layout next to the signing key, CLI for export/import).
 - Cross-SDK canonical-JSON equivalence tests for the envelope.
 
-Until those land, the `--parameter-disclosure` daemon flag is the only sanctioned way to populate the field, and it does so with **redacted plaintext** as an explicit interim step — not the envelope this ADR specifies. Callers other than the daemon's opt-in pipeline **MUST NOT** populate `parameters_disclosure` directly from raw tool arguments; the field is otherwise a forward-compatible placeholder for the envelope. The "plaintext-in-body" mode of the legacy TS `parameters_preview` (as an SDK-public surface) is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
+Until those land, the `--parameter-disclosure` daemon flag is the only sanctioned way to populate the `input` / `output` keys, and it does so with **redacted plaintext** as an explicit interim step — not the envelope this ADR specifies. Callers other than the daemon's opt-in pipeline **MUST NOT** write plaintext tool arguments into `parameters_disclosure`; the field is otherwise a forward-compatible placeholder for the envelope (with the daemon-attested `peer.*` and `emitter.drop_count` metadata noted above as the only other sanctioned entries). The "plaintext-in-body" mode of the legacy TS `parameters_preview` (as an SDK-public surface) is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
 
 This gap is tracked as the remainder of **Phase A**. Phase B and Phase C are unchanged and remain sequenced behind daemon work (ADR-0010) and enterprise pull respectively.
 

--- a/docs/adr/0013-claude-code-hook-channel.md
+++ b/docs/adr/0013-claude-code-hook-channel.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Proposed
+Proposed — **deferred pending integration demand** (2026-05-12). The design is recorded so it is not re-derived from scratch when needed; no implementation work is scheduled. Revisit when a user or downstream caller requests Claude Code receipt emission. See *Deferral note* below.
+
+## Deferral note
+
+This ADR is intentionally parked. The architectural decision is sound and the design is complete enough to start from, but there is no current user or integration pulling for a Claude Code receipt channel. Surface area is large (plugin shape, emitter binary, per-session drop files, runtime-directory handling, hook-event mapping) and the protocol-level value is small until someone is going to consume the receipts.
+
+Trigger conditions for picking this back up: (a) a user, customer, or maintainer asks for Claude Code receipt emission; (b) ADR-0014 (`codex_hook`) is being implemented and we want to land the shared hook substrate once; or (c) the channel-space enumeration in ADR-0010 needs to be extended in a way that benefits from a concrete second example.
+
+If picked up, also revisit whether ADR-0013 and ADR-0014 should collapse into a single "agent hook channel" ADR — the designs overlap enough that one document may serve both better than two parallel ones.
 
 ## Context
 

--- a/docs/adr/0013-claude-code-hook-channel.md
+++ b/docs/adr/0013-claude-code-hook-channel.md
@@ -2,15 +2,27 @@
 
 ## Status
 
-Proposed — **deferred pending integration demand** (2026-05-12). The design is recorded so it is not re-derived from scratch when needed; no implementation work is scheduled. Revisit when a user or downstream caller requests Claude Code receipt emission. See *Deferral note* below.
+Accepted (2026-05-12). Phase A shipped 2026-05-16 in `hook/` v0.10.0 (`agent-receipts-hook` binary). See *Implementation status* below — design landed with one delta (single binary + format map, not per-runtime binaries) and PostToolUse / PreToolUse only (SessionStart and UserPromptSubmit not yet implemented).
 
-## Deferral note
+## Implementation status (as of 2026-05-18)
 
-This ADR is intentionally parked. The architectural decision is sound and the design is complete enough to start from, but there is no current user or integration pulling for a Claude Code receipt channel. Surface area is large (plugin shape, emitter binary, per-session drop files, runtime-directory handling, hook-event mapping) and the protocol-level value is small until someone is going to consume the receipts.
+Shipped:
 
-Trigger conditions for picking this back up: (a) a user, customer, or maintainer asks for Claude Code receipt emission; (b) ADR-0014 (`codex_hook`) is being implemented and we want to land the shared hook substrate once; or (c) the channel-space enumeration in ADR-0010 needs to be extended in a way that benefits from a concrete second example.
+- `hook/cmd/agent-receipts-hook/` — short-lived binary, reads JSON from stdin, maps to `emitter.Event`, forwards to `agent-receipts-daemon` over AF_UNIX. Released as `hook/v0.10.0` (2026-05-16); installable via `brew install agent-receipts/tap/agent-receipts-hook`.
+- **PostToolUse** mapped to `decision: "allowed"`; **PreToolUse** mapped to `decision: "pending"` — full intent + outcome pairs when both are configured in `~/.claude/settings.json`.
+- Runtime detection from the stdin payload (`hook_event_name`), with `CLAUDE_SESSION_ID` env var as a fallback signal (`hook/cmd/agent-receipts-hook/main.go`).
+- Fail-hard exit semantics once a runtime is identified (exit 1 + stderr); silent exit 0 only when no runtime can be detected.
 
-If picked up, also revisit whether ADR-0013 and ADR-0014 should collapse into a single "agent hook channel" ADR — the designs overlap enough that one document may serve both better than two parallel ones.
+Design deltas from this ADR (worth recording, not blockers):
+
+- **One binary, runtime dispatch via a `formats` map**, rather than one binary per runtime. `formats["claude-code"] = readClaudeCode` in `hook/cmd/agent-receipts-hook/main.go`; adding ADR-0014's Codex reader is a one-entry change to the same map. Cleaner than the per-runtime emitter shape the ADR enumerated.
+- **Channel string is `claude-code`** (dash) in `emitter.Event.Channel`, not `claude_code_hook` (the ADR title's convention). Consistent with how the binary names its formats; the ADR title is conceptual, the channel value is what verifiers see.
+- **`tool_use_id` is parsed but not forwarded.** The emitter wire format has no correlation-ID field. Noted in `hook/cmd/agent-receipts-hook/claude_code.go` as pending an ADR-0010 amendment; not a defect in this ADR but tracked here for visibility.
+
+Not yet shipped:
+
+- **SessionStart** and **UserPromptSubmit** hook events. The ADR enumerates both; only PostToolUse and PreToolUse are wired. SessionStart's `session_id` scoping is partially covered today because the existing event readers extract `session_id` from the stdin frame, but no dedicated event-type emission exists.
+- **Per-session drop-counter persistence** described in the ADR's design isn't in the binary. The hook is purely stateless and exits immediately — drop accounting would have to live in the daemon if added later.
 
 ## Context
 

--- a/docs/adr/0014-codex-hook-channel.md
+++ b/docs/adr/0014-codex-hook-channel.md
@@ -2,15 +2,20 @@
 
 ## Status
 
-Proposed — **deferred pending integration demand** (2026-05-12). The design is recorded so it is not re-derived from scratch when needed; no implementation work is scheduled. Revisit when a user or downstream caller requests Codex receipt emission, or in tandem with ADR-0013 if `claude_code_hook` is implemented first. See *Deferral note* below.
+Proposed — substrate shipped, Codex format reader not implemented (2026-05-18). ADR-0013's hook binary (`hook/cmd/agent-receipts-hook/`) shipped on 2026-05-16 with a `formats` map ready to accept additional runtimes; adding Codex is a single-entry registration plus a `readCodex` implementation. No code work is scheduled. See *Implementation note* below.
 
-## Deferral note
+## Implementation note
 
-This ADR is intentionally parked alongside ADR-0013. Codex inherits the same hook-channel substrate Claude Code would and adds a coverage-block schema specific to Codex's sandbox model; building either channel in isolation duplicates work, and there is no current pull for either.
+The substrate this ADR depends on already exists: `hook/cmd/agent-receipts-hook/main.go` defines `formats["claude-code"] = readClaudeCode`, and the dispatch is structured to accept additional runtimes without binary or interface changes. Landing Codex means:
 
-Trigger conditions for picking this back up: (a) a user, customer, or maintainer asks for Codex receipt emission; (b) ADR-0013 is being implemented and the shared hook substrate should be landed once for both channels; or (c) Codex's sandbox-coverage model becomes interesting to a separate workstream (e.g. an audit/compliance integration) that needs receipts as evidence.
+1. Implementing `readCodex` (analogous to `readClaudeCode` in `hook/cmd/agent-receipts-hook/claude_code.go`) to parse Codex's PreToolUse / PostToolUse stdin frames.
+2. Registering it as `formats["codex"]`.
+3. Extending the `detect()` function to recognise Codex-shaped payloads (and/or accepting `--format codex`).
+4. Implementing the coverage-block schema this ADR specifies — the Codex-specific piece that doesn't fall out of the substrate for free.
 
-If picked up alongside ADR-0013, consider collapsing both into a single "agent hook channel" ADR — most of the design is shared, and the Codex-specific concerns (sandbox coverage, hook-gap enumeration) are well-suited to being a section within a unified document rather than a parallel ADR.
+Trigger conditions for picking this up: (a) a user, customer, or maintainer asks for Codex receipt emission; (b) Codex's sandbox-coverage model becomes interesting to a separate workstream (audit/compliance, threat-model integration) that needs receipts as evidence.
+
+If implemented, consider whether ADR-0013 and ADR-0014 should collapse into a single "agent hook channel" ADR — most of the design is now shared at the substrate level, and the Codex-specific concerns (sandbox coverage, hook-gap enumeration) read naturally as a section within a unified document rather than a parallel ADR. The shipped one-binary-many-formats shape makes that consolidation more natural than it was when these ADRs were drafted.
 
 ## Context
 

--- a/docs/adr/0014-codex-hook-channel.md
+++ b/docs/adr/0014-codex-hook-channel.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Proposed
+Proposed — **deferred pending integration demand** (2026-05-12). The design is recorded so it is not re-derived from scratch when needed; no implementation work is scheduled. Revisit when a user or downstream caller requests Codex receipt emission, or in tandem with ADR-0013 if `claude_code_hook` is implemented first. See *Deferral note* below.
+
+## Deferral note
+
+This ADR is intentionally parked alongside ADR-0013. Codex inherits the same hook-channel substrate Claude Code would and adds a coverage-block schema specific to Codex's sandbox model; building either channel in isolation duplicates work, and there is no current pull for either.
+
+Trigger conditions for picking this back up: (a) a user, customer, or maintainer asks for Codex receipt emission; (b) ADR-0013 is being implemented and the shared hook substrate should be landed once for both channels; or (c) Codex's sandbox-coverage model becomes interesting to a separate workstream (e.g. an audit/compliance integration) that needs receipts as evidence.
+
+If picked up alongside ADR-0013, consider collapsing both into a single "agent hook channel" ADR — most of the design is shared, and the Codex-specific concerns (sandbox coverage, hook-gap enumeration) are well-suited to being a section within a unified document rather than a parallel ADR.
 
 ## Context
 

--- a/docs/adr/0015-key-rotation-byok-anchoring.md
+++ b/docs/adr/0015-key-rotation-byok-anchoring.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (2026-05-12). Phase A implementation in progress (`KeySource` interface present in `daemon/internal/keysource/`, file-backed adapter partial, `Rotate()` not yet implemented). Phase B (external anchor) and Phase C (HSM/KMS adapters) deferred — see *Implementation phasing* below.
+Accepted (2026-05-12). Phase A implementation in progress (`KeySource` interface present in `daemon/internal/keysource/`, file-backed adapter partial, `Rotate()` not yet implemented; the rotation-event anchor sink that Phase A also requires is not yet implemented). Phase B (checkpoint anchoring for tail-truncation detection) and Phase C (HSM/KMS adapters) deferred — see *Implementation phasing* below.
 
 ## Context
 

--- a/docs/adr/0015-key-rotation-byok-anchoring.md
+++ b/docs/adr/0015-key-rotation-byok-anchoring.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-12). Phase A implementation in progress (`KeySource` interface present in `daemon/internal/keysource/`, file-backed adapter partial, `Rotate()` not yet implemented). Phase B (external anchor) and Phase C (HSM/KMS adapters) deferred — see *Implementation phasing* below.
 
 ## Context
 
@@ -124,6 +124,21 @@ Implementation phasing keeps the integrity claim honest:
 
 - **Phase A** (the ADR's first implementation): rotation events anchored. Tail integrity is named as a known gap until Phase B.
 - **Phase B** (follow-on issue): checkpoint anchoring lands. Tail integrity claim becomes defensible. Threat model ([#155](https://github.com/agent-receipts/ar/issues/155)) updates concurrently to assert the conditional integrity guarantee.
+- **Phase C** (follow-on issue, deferred): HSM (PKCS#11) and cloud-KMS adapters land as additional `KeySource` backends. Trigger conditions: (a) an enterprise deployment requires key custody outside the file system; (b) the file-backed adapter is mature enough that the interface is unlikely to change.
+
+### Implementation status (as of 2026-05-12)
+
+What has landed:
+
+- `KeySource` interface skeleton at `daemon/internal/keysource/keysource.go` with the `Sign` / `PublicKey` / `Init` / `Teardown` operations defined per this ADR.
+- File-backed adapter scaffolding (signing key load from `~/.agent-receipts/signing.pem`), used by the daemon for the existing single-key signing path.
+
+What has **not** landed and is in scope for Phase A:
+
+- `Rotate()` currently returns `ErrNotImplemented`. No rotation event schema, no `key_rotated` synthetic receipt emission path, no verifier-side rotation traversal.
+- The external anchor write contract for rotation events. Until the anchor sink exists, **the post-compromise integrity guarantee is not honoured** and any rotation work that lands before it is partial.
+
+Phase B (checkpoint anchoring) and Phase C (HSM/KMS adapters) are explicitly deferred and not on a schedule.
 
 ## Consequences
 
@@ -143,7 +158,7 @@ Implementation phasing keeps the integrity claim honest:
 - **Old public keys (or their resolution records) must be retained for verification of historical chain segments.** Retired *private* signing keys SHOULD be destroyed once rotation is anchored externally — unlike ADR-0012's forensic decryption keypair (which legitimately requires private-key retention to read historical encrypted payloads), signing verifiers only need the public key. Reducing private-key blast radius is a positive consequence of rotation, not a tax on it.
 - **Rotation event itself is signed with the outgoing key.** Standard cryptographic-rotation idiom, but documented because operators rotating in response to suspected compromise need to understand they are authenticating the transition with the key they are already retiring. The mitigation is anchoring every rotation event to the external sink, so a compromised daemon cannot forge a backdated rotation that the anchor does not know about.
 - **The `KeySource` interface cannot encode every backend's idiosyncrasies.** KMS rate limits, HSM lockouts, cloud throttling all surface as backend-specific errors with a structured `transient` flag; the daemon's retry/halt policy is uniform across adapters but the operator's alerting must be backend-aware.
-- **Sink configuration is now a load-bearing operational concern, not an optional feature.** Operators who skip configuring an external sink keep the chain integrity guarantees they had before this ADR — but lose the post-compromise integrity guarantee that motivates the design. The `KeySource` work and the anchor work are both required for the full claim.
+- **Sink configuration becomes a load-bearing operational concern from Phase A onward.** Operators who skip configuring an external sink keep the chain integrity guarantees they had before this ADR — but lose the post-compromise integrity guarantee that motivates the design. The `KeySource` work and the anchor work are both required for the full claim; Phase A delivers both for rotation events, Phase B extends the same property to tail integrity via checkpoints.
 
 ## Alternatives considered
 

--- a/docs/adr/0016-mcp-proxy-audit-encryption.md
+++ b/docs/adr/0016-mcp-proxy-audit-encryption.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-12)
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,14 +20,14 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0004](0004-sqlite-for-local-receipt-storage.md) | SQLite for Local Receipt Storage | Accepted |
 | [ADR-0005](0005-independent-sdk-implementations.md) | Independent SDK Implementations (Not Code Generation) | Accepted |
 | [ADR-0006](0006-yaml-for-policy-rules.md) | YAML for Policy Rule Configuration (mcp-proxy) | Accepted |
-| [ADR-0007](0007-did-method-strategy.md) | DID Method Strategy | Accepted (Phase A) |
+| [ADR-0007](0007-did-method-strategy.md) | DID Method Strategy | Accepted (decision only; Phase A scoped, not started) |
 | [ADR-0008](0008-response-hashing-and-chain-completeness.md) | Response Hashing and Chain Completeness | Accepted |
 | [ADR-0009](0009-canonicalization-and-schema-consistency.md) | Canonicalisation Profile and VC Field Name Commitment | Accepted |
 | [ADR-0010](0010-daemon-process-separation.md) | Daemon Process Separation for Signing and Storage | Accepted |
 | [ADR-0011](0011-zod-for-runtime-validation.md) | Zod for runtime schema validation | Accepted |
-| [ADR-0012](0012-payload-disclosure-policy.md) | Payload Disclosure Policy (`parameterDisclosure`) | Accepted (partial impl) |
-| [ADR-0013](0013-claude-code-hook-channel.md) | claude_code_hook Emission Channel | Proposed (deferred) |
-| [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (deferred) |
+| [ADR-0012](0012-payload-disclosure-policy.md) | Payload Disclosure Policy (`parameterDisclosure`) | Accepted (partial impl; plaintext opt-in shipped, envelope pending) |
+| [ADR-0013](0013-claude-code-hook-channel.md) | claude_code_hook Emission Channel | Accepted (Phase A shipped in `hook/` v0.10.0) |
+| [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (substrate shipped, Codex reader pending) |
 | [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Accepted (Phase A in progress) |
 | [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Accepted |
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,7 +20,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0004](0004-sqlite-for-local-receipt-storage.md) | SQLite for Local Receipt Storage | Accepted |
 | [ADR-0005](0005-independent-sdk-implementations.md) | Independent SDK Implementations (Not Code Generation) | Accepted |
 | [ADR-0006](0006-yaml-for-policy-rules.md) | YAML for Policy Rule Configuration (mcp-proxy) | Accepted |
-| [ADR-0007](0007-did-method-strategy.md) | DID Method Strategy | Proposed |
+| [ADR-0007](0007-did-method-strategy.md) | DID Method Strategy | Accepted (Phase A) |
 | [ADR-0008](0008-response-hashing-and-chain-completeness.md) | Response Hashing and Chain Completeness | Accepted |
 | [ADR-0009](0009-canonicalization-and-schema-consistency.md) | Canonicalisation Profile and VC Field Name Commitment | Accepted |
 | [ADR-0010](0010-daemon-process-separation.md) | Daemon Process Separation for Signing and Storage | Accepted |
@@ -28,7 +28,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0012](0012-payload-disclosure-policy.md) | Payload Disclosure Policy (`parameterDisclosure`) | Accepted (partial impl) |
 | [ADR-0013](0013-claude-code-hook-channel.md) | claude_code_hook Emission Channel | Proposed (deferred) |
 | [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (deferred) |
-| [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Proposed |
+| [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Accepted (Phase A in progress) |
 | [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Accepted |
 
 ## References

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,11 +25,11 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0009](0009-canonicalization-and-schema-consistency.md) | Canonicalisation Profile and VC Field Name Commitment | Accepted |
 | [ADR-0010](0010-daemon-process-separation.md) | Daemon Process Separation for Signing and Storage | Accepted |
 | [ADR-0011](0011-zod-for-runtime-validation.md) | Zod for runtime schema validation | Accepted |
-| [ADR-0012](0012-payload-disclosure-policy.md) | Payload Disclosure Policy (`parameterDisclosure`) | Proposed |
-| [ADR-0013](0013-claude-code-hook-channel.md) | claude_code_hook Emission Channel | Proposed |
-| [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed |
+| [ADR-0012](0012-payload-disclosure-policy.md) | Payload Disclosure Policy (`parameterDisclosure`) | Accepted (partial impl) |
+| [ADR-0013](0013-claude-code-hook-channel.md) | claude_code_hook Emission Channel | Proposed (deferred) |
+| [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (deferred) |
 | [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Proposed |
-| [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Proposed |
+| [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Accepted |
 
 ## References
 


### PR DESCRIPTION
## What

Update ADR status from Proposed to Accepted for ADRs 0007, 0012–0016, and document implementation progress across all five ADRs with detailed status sections covering what has shipped, what remains, and phasing for deferred work.

## Why

These ADRs represent decisions made on 2026-05-12 and require status updates to reflect:
- **ADR-0007** (DID Method Strategy): Decision accepted; Phase A scoped but not started (`did:key` implementation pending across SDKs and daemon).
- **ADR-0012** (Payload Disclosure): Partial implementation shipped (field renamed, redacted plaintext opt-in via daemon flag); asymmetric envelope pending.
- **ADR-0013** (Claude Code Hook): Phase A shipped in `hook/` v0.10.0 (2026-05-16); one design delta recorded (single binary + format map); SessionStart/UserPromptSubmit deferred.
- **ADR-0014** (Codex Hook): Substrate shipped via ADR-0013; Codex format reader not yet implemented; trigger conditions documented.
- **ADR-0015** (Key Rotation): Phase A in progress (`KeySource` interface present, file-backed adapter scaffolded, `Rotate()` not yet implemented); Phase B/C deferred.
- **ADR-0016** (Audit Encryption): Accepted with no implementation status section needed (no phasing).

Each ADR now includes an "Implementation status" or "Implementation note" section clarifying the gap between decision and shipped code, enabling readers to distinguish between what is decided, what is partially done, and what is deferred.

## Checklist

- [x] No code changes (documentation only)
- [x] No secrets or keys in diff
- [x] Status updates are consistent with referenced PRs and release notes (hook/ v0.10.0, daemon PRs #427/#429)

## Notes

- ADR-0007 now explicitly notes that Phase A is "scoped but not started" and identifies the daemon's `did:user:unknown` default in `daemon/internal/pipeline/build.go` as a placeholder to be removed.
- ADR-0012 clarifies that the shipped `--parameter-disclosure` flag uses redacted plaintext (not the envelope), and that the legacy TS `parameters_preview` plaintext mode is no longer supported.
- ADR-0013 records the design delta (one binary, runtime dispatch via `formats` map) and notes that `tool_use_id` correlation is pending an ADR-0010 amendment.
- ADR-0014 suggests a future consolidation with ADR-0013 now that the substrate is shared.
- ADR-0015 clarifies that Phase A delivers rotation-event anchoring; Phase B extends to tail integrity via checkpoints.
- README.md table updated to reflect all status changes and implementation notes.