### PR TITLE
chore(sdk): bump manifest versions for v0.3.0 migration alpha

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -9,6 +9,30 @@ This file starts at 0.6.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.11.0-alpha.1] - 2026-05-22
+
+First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).
+
+### Breaking Changes
+
+- **`Action.ParametersDisclosure` type changed** from `map[string]string` to `*DisclosureEnvelope` ([#506](https://github.com/agent-receipts/ar/pull/506)). Per ADR-0012 / spec v0.3.0 ([#496](https://github.com/agent-receipts/ar/pull/496)), the field now carries the HPKE asymmetric encryption envelope. Downstream code that wrote the legacy flat-map shape will not compile.
+
+### Added
+
+- **`EncryptDisclosure` / `DecryptDisclosure` / `GenerateForensicKeyPair`** ([#468](https://github.com/agent-receipts/ar/pull/468)) — RFC 9180 HPKE base-mode helpers (DHKEM(X25519) + HKDF-SHA256 + AES-256-GCM) via `cloudflare/circl`.
+- **`Action.PeerCredential` struct** — typed OS-attested peer process metadata. Field widths match POSIX (`int32` for PID, `uint32` for UID/GID).
+- **`Action.EmitterMetadata` struct** — daemon-observed emitter-side metadata, currently `DropCount`.
+- **Cross-SDK live-emit invariant test** ([#515](https://github.com/agent-receipts/ar/pull/515)).
+
+### Changed
+
+- **`Version` constant bumped from `"0.2.0"` to `"0.3.0"`** ([#515](https://github.com/agent-receipts/ar/pull/515)).
+- Legacy v0.2.x flat-map `parameters_disclosure` receipts no longer round-trip through `receipt.AgentReceipt`. Verifiers ingesting legacy receipts must use `map[string]any` — pattern in `cross-sdk-tests/canonicalization_vectors_test.go::TestParametersDisclosureReceipt`.
+
+### Known issues
+
+- `PeerCredential.UID` and `PeerCredential.GID` are `uint32` with `omitempty`, silently dropping UID=0 / GID=0 (root). Tracked in [#511](https://github.com/agent-receipts/ar/issues/511).
+
 ## [0.10.0] - 2026-05-19
 
 ### Added

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -27,7 +27,7 @@ First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#
 ### Changed
 
 - **`Version` constant bumped from `"0.2.0"` to `"0.3.0"`** ([#515](https://github.com/agent-receipts/ar/pull/515)).
-- Legacy v0.2.x flat-map `parameters_disclosure` receipts no longer round-trip through `receipt.AgentReceipt`. Verifiers ingesting legacy receipts must use `map[string]any` — pattern in `cross-sdk-tests/canonicalization_vectors_test.go::TestParametersDisclosureReceipt`.
+- Legacy v0.2.x flat-map `parameters_disclosure` receipts no longer round-trip through `receipt.AgentReceipt`. Verifiers ingesting legacy receipts must use `map[string]any` — pattern in `sdk/go/receipt/canonicalization_vectors_test.go::TestParametersDisclosureReceipt`.
 
 ### Known issues
 

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,27 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.9.0a1] - 2026-05-22
+
+First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).
+
+### Breaking Changes
+
+- **`Action.parameters_disclosure` shape changed** to the HPKE asymmetric encryption envelope. Was `dict[str, str] | None`, now `DisclosureEnvelope | None`. Downstream code that constructed the legacy flat-map will fail Pydantic validation. See [#505](https://github.com/agent-receipts/ar/pull/505).
+
+### Added
+
+- **`encrypt_disclosure` / `decrypt_disclosure` / `generate_forensic_key_pair`** ([#494](https://github.com/agent-receipts/ar/pull/494)) — RFC 9180 HPKE base-mode helpers (DHKEM(X25519) + HKDF-SHA256 + AES-256-GCM) for the v1 disclosure envelope. Hand-rolled on `pyca/cryptography` (no new top-level deps).
+- **`Action.peer_credential`** — typed OS-attested peer process metadata (`platform`, `pid`, optional `uid`/`gid`/`exe_path`).
+- **`Action.emitter_metadata`** — daemon-observed emitter-side metadata, currently `drop_count`.
+- **Cross-SDK live-emit invariant test** ([#515](https://github.com/agent-receipts/ar/pull/515)).
+- **`typing_extensions.TypedDict` migration** ([#505](https://github.com/agent-receipts/ar/pull/505)) — Pydantic v2 cannot introspect stdlib `typing.TypedDict` on Python < 3.12.
+
+### Changed
+
+- **`VERSION` constant is `"0.3.0"`** — receipts emitted via `create_receipt()` now stamp the v0.3.0 schema label.
+- The typed `AgentReceipt` model only accepts the envelope shape on `parameters_disclosure`. Legacy v0.2.x flat-map receipts will fail `AgentReceipt(**raw_json)` — verifiers ingesting legacy receipts must use `hash_receipt(raw_dict)` and inline signature verification.
+
 ## [0.8.0] - 2026-05-15
 
 ### Changed

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.8.0"
+version = "0.9.0a1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.8.0"
+version = "0.9.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -28,7 +28,7 @@ First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#
 ### Changed
 
 - **`VERSION` constant bumped from `"0.2.0"` to `"0.3.0"`** ([#515](https://github.com/agent-receipts/ar/pull/515)) — receipts emitted via `createReceipt()` now stamp the v0.3.0 schema label.
-- The Zod `agentReceiptSchema` now strictly requires the envelope shape on `parameters_disclosure`. Legacy v0.2.x flat-map receipts will fail to round-trip through `ReceiptStore.parseReceiptJson` — verifiers ingesting legacy receipts must use raw spec-schema validation.
+- The Zod `agentReceiptSchema` now strictly requires the envelope shape on `parameters_disclosure`. Legacy v0.2.x flat-map receipts will fail `agentReceiptSchema.parse()` — including every `ReceiptStore` load method (`getById`, `getChain`, `query`, `verifyStoredChain`) which validates via this schema internally. Verifiers ingesting legacy receipts must use raw spec-schema validation instead.
 
 ## [0.8.0] - 2026-05-15
 

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,6 +9,27 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.9.0-alpha.1] - 2026-05-22
+
+First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).
+
+### Breaking Changes
+
+- **`Action.parameters_disclosure` shape changed** to the HPKE asymmetric encryption envelope. Was `Record<string, string>` (legacy flat-map), now `DisclosureEnvelope | undefined`. Downstream code that constructed the legacy flat-map will not type-check. See [#503](https://github.com/agent-receipts/ar/pull/503).
+
+### Added
+
+- **`encryptDisclosure` / `decryptDisclosure` / `generateForensicKeyPair`** ([#472](https://github.com/agent-receipts/ar/pull/472)) — RFC 9180 HPKE base-mode helpers (DHKEM(X25519) + HKDF-SHA256 + AES-256-GCM) for the v1 disclosure envelope. Currently uses `@hpke/core`; full removal tracked in [#473](https://github.com/agent-receipts/ar/issues/473).
+- **`Action.peer_credential`** — typed OS-attested peer process metadata (`platform`, `pid`, optional `uid`/`gid`/`exe_path`). Populated by the daemon at the SDK↔daemon boundary.
+- **`Action.emitter_metadata`** — daemon-observed emitter-side metadata, currently `drop_count` for synthetic `events_dropped` receipts.
+- **Stricter zod validation** on `parameters_disclosure` envelope — `enc` must be exactly 43 unpadded base64url chars; `ct` must match the unpadded base64url alphabet AND have decodable length (`len % 4 !== 1`).
+- **Cross-SDK live-emit invariant test** ([#515](https://github.com/agent-receipts/ar/pull/515)).
+
+### Changed
+
+- **`VERSION` constant bumped from `"0.2.0"` to `"0.3.0"`** ([#515](https://github.com/agent-receipts/ar/pull/515)) — receipts emitted via `createReceipt()` now stamp the v0.3.0 schema label.
+- The Zod `agentReceiptSchema` now strictly requires the envelope shape on `parameters_disclosure`. Legacy v0.2.x flat-map receipts will fail to round-trip through `ReceiptStore.parseReceiptJson` — verifiers ingesting legacy receipts must use raw spec-schema validation.
+
 ## [0.8.0] - 2026-05-15
 
 ### Changed

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.8.0",
+	"version": "0.9.0-alpha.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Release prerequisite. `scripts/release.sh` validates that each SDK's manifest version matches the tag version being pushed; bumping the manifests is required before tagging the v0.3.0 migration alphas.

## Diff (5 files, +68 / -2)

- `sdk/ts/package.json` — `0.8.0` → `0.9.0-alpha.1`
- `sdk/py/pyproject.toml` — `0.8.0` → `0.9.0a1` (PEP 440 prerelease form)
- `sdk/ts/CHANGELOG.md` — new `[0.9.0-alpha.1]` entry
- `sdk/py/CHANGELOG.md` — new `[0.9.0a1]` entry
- `sdk/go/CHANGELOG.md` — new `[0.11.0-alpha.1]` entry (sdk/go has no manifest; tag is the source of truth)

CHANGELOGs summarise the v0.3.0 migration: typed `Action.parameters_disclosure` envelope, `peer_credential`, `emitter_metadata`, plus a Known Issues callout in sdk/go for #511 (UID/GID=0 drop).

## Why minor (0.9.x) and not patch

`Action.parameters_disclosure` flipped from `dict[str, str]` / `map[string]string` / `Record<string, string>` to the envelope type — structurally breaking for downstream consumers. Pre-1.0 convention in this repo is minor bumps for breaking, patch for fixes only. sdk/go bumps from 0.10.0 to 0.11.0-alpha.1 for the same reason.

## Why alpha (not stable)

Per the queued release plan (`project_release_plan_v030.md`), the v0.3.0 migration ships as a pre-release first. Phase 4 of the plan is an end-to-end test of the live-emitted bytes (the gap that #512 closed at the unit-test level). Once E2E confirms cross-SDK byte-identicality against the published alpha artifacts (not just pre-built fixtures), we graduate to stable in Phase 5.

## Next steps after this merges

```sh
git checkout main && git pull origin main
./scripts/release.sh sdk-go 0.11.0-alpha.1   # tag: sdk/go/v0.11.0-alpha.1
./scripts/release.sh sdk-ts 0.9.0-alpha.1    # tag: sdk-ts-v0.9.0-alpha.1
./scripts/release.sh sdk-py 0.9.0a1          # tag: sdk-py-v0.9.0a1
```

Each tag triggers its `release-<sdk>.yml` workflow → publish to npm / PyPI / Go proxy.

Then Phase 2 (sdk/go consumer dep bump in mcp-proxy/daemon/hook), Phase 3 (binary alphas), Phase 4 (E2E test), Phase 5 (graduate to stable).

## Out of scope

- Bumping consumer modules (mcp-proxy, daemon, hook) — Phase 2 happens in a separate PR after sdk/go alpha publishes
- `RECEIPT_VERSION` constant — already at `"0.3.0"` across all three SDKs per #515 (the `VERSION` exported from `version.ts` / `pyproject.toml` is the npm/PyPI package version, distinct from the receipt schema version)

## References

- Tracking memo: https://github.com/agent-receipts/ar/issues/280#issuecomment-4512591409
- Phase A migration PRs: #468, #472, #494, #496, #499, #503, #505, #506, #515
- Open follow-ups: #509, #510, #511, #512 (closed by #515)