### PR TITLE
fix(sdk): align VERSION constant at "0.3.0" across Go, TS, Python; add live-emit test

### DIFF
--- a/sdk/go/receipt/live_emit_version_test.go
+++ b/sdk/go/receipt/live_emit_version_test.go
@@ -1,0 +1,34 @@
+package receipt
+
+import "testing"
+
+// liveEmitVersion is the cross-SDK invariant: every SDK's createReceipt()
+// (Go: Create) MUST stamp this literal string into the receipt's `version`
+// field. The Go, TS, and Python SDKs each carry their own copy of this test
+// pinned to the same literal — drift in any single SDK's VERSION constant
+// breaks that SDK's test in isolation, closing the gap surfaced by #512 where
+// the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
+// fixture and never consult the SDK's VERSION constant.
+const liveEmitVersion = "0.3.0"
+
+// TestCreateStampsCrossSDKVersion asserts that Create() stamps the
+// cross-SDK-agreed literal version string. This pins the SDK's Version
+// constant to the value the Go/TS/Python SDKs must agree on for newly-minted
+// receipts. The parallel tests in sdk/ts/src/receipt/live-emit-version.test.ts
+// and sdk/py/tests/receipt/test_live_emit_version.py pin the same literal.
+func TestCreateStampsCrossSDKVersion(t *testing.T) {
+	r := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:alice"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+
+	if r.Version != liveEmitVersion {
+		t.Errorf("Create() stamped version %q, want cross-SDK literal %q", r.Version, liveEmitVersion)
+	}
+	if Version != liveEmitVersion {
+		t.Errorf("package Version constant = %q, want cross-SDK literal %q", Version, liveEmitVersion)
+	}
+}

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -16,7 +16,7 @@ func Context() []string { return append([]string{}, protocolContext...) }
 // CredentialType returns a copy of the credential type array.
 func CredentialType() []string { return append([]string{}, protocolCredentialType...) }
 
-const Version = "0.2.0"
+const Version = "0.3.0"
 
 // RiskLevel classifies the security risk of an action.
 type RiskLevel string

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -1,0 +1,57 @@
+"""Cross-SDK live-emit version invariant.
+
+Every SDK's ``createReceipt()`` (Go: ``Create``) MUST stamp the literal
+``LIVE_EMIT_VERSION`` string into the receipt's ``version`` field. The Go, TS,
+and Python SDKs each carry their own copy of this test pinned to the same
+literal — drift in any single SDK's VERSION constant breaks that SDK's test
+in isolation, closing the gap surfaced by issue #512 where the existing
+v030 cross-SDK byte-identicality tests load a pre-built JSON fixture and
+never consult the SDK's ``VERSION`` constant.
+
+Parallel files:
+
+- ``sdk/go/receipt/live_emit_version_test.go``
+- ``sdk/ts/src/receipt/live-emit-version.test.ts``
+"""
+
+from __future__ import annotations
+
+from agent_receipts.receipt.create import (
+    ActionInput,
+    CreateReceiptInput,
+    create_receipt,
+)
+from agent_receipts.receipt.types import (
+    VERSION,
+    Chain,
+    Issuer,
+    Outcome,
+    Principal,
+)
+
+LIVE_EMIT_VERSION = "0.3.0"
+
+
+class TestCreateReceiptCrossSDKVersion:
+    def _make_input(self) -> CreateReceiptInput:
+        return CreateReceiptInput(
+            issuer=Issuer(id="did:agent:test"),
+            principal=Principal(id="did:user:test"),
+            action=ActionInput(
+                type="filesystem.file.read",
+                risk_level="low",
+            ),
+            outcome=Outcome(status="success"),
+            chain=Chain(
+                sequence=1,
+                previous_receipt_hash=None,
+                chain_id="chain_test",
+            ),
+        )
+
+    def test_create_receipt_stamps_cross_sdk_literal(self) -> None:
+        receipt = create_receipt(self._make_input())
+        assert receipt.version == LIVE_EMIT_VERSION
+
+    def test_version_constant_matches_cross_sdk_literal(self) -> None:
+        assert VERSION == LIVE_EMIT_VERSION

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createReceipt } from "./create.js";
+import { VERSION } from "./types.js";
+
+// LIVE_EMIT_VERSION is the cross-SDK invariant: every SDK's createReceipt()
+// (Go: Create) MUST stamp this literal string into the receipt's `version`
+// field. The Go, TS, and Python SDKs each carry their own copy of this test
+// pinned to the same literal — drift in any single SDK's VERSION constant
+// breaks that SDK's test in isolation, closing the gap surfaced by #512 where
+// the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
+// fixture and never consult the SDK's VERSION constant.
+const LIVE_EMIT_VERSION = "0.3.0";
+
+describe("createReceipt cross-SDK version invariant", () => {
+	it("stamps the cross-SDK literal version on freshly-emitted receipts", () => {
+		const receipt = createReceipt({
+			issuer: { id: "did:agent:test-agent" },
+			principal: { id: "did:user:test-user" },
+			action: {
+				type: "filesystem.file.read",
+				risk_level: "low",
+			},
+			outcome: { status: "success" },
+			chain: {
+				sequence: 1,
+				previous_receipt_hash: null,
+				chain_id: "chain_test",
+			},
+		});
+
+		expect(receipt.version).toBe(LIVE_EMIT_VERSION);
+	});
+
+	it("keeps the exported VERSION constant aligned with the cross-SDK literal", () => {
+		expect(VERSION).toBe(LIVE_EMIT_VERSION);
+	});
+});

--- a/sdk/ts/src/receipt/types.test.ts
+++ b/sdk/ts/src/receipt/types.test.ts
@@ -39,8 +39,8 @@ describe("receipt schema constants", () => {
 		expect(CREDENTIAL_TYPE).toEqual(["VerifiableCredential", "AgentReceipt"]);
 	});
 
-	it("has version 0.2.0", () => {
-		expect(VERSION).toBe("0.2.0");
+	it("has version 0.3.0", () => {
+		expect(VERSION).toBe("0.3.0");
 	});
 });
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -18,7 +18,7 @@ export const CREDENTIAL_TYPE = [
 	"AgentReceipt",
 ] as const;
 
-export const VERSION = "0.2.0";
+export const VERSION = "0.3.0";
 
 // --- Risk levels ---
 

--- a/sdk/ts/src/store/store.test.ts
+++ b/sdk/ts/src/store/store.test.ts
@@ -295,7 +295,7 @@ describe("ReceiptStore", () => {
 					"https://agentreceipts.ai/context/v1",
 				],
 				type: ["VerifiableCredential", "AgentReceipt"],
-				version: "0.2.0",
+				version: "0.3.0",
 				issuer: { id: "did:issuer" },
 				issuanceDate: "2024-01-01T00:00:00Z",
 				credentialSubject: {


### PR DESCRIPTION
Closes #512.

## Why

`#503` (TS) and `#506` (Go) kept `VERSION` at `"0.2.0"` while emitting the v0.3.0 envelope shape, deferring the constant bump to a cross-SDK coordination PR. `#505` (Python) bumped to `"0.3.0"` without flagging that as a cross-SDK decision. The three SDKs were out of sync: Python emitted `version: "0.3.0"` from `create_receipt()`, while Go and TS stamped `"0.2.0"` onto receipts carrying v0.3.0 shape — schema-misleading even though technically schema-valid.

The existing v0.3.0 cross-SDK byte-identicality tests (`cross-sdk-tests/v030_vectors.json` + `v030_vectors_test.go` etc.) didn't catch this because they load a pre-built JSON fixture where `version` is already the literal `"0.3.0"` — each SDK's `VERSION` constant was never consulted.

## What

- `sdk/go/receipt/types.go` — `const Version = "0.2.0"` → `"0.3.0"`
- `sdk/ts/src/receipt/types.ts` — `export const VERSION = "0.2.0"` → `"0.3.0"`
- `sdk/ts/src/receipt/types.test.ts` — updated the `"has version 0.2.0"` assertion that pinned the literal old value
- `sdk/ts/src/store/store.test.ts` — updated a synthetic AgentReceipt JSON literal that hardcoded `version: "0.2.0"` for the no-implicit-cap regression test (kept the rest of the fixture intact)
- Python SDK source is unchanged (already `"0.3.0"` after #505)

### New live-emit cross-SDK invariant test

Each SDK gets a parallel test pinning the same literal `"0.3.0"`:

- `sdk/go/receipt/live_emit_version_test.go` (new) — `TestCreateStampsCrossSDKVersion`
- `sdk/ts/src/receipt/live-emit-version.test.ts` (new) — 2 specs under `createReceipt cross-SDK version invariant`
- `sdk/py/tests/receipt/test_live_emit_version.py` (new) — `TestCreateReceiptCrossSDKVersion` × 2

Each test invokes the SDK's `createReceipt()` / `Create()` and asserts the resulting `receipt.version` equals the literal `"0.3.0"` — closing the gap surfaced by #512. If any single SDK's `VERSION` constant drifts again, that SDK's own test breaks in isolation, without depending on the cross-language harness.

Option (b) from the issue was chosen over (a) for the reasons called out there (lower risk, parallel per-SDK ownership, drift in any one language fails that SDK's CI without needing the cross-language harness).

## Verification

- `sdk/go`: `go test ./...` — all packages pass
- `sdk/ts`: `pnpm test` — **298 tests** pass across 15 files (previously 296 across 14)
- `sdk/py`: `uv run pytest` — **323 passed**, 5 skipped (previously 321 passed)
- `cross-sdk-tests`: `go test -tags=integration ./...` — still green; pre-built v030 fixtures continue to verify byte-identically
- `mcp-proxy`, `hook`, `daemon`: all `go test ./...` green (Go workspace picks up the in-tree `sdk/go`)
- `pnpm check` (biome + tsc): clean
- `uv run ruff check` / `uv run pyright src`: clean
- `go vet ./...`: clean

## Out of scope

- Spec-level `if/then` linking `version` to `parameters_disclosure` shape — separate spec discussion noted in #512.
- Whether the daemon should rewrite `version` on relayed receipts — separate question, currently it doesn't.

Tracking memo: https://github.com/agent-receipts/ar/issues/280#issuecomment-4512591409
