### PR TITLE
feat(spec-sdks): formalise sequence contiguity + store trust model (#479)

### DIFF
--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -111,6 +111,54 @@ func TestVerifyChainDetectsBrokenHashLink(t *testing.T) {
 	}
 }
 
+// Spec §7.3.5 / #479 — a gap in chain.sequence within a session is a hard
+// verification failure. Parity with the TS "detects a broken sequence" and
+// Python "test_broken_sequence" tests.
+func TestVerifyChainDetectsSequenceGap(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+
+	// Build a 2-receipt chain manually with sequences 1 and 3 (gap at 2),
+	// preserving valid hash linkage between them so the only invariant
+	// violated is sequence contiguity.
+	first := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, PreviousReceiptHash: nil, ChainID: "chain-gap"},
+	})
+	firstSigned, err := Sign(first, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHash, err := HashReceipt(firstSigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	third := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 3, PreviousReceiptHash: &firstHash, ChainID: "chain-gap"},
+	})
+	thirdSigned, err := Sign(third, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := VerifyChain([]AgentReceipt{firstSigned, thirdSigned}, kp.PublicKey)
+	if result.Valid {
+		t.Fatal("sequence gap (1 → 3) must be rejected")
+	}
+	if result.BrokenAt != 1 {
+		t.Errorf("expected BrokenAt=1, got %d", result.BrokenAt)
+	}
+	if len(result.Receipts) < 2 || result.Receipts[1].SequenceValid {
+		t.Errorf("expected receipts[1].SequenceValid=false, got %+v", result.Receipts)
+	}
+}
+
 func TestVerifyChainSurfacesHashError(t *testing.T) {
 	kp, _ := GenerateKeyPair()
 	chain := buildChain(t, kp, 3)

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -492,6 +492,20 @@ All receipts within a chain MUST share the same `chain.chain_id` (per §7.5, a c
 
 This check parallels §7.3.2: both enforce single-chain integrity invariants that no caller parameter can disable. Verifying receipts from multiple chains requires multiple calls to the chain verifier, one per chain.
 
+#### 7.3.5 Sequence number contiguity and store trust
+
+Verification step 3 (above) mandates strict contiguity: each receipt's `chain.sequence` MUST equal its predecessor's + 1. Any gap (e.g. receipts at sequence 1, 3, 5 missing sequence 2 and 4) is a hard verification failure, not a warning. Verifiers MUST mark the chain invalid and identify the offending index. This applies even when signatures and hash linkage on the surviving receipts are otherwise valid — a partial chain with gaps cannot be silently accepted.
+
+**Store trust model.** Chain verification proves the integrity of the receipts the verifier is *given*; it cannot, on its own, prove that the verifier was given every receipt the issuer wrote. If an attacker can both delete receipts from the store AND re-sign every downstream receipt with an updated `previous_receipt_hash` (which requires the agent's signing key), they can erase mid-chain history undetectably from chain verification alone. The receipt store is therefore a trusted component for completeness claims.
+
+Operators who require detection of store-level tampering SHOULD layer at least one of the following on top of chain verification:
+
+- **Append-only storage backend** — object-lock S3, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.
+- **External chain-state witnesses** — `ExpectedLength` and/or `ExpectedFinalHash` (per §7.3.1) supplied from an out-of-band record the attacker cannot also rewrite (separate audit log, transparency log, signed checkpoint).
+- **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.
+
+These are operational controls outside the protocol; the verifier cannot synthesize them and the spec does not mandate any specific backend. They are listed here so that compliance reviewers can match the protocol's verification contract to their operational threat model.
+
 ### 7.4 Reversal receipts
 
 Receipts are immutable once issued. To record that an action was reversed, issue a new receipt appended to the same chain with:

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -500,7 +500,7 @@ Verification step 3 (above) mandates strict contiguity: each receipt's `chain.se
 
 Operators who require detection of store-level tampering SHOULD layer at least one of the following on top of chain verification:
 
-- **Append-only storage backend** — object-lock S3, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.
+- **Append-only storage backend** — S3 Object Lock, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.
 - **External chain-state witnesses** — `ExpectedLength` and/or `ExpectedFinalHash` (per §7.3.1) supplied from an out-of-band record the attacker cannot also rewrite (separate audit log, transparency log, signed checkpoint).
 - **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.
 


### PR DESCRIPTION
## What

Closes [#479](https://github.com/agent-receipts/ar/issues/479) (ADR-0019 § P5 — v1-blocker).

Investigation found the verifier already enforces strict sequence contiguity (`chain.sequence` must equal predecessor's + 1) in all three SDKs — TS and Python pin it with tests, the Go SDK was missing one. This PR adds the Go test for parity and elevates the spec to make the security implications explicit.

## Changes

**Spec** (`spec/spec/agent-receipt-spec-v0.1.md`)
- New § 7.3.5 "Sequence number contiguity and store trust":
  - Affirms that any gap in `chain.sequence` is a HARD verification failure (not a warning).
  - Documents the store trust model: chain verification proves *what the verifier was given* is internally consistent, but cannot prove the verifier was given every receipt the issuer wrote.
  - Lists three operational controls operators can layer on top of chain verification for store-level tamper detection: append-only backend (object lock / WORM), external chain-state witnesses (`ExpectedLength` / `ExpectedFinalHash` from an out-of-band record), and periodic chain-head anchoring to an append-only public log.
  - Explicitly out-of-protocol controls; spec lists them so compliance reviewers can match the verification contract to their operational threat model.

**Go SDK** (`sdk/go/receipt/chain_test.go`)
- New `TestVerifyChainDetectsSequenceGap`: builds a 2-receipt chain with sequences 1 and 3 (gap at 2), preserves valid hash linkage between them so the only invariant violated is sequence contiguity, asserts `BrokenAt=1` and `SequenceValid=false` on `receipts[1]`. Mirrors the existing TS and Python tests.

**No SDK behaviour change** — strict contiguity was already enforced. The value here is the explicit spec text on the trust model and the previously-missing Go test for parity.

## Tests

- Go: full SDK passes (1 new test in `receipt/`)
- TS / Python: no SDK changes; existing sequence-gap tests still pass

## Pattern

Follows the spec-only-or-near-spec-only shape of similar v1-blocker PRs.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (go vet, conventional-commit hook)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (N/A — no canonicalisation surface touched)
- [ ] AGENTS.md updated (N/A — no project structure change)
- [x] Spec changes — § 7.3.5 added per issue #479 / ADR-0019 § P5

## Security

- [x] Touches the verifier contract via spec documentation only. No cryptographic primitives changed.
- [x] The newly documented store trust model is a faithful description of an existing property (chain verification has never claimed to detect store-level deletion when the attacker controls the signing key); making it explicit helps compliance reviewers calibrate their threat model.