### PR TITLE
feat(sdk/py): HPKE disclosure envelope — types, encrypt/decrypt, forensic key generation

### DIFF
--- a/sdk/py/src/agent_receipts/__init__.py
+++ b/sdk/py/src/agent_receipts/__init__.py
@@ -8,6 +8,14 @@ from agent_receipts.receipt.chain import (
     verify_chain,
 )
 from agent_receipts.receipt.create import CreateReceiptInput, create_receipt
+from agent_receipts.receipt.disclosure import (
+    DisclosureEnvelope,
+    DisclosureRecipient,
+    ForensicKeyPair,
+    decrypt_disclosure,
+    encrypt_disclosure,
+    generate_forensic_key_pair,
+)
 from agent_receipts.receipt.hash import canonicalize, hash_receipt, sha256
 from agent_receipts.receipt.signing import (
     KeyPair,
@@ -69,6 +77,9 @@ classifyToolCall = classify_tool_call
 getActionType = get_action_type
 resolveActionType = resolve_action_type
 loadTaxonomyConfig = load_taxonomy_config
+generateForensicKeyPair = generate_forensic_key_pair
+encryptDisclosure = encrypt_disclosure
+decryptDisclosure = decrypt_disclosure
 
 # RECEIPT_VERSION is the receipt schema version (from types), not the package version
 from agent_receipts.receipt.types import VERSION as RECEIPT_VERSION  # noqa: E402
@@ -102,6 +113,16 @@ __all__ = [
     "CreateReceiptInput",
     "create_receipt",
     "createReceipt",
+    # Disclosure (HPKE envelope, ADR-0012)
+    "DisclosureEnvelope",
+    "DisclosureRecipient",
+    "ForensicKeyPair",
+    "decrypt_disclosure",
+    "decryptDisclosure",
+    "encrypt_disclosure",
+    "encryptDisclosure",
+    "generate_forensic_key_pair",
+    "generateForensicKeyPair",
     # Emitter (ADR-0010 daemon client)
     "Emitter",
     "default_socket_path",

--- a/sdk/py/src/agent_receipts/receipt/disclosure.py
+++ b/sdk/py/src/agent_receipts/receipt/disclosure.py
@@ -1,0 +1,486 @@
+"""HPKE disclosure envelope for parameters_disclosure (ADR-0012, amendment 2026-05-18).
+
+Ciphersuite: hpke-x25519-hkdf-sha256-aes-256-gcm
+(RFC 9180, KEM=DHKEM(X25519,HKDF-SHA256) 0x0020,
+ KDF=HKDF-SHA256 0x0001, AEAD=AES-256-GCM 0x0002).
+
+This module is a hand-rolled implementation of RFC 9180 base-mode HPKE on top
+of pyca/cryptography (X25519, HKDF-SHA256, AES-256-GCM) — matching the no-extra-
+dependency trajectory that PR #473 plans for the TS SDK. It MUST produce
+byte-identical envelopes to the Go SDK (PR #468 / sdk/go/receipt/disclosure.go)
+and the TS SDK (PR #472 / sdk/ts/src/receipt/disclosure.ts); the cross-SDK
+invariant is pinned by spec/test-vectors/disclosure-envelope/vectors.json.
+
+The DHKEM(X25519) ephemeral key MUST be derived via RFC 9180 §7.1.3
+DeriveKeyPair (HKDF over ikmE), not used directly as the X25519 scalar. See
+``_derive_x25519_key_pair`` for the one-shot LabeledExpand path for X25519.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
+
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from agent_receipts.receipt.hash import canonicalize
+
+V1_ALG = "hpke-x25519-hkdf-sha256-aes-256-gcm"
+"""ADR-0012 ciphersuite tag — the only value accepted by v1 decryptors."""
+
+# RFC 9180 §7 codepoints for the pinned ciphersuite.
+_KEM_ID = 0x0020  # DHKEM(X25519, HKDF-SHA256)
+_KDF_ID = 0x0001  # HKDF-SHA256
+_AEAD_ID = 0x0002  # AES-256-GCM
+
+# RFC 9180 §4 / §7 KEM parameters for DHKEM(X25519, HKDF-SHA256).
+_N_SECRET = 32  # KEM shared secret length
+_N_ENC = 32  # encapsulated key length (X25519 public key)
+_N_SK = 32  # private key (scalar) length
+
+# RFC 9180 §4 KDF/AEAD parameters for HKDF-SHA256 + AES-256-GCM.
+_N_H = 32  # HKDF-SHA256 hash length
+_N_K = 32  # AES-256 key length
+_N_N = 12  # AEAD nonce length
+
+# RFC 9180 §4 suite_id values.
+_KEM_SUITE_ID = b"KEM" + _KEM_ID.to_bytes(2, "big")
+_HPKE_SUITE_ID = (
+    b"HPKE"
+    + _KEM_ID.to_bytes(2, "big")
+    + _KDF_ID.to_bytes(2, "big")
+    + _AEAD_ID.to_bytes(2, "big")
+)
+
+# RFC 9180 §5.1 mode byte for base mode.
+_MODE_BASE = 0x00
+
+# Strict unpadded base64url: [A-Za-z0-9_-]+, no padding, no standard-base64 chars.
+_BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class DisclosureRecipient(TypedDict):
+    """One entry in the recipients array of a DisclosureEnvelope.
+
+    Field names match RFC 9180 §4.1 vocabulary ("enc", not "encap").
+    """
+
+    kid: str
+    """Recipient key identifier (did:key DID URL or sha256:<hex> fingerprint)."""
+
+    enc: str
+    """HPKE encapsulated key; unpadded base64url, exactly 43 chars for X25519."""
+
+
+class DisclosureEnvelope(TypedDict):
+    """v1 asymmetric encryption envelope for parameters_disclosure (ADR-0012).
+
+    The signed receipt commits to the ciphertext; only the holder of the
+    forensic private key can recover the plaintext.
+    """
+
+    v: Literal["1"]
+    alg: Literal["hpke-x25519-hkdf-sha256-aes-256-gcm"]
+    recipients: list[DisclosureRecipient]
+    """Length 1 in v1; length >1 is reserved for a future v2 envelope."""
+    ct: str
+    """AEAD ciphertext; unpadded base64url."""
+
+
+@dataclass(frozen=True)
+class ForensicKeyPair:
+    """Raw X25519 key bytes (32 bytes each) for forensic disclosure.
+
+    Separate from the Ed25519 signing key pair per ADR-0001 / ADR-0012.
+    Unlike :class:`KeyPair` (Ed25519, PEM-encoded), these are raw bytes
+    because X25519 has no widespread PKCS8 PEM convention and raw bytes
+    compose more naturally with HPKE library APIs.
+    """
+
+    public_key: bytes
+    """32-byte X25519 public key. Share with emitters to enable encryption."""
+
+    private_key: bytes
+    """32-byte X25519 private key. Keep offline; required to decrypt."""
+
+
+def _b64url_encode(b: bytes) -> str:
+    """Encode bytes as unpadded base64url (RFC 4648 §5)."""
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    """Strict unpadded base64url decoder.
+
+    Rejects:
+        - empty strings
+        - any character outside ``[A-Za-z0-9_-]`` (no ``+``, ``/``, ``=``)
+        - strings where ``len(s) % 4 == 1`` (never valid in base64, even unpadded)
+    """
+    if not s or len(s) % 4 == 1 or not _BASE64URL_RE.fullmatch(s):
+        msg = (
+            "invalid base64url: must be non-empty unpadded base64url "
+            "[A-Za-z0-9_-] with valid length"
+        )
+        raise ValueError(msg)
+    # urlsafe_b64decode requires padding; add it back.
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def _i2osp(n: int, length: int) -> bytes:
+    """RFC 9180 §4 I2OSP: big-endian integer-to-octet-string."""
+    return n.to_bytes(length, "big")
+
+
+def _hkdf_extract(salt: bytes, ikm: bytes) -> bytes:
+    """RFC 5869 HKDF-Extract with SHA-256.
+
+    Hand-rolled because cryptography's :class:`HKDF` only exposes the
+    combined Extract+Expand operation; here we need Extract and Expand
+    separately to match the RFC 9180 labelled-KDF construction.
+    """
+    import hmac
+
+    salt = salt or bytes(_N_H)  # RFC 5869 §2.2: zero salt when not provided
+    return hmac.new(salt, ikm, "sha256").digest()
+
+
+def _hkdf_expand(prk: bytes, info: bytes, length: int) -> bytes:
+    """RFC 5869 HKDF-Expand with SHA-256."""
+    import hmac
+
+    if length > 255 * _N_H:
+        msg = f"HKDF-Expand: requested length {length} exceeds 255*HashLen"
+        raise ValueError(msg)
+    n = (length + _N_H - 1) // _N_H
+    okm = b""
+    t = b""
+    for i in range(1, n + 1):
+        t = hmac.new(prk, t + info + bytes([i]), "sha256").digest()
+        okm += t
+    return okm[:length]
+
+
+def _labeled_extract(salt: bytes, label: bytes, ikm: bytes, suite_id: bytes) -> bytes:
+    """RFC 9180 §4 LabeledExtract.
+
+    LabeledExtract(salt, label, ikm) =
+        HKDF-Extract(salt, "HPKE-v1" || suite_id || label || ikm)
+    """
+    return _hkdf_extract(salt, b"HPKE-v1" + suite_id + label + ikm)
+
+
+def _labeled_expand(
+    prk: bytes, label: bytes, info: bytes, length: int, suite_id: bytes
+) -> bytes:
+    """RFC 9180 §4 LabeledExpand.
+
+    LabeledExpand(prk, label, info, L) =
+        HKDF-Expand(prk, I2OSP(L,2) || "HPKE-v1" || suite_id || label || info, L)
+    """
+    labeled_info = _i2osp(length, 2) + b"HPKE-v1" + suite_id + label + info
+    return _hkdf_expand(prk, labeled_info, length)
+
+
+def _derive_x25519_key_pair(ikm: bytes) -> tuple[bytes, bytes]:
+    """RFC 9180 §7.1.3 DeriveKeyPair for DHKEM(X25519, HKDF-SHA256).
+
+    Returns ``(sk, pk)`` as raw 32-byte values. For X25519 this is a single
+    LabeledExpand — no "candidate" counter loop like the NIST curves use.
+
+    .. note::
+        X25519 scalar clamping (RFC 7748 §5) is applied by
+        ``X25519PrivateKey.from_private_bytes`` on use, so we do NOT apply
+        it here — matching circl (Go SDK) and @hpke/core (TS SDK) behaviour.
+    """
+    dkp_prk = _labeled_extract(b"", b"dkp_prk", ikm, _KEM_SUITE_ID)
+    sk = _labeled_expand(dkp_prk, b"sk", b"", _N_SK, _KEM_SUITE_ID)
+    pk = X25519PrivateKey.from_private_bytes(sk).public_key().public_bytes_raw()
+    return sk, pk
+
+
+def _dh(sk_bytes: bytes, pk_bytes: bytes) -> bytes:
+    """RFC 9180 §7.1.1 DH(skX, pkY) for X25519: raw scalar multiplication output."""
+    sk = X25519PrivateKey.from_private_bytes(sk_bytes)
+    pk = X25519PublicKey.from_public_bytes(pk_bytes)
+    return sk.exchange(pk)
+
+
+def _extract_and_expand(dh: bytes, kem_context: bytes) -> bytes:
+    """RFC 9180 §4.1 ExtractAndExpand step inside DHKEM Encap/Decap.
+
+    eae_prk     = LabeledExtract("", "eae_prk", dh)
+    shared_secret = LabeledExpand(eae_prk, "shared_secret", kem_context, Nsecret)
+    """
+    eae_prk = _labeled_extract(b"", b"eae_prk", dh, _KEM_SUITE_ID)
+    return _labeled_expand(
+        eae_prk, b"shared_secret", kem_context, _N_SECRET, _KEM_SUITE_ID
+    )
+
+
+def _encap(pk_r: bytes, ikm_e: bytes | None) -> tuple[bytes, bytes]:
+    """RFC 9180 §4.1 DHKEM(X25519) Encap (or its deterministic variant).
+
+    Returns ``(shared_secret, enc)`` where ``enc`` is the ephemeral public key
+    that the receiver will use to recover the same shared secret. If ``ikm_e``
+    is provided it is fed through DeriveKeyPair (matching circl's
+    ``Sender.Setup(io.Reader)`` and @hpke/core's ``ekm`` paths); otherwise a
+    fresh ephemeral key pair is generated.
+    """
+    if ikm_e is None:
+        ikm_e = os.urandom(32)
+    sk_e, pk_e = _derive_x25519_key_pair(ikm_e)
+    dh = _dh(sk_e, pk_r)
+    kem_context = pk_e + pk_r
+    shared_secret = _extract_and_expand(dh, kem_context)
+    return shared_secret, pk_e
+
+
+def _decap(enc: bytes, sk_r: bytes) -> bytes:
+    """RFC 9180 §4.1 DHKEM(X25519) Decap.
+
+    Recovers the same ``shared_secret`` that ``_encap`` produced for the
+    matching recipient private key.
+    """
+    pk_r = X25519PrivateKey.from_private_bytes(sk_r).public_key().public_bytes_raw()
+    dh = _dh(sk_r, enc)
+    kem_context = enc + pk_r
+    return _extract_and_expand(dh, kem_context)
+
+
+def _key_schedule_base(shared_secret: bytes) -> tuple[bytes, bytes]:
+    """RFC 9180 §5.1 KeySchedule for mode_base with info="" and psk="".
+
+    Returns ``(key, base_nonce)``. For a single-shot seal/open at seq=0, the
+    AEAD nonce is just ``base_nonce`` (XOR with ``I2OSP(0, Nn)`` is a no-op).
+    """
+    psk_id_hash = _labeled_extract(b"", b"psk_id_hash", b"", _HPKE_SUITE_ID)
+    info_hash = _labeled_extract(b"", b"info_hash", b"", _HPKE_SUITE_ID)
+    key_schedule_context = bytes([_MODE_BASE]) + psk_id_hash + info_hash
+    secret = _labeled_extract(shared_secret, b"secret", b"", _HPKE_SUITE_ID)
+    key = _labeled_expand(secret, b"key", key_schedule_context, _N_K, _HPKE_SUITE_ID)
+    base_nonce = _labeled_expand(
+        secret, b"base_nonce", key_schedule_context, _N_N, _HPKE_SUITE_ID
+    )
+    return key, base_nonce
+
+
+def _is_plain_dict(v: object) -> bool:
+    """Return True iff ``v`` is an exact ``dict`` (not a Mapping subclass).
+
+    Mirrors the TS SDK's ``isPlainObject`` semantics: the JCS canonicaliser
+    only handles plain JSON objects, and accepting arbitrary Mapping subclasses
+    would let custom classes leak through. Pydantic models, OrderedDict, etc.
+    must be converted to ``dict`` by the caller before encryption.
+    """
+    return type(v) is dict
+
+
+def generate_forensic_key_pair() -> ForensicKeyPair:
+    """Generate an X25519 key pair for forensic disclosure.
+
+    The public key is shared with emitters; the private key must be kept
+    offline (separate from the Ed25519 signing key per ADR-0001 / ADR-0012).
+    """
+    sk_obj = X25519PrivateKey.generate()
+    sk = sk_obj.private_bytes_raw()
+    pk = sk_obj.public_key().public_bytes_raw()
+    return ForensicKeyPair(public_key=pk, private_key=sk)
+
+
+def _encrypt_with_options(
+    params: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+    ikm_e: bytes | None,
+) -> DisclosureEnvelope:
+    # RFC 8785 JCS before encryption — cross-SDK interop depends on this.
+    canonical = canonicalize(params)
+
+    shared_secret, enc = _encap(recipient_public_key, ikm_e)
+    key, base_nonce = _key_schedule_base(shared_secret)
+
+    # info="" and AAD="" per ADR-0012 amendment §8: no out-of-band context
+    # binding at the HPKE layer (the receipt signature already authenticates
+    # the parameters_disclosure field).
+    ct = AESGCM(key).encrypt(base_nonce, canonical.encode("utf-8"), b"")
+
+    return {
+        "v": "1",
+        "alg": V1_ALG,
+        "recipients": [{"kid": kid, "enc": _b64url_encode(enc)}],
+        "ct": _b64url_encode(ct),
+    }
+
+
+def encrypt_disclosure(
+    params: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+) -> DisclosureEnvelope:
+    """Encrypt ``params`` as a v1 HPKE disclosure envelope.
+
+    ``params`` is RFC 8785 JCS-canonicalised before encryption so that all
+    SDKs encrypt the same bytes for the same parameters object.
+
+    Args:
+        params: The parameters to encrypt. MUST be a plain ``dict`` (subclasses
+            of ``Mapping`` are rejected to keep canonical-JSON semantics tight).
+        recipient_public_key: 32-byte X25519 forensic public key.
+        kid: Recipient key identifier (did:key DID URL or
+            ``sha256:<hex>`` fingerprint).
+    """
+    if not _is_plain_dict(params):
+        msg = "params must be a plain dict"
+        raise TypeError(msg)
+    if len(recipient_public_key) != 32:
+        msg = f"recipient_public_key must be 32 bytes, got {len(recipient_public_key)}"
+        raise ValueError(msg)
+    if not kid:
+        msg = "kid must not be empty"
+        raise ValueError(msg)
+    return _encrypt_with_options(params, recipient_public_key, kid, None)
+
+
+def _encrypt_disclosure_with_seed(  # pyright: ignore[reportUnusedFunction]
+    params: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+    ikm_e: bytes,
+) -> DisclosureEnvelope:
+    """Deterministic variant of :func:`encrypt_disclosure` for cross-SDK vectors.
+
+    ``ikm_e`` (32 bytes) is fed to RFC 9180 §7.1.3 DeriveKeyPair to derive the
+    ephemeral scalar — it is NOT used directly as the X25519 scalar. This
+    matches circl's ``Sender.Setup(io.Reader)`` (Go SDK) and ``@hpke/core``'s
+    ``ekm`` (TS SDK) and is confirmed by vector-1: ikm_e = RFC 9180 §A.1.1
+    ikmE produces enc = the same RFC's pkEm.
+
+    .. warning::
+        For tests only. Reusing ``ikm_e`` across real encryptions breaks
+        confidentiality.
+    """
+    if not _is_plain_dict(params):
+        msg = "params must be a plain dict"
+        raise TypeError(msg)
+    if len(recipient_public_key) != 32:
+        msg = f"recipient_public_key must be 32 bytes, got {len(recipient_public_key)}"
+        raise ValueError(msg)
+    if not kid:
+        msg = "kid must not be empty"
+        raise ValueError(msg)
+    if len(ikm_e) != 32:
+        msg = f"ikm_e must be 32 bytes, got {len(ikm_e)}"
+        raise ValueError(msg)
+    return _encrypt_with_options(params, recipient_public_key, kid, ikm_e)
+
+
+def decrypt_disclosure(
+    env: DisclosureEnvelope,
+    recipient_private_key: bytes,
+) -> dict[str, Any]:
+    """Recover the plaintext parameters from a v1 HPKE disclosure envelope.
+
+    Args:
+        env: The disclosure envelope to decrypt. Statically a
+            :class:`DisclosureEnvelope`; at runtime the shape is re-validated
+            because callers commonly pass dicts loaded from JSON (e.g., from
+            ``json.loads``) which the type system cannot constrain.
+        recipient_private_key: 32-byte X25519 forensic private key.
+
+    Returns:
+        The decrypted parameters object. The structure reflects the JCS
+        plaintext written by :func:`encrypt_disclosure`.
+
+    Raises:
+        ValueError: On any envelope-shape, encoding, or authentication
+            failure. The error message classifies the failure (version, alg,
+            recipient count, base64url shape, ciphertext length, AEAD auth).
+    """
+    # Defensive runtime checks against malformed input: TypedDict only
+    # constrains the static type. Callers commonly pass dicts loaded from JSON
+    # (e.g., ``json.loads`` output), so re-validate the shape here.
+    if env is None:  # pyright: ignore[reportUnnecessaryComparison]
+        msg = "disclosure envelope must not be None"
+        raise ValueError(msg)
+    if not _is_plain_dict(env):
+        msg = "disclosure envelope must be a dict"
+        raise TypeError(msg)
+    v = env.get("v")
+    if v != "1":
+        msg = f'unsupported envelope version "{v}"'
+        raise ValueError(msg)
+    alg = env.get("alg")
+    if alg != V1_ALG:
+        msg = f'unsupported algorithm "{alg}"'
+        raise ValueError(msg)
+    recipients = env.get("recipients")
+    if not isinstance(recipients, list) or len(recipients) != 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+        got = len(recipients) if isinstance(recipients, list) else 0  # pyright: ignore[reportUnnecessaryIsInstance]
+        msg = f"v1 envelope must have exactly 1 recipient, got {got}"
+        raise ValueError(msg)
+    if len(recipient_private_key) != 32:
+        msg = (
+            f"recipient_private_key must be 32 bytes, got {len(recipient_private_key)}"
+        )
+        raise ValueError(msg)
+    ct = env.get("ct")
+    # 24 chars = 18 bytes minimum: AES-256-GCM 16-byte tag + 2-byte minimum
+    # plaintext ("{}").
+    if not isinstance(ct, str) or len(ct) < 24:  # pyright: ignore[reportUnnecessaryIsInstance]
+        got = len(ct) if isinstance(ct, str) else 0  # pyright: ignore[reportUnnecessaryIsInstance]
+        msg = (
+            "ct is too short: expected at least 24 unpadded base64url "
+            f"characters, got {got}"
+        )
+        raise ValueError(msg)
+
+    recipient = recipients[0]
+    if not _is_plain_dict(recipient):
+        msg = "recipient must be a dict"
+        raise TypeError(msg)
+    enc_s = recipient.get("enc")
+    if not isinstance(enc_s, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+        msg = "recipient enc must be a string"
+        raise TypeError(msg)
+    kid = recipient.get("kid")
+    if not isinstance(kid, str) or len(kid) == 0:  # pyright: ignore[reportUnnecessaryIsInstance]
+        msg = "recipient kid must be a non-empty string"
+        raise ValueError(msg)
+
+    enc = _b64url_decode(enc_s)
+    if len(enc) != _N_ENC:
+        msg = (
+            f"invalid enc: expected {_N_ENC} bytes (X25519 encapsulated key), "
+            f"got {len(enc)}"
+        )
+        raise ValueError(msg)
+    ct_bytes = _b64url_decode(ct)
+
+    shared_secret = _decap(enc, recipient_private_key)
+    key, base_nonce = _key_schedule_base(shared_secret)
+
+    try:
+        plaintext = AESGCM(key).decrypt(base_nonce, ct_bytes, b"")
+    except Exception as exc:  # noqa: BLE001 — cryptography raises InvalidTag
+        msg = f"HPKE open failed (authentication or decryption error): {exc}"
+        raise ValueError(msg) from exc
+
+    try:
+        result = json.loads(plaintext.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        msg = f"decrypted plaintext is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+    if not _is_plain_dict(result):
+        msg = "decrypted plaintext is not a JSON object"
+        raise ValueError(msg)
+    return result

--- a/sdk/py/tests/receipt/test_disclosure.py
+++ b/sdk/py/tests/receipt/test_disclosure.py
@@ -1,0 +1,404 @@
+"""Tests for the HPKE disclosure envelope (ADR-0012, amendment 2026-05-18).
+
+Mirrors sdk/go/receipt/disclosure_test.go and sdk/ts/src/receipt/disclosure.test.ts.
+Both spec test vectors MUST produce byte-identical ``enc`` and ``ct`` across all
+three SDKs — see ``spec/test-vectors/disclosure-envelope/vectors.json``.
+"""
+
+from __future__ import annotations
+
+import binascii
+import json
+from typing import Any, cast
+
+import pytest
+
+from agent_receipts.receipt.disclosure import (
+    DisclosureEnvelope,
+    _encrypt_disclosure_with_seed,
+    decrypt_disclosure,
+    encrypt_disclosure,
+    generate_forensic_key_pair,
+)
+from agent_receipts.receipt.hash import canonicalize
+
+# RFC 7748 §6.1 well-known X25519 test keys. Published IETF test vectors — not
+# real secrets. Verified: X25519(alicePriv, basepoint) === alicePub.
+ALICE_PUB_HEX = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"
+ALICE_PRIV_HEX = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"
+BOB_PUB_HEX = "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"
+BOB_PRIV_HEX = "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"
+
+# ikmE values from spec/test-vectors/disclosure-envelope/vectors.json
+VECTOR1_IKME_HEX = "7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234"
+VECTOR2_IKME_HEX = "909a9b35d3dc4713a5e72a4da274b55d3d3821a37e5d099e74a647db583a904b"
+
+
+def _hex(s: str) -> bytes:
+    return binascii.unhexlify(s)
+
+
+class TestGenerateForensicKeyPair:
+    def test_produces_32_byte_keys(self) -> None:
+        kp = generate_forensic_key_pair()
+        assert len(kp.public_key) == 32
+        assert len(kp.private_key) == 32
+        assert kp.public_key != kp.private_key
+
+    def test_round_trip_with_fresh_keys(self) -> None:
+        kp = generate_forensic_key_pair()
+        params = {"tool": "read_file", "path": "/tmp/test.txt"}
+        env = encrypt_disclosure(params, kp.public_key, "sha256:test")
+        got = decrypt_disclosure(env, kp.private_key)
+        assert got["tool"] == "read_file"
+        assert got["path"] == "/tmp/test.txt"
+
+
+class TestEncryptDisclosure:
+    def test_produces_valid_v1_envelope_shape(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        env = encrypt_disclosure(
+            {"command": 'echo "build complete"'},
+            alice_pub,
+            "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1",
+        )
+        assert env["v"] == "1"
+        assert env["alg"] == "hpke-x25519-hkdf-sha256-aes-256-gcm"
+        assert len(env["recipients"]) == 1
+        # enc: 43 chars = unpadded base64url of 32 bytes
+        assert len(env["recipients"][0]["enc"]) == 43
+        for ch in "+/=":
+            assert ch not in env["recipients"][0]["enc"]
+            assert ch not in env["ct"]
+        assert len(env["ct"]) >= 24
+        # No nonce field — v1 is single-shot.
+        assert "nonce" not in json.dumps(env)
+
+    def test_round_trip_with_alice_rfc7748_keys(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        params = {"command": 'echo "build complete"'}
+        env = encrypt_disclosure(params, alice_pub, "test-kid")
+        got = decrypt_disclosure(env, alice_priv)
+        assert got["command"] == 'echo "build complete"'
+
+    def test_jcs_canonicalizes_plaintext(self) -> None:
+        """Plaintext encrypted into ct MUST be the JCS of params, not raw JSON."""
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        # Non-trivially-ordered keys so JCS sort is observable.
+        params = {"z_last": "last", "a_first": "first", "m_mid": "middle"}
+        env = encrypt_disclosure(params, alice_pub, "test-kid")
+        got = decrypt_disclosure(env, alice_priv)
+        assert canonicalize(got) == canonicalize(params)
+
+    def test_rejects_short_recipient_public_key(self) -> None:
+        with pytest.raises(ValueError, match="32 bytes"):
+            encrypt_disclosure({}, b"\x00" * 16, "kid")
+
+    def test_rejects_long_recipient_public_key(self) -> None:
+        with pytest.raises(ValueError, match="32 bytes"):
+            encrypt_disclosure({}, b"\x00" * 33, "kid")
+
+    def test_rejects_empty_kid(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        with pytest.raises(ValueError, match="kid"):
+            encrypt_disclosure({}, alice_pub, "")
+
+    def test_rejects_non_dict_params(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        # Lists, strings, None, Mapping subclasses are all rejected.
+        with pytest.raises(TypeError, match="plain dict"):
+            encrypt_disclosure(cast("Any", ["a", "b"]), alice_pub, "kid")
+        with pytest.raises(TypeError, match="plain dict"):
+            encrypt_disclosure(cast("Any", None), alice_pub, "kid")
+        with pytest.raises(TypeError, match="plain dict"):
+            encrypt_disclosure(cast("Any", "string"), alice_pub, "kid")
+
+    def test_rejects_mapping_subclass(self) -> None:
+        """Mapping subclasses (OrderedDict, ChainMap, custom dict) are rejected.
+
+        JCS canonicalisation only handles plain dicts; accepting subclasses
+        would let user types leak through.
+        """
+        from collections import OrderedDict
+
+        alice_pub = _hex(ALICE_PUB_HEX)
+        with pytest.raises(TypeError, match="plain dict"):
+            encrypt_disclosure(cast("Any", OrderedDict({"a": 1})), alice_pub, "kid")
+
+
+class TestDecryptDisclosure:
+    def _valid_env(self) -> DisclosureEnvelope:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        return encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+
+    def test_rejects_none_envelope(self) -> None:
+        with pytest.raises(ValueError, match="must not be None"):
+            decrypt_disclosure(cast("Any", None), b"\x00" * 32)
+
+    def test_rejects_wrong_version(self) -> None:
+        env: DisclosureEnvelope = {
+            "v": cast("Any", "2"),
+            "alg": "hpke-x25519-hkdf-sha256-aes-256-gcm",
+            "recipients": [{"kid": "k", "enc": "A" * 43}],
+            "ct": "B" * 24,
+        }
+        with pytest.raises(ValueError, match="unsupported envelope version"):
+            decrypt_disclosure(env, b"\x00" * 32)
+
+    def test_rejects_wrong_alg(self) -> None:
+        env: DisclosureEnvelope = {
+            "v": "1",
+            "alg": cast("Any", "hpke-x25519-chacha20poly1305"),
+            "recipients": [{"kid": "k", "enc": "A" * 43}],
+            "ct": "B" * 24,
+        }
+        with pytest.raises(ValueError, match="unsupported algorithm"):
+            decrypt_disclosure(env, b"\x00" * 32)
+
+    def test_rejects_zero_recipients(self) -> None:
+        env: DisclosureEnvelope = {
+            "v": "1",
+            "alg": "hpke-x25519-hkdf-sha256-aes-256-gcm",
+            "recipients": [],
+            "ct": "B" * 24,
+        }
+        with pytest.raises(ValueError, match="exactly 1 recipient"):
+            decrypt_disclosure(env, b"\x00" * 32)
+
+    def test_rejects_two_recipients(self) -> None:
+        env: DisclosureEnvelope = {
+            "v": "1",
+            "alg": "hpke-x25519-hkdf-sha256-aes-256-gcm",
+            "recipients": [
+                {"kid": "k1", "enc": "A" * 43},
+                {"kid": "k2", "enc": "A" * 43},
+            ],
+            "ct": "B" * 24,
+        }
+        with pytest.raises(ValueError, match="exactly 1 recipient"):
+            decrypt_disclosure(env, b"\x00" * 32)
+
+    def test_rejects_short_private_key(self) -> None:
+        env = self._valid_env()
+        with pytest.raises(ValueError, match="32 bytes"):
+            decrypt_disclosure(env, b"\x00" * 16)
+
+    def test_rejects_long_private_key(self) -> None:
+        env = self._valid_env()
+        with pytest.raises(ValueError, match="32 bytes"):
+            decrypt_disclosure(env, b"\x00" * 33)
+
+    def test_rejects_wrong_private_key_authentication_failure(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        bob_priv = _hex(BOB_PRIV_HEX)
+        env = encrypt_disclosure({"x": 1}, alice_pub, "kid")
+        # Bob's key successfully completes Decap on Alice's envelope but the
+        # derived AEAD key is different, so AES-GCM authentication fails.
+        with pytest.raises(ValueError, match="HPKE open failed"):
+            decrypt_disclosure(env, bob_priv)
+
+    def test_rejects_padded_base64_in_enc(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_enc = env["recipients"][0]["enc"][:42] + "="
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [{"kid": "kid", "enc": bad_enc}],
+        }
+        with pytest.raises(ValueError, match="invalid base64url"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_standard_base64_plus_character(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [{"kid": "kid", "enc": "A" * 42 + "+"}],
+        }
+        with pytest.raises(ValueError, match="invalid base64url"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_enc_with_invalid_base64url_length(self) -> None:
+        """``len % 4 == 1`` is never a valid base64 string, even unpadded."""
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [{"kid": "kid", "enc": "A" * 41}],
+        }
+        with pytest.raises(ValueError, match="invalid base64url"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_ct_shorter_than_24_chars(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {**env, "ct": "A" * 23}
+        with pytest.raises(ValueError, match="ct is too short"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_empty_kid_in_recipient(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [{"kid": "", "enc": env["recipients"][0]["enc"]}],
+        }
+        with pytest.raises(ValueError, match="non-empty string"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_non_string_enc(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [cast("Any", {"kid": "kid", "enc": 42})],
+        }
+        with pytest.raises(TypeError, match="enc must be a string"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_rejects_enc_wrong_byte_length(self) -> None:
+        """A 28-char base64url decodes to 21 bytes — not 32 — so DHKEM must reject."""
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"k": "v"}, alice_pub, "kid")
+        bad_env: DisclosureEnvelope = {
+            **env,
+            "recipients": [{"kid": "kid", "enc": "A" * 28}],
+        }
+        with pytest.raises(ValueError, match="32 bytes"):
+            decrypt_disclosure(bad_env, alice_priv)
+
+    def test_json_round_trip(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_disclosure({"key": "value"}, alice_pub, "test-kid")
+        raw = json.dumps(env)
+        parsed = cast("DisclosureEnvelope", json.loads(raw))
+        got = decrypt_disclosure(parsed, alice_priv)
+        assert got["key"] == "value"
+
+
+class TestEncryptDisclosureWithSeedValidation:
+    def test_rejects_wrong_ikm_e_length(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        for n in (0, 31, 33):
+            with pytest.raises(ValueError, match="32 bytes"):
+                _encrypt_disclosure_with_seed({}, alice_pub, "kid", b"\x00" * n)
+
+    def test_validates_other_inputs_too(self) -> None:
+        ikm = b"\x00" * 32
+        with pytest.raises(ValueError, match="kid"):
+            _encrypt_disclosure_with_seed({}, _hex(ALICE_PUB_HEX), "", ikm)
+        with pytest.raises(ValueError, match="32 bytes"):
+            _encrypt_disclosure_with_seed({}, b"\x00" * 16, "kid", ikm)
+        with pytest.raises(TypeError, match="plain dict"):
+            _encrypt_disclosure_with_seed(
+                cast("Any", []), _hex(ALICE_PUB_HEX), "k", ikm
+            )
+
+
+class TestEnvelopeJCSCanonicalShape:
+    def test_top_level_and_recipient_key_order(self) -> None:
+        """Top-level keys sort as [alg, ct, recipients, v]; recipients as [enc, kid]."""
+        enc = "A" * 43
+        ct = "B" * 24
+        env: DisclosureEnvelope = {
+            "v": "1",
+            "alg": "hpke-x25519-hkdf-sha256-aes-256-gcm",
+            "recipients": [{"kid": "did:key:test#enc-1", "enc": enc}],
+            "ct": ct,
+        }
+        want = (
+            '{"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm","ct":"'
+            + ct
+            + '","recipients":[{"enc":"'
+            + enc
+            + '","kid":"did:key:test#enc-1"}],"v":"1"}'
+        )
+        assert canonicalize(env) == want
+
+
+class TestDeterministicSpecVectors:
+    """Cross-SDK ground truth — both vectors MUST produce byte-identical output.
+
+    See spec/test-vectors/disclosure-envelope/vectors.json for provenance.
+    """
+
+    def test_vector_1_matches_rfc9180_pkem_and_go_ts_sdks(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        ikm_e = _hex(VECTOR1_IKME_HEX)
+        params = {"command": 'echo "build complete"'}
+        kid = "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1"
+
+        env = _encrypt_disclosure_with_seed(params, alice_pub, kid, ikm_e)
+
+        # enc = RFC 9180 §A.1.1 pkEm
+        want_enc = "N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE"
+        assert env["recipients"][0]["enc"] == want_enc
+
+        want_ct = (
+            "YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM"
+        )
+        assert env["ct"] == want_ct
+
+        want_jcs = (
+            '{"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm","ct":"'
+            + want_ct
+            + '","recipients":[{"enc":"'
+            + want_enc
+            + '","kid":"'
+            + kid
+            + '"}],"v":"1"}'
+        )
+        assert canonicalize(env) == want_jcs
+
+        # Plaintext JCS pinned by the vectors file.
+        assert canonicalize(params) == '{"command":"echo \\"build complete\\""}'
+
+        got = decrypt_disclosure(env, alice_priv)
+        assert got["command"] == 'echo "build complete"'
+
+    def test_vector_2_matches_pinned_go_ts_sdk_values(self) -> None:
+        bob_pub = _hex(BOB_PUB_HEX)
+        bob_priv = _hex(BOB_PRIV_HEX)
+        ikm_e = _hex(VECTOR2_IKME_HEX)
+        params = {
+            "method": "POST",
+            "headers": {
+                "content-type": "application/json",
+                "x-request-id": "abc-123",
+            },
+            "body": {"user": "otto", "delta": 42},
+        }
+        kid = "sha256:8f40c5adb68f25624ae5b214ea767a6ec94d829d3d7b5e1ad1ba6f3e2138285f"
+
+        env = _encrypt_disclosure_with_seed(params, bob_pub, kid, ikm_e)
+
+        want_enc = "GvoI097AR6ZDiFFj8RgEdvp921TGqAKeoz-VeWvyrEo"
+        assert env["recipients"][0]["enc"] == want_enc
+
+        want_ct = (
+            "vJG1bfcwNTnyL7gqfzkIg8oDl08Rd0z2kp-HVcRypJDrYdPBwvHWbIwdhCXuYB4mKANMm"
+            "KejzrsDHvaOnFAAHxVzB-f57sljHW5aDsb4kp5mhtM2SIAQwUj6VlVonllEdQquRKOl3"
+            "hjbXEOwjQeXQUxvI7avsiWuk5z41na_Xx6vVJd96lb-59YV"
+        )
+        assert env["ct"] == want_ct
+
+        # Plaintext JCS pinned by the vectors file (sorted: body, headers, method).
+        assert canonicalize(params) == (
+            '{"body":{"delta":42,"user":"otto"},'
+            '"headers":{"content-type":"application/json",'
+            '"x-request-id":"abc-123"},"method":"POST"}'
+        )
+
+        got = decrypt_disclosure(env, bob_priv)
+        assert got["method"] == "POST"


### PR DESCRIPTION
Tracked under #280. Prior ports: #468 (Go), #472 (TS).

## Summary

Implements parameters_disclosure v1 envelopes per ADR-0012 (amendment 2026-05-18) in the Python SDK. Ciphersuite: `hpke-x25519-hkdf-sha256-aes-256-gcm` (RFC 9180 base mode; KEM=DHKEM(X25519,HKDF-SHA256), KDF=HKDF-SHA256, AEAD=AES-256-GCM).

Public surface (snake_case + camelCase aliases at package level):

- `ForensicKeyPair` (frozen dataclass; raw 32-byte X25519 keys)
- `DisclosureRecipient` / `DisclosureEnvelope` (TypedDicts; JCS-stable shape)
- `generate_forensic_key_pair` / `generateForensicKeyPair`
- `encrypt_disclosure` / `encryptDisclosure` — JCS-canonicalises params before encryption
- `decrypt_disclosure` / `decryptDisclosure` — strict runtime re-validation of envelope shape
- `_encrypt_disclosure_with_seed` (test-only deterministic variant)

## Cross-SDK verification

Both spec test vectors (`spec/test-vectors/disclosure-envelope/vectors.json`) are asserted byte-for-byte against the pinned Go (#468) and TS (#472) values:

- **vector-1** `enc = N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE` (= RFC 9180 §A.1.1 `pkEm` — independent cross-check against the IETF RFC)
- **vector-1** `ct = YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM`
- **vector-2** `enc = GvoI097AR6ZDiFFj8RgEdvp921TGqAKeoz-VeWvyrEo`
- **vector-2** `ct` matches the pinned 188-char string in the vectors file.

The deterministic helper feeds `ikm_e` through RFC 9180 §7.1.3 DeriveKeyPair (`LabeledExpand` with label `"sk"`) — NOT directly as the X25519 scalar — matching circl (Go) and `@hpke/core` (TS). Without this, `enc` diverges from the RFC-published `pkEm`.

## Dependency notes

**No new top-level dependencies.** `cryptography >= 41.0` is already in `sdk/py/pyproject.toml`.

### Why hand-roll HPKE? (it's narrower than it sounds)

The cryptographic primitives — X25519 ECDH, HKDF-SHA256, AES-256-GCM — all come from **[pyca/cryptography](https://github.com/pyca/cryptography)** (OpenSSL bindings, the de-facto Python crypto library used by `requests`, `paramiko`, `urllib3`, OpenStack, etc.). We do **not** write curves, KDFs, or ciphers, and we do **not** touch constant-time code paths.

What this PR actually adds is ~120 lines of **glue** defined byte-for-byte by RFC 9180:

- `LabeledExtract` / `LabeledExpand` — concatenate `"HPKE-v1" || suite_id || label || ikm` and feed to HKDF (RFC 9180 §4)
- DHKEM `DeriveKeyPair` — one `LabeledExpand` call producing the X25519 scalar (RFC 9180 §7.1.3)
- Base-mode key schedule — three `LabeledExpand` calls producing key, base_nonce, exporter_secret (RFC 9180 §5.1)
- Single-shot seal/open via `AESGCM` with nonce = `base_nonce` (seq=0)

These are byte-string operations and HKDF invocations on top of audited primitives. The failure mode is "wrong wire format," not "broken crypto." That's the failure mode the spec test vectors are designed to catch:

- **vector-1 `enc` must equal RFC 9180 §A.1.1 `pkEm`** byte-for-byte — an independent cross-check against the published IETF RFC.
- **vectors 1 and 2 must equal Go SDK output** byte-for-byte. The Go SDK uses Cloudflare's [circl](https://github.com/cloudflare/circl) (independently-reviewed HPKE implementation), so byte-identical output here is equivalent to passing circl's correctness contract.

If any byte of the glue is wrong, vector-1 fails immediately. The harness *is* the audit.

### Why not pull a Python HPKE package?

The alternatives on PyPI (`hpke`, `pyhpke`) are themselves thin wrappers over `cryptography`, with materially smaller review surface: single maintainers, no formal audit, low download counts. Pulling one would *increase* supply-chain surface (one more transitive dep, one more maintainership chain to track) without reducing the surface we control — we'd still be trusting `cryptography` underneath, plus the wrapper.

For a cryptographic protocol project, the calculus comes out the other way: ~120 lines of glue under our own CI, pinned to spec vectors and the RFC, is a smaller and more auditable surface than an under-reviewed third-party wrapper.

### Convergence with TS SDK

This matches the planned trajectory of #473 for the TS SDK: drop `@hpke/core`, hand-roll on `node:crypto`. Both non-Go SDKs converge on the same pattern — minimal-dep, glue-only, primitives from a vetted base.

### `cryptography` module choices

HKDF primitives come from `hmac` + `hashlib.sha256` rather than `cryptography.hazmat.primitives.kdf.hkdf` because the latter only exposes the combined Extract+Expand operation; RFC 9180's labelled construction needs them separately. The HMAC-SHA256 invocation pattern is the same — `hashlib.sha256` is a thin Python wrapper around OpenSSL's SHA-256.

## Test plan

- [x] `uv run pytest -v` — 299 passed, 5 skipped (+31 new disclosure tests; 268 baseline)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright src` — 0 errors (strict mode)
- [x] Both spec vectors produce byte-identical `enc` and `ct`
- [x] Round-trip with freshly generated keys
- [x] Round-trip with RFC 7748 §6.1 Alice key
- [x] JCS plaintext shape test (non-trivially-ordered keys)
- [x] Envelope JCS shape test ([alg, ct, recipients, v] top-level; [enc, kid] inside recipients)
- [x] Negative tests: short/long recipient keys (pub + priv), wrong `ikm_e` length, empty/non-string kid, padded base64url (`=`), standard-base64 chars (`+`), `len % 4 == 1` base64url, ct < 24 chars, wrong version, wrong alg, zero/two recipients, non-dict params/recipient, Mapping subclass rejection (OrderedDict), enc wrong byte length (28-char base64url → 21 bytes), wrong private key (AES-GCM authentication failure)
- [x] JSON round-trip (`json.dumps` → `json.loads` → `decrypt_disclosure`)

Files:
- `sdk/py/src/agent_receipts/receipt/disclosure.py` (+486 lines, new)
- `sdk/py/tests/receipt/test_disclosure.py` (+404 lines, new)
- `sdk/py/src/agent_receipts/__init__.py` (+21 lines, re-export)
