### PR TITLE
docs(roadmap): promote #171 to Post 3, #280 to v1-blocker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,10 +64,17 @@ this and undermine the protocol's credibility?"
 | 2 | Silent chain termination — `status` field on `agent_end` | ADR-0019 § P1 | #475 | planned |
 | 3 | `GeneratingKeyProvider` unreachable in production | ADR-0019 § S2 | #476 | planned |
 | 4 | Sequential receipt construction enforced under parallel tool calls | ADR-0020 | #488 | planned |
+| 5 | Document tail-truncation gap in chain verification (spec + SDK doc strings + pinning tests) | spec | #171 | planned |
 
 Item 4 is in this list because the OpenClaw plugin may fire concurrent tool
 invocations during the demo. If concurrent emission produces a broken chain
 live on HN, that is the failure mode that gets quoted in the top comment.
+
+Item 5 is in this list because verifier-only chain-integrity claims are
+exactly the kind of property a sharp HN commenter dissects. `VerifyChain`
+currently returns `Valid: true` on a truncated tail. The fix is small
+(spec section + doc strings + pinning tests) but the discovery cost is
+high — better to document the property up front than to be told.
 
 ---
 
@@ -98,6 +105,7 @@ across workstreams they can be parallelised.
 | Item | ADR | Issue | Status |
 |---|---|---|---|
 | Bounded `input`/`output` payload via `PayloadStrategy` | ADR-0019 § S3 | #478 | planned |
+| `parameterDisclosure` Phase A — cross-SDK + OpenClaw migration (envelope already shipped in Go #468 / TS #472; Python SDK envelope, OpenClaw rename, cross-SDK tests remain) | ADR-0012 | #280 | planned |
 
 ### Cross-SDK parity
 


### PR DESCRIPTION
## What

Adds two issues to the ROADMAP that the post-#493 triage flagged as
misplaced relative to their importance.

### Post 3 (new item 5)

**#171 — chain verification doesn't detect tail truncation.** All three
SDKs' `VerifyChain` checks signature validity, hash linkage, and strict
sequence increment, but not chain completeness. A chain `[A, B, C]`
derived from the original `[A, B, C, D, E]` verifies as `Valid: true,
Length: 3`. The spec, godoc/TSDoc/docstrings, and tests don't currently
state this. That's exactly the kind of verifier-integrity claim a sharp
HN commenter dissects — cheap to document up front (spec section + doc
strings + pinning tests), expensive to be told.

### v1 blocker (SDK payload handling)

**#280 — `parameterDisclosure` as first-class cross-SDK + OpenClaw
feature.** Phase A is already half-shipped: the disclosure envelope
landed in Go (#468) and TypeScript (#472). The remaining Phase A work
is the Python SDK envelope, the OpenClaw plugin rename
(`parameterPreview` → `parameterDisclosure`), and cross-SDK
verification tests. Promoting this to v1-blocker makes the parity gap
explicit instead of letting it linger.

## Why

Issues open at triage time on 2026-05-21: 62. Two of them
(#171, #280) belonged in a milestone but weren't labelled as such.
This PR records the milestone change in the authoritative source of
truth (`ROADMAP.md` per ADR-0019 § "Priority order" footnote and the
ROADMAP's own "How to update this document" section).

The corresponding GitHub labels were updated at the same time:
- #171 gains `post3-blocker`
- #280 gains `v1-blocker`

## Checklist

- [x] Tests pass for all changed components (docs-only)
- [x] Linter passes (docs-only)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (N/A)
- [ ] AGENTS.md updated (N/A)
- [x] Spec changes have been reviewed by a maintainer (ROADMAP edit only — no spec change)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no (sequencing change only; the underlying issues #171 and #280 have their own security implications which are covered in those issues, not introduced here).