### PR TITLE
feat: issuer/operator metadata on receipts (host autodetect + flag overrides)

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Issuer/operator metadata in receipts**: the daemon now stamps `receipt.Issuer.Name`, `receipt.Issuer.Model`, and `receipt.Issuer.Operator` from the proxy-supplied wire fields (`issuer_name`, `issuer_model`, `operator_id`, `operator_name`). Old proxies that omit these fields produce receipts with empty Name/Operator, preserving backwards compatibility.
+
 ### Fixed
 
 - **MCP tool-level failures now record `outcome.status: "failure"`**:

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -26,6 +26,12 @@ import (
 // (multibase prefix "u") rather than the W3C default base58btc ("z").
 const multibaseBase64URL = "u"
 
+// maxIdentityFieldLen caps the byte length of the four proxy-supplied identity
+// fields (IssuerName, IssuerModel, OperatorID, OperatorName). The 1 MiB socket
+// cap is the only ceiling today — this per-field limit catches runaway values
+// early and keeps error messages legible.
+const maxIdentityFieldLen = 256
+
 // SupportedFrameVersion is the only emitter-frame schema this daemon accepts.
 // Bumping it requires a migration plan and a daemon-side translator for the
 // old version; until that exists, accepting unknown versions would silently
@@ -53,16 +59,20 @@ const actionTypeEventsDropped = "agent_receipts.events_dropped"
 // events_dropped receipt with this count before the live receipt so the gap
 // is visible in the chain.
 type EmitterFrame struct {
-	Version   string          `json:"v"`
-	TsEmit    string          `json:"ts_emit"`
-	SessionID string          `json:"session_id"`
-	Channel   string          `json:"channel"`
-	Tool      EmitterTool     `json:"tool"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	Output    json.RawMessage `json:"output,omitempty"`
-	Error     string          `json:"error,omitempty"`
-	Decision  string          `json:"decision"`
-	DropCount int64           `json:"drop_count,omitempty"`
+	Version      string          `json:"v"`
+	TsEmit       string          `json:"ts_emit"`
+	SessionID    string          `json:"session_id"`
+	Channel      string          `json:"channel"`
+	Tool         EmitterTool     `json:"tool"`
+	Input        json.RawMessage `json:"input,omitempty"`
+	Output       json.RawMessage `json:"output,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	Decision     string          `json:"decision"`
+	DropCount    int64           `json:"drop_count,omitempty"`
+	IssuerName   string          `json:"issuer_name,omitempty"`
+	IssuerModel  string          `json:"issuer_model,omitempty"`
+	OperatorID   string          `json:"operator_id,omitempty"`
+	OperatorName string          `json:"operator_name,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -285,6 +295,23 @@ func validateFrame(f *EmitterFrame) error {
 	if f.DropCount < 0 {
 		return fmt.Errorf("drop_count %d is negative", f.DropCount)
 	}
+	// Validate proxy-supplied identity fields: cap length and enforce
+	// operator consistency (operator_name requires operator_id per spec).
+	if len(f.IssuerName) > maxIdentityFieldLen {
+		return fmt.Errorf("issuer_name exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.IssuerName))
+	}
+	if len(f.IssuerModel) > maxIdentityFieldLen {
+		return fmt.Errorf("issuer_model exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.IssuerModel))
+	}
+	if len(f.OperatorID) > maxIdentityFieldLen {
+		return fmt.Errorf("operator_id exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.OperatorID))
+	}
+	if len(f.OperatorName) > maxIdentityFieldLen {
+		return fmt.Errorf("operator_name exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.OperatorName))
+	}
+	if f.OperatorName != "" && f.OperatorID == "" {
+		return fmt.Errorf("operator_name set without operator_id")
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash
@@ -493,11 +520,7 @@ func (p *Pipeline) buildAndSign(
 	}
 
 	return p.signAndHash(receipt.CreateInput{
-		Issuer: receipt.Issuer{
-			ID:        p.IssuerID,
-			Type:      "AgentReceiptsDaemon",
-			SessionID: f.SessionID,
-		},
+		Issuer:    issuerFromFrame(f, p.IssuerID),
 		Principal: receipt.Principal{ID: "did:user:unknown"},
 		Action:    action,
 		Outcome:   outcome,
@@ -509,10 +532,32 @@ func (p *Pipeline) buildAndSign(
 	}, now)
 }
 
+// issuerFromFrame builds the receipt Issuer from the emitter frame and the
+// daemon's own DID. Name, Model, and Operator come from the proxy; they are
+// empty/nil when an old proxy that predates this field set emits the frame.
+func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
+	var op *receipt.Operator
+	if f.OperatorID != "" {
+		op = &receipt.Operator{ID: f.OperatorID, Name: f.OperatorName}
+	}
+	return receipt.Issuer{
+		ID:        daemonID,
+		Type:      "AgentReceiptsDaemon",
+		Name:      f.IssuerName,
+		Model:     f.IssuerModel,
+		Operator:  op,
+		SessionID: f.SessionID,
+	}
+}
+
 // buildAndSignDropReceipt constructs a synthetic events_dropped receipt.
 // seq and prevHash come directly from PairAlloc.FirstSeq/FirstPrev rather
 // than from a chain.Allocation, avoiding the ambiguous no-op Allocation that
 // would be needed to represent the first PairAlloc slot.
+//
+// Drop receipts are synthetic — the proxy didn't supply identity for the
+// gap, so Name/Model/Operator are deliberately left empty (vs. live
+// receipts which get them from the frame via issuerFromFrame).
 func (p *Pipeline) buildAndSignDropReceipt(
 	dropCount int64,
 	sessionID string,

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1020,5 +1021,182 @@ func TestProcess_DropCountSyntheticFailureLiveReceiptPersists(t *testing.T) {
 	}
 	if got := receipts[0].CredentialSubject.Chain.Sequence; got != 1 {
 		t.Errorf("seq = %d, want 1", got)
+	}
+}
+
+// TestProcess_IssuerFieldsFromFrame verifies that IssuerName, IssuerModel, and
+// OperatorID/OperatorName from the emitter frame are stamped onto the receipt
+// Issuer, so proxy-supplied host identity flows through to every receipt.
+func TestProcess_IssuerFieldsFromFrame(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:      "1",
+		TsEmit:       "2026-05-03T00:00:00Z",
+		SessionID:    "sess-abc",
+		Channel:      "mcp",
+		Tool:         EmitterTool{Name: "bash"},
+		Decision:     "allowed",
+		IssuerName:   "Claude Code",
+		IssuerModel:  "claude-opus-4-5",
+		OperatorID:   "did:web:anthropic.com",
+		OperatorName: "Anthropic",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	iss := receipts[0].Issuer
+	if iss.Name != "Claude Code" {
+		t.Errorf("Issuer.Name = %q, want %q", iss.Name, "Claude Code")
+	}
+	if iss.Model != "claude-opus-4-5" {
+		t.Errorf("Issuer.Model = %q, want %q", iss.Model, "claude-opus-4-5")
+	}
+	if iss.Operator == nil {
+		t.Fatal("Issuer.Operator is nil, want non-nil")
+	}
+	if iss.Operator.ID != "did:web:anthropic.com" {
+		t.Errorf("Issuer.Operator.ID = %q, want %q", iss.Operator.ID, "did:web:anthropic.com")
+	}
+	if iss.Operator.Name != "Anthropic" {
+		t.Errorf("Issuer.Operator.Name = %q, want %q", iss.Operator.Name, "Anthropic")
+	}
+	if iss.ID != "did:agent-receipts-daemon:test" {
+		t.Errorf("Issuer.ID = %q; daemon ID must not be overwritten", iss.ID)
+	}
+	if iss.SessionID != "sess-abc" {
+		t.Errorf("Issuer.SessionID = %q, want sess-abc", iss.SessionID)
+	}
+}
+
+// TestProcess_EmptyOperatorFieldsLeaveOperatorNil verifies that when
+// operator_id and operator_name are both absent from the frame, Issuer.Operator
+// remains nil rather than being set to a zero-value struct.
+func TestProcess_EmptyOperatorFieldsLeaveOperatorNil(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "noop"},
+		Decision:  "allowed",
+		// IssuerName set but no operator fields.
+		IssuerName: "Some Host",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipts[0].Issuer.Operator != nil {
+		t.Errorf("Issuer.Operator = %+v; want nil when operator fields are absent", receipts[0].Issuer.Operator)
+	}
+	if receipts[0].Issuer.Name != "Some Host" {
+		t.Errorf("Issuer.Name = %q, want \"Some Host\"", receipts[0].Issuer.Name)
+	}
+}
+
+// TestValidateFrame_RejectsOversizedIdentityField verifies that validateFrame
+// rejects frames where any identity field exceeds maxIdentityFieldLen bytes.
+// The receipt store must remain empty after the rejection.
+func TestValidateFrame_RejectsOversizedIdentityField(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:    "1",
+		TsEmit:     "2026-05-03T00:00:00Z",
+		SessionID:  "s",
+		Channel:    "sdk",
+		Tool:       EmitterTool{Name: "t"},
+		Decision:   "allowed",
+		IssuerName: strings.Repeat("a", 257),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = p.Process(socket.Frame{Payload: body})
+	if err == nil {
+		t.Fatal("expected error for oversized issuer_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "issuer_name") {
+		t.Errorf("error %q should mention \"issuer_name\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "256") {
+		t.Errorf("error %q should mention the limit 256", err.Error())
+	}
+
+	// No receipt should have been stored.
+	receipts, getErr := st.GetChain("chain-1")
+	if getErr != nil {
+		t.Fatalf("GetChain: %v", getErr)
+	}
+	if len(receipts) != 0 {
+		t.Errorf("got %d receipts, want 0 (frame was rejected)", len(receipts))
+	}
+}
+
+// TestValidateFrame_RejectsPartialOperator verifies that validateFrame rejects
+// frames where operator_name is set without operator_id, preventing a receipt
+// with an empty operator.id from being signed.
+func TestValidateFrame_RejectsPartialOperator(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:      "1",
+		TsEmit:       "2026-05-03T00:00:00Z",
+		SessionID:    "s",
+		Channel:      "sdk",
+		Tool:         EmitterTool{Name: "t"},
+		Decision:     "allowed",
+		OperatorName: "Acme",
+		// OperatorID intentionally absent.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = p.Process(socket.Frame{Payload: body})
+	if err == nil {
+		t.Fatal("expected error for operator_name without operator_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "operator_name") {
+		t.Errorf("error %q should mention \"operator_name\"", err.Error())
+	}
+
+	// No receipt should have been stored.
+	receipts, getErr := st.GetChain("chain-1")
+	if getErr != nil {
+		t.Fatalf("GetChain: %v", getErr)
+	}
+	if len(receipts) != 0 {
+		t.Errorf("got %d receipts, want 0 (frame was rejected)", len(receipts))
 	}
 }

--- a/mcp-proxy/AGENTS.md
+++ b/mcp-proxy/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-MCP proxy that sits between an MCP client and server on stdin/stdout, intercepting every tool call to classify, score risk, evaluate policy, sign cryptographic receipts, redact sensitive data, and store an audit trail. Built with Go on [sdk/go](../sdk/go/).
+Thin MCP proxy: enforces policy on tool calls and forwards completed events to the [agent-receipts daemon](https://github.com/agent-receipts/ar/tree/main/daemon) for signing and persistence. The daemon is the sole writer; the proxy holds no SQLite store of its own (since v0.9.0 — see ADR-0010, [#421](https://github.com/agent-receipts/ar/pull/421), [#453](https://github.com/agent-receipts/ar/issues/453)).
 
 ## Getting started
 
@@ -14,11 +14,12 @@ go vet ./...                           # static analysis
 ## Project structure
 
 ```
-cmd/mcp-proxy/     # CLI entry point (serve, list, inspect, verify, export, stats, timing)
+cmd/mcp-proxy/     # CLI entry point (serve, doctor, init)
 internal/
   proxy/           # STDIO proxy, JSON-RPC parsing
-  audit/           # SQLite audit store, classifier, risk scorer, redaction, encryption, intent tracker
+  audit/           # Classifier, risk scorer, approval manager (no persistence)
   policy/          # YAML policy engine (pass/flag/pause/block)
+  host/            # Parent-process host detection (Claude Code, Codex, Cursor, Windsurf)
 configs/           # Default policy rules + bundled taxonomies (embedded into the binary via go:embed)
 ```
 
@@ -28,34 +29,35 @@ configs/           # Default policy rules + bundled taxonomies (embedded into th
 MCP Client → stdin/stdout → mcp-proxy → stdin/stdout → MCP Server
                                │
                                ├── JSON-RPC parser
-                               ├── Classifier + Risk scorer (0-100)
+                               ├── Classifier + Risk scorer
                                ├── Policy engine (YAML rules)
-                               ├── Approval workflow (HTTP)
-                               ├── Intent tracker (temporal grouping)
-                               ├── Receipt emitter (Ed25519, hash-chained)
-                               ├── Redaction (JSON-aware + pattern-based)
-                               ├── Encryption at rest (AES-256-GCM)
-                               └── SQLite audit store
+                               ├── Approval workflow (HTTP, in-memory)
+                               └── Daemon emitter (forwards completed events
+                                   to agent-receipts-daemon over AF_UNIX;
+                                   daemon owns redaction, hashing, signing,
+                                   chaining, and persistence)
 ```
+
+## Flags
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `-rules` | — | — | Policy rules YAML file |
+| `-name` | — | command basename | Server name for audit trail |
+| `-http` | — | `none` | HTTP address for approval listener |
+| `-approval-timeout` | — | `60s` | Max wait for HTTP approval |
+| `-socket` | `AGENTRECEIPTS_SOCKET` | platform default | Daemon Unix socket path |
+| `-issuer-name` | `AGENTRECEIPTS_ISSUER_NAME` | auto-detected | Override detected issuer name |
+| `-issuer-model` | `AGENTRECEIPTS_ISSUER_MODEL` | — | AI model identifier |
+| `-operator-id` | `AGENTRECEIPTS_OPERATOR_ID` | auto-detected | Operator DID |
+| `-operator-name` | `AGENTRECEIPTS_OPERATOR_NAME` | auto-detected | Operator display name |
+
+The proxy auto-detects the host (Claude Code, Codex, Cursor, Windsurf) from the parent process name on Linux. Flags and env vars take precedence over auto-detection.
 
 ## Conventions
 
 - All changes go through pull requests
 - Run `go vet ./...` before committing
-- Never break the MCP protocol — if parsing fails, forward the message raw
+- The proxy must never break the MCP protocol — if parsing fails, forward raw
 - Flush stdout after every proxied message
-- Pure Go SQLite via modernc.org/sqlite — no CGO
-- Tests sit alongside source files as `*_test.go`
-
-## Reference files
-
-- `internal/policy/engine.go` — policy evaluation: structured input/output, validation on init, composable matching logic
-- `internal/audit/classifier.go` — operation classification and risk scoring with priority ordering
-- `internal/audit/redact.go` — two-pass redaction pattern: JSON-aware key matching + regex-based secret detection
-
-## Testing
-
-- Run `go test ./...` to execute all tests
-- Run `go test -v ./internal/audit/` (or any subpackage) to test a single area
-- Tests cover: JSON-RPC parsing, classification, risk scoring, policy evaluation, redaction, encryption, receipt signing, and intent tracking
-- The proxy depends on `sdk/go` via a `replace` directive — if you change `sdk/go`, re-run proxy tests too
+- Redaction and persistence are daemon responsibilities — do not reintroduce a local store

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -9,6 +9,12 @@ This file starts at 0.6.2; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [Unreleased]
+
+### Added
+
+- **Issuer/operator identity on receipts**: auto-detect the host that launched the proxy (Claude Code, Codex, Cursor, Windsurf) from the parent process name on Linux, and stamp `receipt.Issuer.Name`, `receipt.Issuer.Model`, and `receipt.Issuer.Operator` on every emitted receipt. Override or supplement auto-detection with `--issuer-name`, `--issuer-model`, `--operator-id`, `--operator-name` flags (or the matching `AGENTRECEIPTS_*` env vars).
+
 ## [0.9.0] - 2026-05-18
 
 ### Removed (breaking)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -132,8 +132,9 @@ func serve() {
 	if id.OperatorName != "" && id.OperatorID == "" {
 		log.Fatalf("mcp-proxy: --operator-name (or AGENTRECEIPTS_OPERATOR_NAME) requires --operator-id (or AGENTRECEIPTS_OPERATOR_ID)")
 	}
-	if id.IssuerName != "" || id.OperatorName != "" {
-		log.Printf("mcp-proxy: host=%s issuer=%q operator=%q", id.Source, id.IssuerName, id.OperatorName)
+	if id.IssuerName != "" || id.IssuerModel != "" || id.OperatorID != "" || id.OperatorName != "" {
+		log.Printf("mcp-proxy: host=%s issuer=%q model=%q operator.id=%q operator.name=%q",
+			id.Source, id.IssuerName, id.IssuerModel, id.OperatorID, id.OperatorName)
 	}
 
 	sessionID := uuid.New().String()

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -129,6 +129,9 @@ func serve() {
 		id.OperatorName = *operatorName
 		id.Source = "flags"
 	}
+	if id.OperatorName != "" && id.OperatorID == "" {
+		log.Fatalf("mcp-proxy: --operator-name (or AGENTRECEIPTS_OPERATOR_NAME) requires --operator-id (or AGENTRECEIPTS_OPERATOR_ID)")
+	}
 	if id.IssuerName != "" || id.OperatorName != "" {
 		log.Printf("mcp-proxy: host=%s issuer=%q operator=%q", id.Source, id.IssuerName, id.OperatorName)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+	"github.com/agent-receipts/ar/mcp-proxy/internal/host"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
 	"github.com/agent-receipts/ar/sdk/go/emitter"
@@ -69,6 +70,10 @@ func serve() {
 		httpAddr     = flag.String("http", "none", "HTTP address for the approval listener (default: none — listener is off). Pass 127.0.0.1:0 for a random free port or 127.0.0.1:<port> to pin a port. See https://agentreceipts.ai/mcp-proxy/approval-ui/.")
 		approvalWait = flag.Duration("approval-timeout", 60*time.Second, "Maximum time to wait for HTTP approval when a policy rule pauses a tool call")
 		socketPath   = flag.String("socket", emitter.DefaultSocketPath(), "Unix-domain socket for the agent-receipts daemon (ADR-0010). Defaults to AGENTRECEIPTS_SOCKET if set; explicit --socket wins. Pass --socket=\"\" to disable emission entirely. Emit errors are logged but do not block tool calls.")
+		issuerName   = flag.String("issuer-name", envOr("AGENTRECEIPTS_ISSUER_NAME", ""), "Override detected issuer name (env: AGENTRECEIPTS_ISSUER_NAME)")
+		issuerModel  = flag.String("issuer-model", envOr("AGENTRECEIPTS_ISSUER_MODEL", ""), "AI model identifier (env: AGENTRECEIPTS_ISSUER_MODEL)")
+		operatorID   = flag.String("operator-id", envOr("AGENTRECEIPTS_OPERATOR_ID", ""), "Operator DID (env: AGENTRECEIPTS_OPERATOR_ID)")
+		operatorName = flag.String("operator-name", envOr("AGENTRECEIPTS_OPERATOR_NAME", ""), "Operator name (env: AGENTRECEIPTS_OPERATOR_NAME)")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mcp-proxy [flags] <command> [args...]\n")
@@ -105,6 +110,29 @@ func serve() {
 		*serverName = parts[len(parts)-1]
 	}
 
+	// Resolve issuer/operator identity: auto-detect the host, then apply any
+	// flag or env overrides. Flags take precedence over auto-detection.
+	id := host.Detect()
+	if *issuerName != "" {
+		id.IssuerName = *issuerName
+		id.Source = "flags"
+	}
+	if *issuerModel != "" {
+		id.IssuerModel = *issuerModel
+		id.Source = "flags"
+	}
+	if *operatorID != "" {
+		id.OperatorID = *operatorID
+		id.Source = "flags"
+	}
+	if *operatorName != "" {
+		id.OperatorName = *operatorName
+		id.Source = "flags"
+	}
+	if id.IssuerName != "" || id.OperatorName != "" {
+		log.Printf("mcp-proxy: host=%s issuer=%q operator=%q", id.Source, id.IssuerName, id.OperatorName)
+	}
+
 	sessionID := uuid.New().String()
 
 	// One-shot legacy notice. Operators upgrading from <v0.9.0 may have a
@@ -124,6 +152,12 @@ func serve() {
 			emitter.WithSocketPath(sp),
 			emitter.WithSessionID(sessionID),
 			emitter.WithStrictErrors(),
+			emitter.WithIdentity(emitter.Identity{
+				IssuerName:   id.IssuerName,
+				IssuerModel:  id.IssuerModel,
+				OperatorID:   id.OperatorID,
+				OperatorName: id.OperatorName,
+			}),
 		)
 		if initErr != nil {
 			log.Fatalf("mcp-proxy: emitter init: %v", initErr)
@@ -568,6 +602,15 @@ func noteLegacyAuditDB() {
 			"mcp-proxy: [INFO] could not check for legacy audit DB at %s: %v (the file may exist but be unreadable; the daemon's store is authoritative regardless).\n",
 			legacy, err)
 	}
+}
+
+// envOr returns the value of the named environment variable, or fallback when
+// the variable is unset or empty.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 func generateToken(n int) string {

--- a/mcp-proxy/internal/host/detect_linux.go
+++ b/mcp-proxy/internal/host/detect_linux.go
@@ -15,7 +15,7 @@ var readComm = func(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimRight(string(b), "\n"), nil
+	return strings.ToLower(strings.TrimRight(string(b), "\n")), nil
 }
 
 // Detect inspects the parent process name via /proc/<ppid>/comm and returns

--- a/mcp-proxy/internal/host/detect_linux.go
+++ b/mcp-proxy/internal/host/detect_linux.go
@@ -22,7 +22,7 @@ var readComm = func(pid int) (string, error) {
 // the best-guess Identity. Source is "auto:<key>" on a registry hit, or
 // "unknown" when the parent process is not in the built-in registry.
 //
-// TODO: consider env-marker secondary checks for cases where /proc gives no
+// TODO(#462): env-marker secondary checks for cases where /proc gives no
 // useful result (e.g. process name aliased by a wrapper shell):
 //   - CLAUDECODE (Claude Code SDK)
 //   - CURSOR_TRACE_ID (Cursor)

--- a/mcp-proxy/internal/host/detect_linux.go
+++ b/mcp-proxy/internal/host/detect_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package host
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// readComm reads the comm name for the given pid from /proc/<pid>/comm.
+// Swapped in tests to avoid real /proc reads.
+var readComm = func(pid int) (string, error) {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// Detect inspects the parent process name via /proc/<ppid>/comm and returns
+// the best-guess Identity. Source is "auto:<key>" on a registry hit, or
+// "unknown" when the parent process is not in the built-in registry.
+//
+// TODO: consider env-marker secondary checks for cases where /proc gives no
+// useful result (e.g. process name aliased by a wrapper shell):
+//   - CLAUDECODE (Claude Code SDK)
+//   - CURSOR_TRACE_ID (Cursor)
+//   - WINDSURF_* (Windsurf)
+//   - CODEX_* (OpenAI Codex)
+func Detect() Identity {
+	comm, err := readComm(os.Getppid())
+	if err != nil {
+		return Identity{Source: "unknown"}
+	}
+	id, ok := registry[comm]
+	if !ok {
+		return Identity{Source: "unknown"}
+	}
+	id.Source = "auto:" + comm
+	return id
+}

--- a/mcp-proxy/internal/host/detect_linux_test.go
+++ b/mcp-proxy/internal/host/detect_linux_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+package host
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetect_KnownHosts(t *testing.T) {
+	cases := []struct {
+		comm         string
+		wantName     string
+		wantOperator string
+		wantOperID   string
+		wantSource   string
+	}{
+		{"claude", "Claude Code", "Anthropic", "did:web:anthropic.com", "auto:claude"},
+		{"codex", "Codex", "OpenAI", "did:web:openai.com", "auto:codex"},
+		{"cursor", "Cursor", "Cursor", "did:web:cursor.com", "auto:cursor"},
+		{"windsurf", "Windsurf", "Codeium", "did:web:codeium.com", "auto:windsurf"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.comm, func(t *testing.T) {
+			orig := readComm
+			readComm = func(_ int) (string, error) { return tc.comm, nil }
+			t.Cleanup(func() { readComm = orig })
+
+			id := Detect()
+			if id.IssuerName != tc.wantName {
+				t.Errorf("IssuerName = %q, want %q", id.IssuerName, tc.wantName)
+			}
+			if id.OperatorName != tc.wantOperator {
+				t.Errorf("OperatorName = %q, want %q", id.OperatorName, tc.wantOperator)
+			}
+			if id.OperatorID != tc.wantOperID {
+				t.Errorf("OperatorID = %q, want %q", id.OperatorID, tc.wantOperID)
+			}
+			if id.Source != tc.wantSource {
+				t.Errorf("Source = %q, want %q", id.Source, tc.wantSource)
+			}
+			if id.IssuerModel != "" {
+				t.Errorf("IssuerModel = %q, want empty", id.IssuerModel)
+			}
+		})
+	}
+}
+
+func TestDetect_UnknownHost(t *testing.T) {
+	orig := readComm
+	readComm = func(_ int) (string, error) { return "vscode", nil }
+	t.Cleanup(func() { readComm = orig })
+
+	id := Detect()
+	if id.Source != "unknown" {
+		t.Errorf("Source = %q, want \"unknown\"", id.Source)
+	}
+	if id.IssuerName != "" || id.OperatorName != "" || id.OperatorID != "" {
+		t.Errorf("expected empty identity for unknown host, got %+v", id)
+	}
+}
+
+func TestDetect_ReadCommError(t *testing.T) {
+	orig := readComm
+	readComm = func(_ int) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() { readComm = orig })
+
+	id := Detect()
+	if id.Source != "unknown" {
+		t.Errorf("Source = %q, want \"unknown\"", id.Source)
+	}
+	if id.IssuerName != "" {
+		t.Errorf("IssuerName = %q, want empty on read error", id.IssuerName)
+	}
+	if id.IssuerModel != "" {
+		t.Errorf("IssuerModel = %q, want empty on read error", id.IssuerModel)
+	}
+	if id.OperatorID != "" {
+		t.Errorf("OperatorID = %q, want empty on read error", id.OperatorID)
+	}
+	if id.OperatorName != "" {
+		t.Errorf("OperatorName = %q, want empty on read error", id.OperatorName)
+	}
+}

--- a/mcp-proxy/internal/host/detect_other.go
+++ b/mcp-proxy/internal/host/detect_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package host
+
+// Detect returns an empty Identity on non-Linux platforms. /proc-based parent
+// process detection is Linux-only for v1; flags and env vars are the
+// recommended override mechanism on macOS and Windows.
+func Detect() Identity {
+	return Identity{Source: "unknown"}
+}

--- a/mcp-proxy/internal/host/host.go
+++ b/mcp-proxy/internal/host/host.go
@@ -1,0 +1,37 @@
+// Package host detects the MCP host (Claude Code, Codex, Cursor, Windsurf,
+// etc.) that launched this proxy process and returns its issuer/operator
+// identity for stamping on every emitted receipt.
+package host
+
+// Identity is what the proxy reports to the daemon about the host that launched it.
+type Identity struct {
+	IssuerName   string // e.g. "Claude Code"
+	IssuerModel  string // optional, e.g. ""
+	OperatorID   string // e.g. "did:web:anthropic.com"
+	OperatorName string // e.g. "Anthropic"
+	Source       string // "auto:<key>" | "flags" | "unknown" — for logging only
+}
+
+// registry maps parent process comm names to their known Identity.
+var registry = map[string]Identity{
+	"claude": {
+		IssuerName:   "Claude Code",
+		OperatorID:   "did:web:anthropic.com",
+		OperatorName: "Anthropic",
+	},
+	"codex": {
+		IssuerName:   "Codex",
+		OperatorID:   "did:web:openai.com",
+		OperatorName: "OpenAI",
+	},
+	"cursor": {
+		IssuerName:   "Cursor",
+		OperatorID:   "did:web:cursor.com",
+		OperatorName: "Cursor",
+	},
+	"windsurf": {
+		IssuerName:   "Windsurf",
+		OperatorID:   "did:web:codeium.com",
+		OperatorName: "Codeium",
+	},
+}

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -89,6 +89,14 @@ type Event struct {
 	Output   json.RawMessage
 	Error    string
 	Decision string
+
+	// optional issuer/operator identity fields — forwarded to the daemon so
+	// it can stamp receipt.Issuer.Name, receipt.Issuer.Model, and
+	// receipt.Issuer.Operator. When empty, the Emitter's Defaults are used.
+	IssuerName   string
+	IssuerModel  string
+	OperatorID   string
+	OperatorName string
 }
 
 // Option configures an Emitter at construction.
@@ -99,6 +107,17 @@ type config struct {
 	sessionID    string
 	logger       *slog.Logger
 	strictErrors bool
+	defaults     Identity
+}
+
+// Identity holds issuer/operator fields that the Emitter stamps on every
+// frame where the corresponding Event field is empty. Set once at construction
+// via WithIdentity; per-event overrides take precedence.
+type Identity struct {
+	IssuerName   string
+	IssuerModel  string
+	OperatorID   string
+	OperatorName string
 }
 
 // WithSocketPath overrides the daemon socket path. When unset, the path
@@ -143,6 +162,13 @@ func WithStrictErrors() Option {
 	return func(c *config) { c.strictErrors = true }
 }
 
+// WithIdentity sets default issuer/operator fields that are stamped on every
+// frame. Per-event fields on Event take precedence over these defaults.
+// Typically set once at construction from host auto-detection or CLI flags.
+func WithIdentity(id Identity) Option {
+	return func(c *config) { c.defaults = id }
+}
+
 // Emitter is the daemon-socket client. Construct with New, fire events
 // with Emit, release the socket with Close. Safe for concurrent Emit.
 type Emitter struct {
@@ -156,6 +182,7 @@ type Emitter struct {
 	sessionID    string
 	logger       *slog.Logger
 	strictErrors bool
+	defaults     Identity
 
 	mu     sync.Mutex
 	conn   net.Conn
@@ -192,6 +219,7 @@ func New(opts ...Option) (*Emitter, error) {
 		sessionID:    cfg.sessionID,
 		logger:       cfg.logger,
 		strictErrors: cfg.strictErrors,
+		defaults:     cfg.defaults,
 	}, nil
 }
 
@@ -204,16 +232,20 @@ func (e *Emitter) SessionID() string { return e.sessionID }
 // Defined locally so the emitter does not import a daemon-internal
 // package; the wire format is the contract, not the type definition.
 type frame struct {
-	Version   string          `json:"v"`
-	TsEmit    string          `json:"ts_emit"`
-	SessionID string          `json:"session_id"`
-	Channel   string          `json:"channel"`
-	Tool      frameTool       `json:"tool"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	Output    json.RawMessage `json:"output,omitempty"`
-	Error     string          `json:"error,omitempty"`
-	Decision  string          `json:"decision"`
-	DropCount int64           `json:"drop_count,omitempty"`
+	Version      string          `json:"v"`
+	TsEmit       string          `json:"ts_emit"`
+	SessionID    string          `json:"session_id"`
+	Channel      string          `json:"channel"`
+	Tool         frameTool       `json:"tool"`
+	Input        json.RawMessage `json:"input,omitempty"`
+	Output       json.RawMessage `json:"output,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	Decision     string          `json:"decision"`
+	DropCount    int64           `json:"drop_count,omitempty"`
+	IssuerName   string          `json:"issuer_name,omitempty"`
+	IssuerModel  string          `json:"issuer_model,omitempty"`
+	OperatorID   string          `json:"operator_id,omitempty"`
+	OperatorName string          `json:"operator_name,omitempty"`
 }
 
 type frameTool struct {
@@ -277,17 +309,39 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	// restored (see the failure paths below) so it isn't lost.
 	pendingDrops := e.dropCount.Swap(0)
 
+	// Merge per-event identity fields over the emitter-level defaults.
+	issuerName := e.defaults.IssuerName
+	if ev.IssuerName != "" {
+		issuerName = ev.IssuerName
+	}
+	issuerModel := e.defaults.IssuerModel
+	if ev.IssuerModel != "" {
+		issuerModel = ev.IssuerModel
+	}
+	operatorID := e.defaults.OperatorID
+	if ev.OperatorID != "" {
+		operatorID = ev.OperatorID
+	}
+	operatorName := e.defaults.OperatorName
+	if ev.OperatorName != "" {
+		operatorName = ev.OperatorName
+	}
+
 	body, err := json.Marshal(frame{
-		Version:   SupportedFrameVersion,
-		TsEmit:    time.Now().UTC().Format(time.RFC3339Nano),
-		SessionID: e.sessionID,
-		Channel:   ev.Channel,
-		Tool:      frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
-		Input:     ev.Input,
-		Output:    ev.Output,
-		Error:     ev.Error,
-		Decision:  ev.Decision,
-		DropCount: pendingDrops,
+		Version:      SupportedFrameVersion,
+		TsEmit:       time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID:    e.sessionID,
+		Channel:      ev.Channel,
+		Tool:         frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
+		Input:        ev.Input,
+		Output:       ev.Output,
+		Error:        ev.Error,
+		Decision:     ev.Decision,
+		DropCount:    pendingDrops,
+		IssuerName:   issuerName,
+		IssuerModel:  issuerModel,
+		OperatorID:   operatorID,
+		OperatorName: operatorName,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -53,6 +53,12 @@ import (
 // them at read time anyway.
 const MaxFrameSize = 1 << 20
 
+// MaxIdentityFieldLen is the maximum byte length of each identity field
+// (IssuerName, IssuerModel, OperatorID, OperatorName). The daemon enforces
+// the same limit; the emitter validates client-side so violations surface
+// before the write rather than as silent daemon-side rejections.
+const MaxIdentityFieldLen = 256
+
 // SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
 // The wire format is versioned; bumping it requires a daemon-side
 // translator, so a single supported value is the only safe contract.
@@ -336,16 +342,15 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	const maxIdentityField = 256
 	for _, f := range [4]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
 		{"operator_name", operatorName},
 	} {
-		if len(f.val) > maxIdentityField {
+		if len(f.val) > MaxIdentityFieldLen {
 			e.dropCount.Add(pendingDrops)
-			return fmt.Errorf("emitter: %s exceeds %d bytes (got %d)", f.name, maxIdentityField, len(f.val))
+			return fmt.Errorf("emitter: %s exceeds %d bytes (got %d)", f.name, MaxIdentityFieldLen, len(f.val))
 		}
 	}
 

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -327,6 +327,28 @@ func (e *Emitter) Emit(ctx context.Context, ev Event) error {
 		operatorName = ev.OperatorName
 	}
 
+	// Validate merged identity before marshalling. operator_name requires
+	// operator_id (daemon enforces the same rule; catching it here surfaces
+	// a clear error instead of a silent daemon-side rejection).
+	if operatorName != "" && operatorID == "" {
+		e.dropCount.Add(pendingDrops)
+		return fmt.Errorf("emitter: operator_name requires operator_id")
+	}
+	// Mirror the daemon's per-field length cap so oversized values are caught
+	// at the emitter rather than silently rejected by the daemon after the write.
+	const maxIdentityField = 256
+	for _, f := range [4]struct{ name, val string }{
+		{"issuer_name", issuerName},
+		{"issuer_model", issuerModel},
+		{"operator_id", operatorID},
+		{"operator_name", operatorName},
+	} {
+		if len(f.val) > maxIdentityField {
+			e.dropCount.Add(pendingDrops)
+			return fmt.Errorf("emitter: %s exceeds %d bytes (got %d)", f.name, maxIdentityField, len(f.val))
+		}
+	}
+
 	body, err := json.Marshal(frame{
 		Version:      SupportedFrameVersion,
 		TsEmit:       time.Now().UTC().Format(time.RFC3339Nano),

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1048,12 +1047,16 @@ func TestEmit_WithIdentityDefaultsStampedOnFrame(t *testing.T) {
 		}
 
 		frames := rl.waitForFrames(t, 1, 2*time.Second)
-		// Verify the raw JSON does not contain the identity keys at all
-		// (omitempty should suppress them entirely).
-		raw := string(frames[0])
+		// Unmarshal into a map to verify that the identity keys are absent
+		// entirely (omitempty should suppress them), not just absent from
+		// string content.
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(frames[0], &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
 		for _, key := range []string{"issuer_name", "issuer_model", "operator_id", "operator_name"} {
-			if strings.Contains(raw, `"`+key+`"`) {
-				t.Errorf("frame JSON contains %q but should be omitted when empty: %s", key, raw)
+			if _, present := got[key]; present {
+				t.Errorf("frame JSON contains %q but should be omitted when empty", key)
 			}
 		}
 	})

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -975,6 +976,172 @@ func TestEmit_NoStrictErrors_DialFailure(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Emit without strict errors returned error %v; want nil (fire-and-forget)", err)
 	}
+}
+
+// TestEmit_WithIdentityDefaultsStampedOnFrame asserts that identity fields set
+// via WithIdentity are included in every emitted frame and absent when not set.
+func TestEmit_WithIdentityDefaultsStampedOnFrame(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	t.Run("identity fields present", func(t *testing.T) {
+		rl := newRecordingListener(t, dir)
+		em, err := New(
+			WithSocketPath(rl.path),
+			WithLogger(silentLogger()),
+			WithIdentity(Identity{
+				IssuerName:   "Claude Code",
+				IssuerModel:  "claude-opus-4-5",
+				OperatorID:   "did:web:anthropic.com",
+				OperatorName: "Anthropic",
+			}),
+		)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer em.Close()
+
+		if err := em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "bash"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		frames := rl.waitForFrames(t, 1, 2*time.Second)
+		var got frame
+		if err := json.Unmarshal(frames[0], &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.IssuerName != "Claude Code" {
+			t.Errorf("issuer_name = %q; want %q", got.IssuerName, "Claude Code")
+		}
+		if got.IssuerModel != "claude-opus-4-5" {
+			t.Errorf("issuer_model = %q; want %q", got.IssuerModel, "claude-opus-4-5")
+		}
+		if got.OperatorID != "did:web:anthropic.com" {
+			t.Errorf("operator_id = %q; want %q", got.OperatorID, "did:web:anthropic.com")
+		}
+		if got.OperatorName != "Anthropic" {
+			t.Errorf("operator_name = %q; want %q", got.OperatorName, "Anthropic")
+		}
+	})
+
+	t.Run("identity fields absent when not set", func(t *testing.T) {
+		rl := newRecordingListener(t, dir)
+		em, err := New(
+			WithSocketPath(rl.path),
+			WithLogger(silentLogger()),
+			// no WithIdentity
+		)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer em.Close()
+
+		if err := em.Emit(context.Background(), Event{
+			Channel:  "mcp",
+			Tool:     Tool{Name: "bash"},
+			Decision: "allowed",
+		}); err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		frames := rl.waitForFrames(t, 1, 2*time.Second)
+		// Verify the raw JSON does not contain the identity keys at all
+		// (omitempty should suppress them entirely).
+		raw := string(frames[0])
+		for _, key := range []string{"issuer_name", "issuer_model", "operator_id", "operator_name"} {
+			if strings.Contains(raw, `"`+key+`"`) {
+				t.Errorf("frame JSON contains %q but should be omitted when empty: %s", key, raw)
+			}
+		}
+	})
+
+	t.Run("per-event override takes precedence over default", func(t *testing.T) {
+		rl := newRecordingListener(t, dir)
+		em, err := New(
+			WithSocketPath(rl.path),
+			WithLogger(silentLogger()),
+			WithIdentity(Identity{
+				IssuerName:   "Default Host",
+				OperatorName: "Default Operator",
+			}),
+		)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer em.Close()
+
+		if err := em.Emit(context.Background(), Event{
+			Channel:      "mcp",
+			Tool:         Tool{Name: "bash"},
+			Decision:     "allowed",
+			IssuerName:   "Per-Event Host",
+			OperatorName: "Per-Event Operator",
+		}); err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		frames := rl.waitForFrames(t, 1, 2*time.Second)
+		var got frame
+		if err := json.Unmarshal(frames[0], &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.IssuerName != "Per-Event Host" {
+			t.Errorf("issuer_name = %q; want per-event value %q", got.IssuerName, "Per-Event Host")
+		}
+		if got.OperatorName != "Per-Event Operator" {
+			t.Errorf("operator_name = %q; want per-event value %q", got.OperatorName, "Per-Event Operator")
+		}
+	})
+
+	t.Run("partial per-event override merges with defaults independently", func(t *testing.T) {
+		// Defaults: full operator identity. Event overrides only IssuerName.
+		// Verifies that per-field merge is independent: unset event fields fall
+		// through to the default, and the overridden field is taken from the event.
+		rl := newRecordingListener(t, dir)
+		em, err := New(
+			WithSocketPath(rl.path),
+			WithLogger(silentLogger()),
+			WithIdentity(Identity{
+				OperatorID:   "did:web:default.com",
+				OperatorName: "Default",
+			}),
+		)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer em.Close()
+
+		if err := em.Emit(context.Background(), Event{
+			Channel:    "mcp",
+			Tool:       Tool{Name: "bash"},
+			Decision:   "allowed",
+			IssuerName: "Override",
+			// IssuerModel, OperatorID, OperatorName not set — fall through to defaults.
+		}); err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+
+		frames := rl.waitForFrames(t, 1, 2*time.Second)
+		var got frame
+		if err := json.Unmarshal(frames[0], &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.IssuerName != "Override" {
+			t.Errorf("issuer_name = %q; want %q (per-event override)", got.IssuerName, "Override")
+		}
+		if got.OperatorID != "did:web:default.com" {
+			t.Errorf("operator_id = %q; want %q (from default)", got.OperatorID, "did:web:default.com")
+		}
+		if got.OperatorName != "Default" {
+			t.Errorf("operator_name = %q; want %q (from default)", got.OperatorName, "Default")
+		}
+		if got.IssuerModel != "" {
+			t.Errorf("issuer_model = %q; want empty (not in defaults, not in event)", got.IssuerModel)
+		}
+	})
 }
 
 func TestEmit_ConcurrentCallsAreSerialised(t *testing.T) {

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -1065,6 +1065,7 @@ func TestEmit_WithIdentityDefaultsStampedOnFrame(t *testing.T) {
 			WithLogger(silentLogger()),
 			WithIdentity(Identity{
 				IssuerName:   "Default Host",
+				OperatorID:   "did:web:default.com",
 				OperatorName: "Default Operator",
 			}),
 		)
@@ -1078,6 +1079,7 @@ func TestEmit_WithIdentityDefaultsStampedOnFrame(t *testing.T) {
 			Tool:         Tool{Name: "bash"},
 			Decision:     "allowed",
 			IssuerName:   "Per-Event Host",
+			OperatorID:   "did:web:override.com",
 			OperatorName: "Per-Event Operator",
 		}); err != nil {
 			t.Fatalf("Emit: %v", err)
@@ -1090,6 +1092,9 @@ func TestEmit_WithIdentityDefaultsStampedOnFrame(t *testing.T) {
 		}
 		if got.IssuerName != "Per-Event Host" {
 			t.Errorf("issuer_name = %q; want per-event value %q", got.IssuerName, "Per-Event Host")
+		}
+		if got.OperatorID != "did:web:override.com" {
+			t.Errorf("operator_id = %q; want per-event value %q", got.OperatorID, "did:web:override.com")
 		}
 		if got.OperatorName != "Per-Event Operator" {
 			t.Errorf("operator_name = %q; want per-event value %q", got.OperatorName, "Per-Event Operator")


### PR DESCRIPTION
## Summary

- Restore issuer/operator identity in signed receipts. After #421/#454 turned `mcp-proxy` into a thin emitter, the daemon became the sole issuer — but it only stamped `Issuer.ID`. `Issuer.Name`, `Issuer.Model`, and `Issuer.Operator` were dropped on the floor for every receipt.
- `mcp-proxy` now auto-detects the launching host (Claude Code, Codex, Cursor, Windsurf) from `/proc/<ppid>/comm` on Linux.
- Override / supplement with `--issuer-name`, `--issuer-model`, `--operator-id`, `--operator-name` flags (or matching `AGENTRECEIPTS_*` env vars).
- The daemon stamps proxy-supplied fields into `receipt.Issuer.{Name,Model,Operator}` in both `buildAndSign` paths; drop-receipt path intentionally omits identity (synthetic events_dropped — no proxy-supplied source for the gap).

## Wire compatibility

Additive change at frame version `v=1`. All four new fields use `omitempty` on both the proxy `frame` and daemon `EmitterFrame`.

- Old proxy + new daemon → no identity fields on the wire → daemon writes empty `Issuer.Name` / nil `Issuer.Operator` (today's behaviour).
- New proxy + old daemon → unknown JSON fields ignored by `encoding/json`.
- Cross-SDK integration tests (`cross-sdk-tests/spec_examples_test.go`, `spec_schema_test.go`) pass unchanged.

## Validation

At the daemon's `validateFrame` boundary:

- 256-byte cap per identity field (errors name the offending field and length).
- Partial operator rejected: `operator_name` set without `operator_id` returns an error before reaching the chain allocator. The reverse (id-only operator) is allowed — `operator.name` is optional in the spec, `operator.id` is required when operator is present.

The `issuerFromFrame` helper emits `Operator` only when `OperatorID != ""`, which matches the spec exactly given the validator pre-check.

## Auto-detection

Detection lives in `mcp-proxy/internal/host/`:

- Linux: `os.Getppid()` → `/proc/<ppid>/comm` → registry lookup. Registry covers `claude`, `codex`, `cursor`, `windsurf`. Unknown comm → `Identity{Source: "unknown"}` with empty fields.
- Non-Linux: stub returns `unknown` (build-tag split mirrors `daemon/internal/socket/peercred_*.go`). Flags/env vars are the override path on macOS/Windows.
- Env-marker secondary detection (`CLAUDECODE`, `CURSOR_TRACE_ID`, etc.) deferred to a follow-up — see TODO at `detect_linux.go:25`.

## Test plan

- [ ] `cd sdk/go && go test ./...` passes
- [ ] `cd mcp-proxy && go test ./...` passes
- [ ] `cd daemon && go test ./...` passes
- [ ] `cd cross-sdk-tests && go test -tags integration ./...` passes
- [ ] Manual: run `mcp-proxy serve` under Claude Code on Linux; confirm receipts carry `Issuer.Name="Claude Code"`, `Operator={did:web:anthropic.com, "Anthropic"}` and startup log line shows `host=auto:claude`
- [ ] Manual: run with `--issuer-name=Foo`; confirm the flag wins over auto-detection and the log line shows `host=flags`
- [ ] Manual: run with no parent (detached / systemd); confirm receipts have empty Name and nil Operator (graceful fallback)

## Test coverage added

- `mcp-proxy/internal/host/detect_linux_test.go`: known hosts (4), unknown host, `readComm` error path
- `sdk/go/emitter/emitter_unix_test.go`: defaults present, defaults absent (omitempty in raw JSON), per-event override beats defaults, partial per-event merge preserves remaining default fields
- `daemon/internal/pipeline/build_test.go`: end-to-end frame → signed receipt; nil-`Operator` preservation; `validateFrame` rejects oversized identity field; `validateFrame` rejects partial operator

## Notes for review

- Self-review caught two bugs after the initial implementation: `issuerFromFrame` was emitting a partial-operator (spec violation), and `validateFrame` had no length cap on the new fields. Both are fixed and the squashed commit includes the hardening.
- `mcp-proxy/AGENTS.md` got a papercut refresh — the old version still referenced the pre-thin-emitter SQLite store and AES-256-GCM encryption (removed in #421/#454). Now aligned with `mcp-proxy/CLAUDE.md`.