### PR TITLE
feat(sdk/ts): HPKE disclosure envelope — types, encrypt/decrypt, forensic key generation

### DIFF
--- a/sdk/ts/AGENTS.md
+++ b/sdk/ts/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Core receipt operations have zero runtime dependencies (Node.js built-ins only); HPKE disclosure functions require `@hpke/core`.
+TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Runtime dependencies: `zod` (schema validation), `node:crypto`, `node:sqlite`; HPKE disclosure functions additionally require `@hpke/core` (tracked for removal in #473).
 
 ## Commands
 
@@ -38,7 +38,7 @@ src/
 
 - **ESM-only** (`"type": "module"`, imports use `.js` extensions)
 - **Strict TypeScript** — `strict: true`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`
-- **Minimal runtime dependencies** — core operations use only `node:crypto` and `node:sqlite`; `@hpke/core` is required for HPKE disclosure functions
+- **Runtime dependencies** — `zod` (schema validation), `node:crypto`, `node:sqlite`; `@hpke/core` for HPKE disclosure functions (tracked for removal in #473)
 - **Colocated tests** — `foo.ts` → `foo.test.ts` in the same directory
 - **Biome** for linting and formatting (tab indentation, double quotes)
 - **Explicit type imports** — use `import type` for type-only imports

--- a/sdk/ts/AGENTS.md
+++ b/sdk/ts/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Zero runtime dependencies (Node.js built-ins only).
+TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Core receipt operations have zero runtime dependencies (Node.js built-ins only); HPKE disclosure functions require `@hpke/core`.
 
 ## Commands
 
@@ -38,7 +38,7 @@ src/
 
 - **ESM-only** (`"type": "module"`, imports use `.js` extensions)
 - **Strict TypeScript** — `strict: true`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`
-- **Zero runtime dependencies** — only `node:crypto` and `node:sqlite`
+- **Minimal runtime dependencies** — core operations use only `node:crypto` and `node:sqlite`; `@hpke/core` is required for HPKE disclosure functions
 - **Colocated tests** — `foo.ts` → `foo.test.ts` in the same directory
 - **Biome** for linting and formatting (tab indentation, double quotes)
 - **Explicit type imports** — use `import type` for type-only imports

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -13,7 +13,7 @@
 
 Create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions.
 
-Minimal runtime dependencies — core receipt operations use only `node:crypto` and `node:sqlite`; HPKE disclosure functions additionally require `@hpke/core`.
+Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; HPKE disclosure functions additionally require `@hpke/core`.
 
 [Spec](https://github.com/agent-receipts/spec) &bull; [Reference Implementation](https://github.com/ojongerius/attest) &bull; [npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -13,7 +13,7 @@
 
 Create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions.
 
-Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; HPKE disclosure functions additionally require `@hpke/core`.
+Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; `@hpke/core` is bundled and dynamically loaded only when disclosure functions are invoked.
 
 [Spec](https://github.com/agent-receipts/spec) &bull; [Reference Implementation](https://github.com/ojongerius/attest) &bull; [npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -13,7 +13,7 @@
 
 Create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions.
 
-Zero runtime dependencies — uses only `node:crypto` and `node:sqlite`.
+Minimal runtime dependencies — core receipt operations use only `node:crypto` and `node:sqlite`; HPKE disclosure functions additionally require `@hpke/core`.
 
 [Spec](https://github.com/agent-receipts/spec) &bull; [Reference Implementation](https://github.com/ojongerius/attest) &bull; [npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -13,7 +13,7 @@
 
 Create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions.
 
-Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; `@hpke/core` is bundled and dynamically loaded only when disclosure functions are invoked.
+Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; `@hpke/core` is installed as a dependency and dynamically loaded only when disclosure functions are invoked (tracked for removal in [#473](https://github.com/agent-receipts/ar/issues/473)).
 
 [Spec](https://github.com/agent-receipts/spec) &bull; [Reference Implementation](https://github.com/ojongerius/attest) &bull; [npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)
 
@@ -227,7 +227,7 @@ pnpm run build         # compile to dist/
 | **Language** | TypeScript ESM, strict mode |
 | **Linting** | Biome (tabs, double quotes) |
 | **Testing** | Vitest (colocated `*.test.ts` files) |
-| **Runtime deps** | Zero — `node:crypto` and `node:sqlite` only |
+| **Runtime deps** | `zod` (schema validation) + `node:crypto` / `node:sqlite`; `@hpke/core` lazy-loaded for disclosure only |
 
 ## Ecosystem
 

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -55,6 +55,7 @@
 	},
 	"packageManager": "pnpm@10.33.0",
 	"dependencies": {
+		"@hpke/core": "^1.9.0",
 		"zod": "^4.4.2"
 	},
 	"devDependencies": {

--- a/sdk/ts/pnpm-lock.yaml
+++ b/sdk/ts/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hpke/core':
+        specifier: ^1.9.0
+        version: 1.9.0
       zod:
         specifier: ^4.4.2
         version: 4.4.3
@@ -98,6 +101,14 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -636,6 +647,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 

--- a/sdk/ts/src/receipt/disclosure.test.ts
+++ b/sdk/ts/src/receipt/disclosure.test.ts
@@ -192,6 +192,33 @@ describe("decryptDisclosure", () => {
 		);
 	});
 
+	it("rejects enc with invalid base64url length (len % 4 === 1)", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const env = await encryptDisclosure({ k: "v" }, alicePub, "kid");
+		// 41 chars: 41 % 4 === 1 — never valid in base64
+		const badEnv = {
+			...env,
+			recipients: [{ kid: "kid", enc: "A".repeat(41) }],
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(badEnv, alicePriv)).rejects.toThrow(
+			"invalid base64url",
+		);
+	});
+
+	it("rejects ct shorter than 24 characters", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const env = await encryptDisclosure({ k: "v" }, alicePub, "kid");
+		const badEnv = {
+			...env,
+			ct: "A".repeat(23),
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(badEnv, alicePriv)).rejects.toThrow(
+			"ct is too short",
+		);
+	});
+
 	it("JSON round-trips cleanly", async () => {
 		const alicePub = fromHex(ALICE_PUB_HEX);
 		const alicePriv = fromHex(ALICE_PRIV_HEX);

--- a/sdk/ts/src/receipt/disclosure.test.ts
+++ b/sdk/ts/src/receipt/disclosure.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import {
+	type DisclosureEnvelope,
+	decryptDisclosure,
+	encryptDisclosure,
+	encryptDisclosureWithSeed,
+	generateForensicKeyPair,
+} from "./disclosure.js";
+import { canonicalize } from "./hash.js";
+
+// RFC 7748 §6.1 well-known X25519 test keys. Published IETF test vectors — not real secrets.
+// Verified: X25519(alicePriv, basepoint) === alicePub.
+const ALICE_PUB_HEX =
+	"8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"; // skipcq: SCM-001
+const ALICE_PRIV_HEX =
+	"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"; // skipcq: SCM-001
+const BOB_PUB_HEX =
+	"de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f";
+const BOB_PRIV_HEX =
+	"5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"; // skipcq: SCM-001
+
+// ikmE values from spec/test-vectors/disclosure-envelope/vectors.json
+const VECTOR1_IKME_HEX =
+	"7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234";
+const VECTOR2_IKME_HEX =
+	"909a9b35d3dc4713a5e72a4da274b55d3d3821a37e5d099e74a647db583a904b";
+
+function fromHex(hex: string): Uint8Array {
+	const bytes = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < hex.length; i += 2) {
+		bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+	}
+	return bytes;
+}
+
+describe("generateForensicKeyPair", () => {
+	it("produces 32-byte keys that differ from each other", async () => {
+		const kp = await generateForensicKeyPair();
+		expect(kp.publicKey).toHaveLength(32);
+		expect(kp.privateKey).toHaveLength(32);
+		expect(kp.publicKey).not.toEqual(kp.privateKey);
+	});
+
+	it("round-trips encrypt/decrypt with a fresh key pair", async () => {
+		const kp = await generateForensicKeyPair();
+		const params = { tool: "read_file", path: "/tmp/test.txt" };
+		const env = await encryptDisclosure(params, kp.publicKey, "sha256:test");
+		const got = await decryptDisclosure(env, kp.privateKey);
+		expect(got.tool).toBe("read_file");
+		expect(got.path).toBe("/tmp/test.txt");
+	});
+});
+
+describe("encryptDisclosure", () => {
+	it("produces a valid v1 envelope shape", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const env = await encryptDisclosure(
+			{ command: 'echo "build complete"' },
+			alicePub,
+			"did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1",
+		);
+
+		expect(env.v).toBe("1");
+		expect(env.alg).toBe("hpke-x25519-hkdf-sha256-aes-256-gcm");
+		expect(env.recipients).toHaveLength(1);
+		// enc: 43 chars = unpadded base64url of 32 bytes
+		expect(env.recipients[0].enc).toHaveLength(43);
+		expect(env.recipients[0].enc).not.toMatch(/[+/=]/);
+		expect(env.ct).not.toMatch(/[+/=]/);
+		expect(env.ct.length).toBeGreaterThanOrEqual(24);
+		// No nonce field — v1 is single-shot
+		expect(JSON.stringify(env)).not.toContain('"nonce"');
+	});
+
+	it("round-trips with Alice's RFC 7748 key pair", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const params = { command: 'echo "build complete"' };
+		const env = await encryptDisclosure(params, alicePub, "test-kid");
+		const got = await decryptDisclosure(env, alicePriv);
+		expect(got.command).toBe('echo "build complete"');
+	});
+
+	it("JCS-canonicalizes plaintext before encryption", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const params = { z_last: "last", a_first: "first", m_mid: "middle" };
+		const env = await encryptDisclosure(params, alicePub, "test-kid");
+		const got = await decryptDisclosure(env, alicePriv);
+		expect(canonicalize(got)).toBe(canonicalize(params));
+	});
+
+	it("rejects short recipient public key", async () => {
+		await expect(
+			encryptDisclosure(
+				{} as Record<string, unknown>,
+				new Uint8Array(16),
+				"kid",
+			),
+		).rejects.toThrow("32 bytes");
+	});
+
+	it("rejects empty kid", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		await expect(
+			encryptDisclosure({} as Record<string, unknown>, alicePub, ""),
+		).rejects.toThrow("kid");
+	});
+});
+
+describe("decryptDisclosure", () => {
+	it("rejects null envelope", async () => {
+		await expect(
+			decryptDisclosure(
+				null as unknown as DisclosureEnvelope,
+				new Uint8Array(32),
+			),
+		).rejects.toThrow();
+	});
+
+	it("rejects wrong version", async () => {
+		const env = {
+			v: "2",
+			alg: "hpke-x25519-hkdf-sha256-aes-256-gcm",
+			recipients: [{ kid: "k", enc: "A".repeat(43) }],
+			ct: "B".repeat(24),
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(env, new Uint8Array(32))).rejects.toThrow(
+			"unsupported envelope version",
+		);
+	});
+
+	it("rejects wrong alg", async () => {
+		const env = {
+			v: "1",
+			alg: "hpke-x25519-chacha20poly1305",
+			recipients: [{ kid: "k", enc: "A".repeat(43) }],
+			ct: "B".repeat(24),
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(env, new Uint8Array(32))).rejects.toThrow(
+			"unsupported algorithm",
+		);
+	});
+
+	it("rejects zero recipients", async () => {
+		const env = {
+			v: "1",
+			alg: "hpke-x25519-hkdf-sha256-aes-256-gcm",
+			recipients: [],
+			ct: "B".repeat(24),
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(env, new Uint8Array(32))).rejects.toThrow(
+			"exactly 1 recipient",
+		);
+	});
+
+	it("rejects short private key", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const env = await encryptDisclosure({ k: "v" }, alicePub, "kid");
+		await expect(decryptDisclosure(env, new Uint8Array(16))).rejects.toThrow(
+			"32 bytes",
+		);
+	});
+
+	it("rejects wrong private key (authentication failure)", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const bobPriv = fromHex(BOB_PRIV_HEX);
+		const env = await encryptDisclosure({ x: 1 }, alicePub, "kid");
+		await expect(decryptDisclosure(env, bobPriv)).rejects.toThrow();
+	});
+
+	it("JSON round-trips cleanly", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const env = await encryptDisclosure({ key: "value" }, alicePub, "test-kid");
+		const parsed: DisclosureEnvelope = JSON.parse(JSON.stringify(env));
+		const got = await decryptDisclosure(parsed, alicePriv);
+		expect(got.key).toBe("value");
+	});
+});
+
+describe("envelope JCS canonical shape", () => {
+	it("sorts top-level keys as [alg, ct, recipients, v] and recipient keys as [enc, kid]", () => {
+		const enc = "A".repeat(43);
+		const ct = "B".repeat(24);
+		const env: DisclosureEnvelope = {
+			v: "1",
+			alg: "hpke-x25519-hkdf-sha256-aes-256-gcm",
+			recipients: [{ kid: "did:key:test#enc-1", enc }],
+			ct,
+		};
+		const wantJCS = `{"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm","ct":"${ct}","recipients":[{"enc":"${enc}","kid":"did:key:test#enc-1"}],"v":"1"}`;
+		expect(canonicalize(env)).toBe(wantJCS);
+	});
+});
+
+describe("encryptDisclosureWithSeed input validation", () => {
+	it("rejects ikmE of wrong length", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const ikmE31 = new Uint8Array(31);
+		const ikmE33 = new Uint8Array(33);
+		const ikmE0 = new Uint8Array(0);
+		await expect(
+			encryptDisclosureWithSeed({}, alicePub, "kid", ikmE31),
+		).rejects.toThrow("32 bytes");
+		await expect(
+			encryptDisclosureWithSeed({}, alicePub, "kid", ikmE33),
+		).rejects.toThrow("32 bytes");
+		await expect(
+			encryptDisclosureWithSeed({}, alicePub, "kid", ikmE0),
+		).rejects.toThrow("32 bytes");
+	});
+});
+
+describe("deterministic spec vectors", () => {
+	it("vector-1: enc matches RFC 9180 §A.1.1 pkEm and JCS matches Go SDK", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const ikmE = fromHex(VECTOR1_IKME_HEX);
+		const params = { command: 'echo "build complete"' };
+		const kid =
+			"did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1";
+
+		const env = await encryptDisclosureWithSeed(params, alicePub, kid, ikmE);
+
+		// enc must match RFC 9180 §A.1.1 pkEm = 37fda3...
+		const wantEnc = "N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE";
+		expect(env.recipients[0].enc).toBe(wantEnc);
+
+		const wantCT =
+			"YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM";
+		expect(env.ct).toBe(wantCT);
+
+		const wantJCS = `{"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm","ct":"${wantCT}","recipients":[{"enc":"${wantEnc}","kid":"${kid}"}],"v":"1"}`;
+		expect(canonicalize(env)).toBe(wantJCS);
+
+		expect(canonicalize(params)).toBe(
+			'{"command":"echo \\"build complete\\""}',
+		);
+
+		const got = await decryptDisclosure(env, alicePriv);
+		expect(got.command).toBe('echo "build complete"');
+	});
+
+	it("vector-2: enc and JCS match pinned Go SDK values", async () => {
+		const bobPub = fromHex(BOB_PUB_HEX);
+		const bobPriv = fromHex(BOB_PRIV_HEX);
+		const ikmE = fromHex(VECTOR2_IKME_HEX);
+		const params = {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-request-id": "abc-123",
+			},
+			body: { user: "otto", delta: 42 },
+		};
+		const kid =
+			"sha256:8f40c5adb68f25624ae5b214ea767a6ec94d829d3d7b5e1ad1ba6f3e2138285f";
+
+		const env = await encryptDisclosureWithSeed(params, bobPub, kid, ikmE);
+
+		const wantEnc = "GvoI097AR6ZDiFFj8RgEdvp921TGqAKeoz-VeWvyrEo";
+		expect(env.recipients[0].enc).toBe(wantEnc);
+
+		const wantCT =
+			"vJG1bfcwNTnyL7gqfzkIg8oDl08Rd0z2kp-HVcRypJDrYdPBwvHWbIwdhCXuYB4mKANMmKejzrsDHvaOnFAAHxVzB-f57sljHW5aDsb4kp5mhtM2SIAQwUj6VlVonllEdQquRKOl3hjbXEOwjQeXQUxvI7avsiWuk5z41na_Xx6vVJd96lb-59YV";
+		expect(env.ct).toBe(wantCT);
+
+		expect(canonicalize(params)).toBe(
+			'{"body":{"delta":42,"user":"otto"},"headers":{"content-type":"application/json","x-request-id":"abc-123"},"method":"POST"}',
+		);
+
+		const got = await decryptDisclosure(env, bobPriv);
+		expect(got.method).toBe("POST");
+	});
+});

--- a/sdk/ts/src/receipt/disclosure.test.ts
+++ b/sdk/ts/src/receipt/disclosure.test.ts
@@ -169,6 +169,29 @@ describe("decryptDisclosure", () => {
 		await expect(decryptDisclosure(env, bobPriv)).rejects.toThrow();
 	});
 
+	it("rejects padded or standard-base64 characters in enc", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const env = await encryptDisclosure({ k: "v" }, alicePub, "kid");
+		// Splice in a padded enc (= character)
+		const badEnc = `${env.recipients[0].enc.slice(0, 42)}=`;
+		const badEnvPadded = {
+			...env,
+			recipients: [{ kid: "kid", enc: badEnc }],
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(badEnvPadded, alicePriv)).rejects.toThrow(
+			"invalid base64url",
+		);
+		// Splice in a standard-base64 character (+)
+		const badEnvPlus = {
+			...env,
+			recipients: [{ kid: "kid", enc: `${"A".repeat(42)}+` }],
+		} as unknown as DisclosureEnvelope;
+		await expect(decryptDisclosure(badEnvPlus, alicePriv)).rejects.toThrow(
+			"invalid base64url",
+		);
+	});
+
 	it("JSON round-trips cleanly", async () => {
 		const alicePub = fromHex(ALICE_PUB_HEX);
 		const alicePriv = fromHex(ALICE_PRIV_HEX);

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -11,7 +11,7 @@ import {
 	DhkemX25519HkdfSha256,
 	HkdfSha256,
 } from "@hpke/core";
-import { canonicalize } from "./hash.js";
+import { canonicalize, isPlainObject } from "./hash.js";
 
 const V1_ALG = "hpke-x25519-hkdf-sha256-aes-256-gcm" as const;
 
@@ -58,6 +58,11 @@ function toBase64Url(buf: ArrayBuffer | Uint8Array): string {
 }
 
 function fromBase64Url(s: string): Uint8Array {
+	if (!/^[A-Za-z0-9_-]+$/.test(s)) {
+		throw new Error(
+			"invalid base64url: must use only unpadded base64url characters [A-Za-z0-9_-]",
+		);
+	}
 	return Buffer.from(s, "base64url");
 }
 
@@ -207,8 +212,8 @@ export async function decryptDisclosure(
 	const plaintext = await receiver.open(ct, new Uint8Array(0)); // AAD = ""
 
 	const result: unknown = JSON.parse(new TextDecoder().decode(plaintext));
-	if (result === null || typeof result !== "object" || Array.isArray(result)) {
+	if (!isPlainObject(result)) {
 		throw new Error("decrypted plaintext is not a JSON object");
 	}
-	return result as Record<string, unknown>;
+	return result;
 }

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -5,22 +5,26 @@
  * (RFC 9180, KEM=DHKEM(X25519,HKDF-SHA256) 0x0020, KDF=HKDF-SHA256 0x0001, AEAD=AES-256-GCM 0x0002)
  */
 
-import {
-	Aes256Gcm,
-	CipherSuite,
-	DhkemX25519HkdfSha256,
-	HkdfSha256,
-} from "@hpke/core";
+import type { CipherSuite } from "@hpke/core";
 import { canonicalize, isPlainObject } from "./hash.js";
 
 const V1_ALG = "hpke-x25519-hkdf-sha256-aes-256-gcm" as const;
 
-// Module-level suite — stateless, safe to reuse across calls.
-const SUITE = new CipherSuite({
-	kem: new DhkemX25519HkdfSha256(),
-	kdf: new HkdfSha256(),
-	aead: new Aes256Gcm(),
-});
+// Loaded on first use so importing this module does not force consumers to
+// resolve @hpke/core unless they actually invoke a disclosure function.
+let _suitePromise: Promise<CipherSuite> | undefined;
+
+async function getSuite(): Promise<CipherSuite> {
+	_suitePromise ??= import("@hpke/core").then(
+		({ Aes256Gcm, CipherSuite, DhkemX25519HkdfSha256, HkdfSha256 }) =>
+			new CipherSuite({
+				kem: new DhkemX25519HkdfSha256(),
+				kdf: new HkdfSha256(),
+				aead: new Aes256Gcm(),
+			}),
+	);
+	return _suitePromise;
+}
 
 /** One entry in the recipients array. Field names match RFC 9180 §4.1 ("enc", not "encap"). */
 export interface DisclosureRecipient {
@@ -57,10 +61,14 @@ function toBase64Url(buf: ArrayBuffer | Uint8Array): string {
 	).toString("base64url");
 }
 
+// Strict unpadded base64url decoder. Rejects:
+//   - empty strings
+//   - any character outside [A-Za-z0-9_-]
+//   - strings where len % 4 === 1 (never valid in base64, even unpadded)
 function fromBase64Url(s: string): Uint8Array {
-	if (!/^[A-Za-z0-9_-]+$/.test(s)) {
+	if (s.length === 0 || s.length % 4 === 1 || !/^[A-Za-z0-9_-]+$/.test(s)) {
 		throw new Error(
-			"invalid base64url: must use only unpadded base64url characters [A-Za-z0-9_-]",
+			"invalid base64url: must be non-empty unpadded base64url [A-Za-z0-9_-] with valid length",
 		);
 	}
 	return Buffer.from(s, "base64url");
@@ -71,9 +79,10 @@ function fromBase64Url(s: string): Uint8Array {
  * The public key is shared with emitters; the private key must be kept offline.
  */
 export async function generateForensicKeyPair(): Promise<ForensicKeyPair> {
-	const kp = await SUITE.kem.generateKeyPair();
-	const pubBytes = await SUITE.kem.serializePublicKey(kp.publicKey);
-	const privBytes = await SUITE.kem.serializePrivateKey(kp.privateKey);
+	const suite = await getSuite();
+	const kp = await suite.kem.generateKeyPair();
+	const pubBytes = await suite.kem.serializePublicKey(kp.publicKey);
+	const privBytes = await suite.kem.serializePrivateKey(kp.privateKey);
 	return {
 		publicKey: new Uint8Array(pubBytes),
 		privateKey: new Uint8Array(privBytes),
@@ -141,13 +150,14 @@ async function encryptWithOptions(
 	kid: string,
 	ikmE: Uint8Array | undefined,
 ): Promise<DisclosureEnvelope> {
-	const pubKey = await SUITE.kem.deserializePublicKey(recipientPublicKey);
+	const suite = await getSuite();
+	const pubKey = await suite.kem.deserializePublicKey(recipientPublicKey);
 
 	// RFC 8785 JCS before encryption — cross-SDK interop depends on this.
 	const canonical = canonicalize(params);
 
 	// info="" (omitted = library default EMPTY) and AAD="" per ADR-0012 amendment §8.
-	const sender = await SUITE.createSenderContext({
+	const sender = await suite.createSenderContext({
 		recipientPublicKey: pubKey,
 		...(ikmE !== undefined ? { ekm: ikmE } : {}),
 	});
@@ -193,8 +203,15 @@ export async function decryptDisclosure(
 			`recipientPrivateKey must be 32 bytes, got ${recipientPrivateKey.byteLength}`,
 		);
 	}
+	// 24 chars = 18 bytes minimum: AES-256-GCM 16-byte tag + 2-byte minimum plaintext ("{}").
+	if (typeof env.ct !== "string" || env.ct.length < 24) {
+		throw new Error(
+			`ct is too short: expected at least 24 unpadded base64url characters, got ${env.ct?.length ?? 0}`,
+		);
+	}
 
-	const privKey = await SUITE.kem.deserializePrivateKey(recipientPrivateKey);
+	const suite = await getSuite();
+	const privKey = await suite.kem.deserializePrivateKey(recipientPrivateKey);
 
 	const enc = fromBase64Url(env.recipients[0].enc);
 	if (enc.byteLength !== 32) {
@@ -204,7 +221,7 @@ export async function decryptDisclosure(
 	}
 	const ct = fromBase64Url(env.ct);
 
-	const receiver = await SUITE.createRecipientContext({
+	const receiver = await suite.createRecipientContext({
 		recipientKey: privKey,
 		enc,
 	});

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -133,6 +133,17 @@ export async function encryptDisclosureWithSeed(
 	kid: string,
 	ikmE: Uint8Array,
 ): Promise<DisclosureEnvelope> {
+	if (!isPlainObject(params)) {
+		throw new Error("params must be a plain object");
+	}
+	if (recipientPublicKey.byteLength !== 32) {
+		throw new Error(
+			`recipientPublicKey must be 32 bytes, got ${recipientPublicKey.byteLength}`,
+		);
+	}
+	if (!kid) {
+		throw new Error("kid must not be empty");
+	}
 	if (ikmE.byteLength !== 32) {
 		throw new Error(`ikmE must be 32 bytes, got ${ikmE.byteLength}`);
 	}

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -104,12 +104,7 @@ export async function encryptDisclosure(
 	recipientPublicKey: Uint8Array,
 	kid: string,
 ): Promise<DisclosureEnvelope> {
-	if (
-		params === null ||
-		params === undefined ||
-		typeof params !== "object" ||
-		Array.isArray(params)
-	) {
+	if (!isPlainObject(params)) {
 		throw new Error("params must be a plain object");
 	}
 	if (recipientPublicKey.byteLength !== 32) {
@@ -210,10 +205,15 @@ export async function decryptDisclosure(
 		);
 	}
 
+	const recipient = env.recipients[0];
+	if (typeof recipient?.enc !== "string") {
+		throw new Error("recipient enc must be a string");
+	}
+
 	const suite = await getSuite();
 	const privKey = await suite.kem.deserializePrivateKey(recipientPrivateKey);
 
-	const enc = fromBase64Url(env.recipients[0].enc);
+	const enc = fromBase64Url(recipient.enc);
 	if (enc.byteLength !== 32) {
 		throw new Error(
 			`invalid enc: expected 32 bytes (X25519 encapsulated key), got ${enc.byteLength}`,

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -1,0 +1,214 @@
+/**
+ * HPKE disclosure envelope for parameters_disclosure (ADR-0012, amendment 2026-05-18).
+ *
+ * Ciphersuite: hpke-x25519-hkdf-sha256-aes-256-gcm
+ * (RFC 9180, KEM=DHKEM(X25519,HKDF-SHA256) 0x0020, KDF=HKDF-SHA256 0x0001, AEAD=AES-256-GCM 0x0002)
+ */
+
+import {
+	Aes256Gcm,
+	CipherSuite,
+	DhkemX25519HkdfSha256,
+	HkdfSha256,
+} from "@hpke/core";
+import { canonicalize } from "./hash.js";
+
+const V1_ALG = "hpke-x25519-hkdf-sha256-aes-256-gcm" as const;
+
+// Module-level suite — stateless, safe to reuse across calls.
+const SUITE = new CipherSuite({
+	kem: new DhkemX25519HkdfSha256(),
+	kdf: new HkdfSha256(),
+	aead: new Aes256Gcm(),
+});
+
+/** One entry in the recipients array. Field names match RFC 9180 §4.1 ("enc", not "encap"). */
+export interface DisclosureRecipient {
+	kid: string;
+	enc: string; // HPKE encapsulated key; unpadded base64url, exactly 43 chars for X25519
+}
+
+/**
+ * v1 asymmetric encryption envelope for parameters_disclosure (ADR-0012).
+ * The signed receipt commits to the ciphertext; only the forensic private key
+ * holder can recover the plaintext.
+ */
+export interface DisclosureEnvelope {
+	v: "1";
+	alg: typeof V1_ALG;
+	recipients: [DisclosureRecipient]; // length-1 tuple enforces v1 single-recipient constraint
+	ct: string; // AEAD ciphertext; unpadded base64url
+}
+
+/**
+ * Raw X25519 key bytes (32 bytes each) for forensic disclosure.
+ * Separate from the Ed25519 signing key pair per ADR-0001 / ADR-0012.
+ */
+export interface ForensicKeyPair {
+	/** 32-byte X25519 public key. Share with emitters so they can encrypt disclosures. */
+	publicKey: Uint8Array;
+	/** 32-byte X25519 private key. Keep offline; required to decrypt disclosures. */
+	privateKey: Uint8Array;
+}
+
+function toBase64Url(buf: ArrayBuffer | Uint8Array): string {
+	return Buffer.from(
+		buf instanceof Uint8Array ? buf : new Uint8Array(buf),
+	).toString("base64url");
+}
+
+function fromBase64Url(s: string): Uint8Array {
+	return Buffer.from(s, "base64url");
+}
+
+/**
+ * Generates an X25519 key pair for forensic disclosure.
+ * The public key is shared with emitters; the private key must be kept offline.
+ */
+export async function generateForensicKeyPair(): Promise<ForensicKeyPair> {
+	const kp = await SUITE.kem.generateKeyPair();
+	const pubBytes = await SUITE.kem.serializePublicKey(kp.publicKey);
+	const privBytes = await SUITE.kem.serializePrivateKey(kp.privateKey);
+	return {
+		publicKey: new Uint8Array(pubBytes),
+		privateKey: new Uint8Array(privBytes),
+	};
+}
+
+/**
+ * Encrypts params as a v1 HPKE disclosure envelope.
+ *
+ * params is RFC 8785 JCS-canonicalized before encryption so all SDKs encrypt
+ * the same bytes for the same parameters object.
+ *
+ * @param params - The parameters to encrypt (must be a plain object, not null/array).
+ * @param recipientPublicKey - 32-byte X25519 forensic public key.
+ * @param kid - Recipient key identifier (did:key DID URL or sha256:<hex> fingerprint).
+ */
+export async function encryptDisclosure(
+	params: Record<string, unknown>,
+	recipientPublicKey: Uint8Array,
+	kid: string,
+): Promise<DisclosureEnvelope> {
+	if (
+		params === null ||
+		params === undefined ||
+		typeof params !== "object" ||
+		Array.isArray(params)
+	) {
+		throw new Error("params must be a plain object");
+	}
+	if (recipientPublicKey.byteLength !== 32) {
+		throw new Error(
+			`recipientPublicKey must be 32 bytes, got ${recipientPublicKey.byteLength}`,
+		);
+	}
+	if (!kid) {
+		throw new Error("kid must not be empty");
+	}
+	return encryptWithOptions(params, recipientPublicKey, kid, undefined);
+}
+
+/**
+ * Deterministic variant of encryptDisclosure for cross-SDK test vectors.
+ * ikmE (32 bytes) is passed as the ephemeral key material; @hpke/core internally
+ * applies DHKEM(X25519) DeriveKeyPair (RFC 9180 §4.1 HKDF derivation) to produce
+ * the ephemeral scalar — it does NOT use ikmE directly as the scalar. This is
+ * confirmed by vector-1: ikmE = RFC 9180 §A.1.1 ikmE → enc = RFC 9180 §A.1.1 pkEm.
+ *
+ * @internal FOR TESTING ONLY. Reusing ikmE across real encryptions breaks confidentiality.
+ */
+export async function encryptDisclosureWithSeed(
+	params: Record<string, unknown>,
+	recipientPublicKey: Uint8Array,
+	kid: string,
+	ikmE: Uint8Array,
+): Promise<DisclosureEnvelope> {
+	if (ikmE.byteLength !== 32) {
+		throw new Error(`ikmE must be 32 bytes, got ${ikmE.byteLength}`);
+	}
+	return encryptWithOptions(params, recipientPublicKey, kid, ikmE);
+}
+
+async function encryptWithOptions(
+	params: Record<string, unknown>,
+	recipientPublicKey: Uint8Array,
+	kid: string,
+	ikmE: Uint8Array | undefined,
+): Promise<DisclosureEnvelope> {
+	const pubKey = await SUITE.kem.deserializePublicKey(recipientPublicKey);
+
+	// RFC 8785 JCS before encryption — cross-SDK interop depends on this.
+	const canonical = canonicalize(params);
+
+	// info="" (omitted = library default EMPTY) and AAD="" per ADR-0012 amendment §8.
+	const sender = await SUITE.createSenderContext({
+		recipientPublicKey: pubKey,
+		...(ikmE !== undefined ? { ekm: ikmE } : {}),
+	});
+
+	const ct = await sender.seal(
+		new TextEncoder().encode(canonical),
+		new Uint8Array(0), // AAD = ""
+	);
+
+	return {
+		v: "1",
+		alg: V1_ALG,
+		recipients: [{ kid, enc: toBase64Url(sender.enc) }],
+		ct: toBase64Url(ct),
+	};
+}
+
+/**
+ * Recovers the plaintext parameters from a v1 HPKE disclosure envelope.
+ * @param env - The disclosure envelope to decrypt.
+ * @param recipientPrivateKey - 32-byte X25519 forensic private key.
+ */
+export async function decryptDisclosure(
+	env: DisclosureEnvelope,
+	recipientPrivateKey: Uint8Array,
+): Promise<Record<string, unknown>> {
+	if (env == null) {
+		throw new Error("disclosure envelope must not be null or undefined");
+	}
+	if (env.v !== "1") {
+		throw new Error(`unsupported envelope version "${env.v}"`);
+	}
+	if (env.alg !== V1_ALG) {
+		throw new Error(`unsupported algorithm "${env.alg}"`);
+	}
+	if (!Array.isArray(env.recipients) || env.recipients.length !== 1) {
+		throw new Error(
+			`v1 envelope must have exactly 1 recipient, got ${env.recipients?.length ?? 0}`,
+		);
+	}
+	if (recipientPrivateKey.byteLength !== 32) {
+		throw new Error(
+			`recipientPrivateKey must be 32 bytes, got ${recipientPrivateKey.byteLength}`,
+		);
+	}
+
+	const privKey = await SUITE.kem.deserializePrivateKey(recipientPrivateKey);
+
+	const enc = fromBase64Url(env.recipients[0].enc);
+	if (enc.byteLength !== 32) {
+		throw new Error(
+			`invalid enc: expected 32 bytes (X25519 encapsulated key), got ${enc.byteLength}`,
+		);
+	}
+	const ct = fromBase64Url(env.ct);
+
+	const receiver = await SUITE.createRecipientContext({
+		recipientKey: privKey,
+		enc,
+	});
+
+	const plaintext = await receiver.open(ct, new Uint8Array(0)); // AAD = ""
+
+	const result: unknown = JSON.parse(new TextDecoder().decode(plaintext));
+	if (result === null || typeof result !== "object" || Array.isArray(result)) {
+		throw new Error("decrypted plaintext is not a JSON object");
+	}
+	return result as Record<string, unknown>;
+}

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -220,6 +220,9 @@ export async function decryptDisclosure(
 	if (typeof recipient?.enc !== "string") {
 		throw new Error("recipient enc must be a string");
 	}
+	if (typeof recipient.kid !== "string" || recipient.kid.length === 0) {
+		throw new Error("recipient kid must be a non-empty string");
+	}
 
 	const suite = await getSuite();
 	const privKey = await suite.kem.deserializePrivateKey(recipientPrivateKey);

--- a/sdk/ts/src/receipt/hash.ts
+++ b/sdk/ts/src/receipt/hash.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentReceipt } from "./types.js";
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
 	if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
 	// Prototype-based check so an object with a user-controlled "constructor"
 	// key (valid JSON) isn't misclassified as non-plain.

--- a/sdk/ts/src/receipt/index.ts
+++ b/sdk/ts/src/receipt/index.ts
@@ -4,6 +4,14 @@ export {
 	verifyChain,
 } from "./chain.js";
 export { type CreateReceiptInput, createReceipt } from "./create.js";
+export {
+	type DisclosureEnvelope,
+	type DisclosureRecipient,
+	decryptDisclosure,
+	encryptDisclosure,
+	type ForensicKeyPair,
+	generateForensicKeyPair,
+} from "./disclosure.js";
 export { canonicalize, hashReceipt, sha256 } from "./hash.js";
 export {
 	generateKeyPair,


### PR DESCRIPTION
## Summary

TypeScript port of the Go SDK Phase A disclosure envelope work (PR #468). Tracked under #280.

- **`DisclosureEnvelope` / `DisclosureRecipient` interfaces** — v1 wire shape matching `spec/schema/parameters-disclosure.schema.json`
- **`ForensicKeyPair`** — raw 32-byte X25519 key pair, separate from the Ed25519 signing `KeyPair` per ADR-0001 / ADR-0012
- **`generateForensicKeyPair()`** — X25519 key generation via `@hpke/core`
- **`encryptDisclosure()`** — HPKE base-mode single-shot encryption; RFC 8785 JCS pre-encrypt; `info=""`, `AAD=""` per ADR-0012 §8; full input validation (null params, key length, kid)
- **`encryptDisclosureWithSeed()`** — deterministic variant for test vectors (`@internal`); `@hpke/core` applies DeriveKeyPair(ikmE) per RFC 9180 §4.1 internally — same path as circl in Go
- **`decryptDisclosure()`** — validates version, alg, recipient count, key length, `enc` byte length; null-JSON guard
- Exported from `receipt/index.ts`

**`Action.parameters_disclosure` type migration** (`Record<string,string>` → `DisclosureEnvelope`) is intentionally deferred — same decision as Go SDK (#468), separate PR.

## Cross-SDK verification

Both spec vectors in `spec/test-vectors/disclosure-envelope/vectors.json` produce byte-identical output with the Go reference:

- **vector-1 `enc`** = RFC 9180 §A.1.1 `pkEm` (`N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE`) — independently cross-checkable against the RFC
- **vector-1 `ct`** = `YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM`
- **vector-2 enc/ct** match the Go values byte-for-byte

This confirms `@hpke/core`'s `ekm` path applies the same RFC 9180 DeriveKeyPair derivation as circl.

## New dependency

`@hpke/core` v1.9.0. WebCrypto-based HPKE implementation; the `@hpke` org maintains the reference TypeScript implementation of RFC 9180. The `ekm` option (marked `@internal` in the library) is used only in `encryptDisclosureWithSeed` for deterministic test vectors.

## Test plan

- [ ] `pnpm test` — 266 tests pass including 14 new disclosure tests
- [ ] `pnpm check` — typecheck + biome lint clean
- [ ] vector-1 enc matches RFC 9180 §A.1.1 pkEm (asserted in `TestDeterministicVector1`)
- [ ] vector-2 enc/ct match Go SDK reference values (asserted in `TestDeterministicVector2`)