### PR TITLE
chore(release): CHANGELOG for sdk/go v0.10.0, mcp-proxy v0.10.0, daemon v0.11.0

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `agent-receipts-daemon` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2026-05-19
 
 ### Added
 

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -9,7 +9,7 @@ This file starts at 0.6.2; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
-## [Unreleased]
+## [0.10.0] - 2026-05-19
 
 ### Added
 

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -9,6 +9,20 @@ This file starts at 0.6.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.10.0] - 2026-05-19
+
+### Added
+
+- **Issuer/operator identity fields on emitted frames** ([#461](https://github.com/agent-receipts/ar/pull/461)):
+  New `Identity` type and `WithIdentity()` constructor option let callers stamp
+  `issuer_name`, `issuer_model`, `operator_id`, and `operator_name` on every
+  emitted frame. Per-event fields on `Event` take precedence over the
+  emitter-level defaults set via `WithIdentity`. The emitter validates identity
+  fields before marshalling: `operator_name` requires `operator_id`, and each
+  field is capped at 256 bytes (`MaxIdentityFieldLen`), mirroring the daemon's
+  enforcement so violations surface at the emitter rather than being silently
+  rejected after the write.
+
 ## [0.9.0] - 2026-05-16
 
 ### Added


### PR DESCRIPTION
## Summary

- `sdk/go v0.10.0`: add CHANGELOG entry for `Identity`/`WithIdentity` emitter additions (#461)
- `mcp-proxy v0.10.0`: finalize `[Unreleased]` → `[0.10.0] - 2026-05-19` (host auto-detect + identity flags)
- `daemon v0.11.0`: finalize `[Unreleased]` → `[0.11.0] - 2026-05-19` (issuer/operator metadata + isError fix)

## Release sequence after merge

1. `scripts/release.sh sdk-go 0.10.0` — tag and publish sdk/go
2. PR to bump `sdk/go v0.10.0` in `mcp-proxy/go.mod` and `daemon/go.mod`
3. `scripts/release.sh mcp-proxy 0.10.0` + `scripts/release.sh daemon 0.11.0`

## Test plan

- [ ] CHANGELOG entries match the actual diffs in #461 and #460
- [ ] Dates are correct (2026-05-19)
- [ ] `[Unreleased]` sections are gone from mcp-proxy and daemon