### PR TITLE
docs(adr): add ADR-0018/0019/0020 + ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,12 +33,12 @@ regulated industries.
 | Item | ADR | Issue | Status |
 |---|---|---|---|
 | PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #TBD | planned |
-| RFC 3161 TSA timestamp anchoring (elevated from v2) | ADR-0019 § P3 | #TBD | planned |
-| Revocation list format and reference implementation (elevated from v2) | ADR-0019 § O1 | #TBD | planned |
-| `CheckpointPublisher` with object-lock reference backend (elevated from v2) | ADR-0019 § O2 | #TBD | planned |
-| Content-addressed payload storage (GDPR erasure) | ADR-0019 § S3 (extends) | #TBD | planned |
+| RFC 3161 TSA timestamp anchoring (elevated from v2) | ADR-0019 § P3 | #482 | planned |
+| Revocation list format and reference implementation (elevated from v2) | ADR-0019 § O1 | #483 | planned |
+| `CheckpointPublisher` with object-lock reference backend (elevated from v2) | ADR-0019 § O2 | #484 | planned |
+| Content-addressed payload storage (GDPR erasure) | ADR-0019 § S3 (extends) | #478 | planned |
 | Standalone verifier service (separable from SDK) | new ADR needed | #TBD | planned |
-| Downloadable conformance test suite | ADR-0019 § S1 (extends) | #TBD | planned |
+| Downloadable conformance test suite | ADR-0019 § S1 (extends) | #474 | planned |
 | Multi-tenancy guidance — key management at scale | docs | #TBD | planned |
 | Regional TSA support (eIDAS, ICP-Brasil, etc.) | new ADR needed | #TBD | planned |
 
@@ -57,10 +57,10 @@ this and undermine the protocol's credibility?"
 
 | # | Item | ADR | Issue | Status |
 |---|---|---|---|---|
-| 1 | Cross-SDK canonicalisation conformance vectors | ADR-0019 § S1 | #TBD | planned |
-| 2 | Silent chain termination — `status` field on `agent_end` | ADR-0019 § P1 | #TBD | planned |
-| 3 | `GeneratingKeyProvider` unreachable in production | ADR-0019 § S2 | #TBD | planned |
-| 4 | Sequential receipt construction enforced under parallel tool calls | ADR-0020 | #TBD | planned |
+| 1 | Cross-SDK canonicalisation conformance vectors | ADR-0019 § S1 | #474 | planned |
+| 2 | Silent chain termination — `status` field on `agent_end` | ADR-0019 § P1 | #475 | planned |
+| 3 | `GeneratingKeyProvider` unreachable in production | ADR-0019 § S2 | #476 | planned |
+| 4 | Sequential receipt construction enforced under parallel tool calls | ADR-0020 | #488 | planned |
 
 Item 4 is in this list because the OpenClaw plugin may fire concurrent tool
 invocations during the demo. If concurrent emission produces a broken chain
@@ -78,23 +78,23 @@ across workstreams they can be parallelised.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Explicit `sessionId` binding in verifier | ADR-0019 § P4 | #TBD | planned |
-| Strict `sequenceNumber` contiguity in verifier | ADR-0019 § P5 | #TBD | planned |
-| `idempotencyKey` field for retry deduplication | ADR-0019 § S5 | #TBD | planned |
+| Explicit `sessionId` binding in verifier | ADR-0019 § P4 | #477 | planned |
+| Strict `sequenceNumber` contiguity in verifier | ADR-0019 § P5 | #479 | planned |
+| `idempotencyKey` field for retry deduplication | ADR-0019 § S5 | #480 | planned |
 
 ### SDK emitter layer
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| `HttpEmitter` with sync / fire-and-forget strategies | ADR-0020 | #TBD | planned |
-| WAL for at-least-once delivery (long-lived + ephemeral) | ADR-0020 | #TBD | planned |
+| `HttpEmitter` with sync / fire-and-forget strategies | ADR-0020 | #486 | planned |
+| WAL for at-least-once delivery (long-lived + ephemeral) | ADR-0020 | #487 | planned |
 | Verifier-side `incomplete_tool_roundtrip` classification | ADR-0019 § O3 → ADR-0020 | (folded into WAL issue) | planned |
 
 ### SDK payload handling
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Bounded `input`/`output` payload via `PayloadStrategy` | ADR-0019 § S3 | #TBD | planned |
+| Bounded `input`/`output` payload via `PayloadStrategy` | ADR-0019 § S3 | #478 | planned |
 
 ### Cross-SDK parity
 
@@ -113,8 +113,8 @@ an issue open; none are scheduled.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Unauthenticated chain origin (witnessed `agent_start` or trust registry) | ADR-0019 § P2 | #TBD | deferred |
-| `InMemoryKeyProvider` memory safety improvements | ADR-0019 § S4 | #TBD | deferred |
+| Unauthenticated chain origin (witnessed `agent_start` or trust registry) | ADR-0019 § P2 | #481 | deferred |
+| `InMemoryKeyProvider` memory safety improvements | ADR-0019 § S4 | #485 | deferred |
 | Parallel sub-chains (forked chains + merge receipt) | ADR-0020 | not filed | deferred |
 
 The following were originally targeted for v2 but elevated to v1.5
@@ -139,6 +139,6 @@ The following were originally targeted for v2 but elevated to v1.5
 
 | ADR | Title | Status |
 |---|---|---|
-| ADR-0018 | Signer abstraction and cloud-agnostic KeyProvider design | Accepted |
+| ADR-0018 | Signer abstraction and cloud-agnostic KeyProvider design | Proposed |
 | ADR-0019 | Protocol integrity gaps and mitigations | Proposed |
 | ADR-0020 | Emitter abstraction and remote receipt delivery | Proposed |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,10 @@ When this roadmap and an ADR disagree on sequencing, this roadmap wins
 (ADRs are immutable; sequencing changes as work progresses). When they
 disagree on a design decision, the ADR wins.
 
-Each item links to a GitHub issue. Status values: `planned`, `in-progress`,
-`done`, `deferred`.
+Most items link to a GitHub issue. A few rows intentionally don't — they
+are folded into a parent issue, tracked across per-SDK issues opened lazily
+as each SDK starts the work, or explicitly not filed yet. Those rows say so
+inline. Status values: `planned`, `in-progress`, `done`, `deferred`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,9 @@ in-flight, and what's deferred. ADRs record decisions; this roadmap records
 sequencing.
 
 When this roadmap and an ADR disagree on sequencing, this roadmap wins
-(ADRs are immutable; sequencing changes as work progresses). When they
-disagree on a design decision, the ADR wins.
+(ADRs record decisions and may be amended via dated amendments — see
+ADR-0010, ADR-0012, ADR-0015; this roadmap is the sequencing source of
+truth). When they disagree on a design decision, the ADR wins.
 
 Most items link to a GitHub issue. A few rows intentionally don't — they
 are folded into a parent issue, tracked across per-SDK issues opened lazily
@@ -110,8 +111,9 @@ across workstreams they can be parallelised.
 
 ## v2 — deferred
 
-Items remaining for v2 after the regulated-industries elevation. Each has
-an issue open; none are scheduled.
+Items remaining for v2 after the regulated-industries elevation. Most have
+an issue open; parallel sub-chains is intentionally unfiled until the v1
+emitter work clarifies whether the feature is needed. None are scheduled.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,15 +32,15 @@ regulated industries.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #TBD | planned |
+| PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #489 | planned |
 | RFC 3161 TSA timestamp anchoring (elevated from v2) | ADR-0019 § P3 | #482 | planned |
 | Revocation list format and reference implementation (elevated from v2) | ADR-0019 § O1 | #483 | planned |
 | `CheckpointPublisher` with object-lock reference backend (elevated from v2) | ADR-0019 § O2 | #484 | planned |
 | Content-addressed payload storage (GDPR erasure) | ADR-0019 § S3 (extends) | #478 | planned |
-| Standalone verifier service (separable from SDK) | new ADR needed | #TBD | planned |
+| Standalone verifier service (separable from SDK) | new ADR needed | #490 | planned |
 | Downloadable conformance test suite | ADR-0019 § S1 (extends) | #474 | planned |
-| Multi-tenancy guidance — key management at scale | docs | #TBD | planned |
-| Regional TSA support (eIDAS, ICP-Brasil, etc.) | new ADR needed | #TBD | planned |
+| Multi-tenancy guidance — key management at scale | docs | #491 | planned |
+| Regional TSA support (eIDAS, ICP-Brasil, etc.) | new ADR needed | #492 | planned |
 
 These items have a coherent target audience (regulated-industries adopters) and
 should be sequenced together rather than dripped into v2. Moving them to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,144 @@
+# Agent Receipts — Roadmap
+
+This document is the single source of truth for what's planned, what's
+in-flight, and what's deferred. ADRs record decisions; this roadmap records
+sequencing.
+
+When this roadmap and an ADR disagree on sequencing, this roadmap wins
+(ADRs are immutable; sequencing changes as work progresses). When they
+disagree on a design decision, the ADR wins.
+
+Each item links to a GitHub issue. Status values: `planned`, `in-progress`,
+`done`, `deferred`.
+
+---
+
+## Milestones at a glance
+
+| Milestone | Description | Target |
+|---|---|---|
+| **Post 3** | OpenClaw / Claude Code demo published to HN. Subset of v1 blockers required to avoid embarrassing failure modes in the demo. | Next |
+| **v1** | Public protocol release. All known integrity gaps either fixed or explicitly documented as limitations. | After Post 3 |
+| **v1.5** | Regulated-industries readiness. Items required to clear a financial services or healthcare compliance review. | After v1 |
+| **v2** | Trust-model improvements beyond regulated-industries baseline. | Post-v1.5 |
+
+---
+
+## Regulated industries readiness (v1.5)
+
+Items required before a bank, insurer, or healthcare provider can deploy
+Agent Receipts in production. These are not optional for adoption in
+regulated industries.
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #TBD | planned |
+| RFC 3161 TSA timestamp anchoring (elevated from v2) | ADR-0019 § P3 | #TBD | planned |
+| Revocation list format and reference implementation (elevated from v2) | ADR-0019 § O1 | #TBD | planned |
+| `CheckpointPublisher` with object-lock reference backend (elevated from v2) | ADR-0019 § O2 | #TBD | planned |
+| Content-addressed payload storage (GDPR erasure) | ADR-0019 § S3 (extends) | #TBD | planned |
+| Standalone verifier service (separable from SDK) | new ADR needed | #TBD | planned |
+| Downloadable conformance test suite | ADR-0019 § S1 (extends) | #TBD | planned |
+| Multi-tenancy guidance — key management at scale | docs | #TBD | planned |
+| Regional TSA support (eIDAS, ICP-Brasil, etc.) | new ADR needed | #TBD | planned |
+
+These items have a coherent target audience (regulated-industries adopters) and
+should be sequenced together rather than dripped into v2. Moving them to
+v1.5 surfaces them as a deliberate milestone rather than indefinitely
+deferred work.
+
+---
+
+## Post 3 blockers
+
+These are the minimum subset of v1 work required before the HN-targeted
+OpenClaw demo. The criterion is "would a sharp commenter immediately spot
+this and undermine the protocol's credibility?"
+
+| # | Item | ADR | Issue | Status |
+|---|---|---|---|---|
+| 1 | Cross-SDK canonicalisation conformance vectors | ADR-0019 § S1 | #TBD | planned |
+| 2 | Silent chain termination — `status` field on `agent_end` | ADR-0019 § P1 | #TBD | planned |
+| 3 | `GeneratingKeyProvider` unreachable in production | ADR-0019 § S2 | #TBD | planned |
+| 4 | Sequential receipt construction enforced under parallel tool calls | ADR-0020 | #TBD | planned |
+
+Item 4 is in this list because the OpenClaw plugin may fire concurrent tool
+invocations during the demo. If concurrent emission produces a broken chain
+live on HN, that is the failure mode that gets quoted in the top comment.
+
+---
+
+## v1 blockers (post Post 3)
+
+Everything required for a credible public protocol release. Grouped by
+workstream rather than priority — items within a workstream are ordered;
+across workstreams they can be parallelised.
+
+### Protocol semantics
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| Explicit `sessionId` binding in verifier | ADR-0019 § P4 | #TBD | planned |
+| Strict `sequenceNumber` contiguity in verifier | ADR-0019 § P5 | #TBD | planned |
+| `idempotencyKey` field for retry deduplication | ADR-0019 § S5 | #TBD | planned |
+
+### SDK emitter layer
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| `HttpEmitter` with sync / fire-and-forget strategies | ADR-0020 | #TBD | planned |
+| WAL for at-least-once delivery (long-lived + ephemeral) | ADR-0020 | #TBD | planned |
+| Verifier-side `incomplete_tool_roundtrip` classification | ADR-0019 § O3 → ADR-0020 | (folded into WAL issue) | planned |
+
+### SDK payload handling
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| Bounded `input`/`output` payload via `PayloadStrategy` | ADR-0019 § S3 | #TBD | planned |
+
+### Cross-SDK parity
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| Python SDK `eventType` naming alignment | ADR-0019 § S1 | (folded into conformance vectors) | planned |
+| `KeyProvider` / `Signer` parity across TS, Python, Go | ADR-0018 | tracked per-SDK | planned |
+| `HttpEmitter` parity across TS, Python, Go | ADR-0020 | tracked per-SDK | planned |
+
+---
+
+## v2 — deferred
+
+Items remaining for v2 after the regulated-industries elevation. Each has
+an issue open; none are scheduled.
+
+| Item | ADR | Issue | Status |
+|---|---|---|---|
+| Unauthenticated chain origin (witnessed `agent_start` or trust registry) | ADR-0019 § P2 | #TBD | deferred |
+| `InMemoryKeyProvider` memory safety improvements | ADR-0019 § S4 | #TBD | deferred |
+| Parallel sub-chains (forked chains + merge receipt) | ADR-0020 | not filed | deferred |
+
+The following were originally targeted for v2 but elevated to v1.5
+(regulated-industries readiness):
+
+- Trusted timestamp binding (ADR-0019 § P3)
+- Key revocation (ADR-0019 § O1)
+- Receipt store completeness (ADR-0019 § O2)
+
+---
+
+## How to update this document
+
+- A new ADR adds items here; the ADR itself only records the decision.
+- An item moves between milestones (e.g. v1 → Post 3, or v1 → v2) by editing
+  this file. The originating ADR is not amended.
+- An item is marked `done` only when the corresponding issue is closed.
+- When item numbers in ADR-0019's priority table conflict with this roadmap,
+  this roadmap is authoritative.
+
+## ADR index
+
+| ADR | Title | Status |
+|---|---|---|
+| ADR-0018 | Signer abstraction and cloud-agnostic KeyProvider design | Accepted |
+| ADR-0019 | Protocol integrity gaps and mitigations | Proposed |
+| ADR-0020 | Emitter abstraction and remote receipt delivery | Proposed |

--- a/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
+++ b/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
@@ -146,10 +146,10 @@ attributable to a logical agent rather than to an arbitrary compute instance.
 ## Known limitations
 
 - `InMemoryKeyProvider` holds private key bytes as plain heap memory. No
-  memory safety guarantees. See issue #TBD.
+  memory safety guarantees. See issue #485.
 - `did:key` has no revocation mechanism. Key compromise requires out-of-band
-  notification and a new agent identity. See issue #TBD.
-- Timestamp binding is self-reported. See ADR-0019 and issue #TBD.
+  notification and a new agent identity. See issue #483.
+- Timestamp binding is self-reported. See ADR-0019 and issue #482.
 
 ## Related ADRs
 

--- a/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
+++ b/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
@@ -24,8 +24,8 @@ dependencies into the core package, which is unacceptable.
 // @agnt-rcpt/sdk-ts (core)
 
 export interface KeyPair {
-  publicKey: Uint8Array   // 32 bytes, Ed25519
-  privateKey: Uint8Array  // 32 bytes, Ed25519
+  publicKey: string   // SPKI-encoded PEM (Ed25519) — matches existing SDKs and daemon
+  privateKey: string  // PKCS8-encoded PEM (Ed25519) — matches existing SDKs and daemon
 }
 
 // For environments where key bytes are accessible locally
@@ -36,9 +36,17 @@ export interface KeyProvider {
 // For environments where the private key is never extractable
 export interface Signer {
   sign(message: Uint8Array): Promise<Uint8Array>
-  getPublicKey(): Promise<Uint8Array>
+  getPublicKey(): Promise<Uint8Array>  // 32 raw bytes per RFC 8032 §5.1.5
 }
 ```
+
+`KeyPair` carries PKCS8/PEM strings to match the form already used across
+the TypeScript, Go, and Python SDKs and the daemon's on-disk key
+(`daemon/cmd/agent-receipts-daemon/main.go`). `Signer.getPublicKey()`
+returns the raw 32-byte public key — the canonical on-chain encoding
+defined in ADR-0015 — because remote signers (KMS / HSM / TPM) typically
+expose the public key but never the private. See § "Key material
+encoding" below.
 
 `AgentReceiptsClient` accepts a `Signer`. `KeyProvider` is a convenience
 abstraction; all built-in `KeyProvider` implementations wrap themselves
@@ -50,7 +58,7 @@ implementations implement `Signer` directly and never expose a `KeyPair`.
 | Provider | Behaviour | Use case |
 |---|---|---|
 | `FileKeyProvider` | Reads keypair from a file path. Does not auto-generate in production mode (see known limitations). | Dev, long-lived compute with persistent volume |
-| `EnvVarKeyProvider` | Reads `AGENTRECEIPTS_KEY` (base58-encoded key value). Shares the env var name with the daemon (`daemon/README.md`), which interprets the value as a file path; the SDK's `EnvVarKeyProvider` interprets it as the key value directly. The deployment picks the form appropriate to its consumer. | Lambda/Cloud Run baseline, CI |
+| `EnvVarKeyProvider` | Reads `AGENTRECEIPTS_KEY` as a multibase `u`-prefixed base64url-encoded 32-byte Ed25519 seed (RFC 8032 §5.1.5), matching ADR-0001 / ADR-0015 on-chain encoding. Unwraps to PKCS8/PEM internally before handing to the rest of the SDK. The same env var name is used by the daemon, which interprets the value as a file path; the deployment picks the form appropriate to its consumer (path for daemon and SDK `FileKeyProvider`; multibase seed for SDK `EnvVarKeyProvider`). | Lambda/Cloud Run baseline, CI |
 | `InMemoryKeyProvider` | Caller supplies raw `KeyPair` bytes directly. No I/O. Makes no memory safety guarantees (see known limitations). | Tests, delegation target for external-fetch adapters |
 | `GeneratingKeyProvider` | Generates a fresh keypair and delegates persistence to a backing `KeyProvider`. Throws if `AGENTRECEIPTS_PRODUCTION=true`. | Dev and bootstrap only |
 
@@ -119,9 +127,26 @@ SDK to fetch it.
 SDK environment variables use the `AGENTRECEIPTS_` prefix to match existing
 project conventions (`AGENTRECEIPTS_SOCKET`, `AGENTRECEIPTS_KEY`,
 `AGENTRECEIPTS_DB`, etc. — see `daemon/README.md`). `AGENTRECEIPTS_KEY` is
-shared with the daemon by name; its value form depends on the consumer (file
-path for the daemon and the SDK's `FileKeyProvider`; base58-encoded key
-value for the SDK's `EnvVarKeyProvider`).
+shared with the daemon by name; its value form depends on the consumer:
+file path for the daemon and the SDK's `FileKeyProvider`; multibase
+`u`-prefixed base64url of the 32-byte Ed25519 seed for the SDK's
+`EnvVarKeyProvider` (per ADR-0001 / ADR-0015 on-chain encoding).
+
+### Key material encoding
+
+The SDK works with two forms for Ed25519 key material:
+
+| Form | Where | Why |
+|---|---|---|
+| PKCS8/PEM string | `KeyPair.publicKey` / `KeyPair.privateKey`, `FileKeyProvider`, daemon on-disk storage | Self-describing (PKCS8 carries the algorithm identifier — supports the future PQC algorithm-agility implied by ADR-0015). Operator-familiar (works with `openssl`, standard tooling). Matches the existing TS/Go/Python SDKs and the daemon |
+| Raw bytes + multibase `u`-base64url | On-chain (signatures per ADR-0001, public keys per ADR-0015), `EnvVarKeyProvider` env-var value | Compact (~43 chars for a 32-byte Ed25519 seed — practical for env-var injection in ephemeral compute). Matches the on-chain encoding |
+
+`EnvVarKeyProvider` is the only built-in provider that consumes the raw
+form; it decodes the multibase seed and reconstructs the PKCS8/PEM `KeyPair`
+before handing off to the rest of the SDK. `KMSSigner`, `TPMSigner`, and
+other `Signer` implementations expose neither form — they never reveal
+private key material; only `Signer.getPublicKey()` is observable
+externally, and it returns the canonical raw 32-byte form.
 
 ### Session continuity
 

--- a/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
+++ b/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
@@ -50,7 +50,7 @@ implementations implement `Signer` directly and never expose a `KeyPair`.
 | Provider | Behaviour | Use case |
 |---|---|---|
 | `FileKeyProvider` | Reads keypair from a file path. Does not auto-generate in production mode (see known limitations). | Dev, long-lived compute with persistent volume |
-| `EnvVarKeyProvider` | Reads `AGENTRECEIPTS_SIGNING_KEY` (base58-encoded). Caller responsible for how the value entered the environment. | Lambda/Cloud Run baseline, CI |
+| `EnvVarKeyProvider` | Reads `AGENTRECEIPTS_KEY` (base58-encoded key value). Shares the env var name with the daemon (`daemon/README.md`), which interprets the value as a file path; the SDK's `EnvVarKeyProvider` interprets it as the key value directly. The deployment picks the form appropriate to its consumer. | Lambda/Cloud Run baseline, CI |
 | `InMemoryKeyProvider` | Caller supplies raw `KeyPair` bytes directly. No I/O. Makes no memory safety guarantees (see known limitations). | Tests, delegation target for external-fetch adapters |
 | `GeneratingKeyProvider` | Generates a fresh keypair and delegates persistence to a backing `KeyProvider`. Throws if `AGENTRECEIPTS_PRODUCTION=true`. | Dev and bootstrap only |
 
@@ -118,7 +118,10 @@ SDK to fetch it.
 
 SDK environment variables use the `AGENTRECEIPTS_` prefix to match existing
 project conventions (`AGENTRECEIPTS_SOCKET`, `AGENTRECEIPTS_KEY`,
-`AGENTRECEIPTS_DB`, etc. — see `daemon/README.md`).
+`AGENTRECEIPTS_DB`, etc. — see `daemon/README.md`). `AGENTRECEIPTS_KEY` is
+shared with the daemon by name; its value form depends on the consumer (file
+path for the daemon and the SDK's `FileKeyProvider`; base58-encoded key
+value for the SDK's `EnvVarKeyProvider`).
 
 ### Session continuity
 

--- a/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
+++ b/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
@@ -50,9 +50,9 @@ implementations implement `Signer` directly and never expose a `KeyPair`.
 | Provider | Behaviour | Use case |
 |---|---|---|
 | `FileKeyProvider` | Reads keypair from a file path. Does not auto-generate in production mode (see known limitations). | Dev, long-lived compute with persistent volume |
-| `EnvVarKeyProvider` | Reads `AR_SIGNING_KEY` (base58-encoded). Caller responsible for how the value entered the environment. | Lambda/Cloud Run baseline, CI |
+| `EnvVarKeyProvider` | Reads `AGENTRECEIPTS_SIGNING_KEY` (base58-encoded). Caller responsible for how the value entered the environment. | Lambda/Cloud Run baseline, CI |
 | `InMemoryKeyProvider` | Caller supplies raw `KeyPair` bytes directly. No I/O. Makes no memory safety guarantees (see known limitations). | Tests, delegation target for external-fetch adapters |
-| `GeneratingKeyProvider` | Generates a fresh keypair and delegates persistence to a backing `KeyProvider`. Throws if `AR_PRODUCTION=true`. | Dev and bootstrap only |
+| `GeneratingKeyProvider` | Generates a fresh keypair and delegates persistence to a backing `KeyProvider`. Throws if `AGENTRECEIPTS_PRODUCTION=true`. | Dev and bootstrap only |
 
 ### External adapters (user-land, separate packages)
 
@@ -112,8 +112,13 @@ idiomatic form.
 
 Key generation in production is a deliberate out-of-band operation, not
 an automatic SDK behaviour. `GeneratingKeyProvider` is explicitly prohibited
-in production environments (`AR_PRODUCTION=true`). Production deployments
-provision the keypair via their secret store and configure the SDK to fetch it.
+in production environments (`AGENTRECEIPTS_PRODUCTION=true`). Production
+deployments provision the keypair via their secret store and configure the
+SDK to fetch it.
+
+SDK environment variables use the `AGENTRECEIPTS_` prefix to match existing
+project conventions (`AGENTRECEIPTS_SOCKET`, `AGENTRECEIPTS_KEY`,
+`AGENTRECEIPTS_DB`, etc. — see `daemon/README.md`).
 
 ### Session continuity
 

--- a/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
+++ b/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md
@@ -1,0 +1,158 @@
+# ADR-0018: Signer Abstraction and Cloud-Agnostic KeyProvider Design
+
+## Status
+
+Proposed — supersedes a prior keypair management design (keypair management ADR not yet filed in this repository)
+
+## Context
+
+A prior design established that keypair management must support ephemeral compute
+(Lambda, Cloud Run, Fargate) and long-lived compute (EC2, bare metal, VMs).
+During design review it became clear that `KeyProvider` — which returns raw
+key bytes — cannot model environments where the private key is never
+extractable (KMS, HSM, TPM). A second abstraction is required.
+
+Additionally, the prior design implied cloud-specific implementations would ship
+inside the core SDK package. This would introduce transitive cloud SDK
+dependencies into the core package, which is unacceptable.
+
+## Decision
+
+### Two interfaces, one in core
+
+```typescript
+// @agnt-rcpt/sdk-ts (core)
+
+export interface KeyPair {
+  publicKey: Uint8Array   // 32 bytes, Ed25519
+  privateKey: Uint8Array  // 32 bytes, Ed25519
+}
+
+// For environments where key bytes are accessible locally
+export interface KeyProvider {
+  getKeyPair(): Promise<KeyPair>
+}
+
+// For environments where the private key is never extractable
+export interface Signer {
+  sign(message: Uint8Array): Promise<Uint8Array>
+  getPublicKey(): Promise<Uint8Array>
+}
+```
+
+`AgentReceiptsClient` accepts a `Signer`. `KeyProvider` is a convenience
+abstraction; all built-in `KeyProvider` implementations wrap themselves
+as a `Signer` using local key bytes. Cloud-specific and hardware-backed
+implementations implement `Signer` directly and never expose a `KeyPair`.
+
+### Built-in providers (ship in the core SDK package, zero external dependencies)
+
+| Provider | Behaviour | Use case |
+|---|---|---|
+| `FileKeyProvider` | Reads keypair from a file path. Does not auto-generate in production mode (see known limitations). | Dev, long-lived compute with persistent volume |
+| `EnvVarKeyProvider` | Reads `AR_SIGNING_KEY` (base58-encoded). Caller responsible for how the value entered the environment. | Lambda/Cloud Run baseline, CI |
+| `InMemoryKeyProvider` | Caller supplies raw `KeyPair` bytes directly. No I/O. Makes no memory safety guarantees (see known limitations). | Tests, delegation target for external-fetch adapters |
+| `GeneratingKeyProvider` | Generates a fresh keypair and delegates persistence to a backing `KeyProvider`. Throws if `AR_PRODUCTION=true`. | Dev and bootstrap only |
+
+### External adapters (user-land, separate packages)
+
+Cloud-specific and hardware adapters are published as separate packages.
+The core SDK package has zero knowledge of any cloud provider. Package
+names below are TypeScript-flavoured; see the "Package boundaries" section
+below for Python and Go equivalents.
+
+| Package | Adapter | Interface | Notes |
+|---|---|---|---|
+| `@agnt-rcpt/sdk-ts-aws` | `SecretsManagerKeyProvider` | `KeyProvider` | Fetches from AWS Secrets Manager using instance role. Caches in-process (one fetch per cold start). Delegates to `InMemoryKeyProvider`. |
+| `@agnt-rcpt/sdk-ts-aws` | `KMSSigner` | `Signer` | Signs via AWS KMS API. Private key never leaves KMS. |
+| `@agnt-rcpt/sdk-ts-gcp` | `SecretManagerKeyProvider` | `KeyProvider` | GCP Secret Manager equivalent. |
+| `@agnt-rcpt/sdk-ts-gcp` | `CloudKMSSigner` | `Signer` | GCP Cloud KMS equivalent. |
+| `@agnt-rcpt/sdk-ts-tpm` | `TPMSigner` | `Signer` | TPM2 on Linux via tpm2-tss binding. Key generated inside TPM, never extractable. |
+| user-land | any | `KeyProvider` or `Signer` | Implement either interface — no SDK changes required. |
+
+### Package boundaries
+
+The split between core and cloud adapters is itself a design decision, not
+an incidental packaging choice. The principle: **the core SDK package has
+zero cloud or hardware dependencies; every cloud or hardware adapter ships
+as a separate, independently versioned unit.**
+
+Each SDK implements this split in its language-idiomatic way:
+
+| SDK | Core | AWS adapter | GCP adapter | TPM adapter |
+|---|---|---|---|---|
+| TypeScript | `@agnt-rcpt/sdk-ts` | `@agnt-rcpt/sdk-ts-aws` | `@agnt-rcpt/sdk-ts-gcp` | `@agnt-rcpt/sdk-ts-tpm` |
+| Python | `agent-receipts` | `agent-receipts[aws]` | `agent-receipts[gcp]` | `agent-receipts[tpm]` |
+| Go | `github.com/agent-receipts/ar/sdk/go` | `…/sdk/go/aws` (separate module) | `…/sdk/go/gcp` (separate module) | `…/sdk/go/tpm` (separate module) |
+
+TypeScript adapter packages declare core as a `peerDependency` to guarantee
+a single core copy at runtime. Each Go adapter is its own module (separate
+`go.mod`), so a project that does not import the AWS adapter never pulls
+the AWS SDK into its dependency closure — at the cost of independent
+versioning across modules. Python extras pull in the cloud SDK only when
+explicitly requested (`pip install agent-receipts[aws]`).
+
+References throughout this ADR use TypeScript package names for
+concreteness; the same packaging principle applies in each SDK's
+idiomatic form.
+
+### Recommended provider by deployment target
+
+| Environment | Recommended | Interface |
+|---|---|---|
+| Dev / local | `FileKeyProvider` (auto-generate on first run permitted) | `KeyProvider` |
+| CI / test | `InMemoryKeyProvider` (injected fixture keypair) | `KeyProvider` |
+| Lambda / Cloud Run / Fargate | `EnvVarKeyProvider` or `SecretsManagerKeyProvider` | `KeyProvider` |
+| EC2 / VM (baseline) | `FileKeyProvider` (chmod 600, OS keyring encryption at rest) | `KeyProvider` |
+| EC2 / VM (better) | `SecretsManagerKeyProvider` (instance role as trust anchor) | `KeyProvider` |
+| Bare metal / EC2 (best) | `TPMSigner` | `Signer` |
+| KMS / HSM anywhere | `KMSSigner` or equivalent | `Signer` |
+
+### Key generation policy
+
+Key generation in production is a deliberate out-of-band operation, not
+an automatic SDK behaviour. `GeneratingKeyProvider` is explicitly prohibited
+in production environments (`AR_PRODUCTION=true`). Production deployments
+provision the keypair via their secret store and configure the SDK to fetch it.
+
+### Session continuity
+
+The keypair must be stable within a session. The SDK validates on every
+receipt emission that the signing DID matches the DID recorded in the
+session's `agent_start` receipt. A mismatch throws `KeyMismatchError`
+rather than silently producing an unverifiable chain.
+
+Key rotation is not supported within an active session. Rotation requires
+completing the current session (`agent_end`) and starting a new one with
+`previousReceiptHash: null`.
+
+### Identity scoping
+
+One keypair per agent type per deployment stage. All instances of the same
+logical agent in the same stage share a DID. This keeps audit trails
+attributable to a logical agent rather than to an arbitrary compute instance.
+
+## Consequences
+
+- The core SDK package has zero cloud or hardware dependencies.
+- Adding support for a new secret store or HSM requires no changes to core —
+  implement `KeyProvider` or `Signer` and publish a separate package.
+- KMS, HSM, and TPM deployments must implement `Signer`; `KeyProvider` alone
+  cannot model environments where the private key is never extractable.
+- Cross-SDK compatibility (TypeScript, Python, Go) requires equivalent
+  built-in providers in each SDK and a shared conformance test suite
+  (see ADR-0019).
+
+## Known limitations
+
+- `InMemoryKeyProvider` holds private key bytes as plain heap memory. No
+  memory safety guarantees. See issue #TBD.
+- `did:key` has no revocation mechanism. Key compromise requires out-of-band
+  notification and a new agent identity. See issue #TBD.
+- Timestamp binding is self-reported. See ADR-0019 and issue #TBD.
+
+## Related ADRs
+
+- ADR-0019 — Protocol integrity gaps and mitigations (depends on Signer)
+- ADR-0020 — Emitter abstraction and remote receipt delivery (composes with
+  Signer to support ephemeral compute end-to-end)

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -104,17 +104,23 @@ recommended operationally. See also O2 (store completeness).
 
 #### S1: Cross-SDK canonicalisation conformance vectors missing
 
-**Gap.** URDNA2015 implementations differ subtly across languages. The
-Python SDK also has residual Attest Protocol naming (e.g. `eventType:
-"attest"`) that diverges from the canonical vocabulary. Mixed-language
-chains may silently fail to verify.
+**Gap.** RFC 8785 / JCS implementations (per ADR-0002 and ADR-0009)
+may diverge subtly across language SDKs on edge cases: UTF-16 code unit
+ordering of non-ASCII keys, ES6 `Number.toString()` semantics, Unicode
+normalisation of string values. ADR-0002 § Unicode edge cases catalogues
+two latent bugs of this class (Python's UTF-16-LE byte sort #86, Go's
+`sort.Strings()` #82). The Python SDK also has residual Attest Protocol
+naming (e.g. `eventType: "attest"`) that diverges from the canonical
+vocabulary committed in ADR-0009. Mixed-language chains may silently fail
+to verify.
 
 **Decision.** Mandatory before v1 release. Produce a cross-SDK conformance
-test suite: fixed receipt JSON-LD documents with known canonical forms and
-known SHA-256 hash values. All three SDKs must produce and verify
-identically. Fix Python SDK `eventType` naming as part of this work.
-Round-trip matrix: TypeScript → Python, TypeScript → Go, Python → Go,
-and all reverse directions.
+test suite: fixed receipt JSON-LD documents (W3C VC envelope per ADR-0003)
+with known canonical RFC 8785 byte forms and known SHA-256 hash values.
+All three SDKs must produce and verify identically. Fix Python SDK
+`eventType` naming as part of this work. Round-trip matrix:
+TypeScript → Python, TypeScript → Go, Python → Go, and all reverse
+directions.
 
 **Issue.** #474
 

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -56,9 +56,10 @@ given DID is a legitimate agent. Evaluate trust registry and witnessed
 **Gap.** `issuanceDate` is self-reported. An agent or attacker with the
 signing key can backdate or forward-date receipts.
 
-**Decision.** Deferred to v2. Document as a known limitation. Evaluate
-RFC 3161 TSA per-receipt anchoring and periodic chain-head anchoring to
-an append-only public log for v2.
+**Decision.** Deferred from v1; sequenced for v1.5 (regulated-industries
+milestone — RFC 3161 TSA is a compliance requirement in financial services
+and healthcare). Documented as a known limitation in v1. See ROADMAP.md
+for authoritative milestone placement.
 
 **Issue.** #482
 
@@ -198,10 +199,13 @@ legitimate. SDK and MCP proxy to populate automatically where possible.
 an agent's private key is compromised, all historical receipts are suspect
 and there is no way to publish a revocation.
 
-**Decision.** For v1: document the limitation. Publish a signed revocation
-list format (a JSON-LD document listing compromised DIDs with compromise
-timestamps, signed by a well-known Agent Receipts registry key) for v2.
-Evaluate migration path to `did:web` for deployments requiring rotation.
+**Decision.** Document the limitation in v1. Sequenced for v1.5
+(regulated-industries milestone — revocation is a compliance gate):
+publish a signed revocation list format (a JSON-LD document listing
+compromised DIDs with compromise timestamps, signed by a well-known Agent
+Receipts registry key). Evaluate migration path to `did:web` for
+deployments requiring rotation. See ROADMAP.md for authoritative milestone
+placement.
 
 **Issue.** #483
 
@@ -216,7 +220,9 @@ Deleting entire sessions from the store is undetectable by the protocol.
 external append-only log as an operational control. This is out of scope
 for the core protocol but should be documented as a recommended deployment
 practice. An optional `CheckpointPublisher` interface in the SDK can
-facilitate this without mandating a specific backend.
+facilitate this without mandating a specific backend. Sequenced for v1.5
+(regulated-industries milestone — store-completeness evidence is a
+compliance gate). See ROADMAP.md for authoritative milestone placement.
 
 **Issue.** #484
 
@@ -263,9 +269,9 @@ classification is retained.
 | 7 | P5 — Sequence gap enforcement | Low | Before v1 |
 | 8 | S5 — Idempotency key | Low | Before v1 |
 | 9 | P2 — Unauthenticated chain origin | High | v2 |
-| 10 | P3 — Trusted timestamp binding | Medium | v2 |
-| 11 | O1 — Key revocation | High | v2 |
-| 12 | O2 — Store completeness | Medium | v2 |
+| 10 | P3 — Trusted timestamp binding | Medium | v1.5 |
+| 11 | O1 — Key revocation | High | v1.5 |
+| 12 | O2 — Store completeness | Medium | v1.5 |
 | 13 | S4 — InMemoryKeyProvider memory safety | Medium | v2 |
 
 ¹ Superseded by ADR-0020. The WAL has moved to the SDK emitter layer; see
@@ -276,6 +282,10 @@ ADR-0020 for the current v1-blocker tracking. The verifier-side
 
 - Items 1–3 are blockers for Post 3 / HN submission.
 - Items 4–8 are blockers for v1 release.
-- Items 9–13 are documented known limitations in v1, targeted for v2.
+- Items 10–12 (P3 timestamps, O1 revocation, O2 store completeness) are
+  documented known limitations in v1, sequenced for v1.5 (regulated-
+  industries milestone).
+- Items 9 (P2) and 13 (S4) are documented known limitations in v1,
+  deferred to v2.
 - Each gap has a corresponding GitHub issue. This ADR is the authoritative
   record of the decision; issues track implementation progress.

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -7,7 +7,7 @@ Proposed
 ## Context
 
 A structured stress test of the Agent Receipts protocol and SDK design
-identified thirteen gaps across four categories: protocol design, SDK
+identified thirteen gaps across three categories: protocol design, SDK
 implementation, and operational concerns. This ADR documents each gap,
 the decision taken (or deferred), and the rationale.
 
@@ -126,9 +126,9 @@ enforces this. A misconfigured production deployment silently generates
 a new DID on every cold start with no error surfaced.
 
 **Decision.** `GeneratingKeyProvider` throws `ProductionKeyProviderError`
-if instantiated when `AR_PRODUCTION=true`. Emits a loud stderr warning
-in all other non-production cases. Documented explicitly in the deployment
-guide. Applies to all three SDKs.
+if instantiated when `AGENTRECEIPTS_PRODUCTION=true`. Emits a loud stderr
+warning in all other non-production cases. Documented explicitly in the
+deployment guide. Applies to all three SDKs.
 
 **Issue.** #476
 

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -31,7 +31,7 @@ receipt. Auditors cannot distinguish a completed session from a crashed one.
 must flag chains without a terminal receipt as `status: unknown` rather
 than treating them as valid complete chains.
 
-**Issue.** #TBD
+**Issue.** #475
 
 ---
 
@@ -47,7 +47,7 @@ integrity proofs are internal only — the protocol does not assert that a
 given DID is a legitimate agent. Evaluate trust registry and witnessed
 `agent_start` options for v2.
 
-**Issue.** #TBD
+**Issue.** #481
 
 ---
 
@@ -60,7 +60,7 @@ signing key can backdate or forward-date receipts.
 RFC 3161 TSA per-receipt anchoring and periodic chain-head anchoring to
 an append-only public log for v2.
 
-**Issue.** #TBD
+**Issue.** #482
 
 ---
 
@@ -75,7 +75,7 @@ but verifiers should enforce it explicitly.
 match the session being verified. Add explicit sessionId binding check to
 the verification algorithm in the spec and all three SDK verifiers.
 
-**Issue.** #TBD
+**Issue.** #477
 
 ---
 
@@ -93,7 +93,7 @@ Document that the store is a trusted component; store-level integrity
 (checksums, append-only backend) is out of scope for the protocol but
 recommended operationally. See also O2 (store completeness).
 
-**Issue.** #TBD
+**Issue.** #479
 
 ---
 
@@ -115,7 +115,7 @@ identically. Fix Python SDK `eventType` naming as part of this work.
 Round-trip matrix: TypeScript → Python, TypeScript → Go, Python → Go,
 and all reverse directions.
 
-**Issue.** #TBD
+**Issue.** #474
 
 ---
 
@@ -130,7 +130,7 @@ if instantiated when `AR_PRODUCTION=true`. Emits a loud stderr warning
 in all other non-production cases. Documented explicitly in the deployment
 guide. Applies to all three SDKs.
 
-**Issue.** #TBD
+**Issue.** #476
 
 ---
 
@@ -152,7 +152,7 @@ Default recommendation: option 2 for production, option 1 for dev
 convenience. SDK to provide both via a `PayloadStrategy` interface.
 Decision to be finalised in a follow-up ADR.
 
-**Issue.** #TBD
+**Issue.** #478
 
 ---
 
@@ -167,7 +167,7 @@ key bytes from the source buffer after copying into the provider.
 Platform-level memory protection (mlock, secure enclave) is out of scope
 for v1 but noted as a v2 improvement.
 
-**Issue.** #TBD
+**Issue.** #485
 
 ---
 
@@ -184,7 +184,7 @@ Callers may set this to a stable identifier for the logical operation
 `idempotencyKey` values as a warning, not a failure — retries are
 legitimate. SDK and MCP proxy to populate automatically where possible.
 
-**Issue.** #TBD
+**Issue.** #480
 
 ---
 
@@ -203,7 +203,7 @@ list format (a JSON-LD document listing compromised DIDs with compromise
 timestamps, signed by a well-known Agent Receipts registry key) for v2.
 Evaluate migration path to `did:web` for deployments requiring rotation.
 
-**Issue.** #TBD
+**Issue.** #483
 
 ---
 
@@ -218,7 +218,7 @@ for the core protocol but should be documented as a recommended deployment
 practice. An optional `CheckpointPublisher` interface in the SDK can
 facilitate this without mandating a specific backend.
 
-**Issue.** #TBD
+**Issue.** #484
 
 ---
 

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -1,0 +1,281 @@
+# ADR-0019: Protocol Integrity Gaps and Mitigations
+
+## Status
+
+Proposed
+
+## Context
+
+A structured stress test of the Agent Receipts protocol and SDK design
+identified thirteen gaps across four categories: protocol design, SDK
+implementation, and operational concerns. This ADR documents each gap,
+the decision taken (or deferred), and the rationale.
+
+Each gap has a corresponding GitHub issue for implementation tracking.
+This ADR records the design decisions; the issues track the work.
+
+## Gaps and decisions
+
+### Protocol gaps
+
+---
+
+#### P1: Silent chain termination on SDK or process failure
+
+**Gap.** If the SDK throws mid-session the chain stops with no terminal
+receipt. Auditors cannot distinguish a completed session from a crashed one.
+
+**Decision.** Add a `status` field to `agent_end`:
+`complete | interrupted | unknown`. The MCP proxy attempts a best-effort
+`agent_end { status: interrupted }` on SIGTERM/SIGINT. Verifier tooling
+must flag chains without a terminal receipt as `status: unknown` rather
+than treating them as valid complete chains.
+
+**Issue.** #TBD
+
+---
+
+#### P2: Unauthenticated chain origin
+
+**Gap.** An attacker who can write to the receipt store can inject a
+fabricated `agent_start` receipt with `previousReceiptHash: null` and a
+freshly generated keypair. The chain verifies internally but is entirely
+fabricated.
+
+**Decision.** Deferred to v2. For v1, document explicitly that chain
+integrity proofs are internal only — the protocol does not assert that a
+given DID is a legitimate agent. Evaluate trust registry and witnessed
+`agent_start` options for v2.
+
+**Issue.** #TBD
+
+---
+
+#### P3: No trusted timestamp binding
+
+**Gap.** `issuanceDate` is self-reported. An agent or attacker with the
+signing key can backdate or forward-date receipts.
+
+**Decision.** Deferred to v2. Document as a known limitation. Evaluate
+RFC 3161 TSA per-receipt anchoring and periodic chain-head anchoring to
+an append-only public log for v2.
+
+**Issue.** #TBD
+
+---
+
+#### P4: Session ID not explicitly bound in signing input
+
+**Gap.** Nothing prevents replaying a valid receipt from session A into
+session B. The signature verifies and the hash chains if constructed
+carefully. `sessionId` is in the credential body covered by the proof,
+but verifiers should enforce it explicitly.
+
+**Decision.** Verifiers must reject receipts whose `sessionId` does not
+match the session being verified. Add explicit sessionId binding check to
+the verification algorithm in the spec and all three SDK verifiers.
+
+**Issue.** #TBD
+
+---
+
+#### P5: Sequence gap attack
+
+**Gap.** `sequenceNumber` is monotonically increasing but does not enforce
+contiguity. Receipts can be deleted from the store without breaking the
+hash chain by re-signing every downstream receipt with an updated
+`previousReceiptHash` (requires the agent's signing key). Auditors cannot
+detect deletion without external evidence.
+
+**Decision.** Verifiers must enforce strict contiguity — any gap in
+`sequenceNumber` within a session is a verification failure, not a warning.
+Document that the store is a trusted component; store-level integrity
+(checksums, append-only backend) is out of scope for the protocol but
+recommended operationally. See also O2 (store completeness).
+
+**Issue.** #TBD
+
+---
+
+### SDK / implementation gaps
+
+---
+
+#### S1: Cross-SDK canonicalisation conformance vectors missing
+
+**Gap.** URDNA2015 implementations differ subtly across languages. The
+Python SDK also has residual Attest Protocol naming (e.g. `eventType:
+"attest"`) that diverges from the canonical vocabulary. Mixed-language
+chains may silently fail to verify.
+
+**Decision.** Mandatory before v1 release. Produce a cross-SDK conformance
+test suite: fixed receipt JSON-LD documents with known canonical forms and
+known SHA-256 hash values. All three SDKs must produce and verify
+identically. Fix Python SDK `eventType` naming as part of this work.
+Round-trip matrix: TypeScript → Python, TypeScript → Go, Python → Go,
+and all reverse directions.
+
+**Issue.** #TBD
+
+---
+
+#### S2: `GeneratingKeyProvider` reachable in production
+
+**Gap.** `GeneratingKeyProvider` is documented as dev-only but nothing
+enforces this. A misconfigured production deployment silently generates
+a new DID on every cold start with no error surfaced.
+
+**Decision.** `GeneratingKeyProvider` throws `ProductionKeyProviderError`
+if instantiated when `AR_PRODUCTION=true`. Emits a loud stderr warning
+in all other non-production cases. Documented explicitly in the deployment
+guide. Applies to all three SDKs.
+
+**Issue.** #TBD
+
+---
+
+#### S3: Unbounded `input`/`output` payload size
+
+**Gap.** `input` and `output` are serialised JSON strings with no size
+limit. Large LLM responses or tool payloads produce oversized receipts,
+degrading canonicalisation performance, blowing storage budgets, and making
+audit trails unreadable.
+
+**Decision.** Two options to evaluate:
+1. Configurable size cap with truncation — lossy but simple. Truncation
+   must be documented in the receipt (`truncated: true` flag).
+2. Content-addressed off-chain storage — store the SHA-256 hash of the
+   payload in the receipt, the payload in a separate store. Similar to
+   JWT detached payload.
+
+Default recommendation: option 2 for production, option 1 for dev
+convenience. SDK to provide both via a `PayloadStrategy` interface.
+Decision to be finalised in a follow-up ADR.
+
+**Issue.** #TBD
+
+---
+
+#### S4: `InMemoryKeyProvider` memory safety
+
+**Gap.** Private key bytes are held as plain `Uint8Array` on the heap,
+visible in heap dumps, `--inspect` sessions, and V8 snapshots.
+
+**Decision.** Document the limitation explicitly. Recommend against
+`InMemoryKeyProvider` in production. Production adapters should zero
+key bytes from the source buffer after copying into the provider.
+Platform-level memory protection (mlock, secure enclave) is out of scope
+for v1 but noted as a v2 improvement.
+
+**Issue.** #TBD
+
+---
+
+#### S5: No receipt deduplication / idempotency key
+
+**Gap.** If the MCP proxy wraps a tool call that the agent retries on
+timeout, two `tool_call` receipts are emitted for the same logical
+operation. Auditors cannot distinguish a legitimate retry from a
+duplicated emission.
+
+**Decision.** Add an optional `idempotencyKey` field to the event payload.
+Callers may set this to a stable identifier for the logical operation
+(e.g. a request ID). Verifier tooling should surface duplicate
+`idempotencyKey` values as a warning, not a failure — retries are
+legitimate. SDK and MCP proxy to populate automatically where possible.
+
+**Issue.** #TBD
+
+---
+
+### Operational gaps
+
+---
+
+#### O1: No key revocation path for `did:key`
+
+**Gap.** `did:key` has no DID Document and no revocation mechanism. If
+an agent's private key is compromised, all historical receipts are suspect
+and there is no way to publish a revocation.
+
+**Decision.** For v1: document the limitation. Publish a signed revocation
+list format (a JSON-LD document listing compromised DIDs with compromise
+timestamps, signed by a well-known Agent Receipts registry key) for v2.
+Evaluate migration path to `did:web` for deployments requiring rotation.
+
+**Issue.** #TBD
+
+---
+
+#### O2: Receipt store completeness guarantee
+
+**Gap.** Receipts are tamper-evident but the store that holds them is not.
+Deleting entire sessions from the store is undetectable by the protocol.
+
+**Decision.** Recommend periodic publication of chain-head hashes to an
+external append-only log as an operational control. This is out of scope
+for the core protocol but should be documented as a recommended deployment
+practice. An optional `CheckpointPublisher` interface in the SDK can
+facilitate this without mandating a specific backend.
+
+**Issue.** #TBD
+
+---
+
+#### O3: MCP proxy at-least-once receipt emission
+
+> **Superseded by ADR-0020.** The WAL has moved from the MCP proxy to the SDK
+> emitter layer, making it available regardless of whether the MCP proxy is
+> in use. The verifier-side requirement (treat `tool_call` without
+> `tool_result` as `incomplete_tool_roundtrip` rather than a generic chain
+> break) remains in force. See ADR-0020 § "At-least-once delivery and the WAL"
+> for the current design.
+
+**Gap (historical).** If the proxy crashes after a tool executes but before
+emitting the `tool_result` receipt, the tool ran but left no trace. This is
+indistinguishable from a tool that was called and never responded.
+
+**Decision (historical).** The MCP proxy must implement a write-ahead log
+(WAL) of pending receipts. A receipt is considered emitted only after it has
+been durably written to the WAL and acknowledged by the receipt store. On
+restart, the proxy replays any unacknowledged WAL entries. Verifier tooling
+must handle `tool_call` without `tool_result` as a distinct error case
+(`incomplete_tool_roundtrip`), not a generic chain break.
+
+**Current decision.** See ADR-0020. The verifier-side `incomplete_tool_roundtrip`
+classification is retained.
+
+---
+
+## Priority order
+
+> The table below is the priority ordering at the time this ADR was written.
+> For the current authoritative sequencing across all ADRs, see `ROADMAP.md`.
+
+| Priority | Gap | Effort | Target |
+|---|---|---|---|
+| 1 | S1 — Cross-SDK conformance vectors | Medium | Before v1 / Post 3 |
+| 2 | P1 — Silent chain termination | Low | Before v1 / Post 3 |
+| 3 | S2 — GeneratingKeyProvider in prod | Low | Before v1 / Post 3 |
+| 4 | P4 — Session ID binding in verifier | Low | Before v1 |
+| 5 | O3 — MCP proxy at-least-once ¹ | Medium | Before v1 |
+| 6 | S3 — Unbounded payload size | Low–Medium | Before v1 |
+| 7 | P5 — Sequence gap enforcement | Low | Before v1 |
+| 8 | S5 — Idempotency key | Low | Before v1 |
+| 9 | P2 — Unauthenticated chain origin | High | v2 |
+| 10 | P3 — Trusted timestamp binding | Medium | v2 |
+| 11 | O1 — Key revocation | High | v2 |
+| 12 | O2 — Store completeness | Medium | v2 |
+| 13 | S4 — InMemoryKeyProvider memory safety | Medium | v2 |
+
+¹ Superseded by ADR-0020. The WAL has moved to the SDK emitter layer; see
+ADR-0020 for the current v1-blocker tracking. The verifier-side
+`incomplete_tool_roundtrip` classification remains in force.
+
+## Consequences
+
+- Items 1–3 are blockers for Post 3 / HN submission.
+- Items 4–8 are blockers for v1 release.
+- Items 9–13 are documented known limitations in v1, targeted for v2.
+- Each gap has a corresponding GitHub issue. This ADR is the authoritative
+  record of the decision; issues track implementation progress.

--- a/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
+++ b/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
@@ -1,0 +1,228 @@
+# ADR-0020: Emitter Abstraction and Remote Receipt Delivery
+
+## Status
+
+Proposed
+
+## Context
+
+The initial MCP proxy design assumes a long-lived daemon process (sidecar or
+local socket) that handles signing, chaining, and storage on behalf of the
+agent. This works for long-lived compute but fails entirely in ephemeral
+environments (Lambda, Cloud Run, Fargate) where there is no persistent process
+between invocations. There is no sidecar to connect to, and a Lambda Extension
+— while technically feasible — is runtime-specific, adds cold start latency,
+and requires a compiled binary bundled with every deployment.
+
+A secondary concern: the MCP proxy design conflates three responsibilities —
+receipt construction, signing/chaining, and delivery. These should be
+separable.
+
+Two options were evaluated:
+
+**Option A — Lambda Extension.** A sidecar process registered with the Lambda
+Runtime API, surviving between warm invocations. Holds keypair in memory,
+handles signing and chaining, forwards to the receipt store. Discarded: too
+runtime-specific, operational overhead disproportionate to the benefit, and
+does not generalise to Cloud Run, Fargate, or bare metal.
+
+**Option B — Remote emitter over HTTPS.** The SDK emits completed, signed,
+chained receipts directly to a remote collector endpoint over HTTPS. No local
+daemon. The collector receives already-signed receipts and stores them — it has
+no role in chain construction. Adopted.
+
+## Decision
+
+### Emitter interface
+
+A new `Emitter` interface is added to the core SDK package (`@agnt-rcpt/sdk-ts` and equivalents — see ADR-0018 § "Package boundaries"):
+
+```typescript
+interface Emitter {
+  emit(receipt: SignedReceipt): Promise<void>
+}
+```
+
+Receipt construction, signing, and chaining remain client-side in all cases.
+The `Emitter` is responsible only for delivery. The collector is a dumb store —
+it receives complete, signed, already-chained receipts and persists them. It
+has no role in sequencing, hashing, or signing, and is therefore not a trusted
+component in chain construction.
+
+This preserves the core trust model: an auditor needs only the agent's public
+key to verify the entire chain. The collector cannot fabricate or alter
+receipts.
+
+### Built-in emitters (ship in the core SDK package)
+
+#### `HttpEmitter`
+
+Posts signed receipts to a remote HTTPS endpoint. Suitable for all deployment
+targets including ephemeral compute.
+
+```typescript
+interface HttpEmitterConfig {
+  endpoint: string
+  auth?: HttpEmitterAuth
+  strategy?: 'sync' | 'fire-and-forget'
+  retry?: RetryConfig
+  timeoutMs?: number
+}
+
+type HttpEmitterAuth =
+  | { type: 'api-key'; header: string; value: string }
+  | { type: 'bearer'; token: string }
+  | { type: 'mtls'; cert: Uint8Array; key: Uint8Array }
+  | { type: 'none' }
+```
+
+`strategy`:
+- `sync` (default) — `emit()` resolves when the collector acknowledges.
+  Provides at-least-once delivery. Recommended for production.
+- `fire-and-forget` — `emit()` resolves immediately after dispatch. No
+  delivery guarantee. Acceptable for high-throughput workloads where
+  occasional receipt loss is tolerable and latency matters.
+
+#### `DaemonEmitter`
+
+Sends receipts to a local daemon over a Unix socket or named pipe. Existing
+behaviour for long-lived compute deployments with a sidecar. Retained as a
+built-in for backwards compatibility.
+
+#### `CompositeEmitter`
+
+Forwards each receipt to multiple emitters in sequence. Useful for dual-write
+during migration (daemon + HTTP), or for writing to both a local store and a
+remote collector simultaneously.
+
+```typescript
+new CompositeEmitter([daemonEmitter, httpEmitter])
+```
+
+#### `BufferingEmitter`
+
+Wraps another emitter and buffers receipts in memory, flushing on a configurable
+interval or batch size. Useful for high-throughput agents where per-receipt HTTP
+round-trips are cost-prohibitive. Note: buffered receipts are lost if the
+process crashes before flush. Not recommended where audit completeness is
+critical.
+
+#### `InMemoryEmitter`
+
+Holds received receipts in an exposed in-memory array for inspection. Used
+as a test double in unit and integration tests. Performs no I/O and provides
+no delivery guarantee — assertion against captured receipts is the entire
+point. Not for production use.
+
+### Recommended emitter by deployment target
+
+| Environment | Recommended emitter | Notes |
+|---|---|---|
+| Dev / local | `DaemonEmitter` or `HttpEmitter` (localhost) | Local daemon or local collector |
+| CI / test | `InMemoryEmitter` (test double) | No I/O, assertions on emitted receipts |
+| Lambda / Cloud Run / Fargate | `HttpEmitter` (sync) | Only viable option; collector must be reachable from the function VPC |
+| EC2 / VM | `DaemonEmitter` or `HttpEmitter` | Either works; daemon preferred if sidecar already present |
+| Bare metal | `DaemonEmitter` or `HttpEmitter` | As above |
+
+### Collector contract
+
+The collector exposes a single endpoint:
+
+```
+POST /receipts
+Content-Type: application/ld+json
+
+{ ...signedReceipt }
+
+→ 201 Created   (receipt accepted and persisted)
+→ 409 Conflict  (receipt id already exists — idempotent re-delivery acceptable)
+→ 400 Bad Request (malformed receipt — SDK should not retry)
+→ 5xx           (transient error — SDK should retry with backoff)
+```
+
+The collector MUST NOT:
+- Modify receipts
+- Reorder receipts
+- Assign or recompute `previousReceiptHash`
+- Reject receipts solely on the basis of signature verification failure
+  (verification is the auditor's responsibility, not the collector's)
+
+The collector SHOULD:
+- Be append-only
+- Return 409 on duplicate `id` rather than 500, to support safe retry
+
+### Concurrency constraint
+
+Client-side chaining requires that receipt N is fully signed and its hash
+computed before receipt N+1 is constructed. This is naturally satisfied for
+sequential single-process agents. For agents that emit receipts concurrently
+(e.g. parallel tool calls), the SDK must serialise receipt construction through
+a queue. Concurrent signing and emission of independent receipts is not
+supported in v1 — parallel tool calls must be sequenced at the receipt layer
+even if they execute in parallel.
+
+This constraint should be documented explicitly. A future ADR may address
+parallel sub-chains (forked chains with a merge receipt) for v2.
+
+### At-least-once delivery and the WAL
+
+For `sync` strategy, the SDK retries on 5xx with exponential backoff and jitter
+up to a configurable limit. If the retry budget is exhausted, `emit()` throws
+`EmitError`. The caller (SDK internals) should write the receipt to a local WAL
+before attempting delivery, and clear the WAL entry on 201 or 409. On process
+restart, unacknowledged WAL entries are replayed.
+
+For ephemeral compute (Lambda) a WAL on disk is not viable. In this case:
+- The WAL is in-memory only
+- On SIGTERM the SDK attempts a final flush with a short deadline
+- Any undelivered receipts are lost; the chain will show a gap
+- This should be surfaced as `status: interrupted` on the `agent_end` receipt
+  per ADR-0019 § P1
+
+### Interaction with ADR-0018 (Signer) and ADR-0019 (integrity gaps)
+
+The `Emitter` abstraction does not affect signing or chaining. The full
+pipeline remains:
+
+```
+event occurs
+  → SDK constructs receipt payload
+  → Signer signs (local bytes, KMS, TPM — per ADR-0018)
+  → previousReceiptHash computed from prior signed receipt
+  → SignedReceipt complete
+  → Emitter.emit(signedReceipt)
+    → HttpEmitter POSTs to collector  (or DaemonEmitter sends to sidecar)
+```
+
+The collector is downstream of all cryptographic operations.
+
+The WAL requirement in this ADR supersedes the MCP proxy WAL requirement
+in ADR-0019 § O3. The WAL now lives in the SDK emitter layer, not in the
+proxy, making it available regardless of whether the MCP proxy is in use.
+
+## Consequences
+
+> For the consolidated v1 / v2 sequencing across this ADR and ADR-0018/0019,
+> see `ROADMAP.md`.
+
+- The SDK gains a required `Emitter` dependency at construction time alongside
+  `Signer` and `KeyProvider`.
+- Ephemeral compute is fully supported without any runtime-specific extensions
+  or sidecars.
+- The collector is a dumb append-only store. No business logic. No trust
+  assumptions.
+- Concurrent parallel tool calls must be sequenced at the receipt layer in v1.
+  This is a known constraint, not a bug.
+- `DaemonEmitter` is retained. Existing deployments are unaffected.
+- ADR-0019 § O3 (MCP proxy WAL) is superseded by the SDK-layer WAL defined here.
+
+## Known limitations
+
+- In-memory WAL only for ephemeral compute. Receipt loss on hard crash or
+  timeout is possible. Surfaced as `status: interrupted`.
+- `fire-and-forget` strategy provides no delivery guarantee. Caller accepts
+  the risk.
+- Parallel sub-chains not supported in v1. Sequential receipt construction
+  is required.
+- `BufferingEmitter` is not suitable where audit completeness is critical.
+  Loss on crash is documented but easy to misconfigure.

--- a/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
+++ b/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
@@ -53,6 +53,13 @@ This preserves the core trust model: an auditor needs only the agent's public
 key to verify the entire chain. The collector cannot fabricate or alter
 receipts.
 
+> **Note on naming.** The TypeScript SDK already exports an `Emitter` class
+> in `sdk/ts/src/emitter.ts` that forwards *unsigned* tool-call event frames
+> over a Unix socket to the agent-receipts daemon, where signing and chaining
+> happen (per ADR-0010). That class is renamed to `DaemonEmitter` as part of
+> this work; the name `Emitter` is freed up for the new interface defined
+> here. See § "Migration from the current daemon architecture" below.
+
 ### Built-in emitters (ship in the core SDK package)
 
 #### `HttpEmitter`
@@ -85,9 +92,15 @@ type HttpEmitterAuth =
 
 #### `DaemonEmitter`
 
-Sends receipts to a local daemon over a Unix socket or named pipe. Existing
-behaviour for long-lived compute deployments with a sidecar. Retained as a
-built-in for backwards compatibility.
+Sends receipts to a local daemon over a Unix socket or named pipe. Retained
+as a built-in for deployments that already run the agent-receipts daemon
+as a sidecar.
+
+`DaemonEmitter`'s relationship to the new client-side signing model is not
+trivial — see § "Migration from the current daemon architecture" below.
+Until the daemon grows a signed-receipt ingest mode, `DaemonEmitter` keeps
+the existing unsigned-frame protocol from ADR-0010 and does not yet conform
+to the `Emitter` interface defined above.
 
 #### `CompositeEmitter`
 
@@ -178,6 +191,38 @@ For ephemeral compute (Lambda) a WAL on disk is not viable. In this case:
 - Any undelivered receipts are lost; the chain will show a gap
 - This should be surfaced as `status: interrupted` on the `agent_end` receipt
   per ADR-0019 § P1
+
+### Migration from the current daemon architecture
+
+ADR-0010 placed signing and chaining in the daemon and modelled the SDK as
+a thin emitter of *unsigned* tool-call frames. ADR-0020 inverts that —
+signing and chaining are client-side, the receiver is a dumb store. The
+existing daemon path is not obsolete (sidecar deployments remain useful for
+storage, redaction, and local audit query), but its protocol no longer
+matches the new `Emitter` interface. The migration has two steps.
+
+**Step 1 — rename the existing TS class.** `sdk/ts/src/emitter.ts` currently
+exports `Emitter` (unsigned `EmitEvent` frames, daemon signs). That class is
+renamed to `DaemonEmitter` with no behaviour change. Its `emit()` method
+keeps its current signature — it does not yet take `SignedReceipt`. Existing
+callers update the import name; the wire protocol with the daemon is
+unchanged. Python and Go SDKs that grow equivalent helpers follow the same
+rename rule.
+
+**Step 2 — daemon learns to accept signed receipts.** A new frame type is
+added to the daemon socket protocol that carries an already-signed,
+already-chained receipt for storage only (no signing on the daemon side).
+Once the daemon understands this frame, `DaemonEmitter` gains an
+`emit(SignedReceipt)` overload that uses it, and at that point
+`DaemonEmitter` implements the `Emitter` interface defined in this ADR.
+Until then `DaemonEmitter` exists as a legacy adapter with a different
+input shape, and is not interchangeable with `HttpEmitter` in
+`CompositeEmitter`.
+
+Step 1 is mechanical and ships with this ADR's implementation work
+(SDK emitter layer milestone in ROADMAP.md). Step 2 is daemon-side work
+tracked separately — it does not block ADR-0020's primary goal, which is
+ephemeral-compute support via `HttpEmitter`.
 
 ### Interaction with ADR-0018 (Signer) and ADR-0019 (integrity gaps)
 

--- a/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
+++ b/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
@@ -104,13 +104,18 @@ to the `Emitter` interface defined above.
 
 #### `CompositeEmitter`
 
-Forwards each receipt to multiple emitters in sequence. Useful for dual-write
-during migration (daemon + HTTP), or for writing to both a local store and a
-remote collector simultaneously.
+Forwards each receipt to multiple emitters in sequence. Useful for writing
+to two collectors simultaneously (e.g. a primary endpoint plus an offsite
+audit archive) or for dual-writing during a migration between endpoints.
 
 ```typescript
-new CompositeEmitter([daemonEmitter, httpEmitter])
+new CompositeEmitter([primaryHttpEmitter, archiveHttpEmitter])
 ```
+
+`CompositeEmitter` requires every child to implement the `Emitter` interface
+defined above. `DaemonEmitter` does not yet (see § "Migration from the
+current daemon architecture"); the daemon → HTTP dual-write pattern becomes
+available once step 2 of the migration lands.
 
 #### `BufferingEmitter`
 

--- a/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
+++ b/docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md
@@ -39,9 +39,15 @@ A new `Emitter` interface is added to the core SDK package (`@agnt-rcpt/sdk-ts` 
 
 ```typescript
 interface Emitter {
-  emit(receipt: SignedReceipt): Promise<void>
+  emit(receipt: AgentReceipt): Promise<void>
 }
 ```
+
+`AgentReceipt` is the existing signed-receipt type defined in the core SDK
+(`sdk/ts/src/receipt/types.ts` and equivalents in Go and Python) — the
+W3C VC envelope with a required `proof` field. The unsigned variant is
+`UnsignedAgentReceipt = Omit<AgentReceipt, "proof">`. Emitters receive
+already-signed receipts; signing is upstream.
 
 Receipt construction, signing, and chaining remain client-side in all cases.
 The `Emitter` is responsible only for delivery. The collector is a dumb store —
@@ -150,7 +156,7 @@ The collector exposes a single endpoint:
 POST /receipts
 Content-Type: application/ld+json
 
-{ ...signedReceipt }
+{ ...agentReceipt }
 
 → 201 Created   (receipt accepted and persisted)
 → 409 Conflict  (receipt id already exists — idempotent re-delivery acceptable)
@@ -209,7 +215,7 @@ matches the new `Emitter` interface. The migration has two steps.
 **Step 1 — rename the existing TS class.** `sdk/ts/src/emitter.ts` currently
 exports `Emitter` (unsigned `EmitEvent` frames, daemon signs). That class is
 renamed to `DaemonEmitter` with no behaviour change. Its `emit()` method
-keeps its current signature — it does not yet take `SignedReceipt`. Existing
+keeps its current signature — it does not yet take `AgentReceipt`. Existing
 callers update the import name; the wire protocol with the daemon is
 unchanged. Python and Go SDKs that grow equivalent helpers follow the same
 rename rule.
@@ -218,7 +224,7 @@ rename rule.
 added to the daemon socket protocol that carries an already-signed,
 already-chained receipt for storage only (no signing on the daemon side).
 Once the daemon understands this frame, `DaemonEmitter` gains an
-`emit(SignedReceipt)` overload that uses it, and at that point
+`emit(AgentReceipt)` overload that uses it, and at that point
 `DaemonEmitter` implements the `Emitter` interface defined in this ADR.
 Until then `DaemonEmitter` exists as a legacy adapter with a different
 input shape, and is not interchangeable with `HttpEmitter` in
@@ -239,8 +245,8 @@ event occurs
   → SDK constructs receipt payload
   → Signer signs (local bytes, KMS, TPM — per ADR-0018)
   → previousReceiptHash computed from prior signed receipt
-  → SignedReceipt complete
-  → Emitter.emit(signedReceipt)
+  → AgentReceipt complete
+  → Emitter.emit(agentReceipt)
     → HttpEmitter POSTs to collector  (or DaemonEmitter sends to sidecar)
 ```
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (substrate shipped, Codex reader pending) |
 | [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Accepted (Phase A in progress) |
 | [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Accepted |
-| [ADR-0017](0017-central-receipt-hub.md) | Central Receipt Hub and External Anchoring | Proposed |
+| [ADR-0017](0017-central-receipt-hub.md) | Central Receipt Hub and External Anchoring | Accepted |
 | [ADR-0018](0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md) | Signer Abstraction and Cloud-Agnostic KeyProvider Design | Proposed |
 | [ADR-0019](0019-protocol-integrity-gaps-and-mitigations.md) | Protocol Integrity Gaps and Mitigations | Proposed |
 | [ADR-0020](0020-emitter-abstraction-and-remote-receipt-delivery.md) | Emitter Abstraction and Remote Receipt Delivery | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,11 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0014](0014-codex-hook-channel.md) | codex_hook Emission Channel | Proposed (substrate shipped, Codex reader pending) |
 | [ADR-0015](0015-key-rotation-byok-anchoring.md) | Key Rotation, BYOK Abstraction, and External Anchoring | Accepted (Phase A in progress) |
 | [ADR-0016](0016-mcp-proxy-audit-encryption.md) | Audit Store Encryption at Rest (mcp-proxy) | Accepted |
+| [ADR-0018](0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md) | Signer Abstraction and Cloud-Agnostic KeyProvider Design | Proposed |
+| [ADR-0019](0019-protocol-integrity-gaps-and-mitigations.md) | Protocol Integrity Gaps and Mitigations | Proposed |
+| [ADR-0020](0020-emitter-abstraction-and-remote-receipt-delivery.md) | Emitter Abstraction and Remote Receipt Delivery | Proposed |
+
+> ADR-0017 (central receipt hub and external anchoring) is in draft on PR #465.
 
 ## References
 


### PR DESCRIPTION
## What

Three new ADRs (Proposed) plus a new ROADMAP.md at the repo root, sequencing
the design decisions documented in those ADRs.

- **ADR-0018** — Signer abstraction and cloud-agnostic KeyProvider design.
  Splits keypair access into `KeyProvider` (raw bytes) and `Signer` (HSM /
  KMS / TPM). Adds a "Package boundaries" subsection making the multi-package
  split explicit per language: scoped packages in TS, extras in Python,
  separate Go modules.
- **ADR-0019** — 13 protocol integrity gaps (P1–P5, S1–S5, O1–O3) identified
  in a structured stress test, each with a decision (mitigate now, defer, or
  document as known limitation) and a tracking issue. § O3 (MCP proxy WAL)
  is superseded by ADR-0020 — the WAL has moved to the SDK emitter layer.
- **ADR-0020** — Emitter abstraction. `HttpEmitter` for ephemeral compute
  (Lambda, Cloud Run, Fargate); `DaemonEmitter` retained for sidecar
  deployments; `Composite`, `Buffering`, `InMemory` built-ins. Collector
  contract specified as a dumb append-only store — no trust assumptions.
  Client-side WAL for at-least-once delivery.
- **ROADMAP.md** — single source of truth for sequencing. Milestones:
  Post 3 (HN demo blockers), v1 (public release), v1.5 (regulated industries
  readiness), v2 (deferred). 19 tracked issues across the milestones.

## Why

Three forces converged:

1. **Ephemeral compute support is missing.** The current daemon/sidecar
   design doesn't work in Lambda / Cloud Run / Fargate. ADR-0020 adopts
   a remote HTTPS emitter as the primary mechanism for these environments.
2. **A structured stress test of the protocol surfaced 13 gaps.** Some
   are silent failure modes (chain terminates with no terminal receipt);
   some are missing protocol primitives (no `sessionId` binding enforcement);
   some are operational (no key revocation path). ADR-0019 records each gap
   with a deliberate decision rather than leaving them implicit.
3. **The keypair management story doesn't generalise.** The earlier design
   couldn't model HSM/KMS where the private key is never extractable, and
   it implied cloud SDK deps would ship in core. ADR-0018 fixes both.

## Issues filed

19 issues filed and linked from ROADMAP.md and the ADRs: #474–#492.

- Post 3 blockers: #474, #475, #476, #488
- v1 blockers: #477, #478, #479, #480, #486, #487
- v1.5 (regulated industries): #482, #483, #484, #489, #490, #491, #492
- v2 deferred: #481, #485

Also created the `v1.5` label on the repo to track the regulated-industries
milestone (parallels existing `v2`).

## Commits

1. Initial ADRs + ROADMAP with `#TBD` placeholders
2. Backfilled `#TBD` references after filing #474–#488
3. Filed 4 remaining v1.5 issues (#489–#492) and backfilled
4. Merged `main` (resolves ADR README conflict — keeps ADR-0017 alongside the new 0018/19/20)
5. Addressed Copilot review feedback (env-var prefix alignment, ADR-0019 "three categories", ROADMAP intro wording, ADR-0020 Emitter migration plan)

## Known follow-ups (not in this PR)

- Cross-reference between ADR-0017 (central receipt hub, landed via #465)
  and ADR-0020's `HttpEmitter`. Wire formats differ — ADR-0017 uses
  JWS-signed JSONL batches, ADR-0020 uses single-receipt
  `application/ld+json` POST. Reconciling these is real design work
  tracked as a separate follow-up.
- Daemon protocol gains a signed-receipt ingest frame so `DaemonEmitter`
  can implement the new `Emitter` interface defined in ADR-0020. Step 1
  of the migration (renaming the existing TS `Emitter` class to
  `DaemonEmitter` with no behaviour change) ships with ADR-0020's
  implementation work; step 2 (the new daemon frame) is daemon-side work
  tracked separately.

## Checklist

- [x] Tests pass for all changed components (docs-only, no code)
- [x] Linter passes (no code changes)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (N/A — no receipt format changes)
- [ ] AGENTS.md updated (N/A — no project structure changes)
- [x] Spec changes have been reviewed by a maintainer (intentionally Proposed — these are design proposals, not accepted decisions yet)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — yes, indirectly:
  ADR-0018 proposes the Signer/KeyProvider abstractions and per-environment
  key-management recommendations. ADR-0019 catalogues 5 security-relevant
  gaps (P2 unauthenticated origin, P3 timestamp binding, P4 sessionId
  replay, O1 revocation, S4 memory safety). ADR-0020 specifies the
  collector trust model (no business logic, no trust required). All
  three are design documents — no code changes here.