### PR TITLE
chore(sdk/py): re-cut as 0.9.0a2 after publish-py.yml event-type fix

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,10 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.9.0a2] - 2026-05-22
+
+Re-cut of the v0.3.0 pre-release after fixing the publish-py.yml event-type filter ([#518](https://github.com/agent-receipts/ar/pull/518)). No source changes vs `0.9.0a1`; `0.9.0a1` was tagged but never reached PyPI because the publish workflow only listened on `release.types: [published]` and prereleases fire `prereleased`. Skip `0.9.0a1` — install `agent-receipts==0.9.0a2`.
+
 ## [0.9.0a1] - 2026-05-22
 
 First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -11,7 +11,13 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [0.9.0a2] - 2026-05-22
 
-Re-cut of the v0.3.0 pre-release after fixing the publish-py.yml event-type filter ([#518](https://github.com/agent-receipts/ar/pull/518)). No source changes vs `0.9.0a1`; `0.9.0a1` was tagged but never reached PyPI because the publish workflow only listened on `release.types: [published]` and prereleases fire `prereleased`. Skip `0.9.0a1` — install `agent-receipts==0.9.0a2`.
+Re-cut of the v0.3.0 pre-release after fixing the `publish-py.yml`
+event-type filter ([#518](https://github.com/agent-receipts/ar/pull/518)).
+No source changes vs `0.9.0a1`; `0.9.0a1` was tagged but never reached
+PyPI because the publish workflow only listened on
+`release.types: [published]` and prereleases fire `prereleased`.
+
+Skip `0.9.0a1` — install `agent-receipts==0.9.0a2`.
 
 ## [0.9.0a1] - 2026-05-22
 

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.9.0a1"
+version = "0.9.0a2"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Validates #518 end-to-end and recovers the unpublished v0.3.0 Python alpha.

## What happened with `0.9.0a1`

Tagged earlier today as part of the v0.3.0 alpha cut, but the tag fired `release: prereleased` and `publish-py.yml` listened only for `release: published` — so the workflow silently no-op'd and the package never reached PyPI. #518 fixed the event-type filter; this PR creates a fresh tag to test the new trigger.

## Diff (2 files, +5 / -1)

- `sdk/py/pyproject.toml` — version `0.9.0a1` → `0.9.0a2`
- `sdk/py/CHANGELOG.md` — new `[0.9.0a2]` entry that calls out the re-cut and tells consumers to skip `0.9.0a1`

No source changes — `0.9.0a2` is byte-identical SDK code to `0.9.0a1`. The bump is purely to satisfy `release.sh`'s manifest-vs-tag validation and produce a tag the now-fixed workflow can fire on.

## After merge

```sh
git checkout main && git pull origin main
echo y | ./scripts/release.sh sdk-py 0.9.0a2
```

If `publish-py.yml` fires on the new `release: prereleased` event (per #518) and PyPI has `agent-receipts==0.9.0a2` within a few minutes, the fix is validated and the test plan (#519) can proceed.

## Skip versions

PyPI will only have `0.9.0a2`. `0.9.0a1` was tagged but never published; downstream consumers should use `agent-receipts==0.9.0a2`.

## Out of scope

- sdk/ts is already on npm at `0.9.0-alpha.1` via manual `workflow_dispatch` of `publish-ts.yml` — no re-cut needed there.
- sdk/go is already on the Go proxy at `v0.11.0-alpha.1` via auto-indexing — no re-cut needed.

## References

- Workflow fix: #518
- E2E test plan: #519
- Tracking memo: https://github.com/agent-receipts/ar/issues/280#issuecomment-4512591409