### PR TITLE
docs(roadmap): promote #280 (parameterDisclosure) to v1-blocker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,6 +98,7 @@ across workstreams they can be parallelised.
 | Item | ADR | Issue | Status |
 |---|---|---|---|
 | Bounded `input`/`output` payload via `PayloadStrategy` | ADR-0019 § S3 | #478 | planned |
+| `parameterDisclosure` Phase A — cross-SDK + OpenClaw migration (envelope already shipped in Go #468 / TS #472; Python SDK envelope, OpenClaw rename, cross-SDK tests remain) | ADR-0012 | #280 | planned |
 
 ### Cross-SDK parity
 


### PR DESCRIPTION
## What

Adds `parameterDisclosure` Phase A as a v1-blocker under the "SDK payload
handling" workstream.

## Why

The disclosure envelope already shipped in Go (#468) and TypeScript (#472).
The remaining Phase A work — Python SDK envelope, OpenClaw plugin rename
(`parameterPreview` → `parameterDisclosure`), and cross-SDK verification
tests — wasn't recorded in the authoritative sequencing source. Promoting
this to v1-blocker makes the parity gap explicit instead of letting it
linger as unscheduled work.

Label updated on the source issue: #280 gains `v1-blocker`.

## Relationship to PR #497

Supersedes [#497](https://github.com/agent-receipts/ar/pull/497), which
also tried to promote #171 to Post 3. On review, #171's work turned out
to already be shipped:

- `spec/spec/agent-receipt-spec-v0.1.md:454` — § 7.3.1 "Chain truncation detection"
- `sdk/{ts,go,py}/...chain.*` — `VerifyChain` documents the property
- All three SDKs ship `ExpectedLength` / `ExpectedFinalHash` options with pinning tests

[#171 was closed as completed](https://github.com/agent-receipts/ar/issues/171#issuecomment-4506928175); this smaller PR carries only the still-relevant change.

## Checklist

- [x] Tests pass for all changed components (docs-only)
- [x] Linter passes (docs-only)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (N/A)
- [ ] AGENTS.md updated (N/A)
- [x] Spec changes have been reviewed by a maintainer (ROADMAP edit only)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no (sequencing change only).