### PR TITLE
chore(sdk/py): add test/lint/sync wrapper scripts + Claude allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,29 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(sdk/py/scripts/test.sh)",
+      "Bash(sdk/py/scripts/test.sh *)",
+      "Bash(sdk/py/scripts/lint.sh)",
+      "Bash(sdk/py/scripts/lint.sh *)",
+      "Bash(sdk/py/scripts/sync.sh)",
+      "Bash(sdk/py/scripts/sync.sh *)",
+      "Bash(./scripts/test.sh)",
+      "Bash(./scripts/test.sh *)",
+      "Bash(./scripts/lint.sh)",
+      "Bash(./scripts/lint.sh *)",
+      "Bash(./scripts/sync.sh)",
+      "Bash(./scripts/sync.sh *)",
+      "Bash(uv run pytest)",
+      "Bash(uv run pytest *)",
+      "Bash(uv run ruff check)",
+      "Bash(uv run ruff check *)",
+      "Bash(uv run ruff format *)",
+      "Bash(uv run pyright)",
+      "Bash(uv run pyright *)",
+      "Bash(uv sync)",
+      "Bash(uv sync *)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/sdk/py/scripts/lint.sh
+++ b/sdk/py/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Lint + format-check the Python SDK with ruff.
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+
+cd "$(dirname "$0")/.."
+uv run ruff check "$@"
+uv run ruff format --check .

--- a/sdk/py/scripts/sync.sh
+++ b/sdk/py/scripts/sync.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Sync Python SDK dependencies.
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+
+cd "$(dirname "$0")/.."
+exec uv sync "$@"

--- a/sdk/py/scripts/test.sh
+++ b/sdk/py/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run the Python SDK test suite. Bakes in the PATH for uv so the
+# allowlist sees a single stable command form across worktrees.
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+
+cd "$(dirname "$0")/.."
+exec uv run pytest "$@"


### PR DESCRIPTION
## What

~~Add three thin wrapper scripts under `sdk/py/scripts/` (test/lint/sync) and project-local allowlist entries to reduce Claude Code permission prompts on Python tooling.~~

**Closing in favour of a simpler, user-global fix.** Root cause of the prompt churn was `uv` not being on Bash tool's PATH in some spawn contexts, leading to three command-form variants (`PATH=... uv run`, `~/.local/bin/uv run`, bare `uv run`) each prompting separately. Setting `env.PATH` in `~/.claude/settings.json` plus a small `uv run <subcmd>` allowlist solves it once, for every repo, with no scripts to maintain.