### PR TITLE
ci(publish): fire publish workflows on prereleased events too

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -2,7 +2,13 @@ name: Publish Go Modules
 
 on:
   release:
-    types: [published]
+    # `prereleased` covers alpha/beta tags (e.g. sdk/go/v0.11.0-alpha.1);
+    # `published` covers stable releases. Note: Go modules don't strictly
+    # need this workflow to be installable — the Go proxy auto-indexes on
+    # tag push. The workflow runs post-tag validation (rejects local
+    # replace directives, verifies module path) which we want for both
+    # stable and prerelease tags.
+    types: [published, prereleased]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -2,7 +2,11 @@ name: Publish SDK (Python) to PyPI
 
 on:
   release:
-    types: [published]
+    # `prereleased` covers alpha/beta tags (e.g. sdk-py-v0.9.0a1); `published`
+    # covers stable releases. GitHub fires only one of the two per release
+    # creation depending on the prerelease flag, so we need both listed to
+    # publish every release shape we tag.
+    types: [published, prereleased]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -2,7 +2,11 @@ name: Publish SDK (TypeScript) to npm
 
 on:
   release:
-    types: [published]
+    # `prereleased` covers alpha/beta tags (e.g. sdk-ts-v0.9.0-alpha.1);
+    # `published` covers stable releases. GitHub fires only one of the two
+    # per release creation depending on the prerelease flag, so we need
+    # both listed to publish every release shape we tag.
+    types: [published, prereleased]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes the silent-skip bug that just hit the v0.3.0 alpha cut.

## What happened

All six v0.3.0 migration alpha tags pushed earlier today (sdk/go, sdk-ts, sdk-py, mcp-proxy, daemon, hook) created GitHub Releases successfully — but **none of the publish-* workflows fired**. Same was true for the previous v0.8.0-alpha.2 cycle, just never noticed because there was no E2E test depending on the registry artifacts.

## Why

GitHub fires either `published` or `prereleased` on release creation depending on the prerelease flag, never both. The three `publish-*.yml` workflows had:

```yaml
on:
  release:
    types: [published]
```

So they fired for stable releases (e.g. v0.8.0) but silently no-op'd for every alpha/beta/rc.

## Fix

Add `prereleased` alongside `published` in all three:

```yaml
on:
  release:
    types: [published, prereleased]
```

That's it. 3 files, +17 / -3 lines (the bulk is explanatory comments).

## Effect

- **Future alpha tags** will auto-publish to npm / PyPI / Go proxy validation, same as stable tags.
- **Today's six in-flight alphas** are NOT retroactively triggered by this PR. Recovery options for those (handled separately):
  - sdk/go: ✅ already on the Go proxy (auto-indexed on tag push; doesn't need publish-go.yml)
  - mcp-proxy/daemon/hook: ✅ usable via `go install ...@v0.11.0-alpha.1` (auto-indexed too)
  - sdk-ts: ❌ needs `npm publish` — can manually trigger via `workflow_dispatch` (publish-ts.yml already has it) once this PR merges, OR run `pnpm publish` locally with npm credentials
  - sdk-py: ❌ needs `uv publish` — no workflow_dispatch on publish-py.yml currently, so options are (a) add it in a follow-up, (b) delete + recreate the GitHub Release (would fire `prereleased` under the new workflow), or (c) manually run `uv publish` locally

## Not in scope

- **Homebrew tap for binary prereleases:** `daemon/.goreleaser.yaml:71` has `brews.skip_upload: auto`, which makes GoReleaser intentionally skip Homebrew formula push for prereleases. Not changing — alpha tags polluting the stable tap is the wrong tradeoff.
- **Adding `workflow_dispatch` to publish-py.yml / publish-go.yml for manual re-triggering:** worth doing for future recovery scenarios but not blocking this fix.

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger publish-ts.yml via `workflow_dispatch` for the current `sdk-ts-v0.9.0-alpha.1` tag → confirm package appears on npm
- [ ] Recover sdk-py (delete+recreate release OR local `uv publish`) → confirm on PyPI
- [ ] Cut a throwaway test prerelease tag (`sdk-py-v0.9.0a2` or similar with a no-op commit) → confirm all three publish workflows auto-fire on that tag without manual intervention