### PR TITLE
chore: remove residual "Attest" proper-noun references

### DIFF
--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -109,16 +109,15 @@ may diverge subtly across language SDKs on edge cases: UTF-16 code unit
 ordering of non-ASCII keys, ES6 `Number.toString()` semantics, Unicode
 normalisation of string values. ADR-0002 § Unicode edge cases catalogues
 two latent bugs of this class (Python's UTF-16-LE byte sort #86, Go's
-`sort.Strings()` #82). The Python SDK also has residual Attest Protocol
-naming (e.g. `eventType: "attest"`) that diverges from the canonical
-vocabulary committed in ADR-0009. Mixed-language chains may silently fail
-to verify.
+`sort.Strings()` #82). The Python SDK previously diverged on
+canonical-vocabulary naming (a pre-rename `eventType: "attest"` symbol);
+that specific symbol is fixed, but the divergence class it illustrated
+remains live. Mixed-language chains may silently fail to verify.
 
 **Decision.** Mandatory before v1 release. Produce a cross-SDK conformance
 test suite: fixed receipt JSON-LD documents (W3C VC envelope per ADR-0003)
 with known canonical RFC 8785 byte forms and known SHA-256 hash values.
-All three SDKs must produce and verify identically. Fix Python SDK
-`eventType` naming as part of this work. Round-trip matrix:
+All three SDKs must produce and verify identically. Round-trip matrix:
 TypeScript → Python, TypeScript → Go, Python → Go, and all reverse
 directions.
 

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -1,6 +1,6 @@
 """Agent Receipt schema types.
 
-These types model the Attest Agent Receipt as a W3C Verifiable Credential.
+These types model the Agent Receipt as a W3C Verifiable Credential.
 Both the full and minimal receipt variants share the same type — optional
 fields are marked with ``None`` defaults.
 """

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -17,7 +17,7 @@ class TestConstants:
     def test_context_starts_with_w3c(self) -> None:
         assert CONTEXT[0] == "https://www.w3.org/ns/credentials/v2"
 
-    def test_context_includes_attest(self) -> None:
+    def test_context_includes_agent_receipts_uri(self) -> None:
         assert CONTEXT[1] == "https://agentreceipts.ai/context/v1"
 
     def test_credential_type_has_two_entries(self) -> None:

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -1,7 +1,7 @@
 /**
  * Agent Receipt schema types.
  *
- * These types model the Attest Agent Receipt as a W3C Verifiable Credential.
+ * These types model the Agent Receipt as a W3C Verifiable Credential.
  * Both the full and minimal receipt variants share the same type — optional
  * fields are marked with `?`.
  */

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -24,7 +24,7 @@
       ],
       "minItems": 2,
       "items": { "type": "string" },
-      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Attest context URIs in order. Additional context URIs MAY follow."
+      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Agent Receipts context URIs in order. Additional context URIs MAY follow."
     },
     "id": {
       "type": "string",

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -214,7 +214,7 @@ All five `proof` fields are required even in the minimal form.
 
 | Field | Required | Description |
 |---|---|---|
-| `@context` | Yes | JSON-LD context. MUST include the W3C VC v2 and Attest context URIs in the order shown. |
+| `@context` | Yes | JSON-LD context. MUST include the W3C VC v2 and Agent Receipts context URIs in the order shown. |
 | `id` | Yes | Globally unique receipt identifier. MUST be a `urn:receipt:<uuid>`. |
 | `type` | Yes | MUST be `["VerifiableCredential", "AgentReceipt"]`. |
 | `version` | Yes | Spec version this receipt conforms to. MUST be `"0.1.0"` for this version. |


### PR DESCRIPTION
## What

Removes leftover `Attest` / `Attest Protocol` proper-noun references from spec prose, two SDK doc-comments, one Python test name, and ADR-0019.

- `spec/spec/agent-receipt-spec-v0.1.md`, `spec/schema/agent-receipt.schema.json`: `@context` description now says "Agent Receipts context URIs" instead of "Attest context URIs"
- `sdk/ts/src/receipt/types.ts`, `sdk/py/src/agent_receipts/receipt/types.py`: module doc-comment now says "Agent Receipt" instead of "Attest Agent Receipt"
- `sdk/py/tests/receipt/test_types.py`: renamed `test_context_includes_attest` → `test_context_includes_agent_receipts_uri`
- `docs/adr/0019-protocol-integrity-gaps-and-mitigations.md` (status: Proposed): rephrases S1's Gap statement past-tense — the `eventType: "attest"` symbol it cited no longer exists in the tree — and drops the matching "Fix Python SDK `eventType` naming as part of this work" sentence from the Decision.

## Why

Per `CONTEXT.md`, any `Attest*` proper noun is treated as a bug from the pre-rename "Attest Protocol" era. This closes the leak in the spec, both SDKs, and ADR-0019's stale residual-naming claim.

The lowercase verb `attest` / `attested` / `attestation` used by the threat model (OS peer-credential attestation in `daemon/`, ADR-0010/0013/0014/0017) is intentionally left untouched — it is the correct domain term, not a brand leak.

External `github.com/ojongerius/attest` reference-implementation links in `spec/README.md`, `sdk/{ts,py}/README.md`, and `site/README.md` are deliberately out of scope — they're a separate decision (rename the external repo? swap the link? keep as historical pointer?).

## Checklist

- [x] Tests pass for all changed components — `py-test`, `ts-test`, `ts-typecheck` all green on pre-push
- [x] Linter passes — `ruff check`, `biome check` ran clean on pre-commit
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass — N/A; no receipt format, signing, or hashing changed
- [x] AGENTS.md updated — N/A; no project structure changes
- [ ] Spec changes have been reviewed by a maintainer — the spec edits are description-string fixes only, no wire-format implications, but flagging for awareness

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no