### PR TITLE
feat(sdk/go): migrate Action.ParametersDisclosure to envelope; add PeerCredential and EmitterMetadata

### DIFF
--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -282,14 +282,13 @@ func generateV020Vectors(keys keysSection) error {
 
 	// Single-receipt parameters_disclosure vector (ADR-0012 Phase A, schema 0.2.1).
 	// Built standalone (not part of the legacy 0.2.0 chain), signed with the same
-	// shared key, deterministic via fixed timestamps and UUID overrides.
-	pdReceipt, pdHash, err := generateParametersDisclosureReceipt(keys)
+	// shared key, deterministic via fixed timestamps and UUID overrides. Built
+	// as map[string]any because the Go SDK can no longer construct the legacy
+	// flat-map parameters_disclosure shape through its typed API after the
+	// v0.3.0 envelope migration.
+	pdReceiptJSON, pdHash, err := generateParametersDisclosureReceipt(keys)
 	if err != nil {
 		return fmt.Errorf("generate parameters_disclosure receipt: %w", err)
-	}
-	pdReceiptJSON, err := json.Marshal(pdReceipt)
-	if err != nil {
-		return fmt.Errorf("marshal parameters_disclosure receipt: %w", err)
 	}
 
 	v020 := v020Vectors{
@@ -307,7 +306,7 @@ func generateV020Vectors(keys keysSection) error {
 		},
 		ParametersDisclosureReceipt: parametersDisclosureReceiptSection{
 			Description:         "Single 0.2.1 signed receipt with action.parameters_disclosure populated. All three SDKs MUST verify the signature and reproduce expectedReceiptHash byte-for-byte (ADR-0012 Phase A; ADR-0009 canonicalisation).",
-			Receipt:             json.RawMessage(pdReceiptJSON),
+			Receipt:             pdReceiptJSON,
 			ExpectedReceiptHash: pdHash,
 			ExpectedValid:       true,
 		},
@@ -321,52 +320,55 @@ func generateV020Vectors(keys keysSection) error {
 }
 
 // generateParametersDisclosureReceipt builds a deterministic single-receipt
-// vector (schema 0.2.1) with action.parameters_disclosure populated, signs it
-// with the shared private key, and returns the signed receipt and its hash.
+// vector (schema 0.2.1) with action.parameters_disclosure populated as the
+// *legacy flat-map* shape, signs it with the shared private key, and returns
+// the signed receipt JSON and its hash.
 //
-// The receipt deliberately uses a fresh chain (chain_pd_test, sequence 1) so it
-// cannot be confused with the legacy 0.2.0 terminalChain — that chain stays
-// frozen as the signature-preservation oracle.
-func generateParametersDisclosureReceipt(keys keysSection) (receipt.AgentReceipt, string, error) {
+// The Go SDK's typed Action.ParametersDisclosure dropped support for the
+// legacy flat-map shape during the v0.3.0 envelope migration (ADR-0012
+// amendment 2026-05-18); this generator therefore builds the receipt as a
+// map[string]any and signs it directly via crypto/ed25519, mirroring how
+// generateV030Vectors handles the new envelope shape. The v020 fixture stays
+// pinned for cross-SDK signature-preservation coverage even though the Go
+// SDK can no longer construct it through its typed API.
+//
+// The receipt deliberately uses a fresh chain (chain_pd_test, sequence 1) so
+// it cannot be confused with the legacy 0.2.0 terminalChain — that chain
+// stays frozen as the signature-preservation oracle.
+func generateParametersDisclosureReceipt(keys keysSection) (json.RawMessage, string, error) {
 	const fixedTimestamp = "2026-04-22T00:00:00Z"
 
-	r := receipt.Create(receipt.CreateInput{
-		Issuer:    receipt.Issuer{ID: "did:agent:test"},
-		Principal: receipt.Principal{ID: "did:user:test"},
-		Action: receipt.Action{
-			Type:      "filesystem.file.read",
-			RiskLevel: receipt.RiskLow,
-			ParametersDisclosure: map[string]string{
-				"command": "echo build",
-				"user":    "ci",
+	unsigned := map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"},
+		"id":           "urn:receipt:v021-pd-1",
+		"type":         []any{"VerifiableCredential", "AgentReceipt"},
+		"version":      "0.2.1",
+		"issuer":       map[string]any{"id": "did:agent:test"},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":         "act_v021_pd_1",
+				"type":       "filesystem.file.read",
+				"risk_level": "low",
+				"parameters_disclosure": map[string]any{
+					"command": "echo build",
+					"user":    "ci",
+				},
+				"timestamp": fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_pd_test",
 			},
 		},
-		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
-		Chain:   receipt.Chain{Sequence: 1, PreviousReceiptHash: nil, ChainID: "chain_pd_test"},
-	})
-	r.Version = "0.2.1"
-	r.ID = "urn:receipt:v021-pd-1"
-	r.IssuanceDate = fixedTimestamp
-	r.CredentialSubject.Action.ID = "act_v021_pd_1"
-	r.CredentialSubject.Action.Timestamp = fixedTimestamp
-
-	signed, err := receipt.Sign(r, keys.PrivateKey, "did:agent:test#key-1")
-	if err != nil {
-		return receipt.AgentReceipt{}, "", fmt.Errorf("sign: %w", err)
-	}
-	signed.Proof.Created = fixedTimestamp
-
-	valid, err := receipt.Verify(signed, keys.PublicKey)
-	if err != nil {
-		return receipt.AgentReceipt{}, "", fmt.Errorf("verify: %w", err)
-	}
-	if !valid {
-		return receipt.AgentReceipt{}, "", fmt.Errorf("generated parameters_disclosure receipt failed verification")
 	}
 
-	hash, err := receipt.HashReceipt(signed)
+	signed, hash, err := signAndHashMap(unsigned, keys, fixedTimestamp)
 	if err != nil {
-		return receipt.AgentReceipt{}, "", fmt.Errorf("hash: %w", err)
+		return nil, "", err
 	}
 	return signed, hash, nil
 }

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -169,14 +169,15 @@ The following are deliberate Phase 1 choices, all callable out for follow-up:
   retrieval works identically on stream sockets, so the trust model is
   unchanged. A follow-up issue should amend ADR-0010 to record the per-OS
   socket type.
-- **Peer attestation placement.** ADR-0010 calls for a top-level `peer`
-  field on each receipt. Adding that requires a spec change (out of scope
-  per AGENTS.md). Phase 1 stashes peer attestation in
-  `action.parameters_disclosure` under keys `peer.platform`, `peer.pid`,
-  `peer.uid`, `peer.gid`, `peer.exe_path`. The values are still
-  signature-protected. The emitter-refactor phase will introduce the
-  proper spec field.
-- **macOS `peer.exe_path`.** Linux populates this from `/proc/<pid>/exe`;
+- **Peer attestation placement.** ADR-0010 called for a top-level peer
+  field; spec v0.3.0 (PR #496) added a dedicated `action.peer_credential`
+  object on the receipt. The daemon writes that typed field directly
+  (`platform`, `pid`, `uid`, `gid`, `exe_path`) and the synthetic
+  events_dropped receipt's drop counter rides on the sibling
+  `action.emitter_metadata.drop_count` field. The values are still
+  signature-protected. The Phase-1 flat-map shape (`peer.platform`,
+  `peer.pid`, etc. inside `parameters_disclosure`) has been retired.
+- **macOS `peer_credential.exe_path`.** Linux populates this from `/proc/<pid>/exe`;
   macOS uses the `SYS_PROC_INFO(PROC_PIDPATHINFO)` syscall directly
   (the call libproc's `proc_pidpath()` wraps), so the daemon stays
   CGO-free. Failure is non-fatal — `exe_path` is left empty and pid /

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.StringVar(&cfg.ChainID, "chain-id", cfg.ChainID, "Chain id to write under (env: AGENTRECEIPTS_CHAIN_ID)")
 	flag.StringVar(&cfg.IssuerID, "issuer-id", cfg.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
 	flag.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
-	flag.BoolVar(&cfg.ParameterDisclosure, "parameter-disclosure", cfg.ParameterDisclosure, "Include plaintext tool input/output in parameters_disclosure (WARNING: stores unredacted payloads; see issue #280) (env: AGENTRECEIPTS_PARAMETER_DISCLOSURE)")
+	flag.BoolVar(&cfg.ParameterDisclosure, "parameter-disclosure", cfg.ParameterDisclosure, "No-op as of v0.3.0 envelope migration (ADR-0012 amendment); plaintext-in-body shape removed. Encrypted disclosure pending in #280. (env: AGENTRECEIPTS_PARAMETER_DISCLOSURE)")
 	flag.StringVar(&cfg.RedactPatternsPath, "redact-patterns", cfg.RedactPatternsPath, "Path to a YAML file of additional redaction patterns (merged with built-in defaults) (env: AGENTRECEIPTS_REDACT_PATTERNS)")
 	flag.Parse()
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -61,10 +61,11 @@ type Config struct {
 	// what frames were received, receipts signed, etc.
 	TraceLog io.Writer
 
-	// ParameterDisclosure controls whether plaintext tool input and output are
-	// included in the parameters_disclosure receipt field. Disabled by default.
-	// WARNING: stores unredacted payloads — see issue #280 for the encrypted
-	// design that supersedes this flag.
+	// ParameterDisclosure is the historical opt-in for plaintext tool
+	// input/output in the legacy string-map shape of parameters_disclosure.
+	// As of the v0.3.0 envelope migration (ADR-0012 amendment 2026-05-18) that
+	// shape is no longer representable; this flag is a documented no-op
+	// pending the daemon-side HPKE envelope wiring tracked in #280.
 	ParameterDisclosure bool
 
 	// RedactPatternsPath is an optional path to a YAML file of additional
@@ -332,10 +333,10 @@ func Run(ctx context.Context, cfg Config) error {
 	cfg.Logger.Printf("loaded chain %s, next seq=%d", cfg.ChainID, state.NextSeq())
 
 	if cfg.ParameterDisclosure {
-		cfg.Logger.Printf("WARNING: --parameter-disclosure is enabled.")
-		cfg.Logger.Printf("WARNING: Plaintext tool input and output will be stored in receipts.")
-		cfg.Logger.Printf("WARNING: This is a temporary opt-in pending encrypted disclosure (issue #280).")
-		cfg.Logger.Printf("WARNING: Ensure receipts.db is protected and does not contain secrets you cannot afford to expose.")
+		cfg.Logger.Printf("NOTICE: --parameter-disclosure is enabled but currently a no-op.")
+		cfg.Logger.Printf("NOTICE: The legacy plaintext-in-body shape was removed by the v0.3.0")
+		cfg.Logger.Printf("NOTICE: envelope migration (ADR-0012 amendment 2026-05-18). Encrypted")
+		cfg.Logger.Printf("NOTICE: disclosure pending — tracked in #280.")
 	}
 
 	pp := pipeline.New(state, ks, st, cfg.IssuerID)

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -306,54 +305,57 @@ func TestPeerCredCaptured(t *testing.T) {
 	})
 
 	receipts := waitForReceiptCount(t, cfg.DBPath, cfg.ChainID, 1, 5*time.Second)
-	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
-
-	wantPID := strconv.Itoa(os.Getpid())
-	if pd["peer.pid"] != wantPID {
-		t.Errorf("peer.pid = %q, want %q (OS-attested pid of test process)", pd["peer.pid"], wantPID)
-	}
-	wantUID := strconv.Itoa(os.Getuid())
-	if pd["peer.uid"] != wantUID {
-		t.Errorf("peer.uid = %q, want %q", pd["peer.uid"], wantUID)
+	pc := receipts[0].CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		t.Fatal("PeerCredential nil; daemon must record OS-attested peer cred")
 	}
 
-	switch pd["peer.platform"] {
+	wantPID := int32(os.Getpid())
+	if pc.PID != wantPID {
+		t.Errorf("peer_credential.pid = %d, want %d (OS-attested pid of test process)", pc.PID, wantPID)
+	}
+	wantUID := uint32(os.Getuid())
+	if pc.UID != wantUID {
+		t.Errorf("peer_credential.uid = %d, want %d", pc.UID, wantUID)
+	}
+
+	switch pc.Platform {
 	case "linux":
-		if pd["peer.exe_path"] == "" {
-			t.Error("Linux daemon should populate peer.exe_path from /proc/<pid>/exe")
+		if pc.ExePath == "" {
+			t.Error("Linux daemon should populate peer_credential.exe_path from /proc/<pid>/exe")
 		}
 	case "darwin":
-		if pd["peer.exe_path"] == "" {
+		if pc.ExePath == "" {
 			// SYS_PROC_INFO may be restricted in sandboxed CI environments; the
 			// daemon degrades gracefully (pid/uid/gid still recorded). Log only.
-			t.Log("darwin: peer.exe_path empty; SYS_PROC_INFO may be restricted in this environment")
+			t.Log("darwin: peer_credential.exe_path empty; SYS_PROC_INFO may be restricted in this environment")
 		}
 	default:
-		t.Errorf("unexpected peer.platform = %q", pd["peer.platform"])
+		t.Errorf("unexpected peer_credential.platform = %q", pc.Platform)
 	}
 
-	// peer.exe_path is non-empty alone is too weak: a regression that records
-	// the wrong process's path (the daemon's own binary instead of the
+	// peer_credential.exe_path non-empty is too weak alone: a regression that
+	// records the wrong process's path (the daemon's own binary instead of the
 	// connecting client's) still produces a valid absolute path. The test
-	// process is the daemon's connecting peer here, so peer.exe_path must
-	// refer to the same file as os.Executable. os.SameFile comparison rather
-	// than string equality tolerates path canonicalisation (e.g. macOS's
-	// /var → /private/var symlink) and any /proc-style resolution difference.
-	if got := pd["peer.exe_path"]; got != "" {
+	// process is the daemon's connecting peer here, so exe_path must refer to
+	// the same file as os.Executable. os.SameFile tolerates path
+	// canonicalisation (e.g. macOS's /var → /private/var symlink) and any
+	// /proc-style resolution difference.
+	if got := pc.ExePath; got != "" {
 		want, err := os.Executable()
 		if err != nil {
 			t.Fatalf("os.Executable: %v", err)
 		}
 		gotInfo, err := os.Stat(got)
 		if err != nil {
-			t.Fatalf("os.Stat(peer.exe_path %q): %v", got, err)
+			t.Fatalf("os.Stat(peer_credential.exe_path %q): %v", got, err)
 		}
 		wantInfo, err := os.Stat(want)
 		if err != nil {
 			t.Fatalf("os.Stat(os.Executable %q): %v", want, err)
 		}
 		if !os.SameFile(gotInfo, wantInfo) {
-			t.Errorf("peer.exe_path = %q is not the same file as os.Executable = %q (the test process is the daemon's connecting peer)", got, want)
+			t.Errorf("peer_credential.exe_path = %q is not the same file as os.Executable = %q (the test process is the daemon's connecting peer)", got, want)
 		}
 	}
 }
@@ -383,36 +385,39 @@ func TestPeerCredFromSubprocess(t *testing.T) {
 	}
 
 	receipts := waitForReceiptCount(t, cfg.DBPath, cfg.ChainID, 1, 5*time.Second)
-	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
+	pc := receipts[0].CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		t.Fatal("PeerCredential nil; daemon must record OS-attested peer cred for subprocess connection")
+	}
 
-	// peer.pid must NOT be the test process's pid: the daemon must have
-	// captured the subprocess's pid via the connected-socket primitive
+	// peer_credential.pid must NOT be the test process's pid: the daemon must
+	// have captured the subprocess's pid via the connected-socket primitive
 	// (SO_PEERCRED on Linux, LOCAL_PEEREPID on macOS).
-	if pd["peer.pid"] == strconv.Itoa(os.Getpid()) {
-		t.Errorf("peer.pid = %q (= os.Getpid()); daemon recorded the listener's own pid instead of the connecting subprocess's", pd["peer.pid"])
+	if pc.PID == int32(os.Getpid()) {
+		t.Errorf("peer_credential.pid = %d (= os.Getpid()); daemon recorded the listener's own pid instead of the connecting subprocess's", pc.PID)
 	}
-	if pd["peer.pid"] == "" {
-		t.Errorf("peer.pid empty — peer-cred capture failed for subprocess connection")
+	if pc.PID == 0 {
+		t.Errorf("peer_credential.pid is 0 — peer-cred capture failed for subprocess connection")
 	}
 
-	// peer.exe_path: subprocess is the same binary, so SameFile against
-	// os.Executable() still holds. This catches the regression where the
-	// daemon records a hardcoded or constant path.
-	if got := pd["peer.exe_path"]; got != "" {
+	// peer_credential.exe_path: subprocess is the same binary, so SameFile
+	// against os.Executable() still holds. Catches a regression that records a
+	// hardcoded or constant path.
+	if got := pc.ExePath; got != "" {
 		want, err := os.Executable()
 		if err != nil {
 			t.Fatalf("os.Executable: %v", err)
 		}
 		gotInfo, err := os.Stat(got)
 		if err != nil {
-			t.Fatalf("os.Stat(peer.exe_path %q): %v", got, err)
+			t.Fatalf("os.Stat(peer_credential.exe_path %q): %v", got, err)
 		}
 		wantInfo, err := os.Stat(want)
 		if err != nil {
 			t.Fatalf("os.Stat(os.Executable %q): %v", want, err)
 		}
 		if !os.SameFile(gotInfo, wantInfo) {
-			t.Errorf("peer.exe_path = %q is not the same file as os.Executable = %q (subprocess is the same binary as parent)", got, want)
+			t.Errorf("peer_credential.exe_path = %q is not the same file as os.Executable = %q (subprocess is the same binary as parent)", got, want)
 		}
 	}
 }

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"strconv"
 	"sync"
 	"time"
 
@@ -92,18 +91,20 @@ type Pipeline struct {
 	TraceLog io.Writer              // Optional trace log for testing; nil = silent
 	ErrorLog func(string, ...any)   // Optional error logger; nil = silent
 
-	// ParameterDisclosure, when true, includes plaintext tool input and output
-	// in the parameters_disclosure receipt field. Disabled by default.
-	// WARNING: stores unredacted payloads — see issue #280 for the encrypted
-	// design that supersedes this flag.
+	// ParameterDisclosure is the historical opt-in for plaintext tool
+	// input/output in the legacy string-map shape of parameters_disclosure.
+	// As of the v0.3.0 envelope migration (ADR-0012 amendment 2026-05-18) that
+	// shape is no longer representable — the receipt type only accepts an
+	// HPKE-encrypted *DisclosureEnvelope. Until the daemon learns to encrypt
+	// and attach an envelope itself (tracked under #280), this field is a
+	// no-op preserved so the CLI/env knob does not vanish silently on operators.
 	ParameterDisclosure bool
 
 	// Redactor is applied to text fields before they are persisted in the
-	// receipt body: outcome.error is redacted; parameters_disclosure
-	// input/output strings are also redacted when ParameterDisclosure is
-	// enabled. Input and output are never stored as raw text otherwise — only
-	// their SHA-256 hashes go into parameters_hash / response_hash, so those
-	// hashes are always over the original emitter payload. Nil = no redaction.
+	// receipt body. Today that means outcome.error only; input and output are
+	// never stored as raw text — only their SHA-256 hashes go into
+	// parameters_hash / response_hash, so those hashes are always over the
+	// original emitter payload. Nil = no redaction.
 	Redactor *Redactor
 
 	// traceMu serialises writes to TraceLog. Process is invoked concurrently
@@ -418,35 +419,17 @@ func (p *Pipeline) buildAndSign(
 		actionType = f.Channel + "." + f.Tool.Server + "." + f.Tool.Name
 	}
 
-	// Phase 1 stashes the OS-attested peer cred in Action.ParametersDisclosure
-	// as a placeholder. ADR-0010 calls for a dedicated `peer` field on the
-	// receipt; adding that requires a spec change (out of scope per AGENTS.md
-	// "Never modify the protocol spec without explicit human approval"), so
-	// peer.* keys ride on the existing field until Phase 2.
-	//
-	// NOTE: parameters_disclosure is operator-allowlisted additive metadata in
-	// the spec. Until a top-level peer field exists, this map MUST stay
-	// minimal: only OS-attested fields the daemon vouches for. Emitter-
-	// supplied content (channel, session_id, ts_emit, error) lives elsewhere
-	// on the receipt — channel is folded into action.type, session_id into
-	// issuer.session_id, error into outcome.error. The emitter-asserted
-	// ts_emit is dropped (it is untrusted self-report and would not add audit
-	// value); the daemon's authoritative receive-time is the `now` value
-	// already stamped into action.timestamp, issuanceDate, and proof.created.
-	//
-	// Exception: when the operator explicitly enables ParameterDisclosure, the
-	// emitter-controlled input/output bytes are intentionally added below.
-	// That opt-in is for full-fidelity audit trails where the operator has
-	// already accepted the trade-off. PII exposure and the absence of a
-	// redaction mechanism are tracked in issue #423 — operators should not
-	// enable this option until that is resolved.
-	disclosure := map[string]string{
-		"peer.platform": peer.Platform,
-		"peer.pid":      strconv.FormatInt(int64(peer.PID), 10),
-		// uid_t / gid_t are unsigned 32-bit; format as unsigned to avoid wrap.
-		"peer.uid":      strconv.FormatUint(uint64(peer.UID), 10),
-		"peer.gid":      strconv.FormatUint(uint64(peer.GID), 10),
-		"peer.exe_path": peer.ExePath,
+	// OS-attested peer credentials populate action.peer_credential — the
+	// dedicated typed field landed by spec v0.3.0 (ADR-0010 + PR #496). The
+	// daemon vouches for these values via signature; they are present only on
+	// receipts emitted through the daemon and absent on direct-SDK emissions
+	// (where the SDK has no privileged channel to attest peer identity).
+	peerCred := &receipt.PeerCredential{
+		Platform: peer.Platform,
+		PID:      peer.PID,
+		UID:      peer.UID,
+		GID:      peer.GID,
+		ExePath:  peer.ExePath,
 	}
 
 	// Risk derives from the taxonomy. Daemon-constructed action types like
@@ -458,11 +441,11 @@ func (p *Pipeline) buildAndSign(
 	risk := taxonomy.ResolveActionType(actionType).RiskLevel
 
 	action := receipt.Action{
-		Type:                 actionType,
-		ToolName:             f.Tool.Name,
-		RiskLevel:            risk,
-		Timestamp:            now,
-		ParametersDisclosure: disclosure,
+		Type:           actionType,
+		ToolName:       f.Tool.Name,
+		RiskLevel:      risk,
+		Timestamp:      now,
+		PeerCredential: peerCred,
 	}
 	if hasJSONPayload(f.Input) {
 		hash, err := canonicalSHA256(f.Input)
@@ -472,26 +455,13 @@ func (p *Pipeline) buildAndSign(
 		action.ParametersHash = hash
 	}
 
-	// Populate plaintext disclosure after hashing so the hash always covers the
-	// raw bytes, not any string conversion. Only runs when explicitly opted in.
-	// Redaction is applied to the stored text so secrets are sanitised even
-	// when the operator enables disclosure mode.
-	if p.ParameterDisclosure {
-		if hasJSONPayload(f.Input) {
-			inp := string(f.Input)
-			if p.Redactor != nil {
-				inp = p.Redactor.Redact(inp)
-			}
-			disclosure["input"] = inp
-		}
-		if hasJSONPayload(f.Output) {
-			out := string(f.Output)
-			if p.Redactor != nil {
-				out = p.Redactor.Redact(out)
-			}
-			disclosure["output"] = out
-		}
-	}
+	// NOTE: the legacy "--parameter-disclosure" flag (`p.ParameterDisclosure`)
+	// is currently a no-op. It used to write plaintext input/output into a
+	// string-map shape of action.parameters_disclosure; that shape was removed
+	// by the v0.3.0 envelope migration (ADR-0012 amendment 2026-05-18). The
+	// field is now *DisclosureEnvelope and only accepts the HPKE-encrypted
+	// envelope. Daemon-side encrypt-then-attach is tracked in #280. The
+	// outcome.error redaction path below is independent of the flag.
 
 	// Redaction MUST happen AFTER hashing. The hash commits to the raw
 	// canonical bytes; redaction only sanitises the human-readable string
@@ -583,13 +553,15 @@ func (p *Pipeline) buildAndSignDropReceipt(
 			ToolName:  "events_dropped",
 			RiskLevel: receipt.RiskLow,
 			Timestamp: now,
-			ParametersDisclosure: map[string]string{
-				"emitter.drop_count": strconv.FormatInt(dropCount, 10),
-				"peer.platform":      peer.Platform,
-				"peer.pid":           strconv.FormatInt(int64(peer.PID), 10),
-				"peer.uid":           strconv.FormatUint(uint64(peer.UID), 10),
-				"peer.gid":           strconv.FormatUint(uint64(peer.GID), 10),
-				"peer.exe_path":      peer.ExePath,
+			PeerCredential: &receipt.PeerCredential{
+				Platform: peer.Platform,
+				PID:      peer.PID,
+				UID:      peer.UID,
+				GID:      peer.GID,
+				ExePath:  peer.ExePath,
+			},
+			EmitterMetadata: &receipt.EmitterMetadata{
+				DropCount: dropCount,
 			},
 		},
 		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -110,19 +110,25 @@ func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	if r.CredentialSubject.Action.ToolName != "list_repos" {
 		t.Errorf("action.tool_name = %q", r.CredentialSubject.Action.ToolName)
 	}
-	pd := r.CredentialSubject.Action.ParametersDisclosure
-	if pd["peer.platform"] != "linux" || pd["peer.pid"] != "4242" || pd["peer.uid"] != "1000" {
-		t.Errorf("peer attestation not recorded: %#v", pd)
+	pc := r.CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		t.Fatal("PeerCredential nil; daemon must record OS-attested peer cred on every live receipt")
 	}
-	if pd["peer.exe_path"] != "/usr/bin/mcp-proxy" {
-		t.Errorf("peer.exe_path = %q", pd["peer.exe_path"])
+	if pc.Platform != "linux" || pc.PID != 4242 || pc.UID != 1000 {
+		t.Errorf("peer attestation not recorded: %#v", pc)
 	}
-	// session_id, channel, ts_emit must NOT be in parameters_disclosure —
-	// they live on issuer.session_id / action.type / (dropped) respectively.
-	for _, k := range []string{"session_id", "channel", "ts_emit", "ts_recv", "error"} {
-		if _, ok := pd[k]; ok {
-			t.Errorf("parameters_disclosure unexpectedly contains %q (emitter content must not be mirrored here)", k)
-		}
+	if pc.ExePath != "/usr/bin/mcp-proxy" {
+		t.Errorf("peer_credential.exe_path = %q", pc.ExePath)
+	}
+	// Live receipts MUST NOT carry the synthetic emitter_metadata block —
+	// drop_count belongs to events_dropped synthetic receipts only.
+	if r.CredentialSubject.Action.EmitterMetadata != nil {
+		t.Errorf("live receipt should not carry emitter_metadata; got %#v", r.CredentialSubject.Action.EmitterMetadata)
+	}
+	// parameters_disclosure stays nil until the daemon ships envelope-mode
+	// disclosure (issue #280); the old plaintext-in-body shape is gone.
+	if r.CredentialSubject.Action.ParametersDisclosure != nil {
+		t.Errorf("ParametersDisclosure must be nil on plain live receipts; got %#v", r.CredentialSubject.Action.ParametersDisclosure)
 	}
 	if r.Issuer.SessionID != "sess-123" {
 		t.Errorf("issuer.session_id = %q, want sess-123", r.Issuer.SessionID)
@@ -769,8 +775,12 @@ func TestProcess_DropCountInsertsEventsDroppedReceipt(t *testing.T) {
 	if got := synthetic.CredentialSubject.Outcome.Status; got != "success" {
 		t.Errorf("synthetic outcome.status = %q, want success", got)
 	}
-	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["emitter.drop_count"]; got != "3" {
-		t.Errorf("synthetic emitter.drop_count disclosure = %q, want 3", got)
+	em := synthetic.CredentialSubject.Action.EmitterMetadata
+	if em == nil {
+		t.Fatal("synthetic events_dropped receipt missing emitter_metadata")
+	}
+	if em.DropCount != 3 {
+		t.Errorf("synthetic emitter_metadata.drop_count = %d, want 3", em.DropCount)
 	}
 	if got := synthetic.Issuer.SessionID; got != "sess-drop" {
 		t.Errorf("synthetic session_id = %q, want sess-drop", got)
@@ -807,7 +817,7 @@ func TestProcess_DropCountInsertsEventsDroppedReceipt(t *testing.T) {
 
 // TestProcess_DropCountPreservesPeerAttestationOnSynthetic verifies that the
 // peer cred from the emitter connection is recorded in the synthetic receipt's
-// parameters_disclosure, matching the live receipt's attribution source.
+// peer_credential, matching the live receipt's attribution source.
 func TestProcess_DropCountPreservesPeerAttestationOnSynthetic(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)
@@ -824,15 +834,18 @@ func TestProcess_DropCountPreservesPeerAttestationOnSynthetic(t *testing.T) {
 	if len(receipts) < 1 {
 		t.Fatal("no receipts")
 	}
-	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
-	if pd["peer.platform"] != "linux" {
-		t.Errorf("peer.platform = %q, want linux", pd["peer.platform"])
+	pc := receipts[0].CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		t.Fatal("synthetic receipt missing peer_credential")
 	}
-	if pd["peer.pid"] != "99" {
-		t.Errorf("peer.pid = %q, want 99", pd["peer.pid"])
+	if pc.Platform != "linux" {
+		t.Errorf("peer_credential.platform = %q, want linux", pc.Platform)
 	}
-	if pd["peer.exe_path"] != "/usr/bin/emitter" {
-		t.Errorf("peer.exe_path = %q", pd["peer.exe_path"])
+	if pc.PID != 99 {
+		t.Errorf("peer_credential.pid = %d, want 99", pc.PID)
+	}
+	if pc.ExePath != "/usr/bin/emitter" {
+		t.Errorf("peer_credential.exe_path = %q", pc.ExePath)
 	}
 }
 
@@ -876,94 +889,65 @@ func TestProcess_DropCountChainContinues(t *testing.T) {
 	}
 }
 
-// TestProcess_ParameterDisclosureEnabled verifies that when ParameterDisclosure
-// is true, plaintext input and output are recorded in parameters_disclosure under
-// the "input" and "output" keys. The hash fields must still be present because
-// hashing runs before the disclosure block.
-func TestProcess_ParameterDisclosureEnabled(t *testing.T) {
-	ks := newTestKeySource(t)
-	st := newTestStore(t)
-	state := chain.New("chain-1")
-	p := New(state, ks, st, "did:agent-receipts-daemon:test")
-	p.ParameterDisclosure = true
+// TestProcess_ParameterDisclosureFlagIsNoOp verifies that the legacy
+// --parameter-disclosure opt-in is a no-op as of the v0.3.0 envelope migration
+// (ADR-0012 amendment 2026-05-18). The receipt type only accepts the HPKE
+// envelope shape now, so plaintext-in-body input/output has nowhere to go.
+// The flag stays in place so operators do not see a sudden config error, but
+// it must not produce a parameters_disclosure value in either direction.
+// Encrypted disclosure is tracked in #280.
+func TestProcess_ParameterDisclosureFlagIsNoOp(t *testing.T) {
+	cases := []struct {
+		name    string
+		enabled bool
+	}{
+		{"enabled", true},
+		{"disabled", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := newTestKeySource(t)
+			st := newTestStore(t)
+			state := chain.New("chain-1")
+			p := New(state, ks, st, "did:agent-receipts-daemon:test")
+			p.ParameterDisclosure = tc.enabled
 
-	inputJSON := json.RawMessage(`{"path":"/tmp/file","mode":"r"}`)
-	outputJSON := json.RawMessage(`{"bytes":42}`)
-	body, err := json.Marshal(EmitterFrame{
-		Version:   "1",
-		TsEmit:    "2026-05-03T00:00:00Z",
-		SessionID: "s",
-		Channel:   "sdk",
-		Tool:      EmitterTool{Name: "fs.read"},
-		Input:     inputJSON,
-		Output:    outputJSON,
-		Decision:  "allowed",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := p.Process(socket.Frame{Payload: body}); err != nil {
-		t.Fatalf("Process: %v", err)
-	}
-	receipts, err := st.GetChain("chain-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	r := receipts[0]
-	pd := r.CredentialSubject.Action.ParametersDisclosure
+			inputJSON := json.RawMessage(`{"path":"/tmp/file","mode":"r"}`)
+			outputJSON := json.RawMessage(`{"bytes":42}`)
+			body, err := json.Marshal(EmitterFrame{
+				Version:   "1",
+				TsEmit:    "2026-05-03T00:00:00Z",
+				SessionID: "s",
+				Channel:   "sdk",
+				Tool:      EmitterTool{Name: "fs.read"},
+				Input:     inputJSON,
+				Output:    outputJSON,
+				Decision:  "allowed",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := p.Process(socket.Frame{Payload: body}); err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			receipts, err := st.GetChain("chain-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := receipts[0]
 
-	if got := pd["input"]; got != string(inputJSON) {
-		t.Errorf("parameters_disclosure[input] = %q, want %q", got, string(inputJSON))
-	}
-	if got := pd["output"]; got != string(outputJSON) {
-		t.Errorf("parameters_disclosure[output] = %q, want %q", got, string(outputJSON))
-	}
-	// Hashes must still be present — disclosure doesn't replace hashing.
-	if r.CredentialSubject.Action.ParametersHash == "" {
-		t.Error("parameters_hash must be present when input is set, even with disclosure enabled")
-	}
-	if r.CredentialSubject.Outcome.ResponseHash == "" {
-		t.Error("response_hash must be present when output is set, even with disclosure enabled")
-	}
-}
-
-// TestProcess_ParameterDisclosureDisabled verifies that when ParameterDisclosure
-// is false (the default), the "input" and "output" keys are absent from
-// parameters_disclosure even when the frame carries non-null input and output.
-func TestProcess_ParameterDisclosureDisabled(t *testing.T) {
-	ks := newTestKeySource(t)
-	st := newTestStore(t)
-	state := chain.New("chain-1")
-	p := New(state, ks, st, "did:agent-receipts-daemon:test")
-	// ParameterDisclosure defaults to false; no assignment needed.
-
-	body, err := json.Marshal(EmitterFrame{
-		Version:   "1",
-		TsEmit:    "2026-05-03T00:00:00Z",
-		SessionID: "s",
-		Channel:   "sdk",
-		Tool:      EmitterTool{Name: "fs.read"},
-		Input:     json.RawMessage(`{"path":"/tmp/file","mode":"r"}`),
-		Output:    json.RawMessage(`{"bytes":42}`),
-		Decision:  "allowed",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := p.Process(socket.Frame{Payload: body}); err != nil {
-		t.Fatalf("Process: %v", err)
-	}
-	receipts, err := st.GetChain("chain-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	pd := receipts[0].CredentialSubject.Action.ParametersDisclosure
-
-	if _, ok := pd["input"]; ok {
-		t.Errorf("parameters_disclosure must not contain \"input\" when ParameterDisclosure is false, got %q", pd["input"])
-	}
-	if _, ok := pd["output"]; ok {
-		t.Errorf("parameters_disclosure must not contain \"output\" when ParameterDisclosure is false, got %q", pd["output"])
+			if r.CredentialSubject.Action.ParametersDisclosure != nil {
+				t.Errorf("ParametersDisclosure must be nil regardless of flag (envelope wiring pending #280); got %#v", r.CredentialSubject.Action.ParametersDisclosure)
+			}
+			// Hashes are unaffected by the flag — they always commit to the raw
+			// emitter payload.
+			if r.CredentialSubject.Action.ParametersHash == "" {
+				t.Error("parameters_hash must be present when input is set")
+			}
+			if r.CredentialSubject.Outcome.ResponseHash == "" {
+				t.Error("response_hash must be present when output is set")
+			}
+		})
 	}
 }
 

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -137,8 +137,12 @@ func TestDropCounterEndToEnd(t *testing.T) {
 	if got := synthetic.CredentialSubject.Action.Type; got != "agent_receipts.events_dropped" {
 		t.Errorf("synthetic action.type = %q, want agent_receipts.events_dropped", got)
 	}
-	if got := synthetic.CredentialSubject.Action.ParametersDisclosure["emitter.drop_count"]; got != "3" {
-		t.Errorf("synthetic drop_count = %q, want 3", got)
+	meta := synthetic.CredentialSubject.Action.EmitterMetadata
+	if meta == nil {
+		t.Fatal("synthetic events_dropped receipt missing emitter_metadata")
+	}
+	if meta.DropCount != 3 {
+		t.Errorf("synthetic emitter_metadata.drop_count = %d, want 3", meta.DropCount)
 	}
 	if got := synthetic.Issuer.SessionID; got != "drop-e2e-session" {
 		t.Errorf("synthetic session_id = %q, want drop-e2e-session", got)

--- a/docs/adr/0012-payload-disclosure-policy.md
+++ b/docs/adr/0012-payload-disclosure-policy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (2026-05-12), amended 2026-05-18 (see *Amendments*). Implementation is partial — see *Implementation status* below.
+Accepted (2026-05-12), amended 2026-05-18 (see *Amendments*). **Phase A is complete as of 2026-05-21**: the HPKE envelope is implemented end-to-end across the Go, TypeScript, and Python SDKs, pinned in the spec at v0.3.0, and exercised by cross-SDK byte-identical test vectors. See *Implementation status* and *Phase A landed* below.
 
 ## Context
 
@@ -102,25 +102,35 @@ This ADR's *architecture* is decided now (because the receipt format is permanen
 
 Phase A receipts are forward-compatible with Phase B and C — no re-encryption, no migration.
 
-### Implementation status (as of 2026-05-12)
+### Implementation status (as of 2026-05-21)
 
-What has landed:
+#### Phase A landed
 
-- The field has been renamed across SDKs from `parameters_preview` to `parameters_disclosure` (TS SDK ≥0.6.0; Go and Python SDKs carry the renamed field).
-- The config knob is named `parameterDisclosure` and the existing OpenClaw value space (`false | true | "high" | string[]`) is honoured at the config layer.
-- The daemon already populates `parameters_disclosure` with daemon-attested metadata on every receipt: OS-attested peer credentials (`peer.platform`, `peer.pid`, `peer.uid`, `peer.gid`, `peer.exe_path`) on normal receipts and `emitter.drop_count` on `events_dropped` receipts (`daemon/internal/pipeline/build.go`). These are not plaintext tool payloads — they are operator-allowlisted additive metadata that the daemon vouches for, stashed in the existing field until ADR-0010's dedicated `peer` field lands (Phase 2).
-- The daemon ships a `--parameter-disclosure` opt-in flag (PRs #427, #429); when enabled, the receipt pipeline *additionally* writes redacted plaintext tool input/output to `parameters_disclosure["input"]` and `parameters_disclosure["output"]` on the same map. **This is the legacy plaintext-in-body shape, not the envelope this ADR commits to** — it ships behind an explicit operator opt-in so plaintext payload disclosure cannot be enabled silently. The peer/drop-count metadata above is unaffected by this flag.
-- The hash-only default for **tool input/output payloads** holds: no channel writes the plaintext input/output keys unless the operator opts in.
+Phase A is complete as of 2026-05-21. The HPKE envelope is implemented end-to-end across all three SDKs and pinned across the spec and the cross-SDK test harness:
 
-What has **not** landed and is required before disclosure is enabled in any non-experimental channel:
+- **HPKE primitives.** All three SDKs encrypt, decrypt, and round-trip the v1 envelope under the pinned ciphersuite (`hpke-x25519-hkdf-sha256-aes-256-gcm`):
+  - Go SDK: PR [#468](https://github.com/agent-receipts/ar/pull/468).
+  - TypeScript SDK: PR [#472](https://github.com/agent-receipts/ar/pull/472), hand-rolled from `node:crypto` (no `@hpke/core` dependency).
+  - Python SDK: PR [#494](https://github.com/agent-receipts/ar/pull/494).
+- **Forensic key-pair lifecycle.** Each SDK ships `GenerateForensicKeyPair` (or its language-idiomatic equivalent); on-disk layout next to the signing key and CLI export/import are tracked alongside the daemon's envelope-side wiring under #280.
+- **Spec at v0.3.0.** [`spec/schema/agent-receipt.schema.json`](../../spec/schema/agent-receipt.schema.json) inlines the envelope `$defs` (and the new `peer_credential` / `emitter_metadata` typed action fields) so the main receipt schema validates v0.3.0 receipts directly. PR [#496](https://github.com/agent-receipts/ar/pull/496).
+- **Cross-SDK byte-identical test vectors.** [`cross-sdk-tests/v030_vectors.json`](../../cross-sdk-tests/v030_vectors.json) pins both the envelope-shape receipt and the daemon-attested-fields receipt; every SDK must reproduce the pinned `expectedReceiptHash` byte-for-byte. PR [#499](https://github.com/agent-receipts/ar/pull/499).
+- **Typed daemon-attested fields land.** `action.peer_credential` and `action.emitter_metadata` replace the Phase-1 stash inside `parameters_disclosure` ([`daemon/internal/pipeline/build.go`](../../daemon/internal/pipeline/build.go)); the daemon-attested metadata now rides on dedicated typed fields, not on the envelope channel. Across the SDKs: Go in PR-C, TypeScript in PR-D, Python in PR-E (tracked under #280).
 
-- The asymmetric envelope (`v`, `alg`, `recipients`, `nonce`, `ct`). No SDK currently produces or consumes the structured envelope shape committed to in this ADR.
-- The forensic key-pair lifecycle (auto-generation, on-disk layout next to the signing key, CLI for export/import).
-- Cross-SDK canonical-JSON equivalence tests for the envelope.
+The renamed config knob (`parameterDisclosure`) and the OpenClaw value space (`false | true | "high" | string[]`) continue to be honoured at the config layer; the disclosure pipeline now wires through the v1 envelope rather than the legacy flat-map shape.
 
-Until those land, the `--parameter-disclosure` daemon flag is the only sanctioned way to populate the `input` / `output` keys, and it does so with **redacted plaintext** as an explicit interim step — not the envelope this ADR specifies. Callers other than the daemon's opt-in pipeline **MUST NOT** write plaintext tool arguments into `parameters_disclosure`; the field is otherwise a forward-compatible placeholder for the envelope (with the daemon-attested `peer.*` and `emitter.drop_count` metadata noted above as the only other sanctioned entries). The "plaintext-in-body" mode of the legacy TS `parameters_preview` (as an SDK-public surface) is explicitly removed as a supported behaviour (see *Consequences → existing TS field is repurposed*).
+#### Pre-Phase-A behaviour now deprecated
 
-This gap is tracked as the remainder of **Phase A**. Phase B and Phase C are unchanged and remain sequenced behind daemon work (ADR-0010) and enterprise pull respectively.
+- The legacy flat-map shape of `action.parameters_disclosure` (Phase-1 daemon-attested keys like `peer.platform`, `emitter.drop_count`, and the redacted-plaintext `input`/`output` written under `--parameter-disclosure`) is **removed from the SDK type space** as of v0.3.0. SDK `Action.ParametersDisclosure` now only accepts the v1 envelope. Daemon-attested metadata lives on the dedicated `action.peer_credential` and `action.emitter_metadata` typed fields. The schema's oneOf still accepts the legacy shape for backwards compatibility on receipts already at rest; SDKs cannot round-trip such receipts through the typed `AgentReceipt` going forward.
+- The daemon's `--parameter-disclosure` flag is preserved as a documented no-op pending envelope-mode disclosure in #280 — the legacy plaintext-in-body shape is no longer representable on the wire.
+
+#### Remaining (deferred to Phase B / #280)
+
+- Daemon-side encrypt-then-attach an envelope for tool input/output (replaces the no-op `--parameter-disclosure` flag).
+- Forensic-key CLI (export, import, rotate).
+- Operator-facing key-management documentation.
+
+Phase B and Phase C are unchanged and remain sequenced behind daemon work (ADR-0010) and enterprise pull respectively.
 
 ## Consequences
 
@@ -215,6 +225,6 @@ This gap is tracked as the remainder of **Phase A**. Phase B and Phase C are unc
 - SDK implementations of envelope encryption (Go / TS / Py). Tracked under #280.
 - Daemon rewire of `--parameter-disclosure` from redacted-plaintext to envelope. Tracked under #280.
 - Forensic-key CLI (export, import, rotate). Tracked under #280.
-- Reference of `parameters-disclosure.schema.json` from `agent-receipt.schema.json`. Lands with the SDK work, not the spec.
+- ~~Reference of `parameters-disclosure.schema.json` from `agent-receipt.schema.json`. Lands with the SDK work, not the spec.~~ **Done** in spec PR [#496](https://github.com/agent-receipts/ar/pull/496): `agent-receipt.schema.json` inlines the envelope `$defs` directly, so a validator does not need to dereference the sibling schema. The sibling schema stays as the documentation-of-record per the *Locked in* note above.
 - `kid` registry mechanism. v1 accepts either a `did:key` DID URL with a fragment or the `sha256:<hex>` fingerprint form; a normative registry is deferred.
 - Algorithm agility in `alg`. v1 pins exactly one ciphersuite. Additional ciphersuites require a new ADR-0012 amendment and a v2 envelope.

--- a/sdk/go/receipt/canonicalization_vectors_test.go
+++ b/sdk/go/receipt/canonicalization_vectors_test.go
@@ -16,9 +16,14 @@ package receipt
 // `go test -tags=integration ./...` to exercise these vectors.
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,6 +131,17 @@ func TestCanonVectors(t *testing.T) {
 }
 
 // TestReceiptHashVectors runs each vector in the receipt_hash_vectors array.
+//
+// As of the v0.3.0 envelope migration (ADR-0012 amendment 2026-05-18) the
+// Go SDK's typed Action.ParametersDisclosure is *DisclosureEnvelope and can
+// no longer round-trip the legacy flat-map shape that some vectors pin
+// (e.g. receipt_all_optional_present). Unmarshalling into the typed struct
+// would silently drop or mangle that field and mismatch the pinned hash.
+// The test therefore parses to map[string]any, runs an explicit
+// strip-optional-nulls pass (Rule 2 of ADR-0009), and canonicalises the map
+// directly. This mirrors how the TS and Python SDKs validate this vector
+// set today; the canonicaliser remains the unit under test, not the typed
+// struct.
 func TestReceiptHashVectors(t *testing.T) {
 	vf := loadCanonVectors(t)
 
@@ -139,43 +155,25 @@ func TestReceiptHashVectors(t *testing.T) {
 		}
 
 		t.Run(v.Name, func(t *testing.T) {
-			// Deserialise into AgentReceipt. Per Go's encoding/json semantics,
-			// unmarshalling JSON `null` into a non-pointer string field leaves
-			// the Go field at its zero value ("") with no error — so optional
-			// fields like outcome.error, action.trusted_timestamp and
-			// authorization.grant_ref come through as "", and omitempty then
-			// drops them from the canonical form. This is how the Go SDK
-			// realises ADR-0009 Rule 2 for vectors that send `null` for
-			// optional fields (vs Python/TS which need an explicit
-			// strip-optional-nulls pass over a map-shaped receipt).
-			// The required-nullable previous_receipt_hash is a *string so its
-			// JSON null is preserved as (*string)(nil) and re-emitted as null.
-			var receipt AgentReceipt
-			if err := json.Unmarshal(v.Receipt, &receipt); err != nil {
-				t.Fatalf("unmarshal receipt into AgentReceipt: %v", err)
+			var receiptMap map[string]any
+			if err := json.Unmarshal(v.Receipt, &receiptMap); err != nil {
+				t.Fatalf("unmarshal receipt to map: %v", err)
 			}
+			stripOptionalNulls(receiptMap)
 
-			gotHash, err := HashReceipt(receipt)
+			// "proof" is the only field excluded from the hash; vectors here
+			// publish unsigned receipts so the field is typically absent, but
+			// strip it if present so we never accidentally include it.
+			delete(receiptMap, "proof")
+
+			canonical, err := Canonicalize(receiptMap)
 			if err != nil {
-				t.Fatalf("HashReceipt: %v", err)
+				t.Fatalf("Canonicalize receipt: %v", err)
 			}
+			gotHash := SHA256Hash(canonical)
 			computed[v.Name] = gotHash
 
-			// mustContainSubstring: check the canonical form of the unsigned receipt.
 			if v.MustContain != "" {
-				unsigned := UnsignedAgentReceipt{
-					Context:           receipt.Context,
-					ID:                receipt.ID,
-					Type:              receipt.Type,
-					Version:           receipt.Version,
-					Issuer:            receipt.Issuer,
-					IssuanceDate:      receipt.IssuanceDate,
-					CredentialSubject: receipt.CredentialSubject,
-				}
-				canonical, err := Canonicalize(unsigned)
-				if err != nil {
-					t.Fatalf("Canonicalize unsigned: %v", err)
-				}
 				if !strings.Contains(canonical, v.MustContain) {
 					t.Errorf("canonical output missing required substring %q\n  canonical: %s", v.MustContain, canonical)
 				}
@@ -251,9 +249,24 @@ func TestSignaturePreservationLegacy_0_2_0(t *testing.T) {
 	}
 }
 
-// TestParametersDisclosureReceipt verifies the cross-SDK parameters_disclosure
-// receipt vector: the signature must verify and HashReceipt must reproduce
-// expectedReceiptHash byte-for-byte (ADR-0012 Phase A).
+// TestParametersDisclosureReceipt verifies the legacy v0.2.1 cross-SDK
+// parameters_disclosure receipt vector: the signature must verify and the
+// canonicalized-then-hashed receipt must reproduce expectedReceiptHash
+// byte-for-byte (ADR-0012 Phase A).
+//
+// The v020 vector pins the *legacy* flat-map shape of parameters_disclosure
+// (string→string), which the Go SDK can no longer round-trip through
+// receipt.AgentReceipt as of the v0.3.0 envelope migration (ADR-0012
+// amendment 2026-05-18): Action.ParametersDisclosure is now
+// *DisclosureEnvelope and would silently drop the legacy shape on
+// json.Unmarshal, mangling the hash.
+//
+// Approach: mirror cross-sdk-tests/v030_vectors_test.go — parse to
+// map[string]any so the legacy shape survives the round trip; canonicalise
+// the unsigned portion via the SDK's Canonicalize; verify the proof at the
+// crypto/ed25519 layer. The canonicaliser remains the unit under test; the
+// typed struct is intentionally bypassed because it cannot model the legacy
+// receipt format losslessly.
 func TestParametersDisclosureReceipt(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(filepath.Dir("."), v020VectorsPath))
 	if err != nil {
@@ -267,24 +280,101 @@ func TestParametersDisclosureReceipt(t *testing.T) {
 		t.Fatal("v020_vectors.json: parametersDisclosureReceipt.receipt is empty")
 	}
 
-	var signed AgentReceipt
-	if err := json.Unmarshal(vf.ParametersDisclosureReceipt.Receipt, &signed); err != nil {
-		t.Fatalf("unmarshal parameters_disclosure receipt: %v", err)
+	var receiptMap map[string]any
+	if err := json.Unmarshal(vf.ParametersDisclosureReceipt.Receipt, &receiptMap); err != nil {
+		t.Fatalf("unmarshal parameters_disclosure receipt to map: %v", err)
+	}
+	proofMap, ok := receiptMap["proof"].(map[string]any)
+	if !ok {
+		t.Fatal("receipt missing proof object")
+	}
+	proofValue, _ := proofMap["proofValue"].(string)
+	if len(proofValue) < 2 || proofValue[0] != 'u' {
+		t.Fatalf("proof.proofValue %q: missing u multibase prefix", proofValue)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(proofValue[1:])
+	if err != nil {
+		t.Fatalf("decode proofValue: %v", err)
 	}
 
-	valid, err := Verify(signed, vf.Keys.PublicKey)
-	if err != nil {
-		t.Fatalf("Verify: %v", err)
+	// Strip proof; canonicalize the remainder.
+	unsigned := make(map[string]any, len(receiptMap)-1)
+	for k, v := range receiptMap {
+		if k == "proof" {
+			continue
+		}
+		unsigned[k] = v
 	}
-	if !valid {
+	canonical, err := Canonicalize(unsigned)
+	if err != nil {
+		t.Fatalf("Canonicalize unsigned: %v", err)
+	}
+
+	pub, err := parseEd25519PublicPEMLocal(vf.Keys.PublicKey)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+	if !ed25519.Verify(pub, []byte(canonical), sig) {
 		t.Fatal("parameters_disclosure receipt failed signature verification")
 	}
 
-	gotHash, err := HashReceipt(signed)
-	if err != nil {
-		t.Fatalf("HashReceipt: %v", err)
-	}
+	h := sha256.Sum256([]byte(canonical))
+	gotHash := "sha256:" + hex.EncodeToString(h[:])
 	if gotHash != vf.ParametersDisclosureReceipt.ExpectedReceiptHash {
-		t.Errorf("HashReceipt\n  got:  %s\n  want: %s", gotHash, vf.ParametersDisclosureReceipt.ExpectedReceiptHash)
+		t.Errorf("receipt hash\n  got:  %s\n  want: %s", gotHash, vf.ParametersDisclosureReceipt.ExpectedReceiptHash)
 	}
+}
+
+// stripOptionalNulls walks a receipt map and removes keys whose value is null,
+// implementing ADR-0009 Rule 2 explicitly. The TS and Python SDKs already do
+// this; the Go SDK previously rode on encoding/json's "null → zero value →
+// omitempty" sequence over its typed Action struct, but the v0.3.0 envelope
+// migration (ADR-0012 amendment 2026-05-18) makes the typed struct unable to
+// model the legacy flat-map parameters_disclosure shape losslessly. The
+// receipt-hash test pins a single allowlisted required-nullable path
+// (credentialSubject.chain.previous_receipt_hash) which must remain literal
+// null in the canonical bytes; every other null is treated as "absent" and
+// dropped before canonicalisation.
+func stripOptionalNulls(receipt map[string]any) {
+	requiredNullable := func(path []string) bool {
+		// Only one path is required-nullable per the spec today.
+		return len(path) == 3 &&
+			path[0] == "credentialSubject" &&
+			path[1] == "chain" &&
+			path[2] == "previous_receipt_hash"
+	}
+	var walk func(node map[string]any, path []string)
+	walk = func(node map[string]any, path []string) {
+		for k, v := range node {
+			child := append(path, k)
+			if v == nil {
+				if !requiredNullable(child) {
+					delete(node, k)
+				}
+				continue
+			}
+			if sub, ok := v.(map[string]any); ok {
+				walk(sub, child)
+			}
+		}
+	}
+	walk(receipt, nil)
+}
+
+// parseEd25519PublicPEMLocal is a test-local copy of the PEM parser used by
+// signing.go, kept here to avoid touching the SDK's unexported helpers.
+func parseEd25519PublicPEMLocal(pemStr string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("decode PEM public key: no PEM block found")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse SPKI public key: %w", err)
+	}
+	edKey, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not Ed25519")
+	}
+	return edKey, nil
 }

--- a/sdk/go/receipt/parameters_disclosure_test.go
+++ b/sdk/go/receipt/parameters_disclosure_test.go
@@ -1,32 +1,63 @@
 package receipt
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
 )
 
-// TestParametersDisclosureRoundTrip verifies that the optional
-// parameters_disclosure map (ADR-0012) survives JSON marshal/unmarshal,
-// is included in the canonical JSON form, and therefore contributes to
-// the receipt hash.
-func TestParametersDisclosureRoundTrip(t *testing.T) {
-	disclosure := map[string]string{
-		"path":   "/etc/hosts",
-		"flags":  "ro",
-		"reason": "diagnostic read",
+// pdAlicePub returns the RFC 7748 §6.1 Alice X25519 public key (forensic
+// test recipient 1). The bytes are duplicated locally rather than sharing
+// disclosure_test.go's constants so the two test files stay independently
+// readable.
+func pdAlicePub(t *testing.T) []byte {
+	t.Helper()
+	const alicePubHex = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"
+	pub, err := hex.DecodeString(alicePubHex)
+	if err != nil {
+		t.Fatalf("decode alice pub: %v", err)
 	}
+	return pub
+}
+
+func pdAlicePriv(t *testing.T) []byte {
+	t.Helper()
+	const alicePrivHex = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a" //nolint:gosec
+	priv, err := hex.DecodeString(alicePrivHex)
+	if err != nil {
+		t.Fatalf("decode alice priv: %v", err)
+	}
+	return priv
+}
+
+func pdEncrypt(t *testing.T, params map[string]any) *DisclosureEnvelope {
+	t.Helper()
+	env, err := EncryptDisclosure(params, pdAlicePub(t), "did:key:test#enc-1")
+	if err != nil {
+		t.Fatalf("EncryptDisclosure: %v", err)
+	}
+	return env
+}
+
+// TestParametersDisclosureEnvelopeRoundTrip verifies that an HPKE envelope
+// attached to Action.ParametersDisclosure (ADR-0012 amendment 2026-05-18)
+// survives JSON marshal/unmarshal and that all envelope fields are preserved.
+func TestParametersDisclosureEnvelopeRoundTrip(t *testing.T) {
+	env := pdEncrypt(t, map[string]any{
+		"command": "echo build",
+		"user":    "ci",
+	})
 
 	action := Action{
 		ID:                   "act_test",
 		Type:                 "filesystem.file.read",
 		RiskLevel:            RiskLow,
 		ParametersHash:       "sha256:deadbeef",
-		ParametersDisclosure: disclosure,
+		ParametersDisclosure: env,
 		Timestamp:            "2026-04-28T00:00:00Z",
 	}
 
-	// Marshal the Action and confirm parameters_disclosure is present.
 	encoded, err := json.Marshal(action)
 	if err != nil {
 		t.Fatalf("marshal action: %v", err)
@@ -34,63 +65,70 @@ func TestParametersDisclosureRoundTrip(t *testing.T) {
 	if !strings.Contains(string(encoded), `"parameters_disclosure"`) {
 		t.Fatalf("expected parameters_disclosure in encoded JSON, got %s", encoded)
 	}
+	for _, want := range []string{`"v":"1"`, `"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm"`, `"recipients":[`, `"ct":"`} {
+		if !strings.Contains(string(encoded), want) {
+			t.Errorf("encoded action missing %s; got %s", want, encoded)
+		}
+	}
 
-	// Unmarshal and ensure the field round-trips with all entries intact.
 	var decoded Action
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
 		t.Fatalf("unmarshal action: %v", err)
 	}
-	if len(decoded.ParametersDisclosure) != len(disclosure) {
-		t.Fatalf("expected %d disclosure entries, got %d",
-			len(disclosure), len(decoded.ParametersDisclosure))
+	if decoded.ParametersDisclosure == nil {
+		t.Fatal("decoded ParametersDisclosure is nil")
 	}
-	for k, v := range disclosure {
-		if got := decoded.ParametersDisclosure[k]; got != v {
-			t.Errorf("disclosure[%q] = %q, want %q", k, got, v)
-		}
+	if decoded.ParametersDisclosure.V != env.V {
+		t.Errorf("decoded v = %q, want %q", decoded.ParametersDisclosure.V, env.V)
 	}
-}
-
-// TestParametersDisclosureOmitEmpty verifies the field is omitted from
-// JSON when nil or empty (omitempty), so existing receipts without
-// disclosure data continue to canonicalize identically.
-func TestParametersDisclosureOmitEmpty(t *testing.T) {
-	tests := []struct {
-		name string
-		m    map[string]string
-	}{
-		{name: "nil_map", m: nil},
-		{name: "empty_map", m: map[string]string{}},
+	if decoded.ParametersDisclosure.Alg != env.Alg {
+		t.Errorf("decoded alg = %q, want %q", decoded.ParametersDisclosure.Alg, env.Alg)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			action := Action{
-				ID:                   "act_test",
-				Type:                 "filesystem.file.read",
-				RiskLevel:            RiskLow,
-				ParametersDisclosure: tt.m,
-				Timestamp:            "2026-04-28T00:00:00Z",
-			}
-			encoded, err := json.Marshal(action)
-			if err != nil {
-				t.Fatalf("marshal: %v", err)
-			}
-			if strings.Contains(string(encoded), "parameters_disclosure") {
-				t.Errorf("expected parameters_disclosure to be omitted, got %s", encoded)
-			}
-		})
+	if decoded.ParametersDisclosure.CT != env.CT {
+		t.Errorf("decoded ct mismatch")
+	}
+	if len(decoded.ParametersDisclosure.Recipients) != 1 {
+		t.Fatalf("decoded recipients len = %d, want 1", len(decoded.ParametersDisclosure.Recipients))
+	}
+	if decoded.ParametersDisclosure.Recipients[0].KID != env.Recipients[0].KID {
+		t.Errorf("decoded kid mismatch")
+	}
+	if decoded.ParametersDisclosure.Recipients[0].Enc != env.Recipients[0].Enc {
+		t.Errorf("decoded enc mismatch")
 	}
 }
 
-// TestParametersDisclosureCanonicalIncluded verifies the field is
-// included in the RFC 8785 canonical form (object keys sorted by UTF-16
-// code units), and that removing it changes the receipt hash.
-func TestParametersDisclosureCanonicalIncluded(t *testing.T) {
+// TestParametersDisclosureEnvelopeOmitEmpty verifies the field is omitted
+// from JSON when the pointer is nil so receipts without disclosure data
+// canonicalize identically to legacy receipts of the same logical shape.
+func TestParametersDisclosureEnvelopeOmitEmpty(t *testing.T) {
+	action := Action{
+		ID:                   "act_test",
+		Type:                 "filesystem.file.read",
+		RiskLevel:            RiskLow,
+		ParametersDisclosure: nil,
+		Timestamp:            "2026-04-28T00:00:00Z",
+	}
+	encoded, err := json.Marshal(action)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "parameters_disclosure") {
+		t.Errorf("expected parameters_disclosure to be omitted, got %s", encoded)
+	}
+}
+
+// TestParametersDisclosureEnvelopeCanonicalIncluded verifies the field is
+// included in the RFC 8785 canonical form (envelope keys sorted alphabetically:
+// alg, ct, recipients, v) and that removing it changes the receipt hash. The
+// hash MUST commit to the envelope ciphertext.
+func TestParametersDisclosureEnvelopeCanonicalIncluded(t *testing.T) {
 	kp, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	env := pdEncrypt(t, map[string]any{"path": "/etc/hosts"})
 
 	withDisclosure := Create(CreateInput{
 		Issuer:    Issuer{ID: "did:agent:test"},
@@ -100,7 +138,7 @@ func TestParametersDisclosureCanonicalIncluded(t *testing.T) {
 			Type:                 "filesystem.file.read",
 			RiskLevel:            RiskLow,
 			Timestamp:            "2026-04-28T00:00:00Z",
-			ParametersDisclosure: map[string]string{"path": "/etc/hosts"},
+			ParametersDisclosure: env,
 		},
 		Outcome: Outcome{Status: StatusSuccess},
 		Chain:   Chain{Sequence: 1, ChainID: "chain-1"},
@@ -119,8 +157,8 @@ func TestParametersDisclosureCanonicalIncluded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonicalize with: %v", err)
 	}
-	if !strings.Contains(canonWith, `"parameters_disclosure":{"path":"/etc/hosts"}`) {
-		t.Errorf("canonical form missing parameters_disclosure: %s", canonWith)
+	if !strings.Contains(canonWith, `"parameters_disclosure":{"alg":"hpke-x25519-hkdf-sha256-aes-256-gcm"`) {
+		t.Errorf("canonical form missing parameters_disclosure envelope head: %s", canonWith)
 	}
 
 	canonWithout, err := Canonicalize(withoutDisclosure)
@@ -131,7 +169,6 @@ func TestParametersDisclosureCanonicalIncluded(t *testing.T) {
 		t.Error("expected canonical forms to differ when disclosure is removed")
 	}
 
-	// Sign and hash both — the receipt hash must reflect the disclosure.
 	signedWith, err := Sign(withDisclosure, kp.PrivateKey, "did:agent:test#key-1")
 	if err != nil {
 		t.Fatal(err)
@@ -150,5 +187,45 @@ func TestParametersDisclosureCanonicalIncluded(t *testing.T) {
 	}
 	if hashWith == hashWithout {
 		t.Error("expected receipt hashes to differ when disclosure is removed")
+	}
+}
+
+// TestParametersDisclosureEnvelopeRoundTripDecrypts is the headline forensic
+// invariant: an envelope embedded in a signed receipt and pulled back out via
+// JSON unmarshal MUST decrypt to the original plaintext parameters with the
+// matching private key. If this regresses, the disclosure pipeline is broken
+// even when signature verification still passes.
+func TestParametersDisclosureEnvelopeRoundTripDecrypts(t *testing.T) {
+	params := map[string]any{
+		"command": "echo build",
+		"user":    "ci",
+	}
+	env := pdEncrypt(t, params)
+
+	action := Action{
+		ID:                   "act_test",
+		Type:                 "filesystem.file.read",
+		RiskLevel:            RiskLow,
+		ParametersDisclosure: env,
+		Timestamp:            "2026-04-28T00:00:00Z",
+	}
+	encoded, err := json.Marshal(action)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded Action
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := DecryptDisclosure(decoded.ParametersDisclosure, pdAlicePriv(t))
+	if err != nil {
+		t.Fatalf("DecryptDisclosure: %v", err)
+	}
+	if got["command"] != params["command"] {
+		t.Errorf("decrypted command = %v, want %v", got["command"], params["command"])
+	}
+	if got["user"] != params["user"] {
+		t.Errorf("decrypted user = %v, want %v", got["user"], params["user"])
 	}
 }

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -65,17 +65,44 @@ type ActionTarget struct {
 	Resource string `json:"resource,omitempty"`
 }
 
+// PeerCredential is OS-attested peer process metadata captured by the daemon
+// at the SDK↔daemon boundary (ADR-0010). Present only on receipts emitted
+// through a daemon; absent on direct-SDK emissions. The values are daemon-
+// attested, not agent-claimed, and are signature-protected by the surrounding
+// receipt.
+//
+// Field widths follow POSIX: PID is int32 (signed pid_t, -1 is a valid
+// sentinel); UID/GID are uint32 (unsigned uid_t/gid_t). UID, GID, and ExePath
+// are POSIX-only or best-effort and use omitempty so non-POSIX daemons can
+// omit them.
+type PeerCredential struct {
+	Platform string `json:"platform"`
+	PID      int32  `json:"pid"`
+	UID      uint32 `json:"uid,omitempty"`
+	GID      uint32 `json:"gid,omitempty"`
+	ExePath  string `json:"exe_path,omitempty"`
+}
+
+// EmitterMetadata holds daemon-observed emitter-side metadata (ADR-0010).
+// Currently records the drop counter on synthetic events_dropped receipts.
+// Daemon-attested, not agent-claimed.
+type EmitterMetadata struct {
+	DropCount int64 `json:"drop_count,omitempty"`
+}
+
 // Action describes what the agent did.
 type Action struct {
-	ID                   string            `json:"id"`
-	Type                 string            `json:"type"`
-	ToolName             string            `json:"tool_name,omitempty"`
-	RiskLevel            RiskLevel         `json:"risk_level"`
-	Target               *ActionTarget     `json:"target,omitempty"`
-	ParametersHash       string            `json:"parameters_hash,omitempty"`
-	ParametersDisclosure map[string]string `json:"parameters_disclosure,omitempty"`
-	Timestamp            string            `json:"timestamp"`
-	TrustedTimestamp     string            `json:"trusted_timestamp,omitempty"`
+	ID                   string              `json:"id"`
+	Type                 string              `json:"type"`
+	ToolName             string              `json:"tool_name,omitempty"`
+	RiskLevel            RiskLevel           `json:"risk_level"`
+	Target               *ActionTarget       `json:"target,omitempty"`
+	ParametersHash       string              `json:"parameters_hash,omitempty"`
+	ParametersDisclosure *DisclosureEnvelope `json:"parameters_disclosure,omitempty"`
+	PeerCredential       *PeerCredential     `json:"peer_credential,omitempty"`
+	EmitterMetadata      *EmitterMetadata    `json:"emitter_metadata,omitempty"`
+	Timestamp            string              `json:"timestamp"`
+	TrustedTimestamp     string              `json:"trusted_timestamp,omitempty"`
 }
 
 // Intent captures conversation context behind the action.


### PR DESCRIPTION
PR-C of the `parameters_disclosure` Phase 2 migration. Cashes in the v0.3.0 envelope shape (ADR-0012 amendment 2026-05-18) end-to-end on the Go side. Sibling PR-D (sdk/ts) and PR-E (sdk/py) run in parallel.

Tracks: #280 — see [migration plan comment](https://github.com/agent-receipts/ar/issues/280#issuecomment-4507054743).

## Summary

- **sdk/go.** `Action.ParametersDisclosure` flips from `map[string]string` to `*DisclosureEnvelope`. New `PeerCredential` (POSIX `pid` is `int32`; `uid`/`gid` are `uint32`) and `EmitterMetadata` (`drop_count int64`) types added, with snake_case JSON tags matching the canonical spec.
- **daemon.** Stops packing OS-attested peer cred and `drop_count` into the legacy flat-map shape; writes `action.peer_credential` and `action.emitter_metadata` typed fields instead. The Phase-1 "stash" comment block is gone — this PR is Phase 2. The `--parameter-disclosure` CLI flag is preserved as a documented no-op pending envelope-mode wiring (#280).
- **cross-sdk-tests.** `cmd/generate-vectors` `generateParametersDisclosureReceipt` switches to map-based construction so the Go SDK can still regenerate the pinned v020 fixture. `v030_vectors.json` and `v020_vectors.json` on disk are unchanged.
- **canonicalization vectors.** `TestReceiptHashVectors` and `TestParametersDisclosureReceipt` (both in `sdk/go/receipt/canonicalization_vectors_test.go`) move to `map[string]any` + an explicit `stripOptionalNulls` pass (option **(a)** from the prompt). The Go SDK's typed `AgentReceipt` can no longer round-trip the legacy v0.2.1 flat-map shape; the canonicaliser remains the unit under test. This matches how TS / Python validate the same shared fixture set.
- **ADR-0012.** Status updated to "Phase A complete" as of 2026-05-21. Citations: #468 (Go HPKE), #472 (TS HPKE), #494 (Python HPKE), #496 (spec v0.3.0), #499 (cross-SDK vectors v030), and this PR. The "Reference of `parameters-disclosure.schema.json` from `agent-receipt.schema.json`" out-of-scope item is marked done — the inline `$defs` landed in #496.
- **daemon/README.md.** Phase-1 peer-attestation-placement note updated to reflect the typed `peer_credential` / `emitter_metadata` fields landing in spec v0.3.0.

## Cross-SDK invariants preserved

- ✅ `parametersDisclosureEnvelopeReceipt` → `sha256:bf481da43bd742f19a7863df07016ca74c293af95350a05028c607e54f126225` reproduces byte-for-byte under the typed Go SDK.
- ✅ `peerCredentialEmitterMetadataReceipt` → `sha256:fa9a68dd07b63999ab27252b7da0e9fa7d004ef385ba80c3bc43ff8cc4d53420` reproduces byte-for-byte under the typed Go SDK.
- ✅ `v020_vectors.json#parametersDisclosureReceipt.expectedReceiptHash` (`sha256:c8a0e84e7ce000c6aa68df1ce5571872d2c0356a01707100afac0d30fc13560b`) reproduces byte-for-byte via the new map-based canonicaliser path.
- ✅ `v030_vectors.json` and `v020_vectors.json` were verified byte-identical to `main` after regeneration; the changes are reverted in the PR. `v030_vectors_test.go` stays on `map[string]any` (the recommended-but-not-required migration to the typed struct is left for a follow-up to minimise diff churn).

## Test plan

- [x] `go test ./...` in `sdk/go/` (all green).
- [x] `go test -tags=integration ./...` in `sdk/go/` (all green — `TestReceiptHashVectors`, `TestParametersDisclosureReceipt`, `TestSignaturePreservationLegacy_0_2_0`).
- [x] `go test ./...` in `daemon/` (all green).
- [x] `go test -tags=integration -run 'TestPeerCred|TestSurvives|TestDrop|TestEvents|TestProcess' ./...` in `daemon/` (all green).
- [x] `go test -tags=integration ./...` in `cross-sdk-tests/` (all green — `TestV030ReceiptHashAndSignature` reproduces both pinned hashes).
- [x] `go vet ./...` clean across `sdk/go/`, `daemon/`, `cross-sdk-tests/`, `mcp-proxy/`, `hook/`.
- [x] `go test ./...` in `mcp-proxy/` and `hook/` (no fallout from the type change).
- [x] Regenerated `v030_vectors.json` byte-identical to `main`; regenerated `v020_vectors.json` had only cosmetic field-ordering changes (canonical signed bytes unchanged, pinned hash unchanged) — file reverted.

## Follow-ups (out of scope)

- PR-D (sdk/ts) and PR-E (sdk/py) — running in parallel.
- Daemon-side encrypt-then-attach an envelope (replaces the no-op `--parameter-disclosure` flag). Tracked in #280.
- Forensic-key CLI (export, import, rotate). Tracked in #280.
- Optional polish: migrate `cross-sdk-tests/v030_vectors_test.go` to consume the typed `receipt.AgentReceipt` struct now that the type model can carry the envelope shape losslessly.