### PR TITLE
docs(adr-0007): pin did:key v0.7 wire format and test vectors

### DIFF
--- a/docs/adr/0007-did-method-strategy.md
+++ b/docs/adr/0007-did-method-strategy.md
@@ -48,6 +48,118 @@ A tiered approach:
 - **Phase B (deferred).** `did:web` resolution lands in all SDKs along with the pluggable resolver interface. Trigger conditions: (a) a production deployment needs organizational anchoring; (b) a verifier needs to validate receipts whose issuer has rotated keys (ADR-0015 Phase A reaches the daemon); (c) `did:web` is required for cross-org interoperability with a named consumer.
 - **Phase C (deferred).** Verifier-side DID Document caching/pinning, historical resolution for long-lived receipts, and `did:tdw` evaluation.
 
+## Implementation spec — `did:key` v0.7 wire format
+
+This subsection is the normative wire shape that all SDKs and the hub re-verifier
+MUST conform to for `did:key`. It pins the format only — implementation lands as
+part of Phase A and is out of scope for this ADR. Static test vectors live in
+[`spec/test-vectors/did-key/vectors.json`](../../spec/test-vectors/did-key/vectors.json).
+
+### DID format
+
+```
+did:key:z<multibase-base58btc(0xed01 || ed25519-pubkey-bytes)>
+```
+
+- `0xed01` is the unsigned-varint multicodec identifier for an Ed25519 public key
+  (the byte sequence `0xed 0x01`, not a two-byte big-endian integer).
+- `ed25519-pubkey-bytes` is the 32 raw bytes of the Ed25519 public key per
+  RFC 8032 §5.1.5. No PEM, SPKI, JWK, or other wrapper is permitted in the
+  encoded payload.
+- The multibase prefix is the single ASCII character `z`, indicating base58btc
+  encoding of the concatenated multicodec-prefixed key bytes. No padding.
+- Implementations MUST produce and accept exactly this form; they MUST reject
+  any other multibase prefix, any multicodec other than `0xed01`, and any
+  decoded payload length other than 34 bytes (2-byte prefix + 32-byte key).
+
+### Resolution algorithm
+
+Given an input string `did`:
+
+1. Reject unless `did` begins with the literal ASCII prefix `did:key:z`.
+2. Multibase-decode the substring after `did:key:` using base58btc (the `z`
+   prefix). Reject on any non-alphabet character.
+3. Verify the decoded payload is exactly 34 bytes.
+4. Verify the first two bytes are `0xed 0x01`. Reject otherwise.
+5. The remaining 32 bytes are the Ed25519 public key. No further validation of
+   the curve point is required by this spec (RFC 8032 verification handles
+   malformed points at signature-check time); resolvers MAY perform additional
+   checks.
+6. Construct the DID Document per *DID Document shape* below using the same
+   `z`-prefixed substring (i.e., the value of `did` after `did:key:`) as both
+   the verification-method fragment and the `publicKeyMultibase` value.
+
+Resolution is purely a function of the input string. No network access, no
+caching state, no out-of-band knowledge is consulted.
+
+### DID Document shape
+
+The resolved DID Document for a `did:key` identifier `did:key:z<X>` is exactly:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "id": "did:key:z<X>",
+  "verificationMethod": [
+    {
+      "id": "did:key:z<X>#z<X>",
+      "type": "Multikey",
+      "controller": "did:key:z<X>",
+      "publicKeyMultibase": "z<X>"
+    }
+  ],
+  "authentication":   ["did:key:z<X>#z<X>"],
+  "assertionMethod":  ["did:key:z<X>#z<X>"]
+}
+```
+
+Notes:
+
+- `type` is `Multikey` (current W3C recommendation), **not** the older
+  `Ed25519VerificationKey2020`. The hub and SDKs reject the older form to keep
+  one shape across the codebase.
+- `keyAgreement`, `capabilityInvocation`, and `capabilityDelegation` are
+  intentionally omitted. `did:key` permits deriving an X25519 key-agreement key
+  from the Ed25519 signing key; Agent Receipts does not use key agreement and
+  resolvers MUST NOT emit a `keyAgreement` entry.
+- Canonicalisation of this Document, when needed (e.g., for hashing), follows
+  [ADR-0009](./0009-canonicalization-and-schema-consistency.md). This ADR does
+  not introduce new canonicalisation rules.
+
+### Encoding parity with ADR-0001
+
+`did:key` and ADR-0001 receipt fingerprints both use multibase, but with
+different alphabets:
+
+| Surface                       | Multibase prefix | Alphabet   | Payload                                  |
+|-------------------------------|------------------|------------|------------------------------------------|
+| `did:key` identifier          | `z`              | base58btc  | `0xed01` ‖ 32-byte Ed25519 public key    |
+| Receipt `proofValue` (ADR-0001) | `u`            | base64url  | Raw 64-byte Ed25519 signature, no padding |
+
+A verifier that touches both surfaces MUST dispatch on the multibase prefix
+character before decoding. A `u`-prefixed string is never a valid `did:key`,
+and a `z`-prefixed string is never a valid receipt `proofValue`. Implementations
+MUST reject the wrong prefix at parse time rather than silently attempting the
+other decoder.
+
+### Worked example
+
+Public key (hex, RFC 8032 §7.1 TEST 1):
+`d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a`
+
+Multicodec-prefixed payload (hex, 34 bytes):
+`ed01 d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a`
+
+Multibase base58btc encoding with `z` prefix:
+`z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw`
+
+Final DID: `did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw`
+
+Resolved DID Document: see `vector-1-rfc8032-test-1` in the test-vectors file.
+
 ## Security Considerations
 
 ### Key-DID binding
@@ -82,3 +194,18 @@ If the protocol supports multiple DID methods, two deployments using different m
 - Key rotation semantics for receipt chains must be specified — either in this ADR or a companion ADR — before `did:web` can be recommended for production use.
 - Cross-SDK DID resolution test vectors are needed to ensure all three implementations resolve the same `did:key` identifiers to the same public keys.
 - The verification algorithm (spec §7.1, §7.3) must be updated to include DID resolution as an explicit step with defined error handling.
+
+## Amendments
+
+### 2026-05-18: Pin `did:key` v0.7 wire format and resolution algorithm
+
+Added the *Implementation spec — `did:key` v0.7 wire format* subsection above
+(DID format, resolution algorithm, DID Document shape, encoding parity with
+ADR-0001, and a worked example) plus the companion fixtures under
+[`spec/test-vectors/did-key/`](../../spec/test-vectors/did-key/). The Status,
+Decision, Resolved questions, and Implementation phasing sections are unchanged
+— Phase A is still scoped-but-not-started; this amendment only fixes the wire
+shape that Phase A and the central receipt hub (ADR-0017) will consume so the
+three SDKs and the hub re-verifier can implement against one normative
+description. No protocol or schema changes; documentation and JSON fixtures
+only.

--- a/docs/adr/0007-did-method-strategy.md
+++ b/docs/adr/0007-did-method-strategy.md
@@ -58,16 +58,22 @@ part of Phase A and is out of scope for this ADR. Static test vectors live in
 ### DID format
 
 ```
-did:key:z<multibase-base58btc(0xed01 || ed25519-pubkey-bytes)>
+did:key:z<base58btc(0xed01 || ed25519-pubkey-bytes)>
 ```
 
+- The leading `z` is the literal multibase prefix character, applied verbatim
+  (not produced by the `base58btc(...)` function below). This avoids the
+  double-`z` mistake that arises when a multibase helper that *already*
+  includes the prefix is composed under the formula.
+- `base58btc(...)` is the Bitcoin base58 character-encoding of the raw byte
+  string `0xed01 || ed25519-pubkey-bytes`, with no leading prefix character of
+  its own. The full identifier is the literal `did:key:z` concatenated with
+  the base58btc output.
 - `0xed01` is the unsigned-varint multicodec identifier for an Ed25519 public key
   (the byte sequence `0xed 0x01`, not a two-byte big-endian integer).
 - `ed25519-pubkey-bytes` is the 32 raw bytes of the Ed25519 public key per
   RFC 8032 §5.1.5. No PEM, SPKI, JWK, or other wrapper is permitted in the
   encoded payload.
-- The multibase prefix is the single ASCII character `z`, indicating base58btc
-  encoding of the concatenated multicodec-prefixed key bytes. No padding.
 - Implementations MUST produce and accept exactly this form; they MUST reject
   any other multibase prefix, any multicodec other than `0xed01`, and any
   decoded payload length other than 34 bytes (2-byte prefix + 32-byte key).
@@ -78,7 +84,11 @@ Given an input string `did`:
 
 1. Reject unless `did` begins with the literal ASCII prefix `did:key:z`.
 2. Multibase-decode the substring after `did:key:` using base58btc (the `z`
-   prefix). Reject on any non-alphabet character.
+   prefix). Reject any character outside the base58btc alphabet — note that
+   `0`, `O`, `I`, and `l` are explicitly excluded from base58btc to avoid
+   visual ambiguity even though they are otherwise alphanumeric. A conformant
+   base58btc decoder enforces this; implementations MAY simply propagate that
+   decoder's error rather than checking characters separately.
 3. Verify the decoded payload is exactly 34 bytes.
 4. Verify the first two bytes are `0xed 0x01`. Reject otherwise.
 5. The remaining 32 bytes are the Ed25519 public key. No further validation of

--- a/spec/test-vectors/did-key/README.md
+++ b/spec/test-vectors/did-key/README.md
@@ -15,13 +15,15 @@ are not yet wired into any test suite.
   "spec_version":          "did:key v0.7",
   "adr":                   "docs/adr/0007-did-method-strategy.md",
   "multicodec_prefix_hex": "ed01",
-  "multibase_prefix":      "z (base58btc)",
+  "multibase_prefix":      "z",
+  "multibase_encoding":    "base58btc",
   "vectors":               [ { ... }, ... ]
 }
 ```
 
 Consumers building a strict schema MAY ignore unknown top-level fields; the
-load-bearing keys are `vectors`, `multicodec_prefix_hex`, and `multibase_prefix`.
+load-bearing keys are `vectors`, `multicodec_prefix_hex`, `multibase_prefix`, and
+`multibase_encoding`.
 
 Each entry in `vectors[]` has:
 
@@ -60,4 +62,4 @@ sources.
 These are spec-side reference fixtures. Each SDK will gain its own resolver and
 load these vectors in a follow-up track; the cross-language test harness in
 `cross-sdk-tests/` will be extended to assert SDK-resolved DID Documents
-byte-equal the `did_document` field here under RFC 8785 canonicalisation.
+byte-equal to the `did_document` field here under RFC 8785 canonicalisation.

--- a/spec/test-vectors/did-key/README.md
+++ b/spec/test-vectors/did-key/README.md
@@ -11,13 +11,17 @@ are not yet wired into any test suite.
 
 ```
 {
-  "spec_version": "did:key v0.7",
-  "adr":          "docs/adr/0007-did-method-strategy.md",
+  "$comment":              "<descriptive header text>",
+  "spec_version":          "did:key v0.7",
+  "adr":                   "docs/adr/0007-did-method-strategy.md",
   "multicodec_prefix_hex": "ed01",
   "multibase_prefix":      "z (base58btc)",
-  "vectors": [ { ... }, ... ]
+  "vectors":               [ { ... }, ... ]
 }
 ```
+
+Consumers building a strict schema MAY ignore unknown top-level fields; the
+load-bearing keys are `vectors`, `multicodec_prefix_hex`, and `multibase_prefix`.
 
 Each entry in `vectors[]` has:
 

--- a/spec/test-vectors/did-key/README.md
+++ b/spec/test-vectors/did-key/README.md
@@ -1,0 +1,59 @@
+# did:key Resolution Test Vectors
+
+Static expected-output fixtures for `did:key` v0.7 resolution as pinned in
+[ADR-0007](../../../docs/adr/0007-did-method-strategy.md). These vectors fix the wire
+shape that the hub re-verifier and the three SDKs (Go, TS, Py) will consume; they
+are not yet wired into any test suite.
+
+## File format
+
+`vectors.json` is a single JSON document with the following shape:
+
+```
+{
+  "spec_version": "did:key v0.7",
+  "adr":          "docs/adr/0007-did-method-strategy.md",
+  "multicodec_prefix_hex": "ed01",
+  "multibase_prefix":      "z (base58btc)",
+  "vectors": [ { ... }, ... ]
+}
+```
+
+Each entry in `vectors[]` has:
+
+| Field            | Description                                                                           |
+|------------------|---------------------------------------------------------------------------------------|
+| `name`           | Stable identifier for cross-referencing in SDK test suites.                           |
+| `source`         | Where the public key comes from (RFC, registry, etc.) so reviewers can reproduce it.  |
+| `public_key_hex` | The 32 raw Ed25519 public-key bytes (RFC 8032 §5.1.5) encoded as lowercase hex.       |
+| `did`            | The expected `did:key:z<...>` identifier produced by the resolution algorithm.        |
+| `did_document`   | The full resolved DID Document a conformant resolver MUST produce for that key.       |
+
+## What the vectors test
+
+Each vector pins three things at once:
+
+1. **Multicodec framing.** The byte sequence fed to base58btc is exactly `0xed 0x01`
+   followed by the 32 raw public-key bytes — never PEM, SPKI, or any other wrapper.
+2. **Multibase encoding choice.** `did:key` uses base58btc with the `z` prefix.
+   This is *not* the same encoding ADR-0001 uses for receipt `proofValue` fingerprints
+   (multibase base64url, `u` prefix). The two encodings must not be conflated; an
+   `id`-shaped string starting with `u` is never a valid `did:key`, and a fingerprint
+   starting with `z` is never a valid receipt `proofValue`.
+3. **DID Document shape.** The resolved Document uses the W3C `Multikey` verification
+   method (current recommendation), not the older `Ed25519VerificationKey2020`, with a
+   single verification method referenced from both `authentication` and `assertionMethod`.
+
+## Reproducibility
+
+Vectors use deterministic public keys only — RFC 8032 §7.1 TEST 1 / TEST 2 and the
+W3C `did:key` registry's Example 1. Do not regenerate them from fresh random
+keys; reviewers must be able to recompute the expected outputs by hand from these
+sources.
+
+## Status
+
+These are spec-side reference fixtures. Each SDK will gain its own resolver and
+load these vectors in a follow-up track; the cross-language test harness in
+`cross-sdk-tests/` will be extended to assert SDK-resolved DID Documents
+byte-equal the `did_document` field here under RFC 8785 canonicalisation.

--- a/spec/test-vectors/did-key/vectors.json
+++ b/spec/test-vectors/did-key/vectors.json
@@ -1,0 +1,90 @@
+{
+  "$comment": "did:key v0.7 resolution test vectors for Agent Receipts. Each vector pins the wire-shape mapping from a 32-byte Ed25519 public key (RFC 8032 §5.1.5) to (a) the did:key identifier and (b) the resolved DID Document with a single Multikey verification method. See docs/adr/0007-did-method-strategy.md (Implementation spec — did:key v0.7 wire format) for the normative algorithm. Vectors use deterministic public keys taken from RFC 8032 §7.1 and the W3C did:key registry so reviewers can reproduce them without re-running an SDK. These are static expected outputs; wiring them into SDK test suites is a later track.",
+  "spec_version": "did:key v0.7",
+  "adr": "docs/adr/0007-did-method-strategy.md",
+  "multicodec_prefix_hex": "ed01",
+  "multibase_prefix": "z (base58btc)",
+  "vectors": [
+    {
+      "name": "vector-1-rfc8032-test-1",
+      "source": "RFC 8032 §7.1, TEST 1 (secret key 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60).",
+      "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "did": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+            "type": "Multikey",
+            "controller": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+            "publicKeyMultibase": "z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+        ],
+        "assertionMethod": [
+          "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+        ]
+      }
+    },
+    {
+      "name": "vector-2-rfc8032-test-2",
+      "source": "RFC 8032 §7.1, TEST 2 (secret key 4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb).",
+      "public_key_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      "did": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+            "type": "Multikey",
+            "controller": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+            "publicKeyMultibase": "z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+        ],
+        "assertionMethod": [
+          "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+        ]
+      }
+    },
+    {
+      "name": "vector-3-w3c-did-key-registry-example",
+      "source": "W3C did:key Method Specification, Example 1 (Ed25519). Public key 3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29; matches the registry's canonical reference identifier.",
+      "public_key_hex": "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+      "did": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+            "type": "Multikey",
+            "controller": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+            "publicKeyMultibase": "z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+        ],
+        "assertionMethod": [
+          "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/test-vectors/did-key/vectors.json
+++ b/spec/test-vectors/did-key/vectors.json
@@ -3,7 +3,8 @@
   "spec_version": "did:key v0.7",
   "adr": "docs/adr/0007-did-method-strategy.md",
   "multicodec_prefix_hex": "ed01",
-  "multibase_prefix": "z (base58btc)",
+  "multibase_prefix": "z",
+  "multibase_encoding": "base58btc",
   "vectors": [
     {
       "name": "vector-1-rfc8032-test-1",


### PR DESCRIPTION
## Context

ADR-0007 currently fixes the DID-method strategy (default `did:key`, recommend `did:web`, pluggable resolver) but leaves the `did:key` wire shape implicit. The hub re-verifier in ADR-0017 plus the three SDKs (Go, TS, Py) all need to agree on the exact identifier format, the resolution algorithm, and the resolved DID Document shape before any of them start implementing. This PR pins that wire shape and ships static test vectors so the implementations can be reviewed against a single normative description.

## What's in this PR

- **`docs/adr/0007-did-method-strategy.md`** — new "Implementation spec — `did:key` v0.7 wire format" subsection inserted between *Implementation phasing* and *Security Considerations*. Covers:
  - DID format: `did:key:z` with explicit length/prefix rejection rules.
  - Resolution algorithm (purely a function of the input string, no I/O).
  - Resolved DID Document shape using the W3C `Multikey` verification method (not the older `Ed25519VerificationKey2020`), with `authentication` and `assertionMethod` references and `keyAgreement` explicitly excluded.
  - Encoding-parity note vs ADR-0001: `did:key` uses `z`/base58btc; receipt `proofValue` uses `u`/base64url. Implementations MUST dispatch on the prefix and reject the wrong one rather than silently retrying.
  - Worked example using RFC 8032 §7.1 TEST 1.
  - Amendments entry at the bottom matching the ADR-0010 pattern. Status, Decision, Resolved questions, and Implementation phasing are unchanged.
- **`spec/test-vectors/did-key/vectors.json`** — three deterministic test vectors using RFC 8032 §7.1 TEST 1, TEST 2, and the W3C did:key registry's Example 1 public key. Each vector pins `public_key_hex`, the resulting `did`, and the full resolved `did_document`. No fresh random keys.
- **`spec/test-vectors/did-key/README.md`** — file-format reference and a note that these are static expected outputs; SDK wiring lands in a later track.

## What's not in this PR

No code changes. No schema or protocol-version change (hence no `spec/CHANGELOG.md` entry — that file's convention tracks spec-version bumps, and this is an ADR amendment plus reference fixtures). No edits to other ADRs.

## Status

Draft. Part of a coordinated three-PR spec pass for ADR-0017 (Central Receipt Hub and External Anchoring) readiness. Sibling PRs are the rotation-event wire format (ADR-0015 amendment) and the disclosure-envelope canonical shape (ADR-0012 amendment). The three are independent and can land in any order; this one is intentionally the smallest. The plan is to land diagrams + POCs before flipping any of them out of draft.

Unblocks: ADR-0017 (the hub's JWS auth uses `kid = node DID URL` resolved via the algorithm pinned here).