### PR TITLE
fix(daemon): honour MCP isError flag in outcome.status

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **MCP tool-level failures now record `outcome.status: "failure"`**:
+  When an MCP tool call returned a `CallToolResult` envelope with
+  `"isError": true`, the JSON-RPC call still succeeded (no `Error` on the
+  emitter frame), so the daemon stamped the receipt with
+  `outcome.status: "success"`. The pipeline now inspects the result body for
+  the MCP `isError` flag on `channel == "mcp"` frames and maps it to
+  `failure`. Other channels are unaffected — a top-level `isError` outside
+  the MCP envelope is not reinterpreted.
+
 ## [0.10.1] - 2026-05-18
 
 ### Security

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -292,6 +292,30 @@ func validateFrame(f *EmitterFrame) error {
 	return nil
 }
 
+// mcpOutputIsError reports whether an MCP tool response carries
+// `"isError": true`. The MCP `CallToolResult` envelope signals tool-level
+// failure with this flag; the surrounding JSON-RPC call still succeeds, so
+// f.Error is empty and the daemon would otherwise stamp outcome.status as
+// "success". See ADR-0010 and the MCP spec (CallToolResult).
+//
+// Gated on channel == "mcp" because the envelope is MCP-specific: other
+// channels may use a top-level `isError` field with different semantics, and
+// the daemon must not silently reinterpret them. Returns false on parse
+// failure, non-object output, missing field, or a non-true value — only an
+// explicit boolean true escalates to failure.
+func mcpOutputIsError(channel string, raw json.RawMessage) bool {
+	if channel != "mcp" || !hasJSONPayload(raw) {
+		return false
+	}
+	var env struct {
+		IsError *bool `json:"isError"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return false
+	}
+	return env.IsError != nil && *env.IsError
+}
+
 // hasJSONPayload reports whether raw is a JSON value other than null.
 // Whitespace and the literal "null" both count as no-payload.
 func hasJSONPayload(raw json.RawMessage) bool {
@@ -351,7 +375,7 @@ func (p *Pipeline) buildAndSign(
 	var status receipt.OutcomeStatus
 	switch f.Decision {
 	case "allowed":
-		if f.Error != "" {
+		if f.Error != "" || mcpOutputIsError(f.Channel, f.Output) {
 			status = receipt.StatusFailure
 		} else {
 			status = receipt.StatusSuccess

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -186,6 +186,67 @@ func TestProcess_OutcomeStatus(t *testing.T) {
 	}
 }
 
+// TestProcess_MCPIsErrorOutcome covers the MCP CallToolResult envelope: a
+// JSON-RPC call that returns successfully but whose result body sets
+// "isError": true is a tool-level failure. The proxy reports it with
+// decision="allowed" and an empty error field (no JSON-RPC error was
+// returned), so the daemon must inspect the result body to derive
+// outcome.status. Non-mcp channels must keep their existing mapping —
+// other channels may use isError with different semantics.
+func TestProcess_MCPIsErrorOutcome(t *testing.T) {
+	mcpErrorOutput := json.RawMessage(`{"content":[{"type":"text","text":"401 Bad credentials"}],"isError":true}`)
+	mcpOKOutput := json.RawMessage(`{"content":[{"type":"text","text":"ok"}],"isError":false}`)
+	mcpImplicitOKOutput := json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)
+
+	cases := []struct {
+		name    string
+		channel string
+		output  json.RawMessage
+		want    receipt.OutcomeStatus
+	}{
+		{"mcp isError true → failure", "mcp", mcpErrorOutput, receipt.StatusFailure},
+		{"mcp isError false → success", "mcp", mcpOKOutput, receipt.StatusSuccess},
+		{"mcp isError absent → success", "mcp", mcpImplicitOKOutput, receipt.StatusSuccess},
+		{"mcp empty output → success", "mcp", nil, receipt.StatusSuccess},
+		{"mcp malformed JSON → success (no escalation on parse failure)", "mcp", json.RawMessage(`"not-an-object"`), receipt.StatusSuccess},
+		// Other channels must not be reinterpreted: a top-level isError
+		// field there is not the MCP envelope.
+		{"non-mcp channel with isError true → success", "sdk", mcpErrorOutput, receipt.StatusSuccess},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := newTestKeySource(t)
+			st := newTestStore(t)
+			state := chain.New("chain-1")
+			p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+			body, err := json.Marshal(EmitterFrame{
+				Version:   "1",
+				TsEmit:    "2026-05-03T00:00:00Z",
+				SessionID: "s",
+				Channel:   tc.channel,
+				Tool:      EmitterTool{Server: "github", Name: "create_pull_request"},
+				Output:    tc.output,
+				Decision:  "allowed",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := p.Process(socket.Frame{Payload: body}); err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			receipts, err := st.GetChain("chain-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := receipts[0].CredentialSubject.Outcome.Status
+			if got != tc.want {
+				t.Errorf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProcess_AdvancesSequenceAndPrevHash(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -208,7 +208,7 @@ func TestProcess_MCPIsErrorOutcome(t *testing.T) {
 		{"mcp isError false → success", "mcp", mcpOKOutput, receipt.StatusSuccess},
 		{"mcp isError absent → success", "mcp", mcpImplicitOKOutput, receipt.StatusSuccess},
 		{"mcp empty output → success", "mcp", nil, receipt.StatusSuccess},
-		{"mcp malformed JSON → success (no escalation on parse failure)", "mcp", json.RawMessage(`"not-an-object"`), receipt.StatusSuccess},
+		{"mcp non-object output → success (no escalation on parse failure)", "mcp", json.RawMessage(`"not-an-object"`), receipt.StatusSuccess},
 		// Other channels must not be reinterpreted: a top-level isError
 		// field there is not the MCP envelope.
 		{"non-mcp channel with isError true → success", "sdk", mcpErrorOutput, receipt.StatusSuccess},


### PR DESCRIPTION
## Summary

When an MCP tool returns `{"isError": true, ...}` as a successful JSON-RPC response, the daemon was recording the receipt with `outcome.status = "success"`. MCP servers signal tool-level failures via the `isError` flag on the result envelope rather than via a JSON-RPC error, so a clean transport response can still carry a failed tool call. Audit consumers filtering on `outcome.status == "failure"` were missing these.

This change escalates `outcome.status` to `"failure"` for MCP-channel receipts whose emitted output contains `isError: true`, in addition to the existing transport-error path.

## Changes

- `daemon/internal/pipeline/build.go` — when `channel == "mcp"`, decode the buffered `EmitterFrame.Output` and treat `isError: true` as a failure signal alongside `frame.Error`. New helper `mcpOutputIsError` is conservative: parse failures, missing `isError`, non-object outputs, and explicit `false` all preserve the prior behaviour.
- `daemon/internal/pipeline/build_test.go` — six new cases covering `isError` true/false/absent/empty-output/non-object-output, plus a guard that non-mcp channels are untouched.
- `daemon/CHANGELOG.md` — `[Unreleased] → Fixed` entry.

## Scope notes

- Only the derived `outcome.status` claim changes; the receipt hash inputs and signature flow are untouched.
- `pending` decisions still win — a buggy emitter cannot reclassify an in-flight call as failed mid-stream.
- `outcome.error` is intentionally left empty when only `isError` signals failure; lifting the MCP error text into `outcome.error` is a separate enhancement and can follow if downstream consumers need it without parsing `parameters_disclosure.output`.
- No spec, SDK, or workflow changes.

## Test plan

- [x] `go test ./daemon/...` (new cases + existing suite)
- [x] `go vet ./...`
- [ ] Reviewer: confirm the MCP-only gating matches the intent of channel semantics in `daemon/internal/pipeline`.