### PR TITLE
ci(publish-py): add workflow_dispatch escape hatch

### DIFF
--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -7,6 +7,11 @@ on:
     # creation depending on the prerelease flag, so we need both listed to
     # publish every release shape we tag.
     types: [published, prereleased]
+  # Manual escape hatch for cases where the release event does not propagate
+  # (e.g. release-sdk-py.yml created the GitHub Release via GITHUB_TOKEN,
+  # which suppresses downstream workflow triggers — see #521). Dispatching
+  # from `main` publishes whatever version pyproject.toml currently has.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,7 +23,7 @@ defaults:
 
 jobs:
   publish:
-    if: startsWith(github.ref_name, 'sdk-py-v')
+    if: startsWith(github.ref_name, 'sdk-py-v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -23,7 +23,12 @@ defaults:
 
 jobs:
   publish:
-    if: startsWith(github.ref_name, 'sdk-py-v') || github.event_name == 'workflow_dispatch'
+    # Tag-triggered releases: any sdk-py-v* tag. Manual dispatch: only from
+    # `main` — dispatch from a feature branch could publish unreviewed code
+    # to PyPI under whatever pyproject.toml version that branch has.
+    if: |
+      startsWith(github.ref_name, 'sdk-py-v') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -19,7 +19,12 @@ defaults:
 
 jobs:
   publish:
-    if: startsWith(github.ref_name, 'sdk-ts-v') || github.event_name == 'workflow_dispatch'
+    # Tag-triggered releases: any sdk-ts-v* tag. Manual dispatch: only from
+    # `main` — dispatch from a feature branch could publish unreviewed code
+    # to npm under whatever package.json version that branch has.
+    if: |
+      startsWith(github.ref_name, 'sdk-ts-v') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Recovery path for the v0.3.0 alpha cut + future prereleases. Mirrors what `publish-ts.yml` already has.

## Context

`publish-py.yml` only triggered on `release` events. Today's v0.3.0 alpha tagging hit the `GITHUB_TOKEN`-doesn't-propagate-downstream-events safeguard ([documented](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)), so the `release: prereleased` events from `release-sdk-py.yml`'s `gh release create` never reached `publish-py.yml`. Full diagnosis in #521.

`publish-ts.yml` already had a `workflow_dispatch` escape hatch from a prior round (used successfully earlier today to recover `sdk-ts-v0.9.0-alpha.1` → npm). `publish-py.yml` didn't, so the Python alpha sat unpublished.

## Diff (1 file, +6 / -1)

- Add `workflow_dispatch:` to the `on:` block
- Relax the job condition: `if: startsWith(github.ref_name, 'sdk-py-v') || github.event_name == 'workflow_dispatch'`

Pattern is 1:1 with `publish-ts.yml`.

## Behaviour

- **Normal path** (when release events propagate, post the deeper #521 fix): publish-py.yml fires on `release: published` / `release: prereleased` like it does today.
- **Manual escape hatch**: dispatching from the Actions UI on `main` builds + publishes whatever version is currently in `sdk/py/pyproject.toml`. Today that's `0.9.0a2` (post-#520).

## After merge

```sh
gh workflow run "Publish SDK (Python) to PyPI" --ref main
```

Workflow runs, builds `agent-receipts==0.9.0a2`, publishes to PyPI via `pypa/gh-action-pypi-publish` (the same trusted-publishing flow as the auto-triggered path — same CI, same audit trail, same OIDC, same release artifacts).

## Out of scope

- **#521 (deeper architectural fix)** — collapse the two-step pipeline so prerelease events don't matter. This PR is the small-blast-radius recovery; the deeper fix can land separately on its own timeline.
- **Adding workflow_dispatch to publish-go.yml** — Go modules don't need it (Go proxy auto-indexes on tag push). Worth doing for symmetry but not blocking the test plan.

## References

- #518 (necessary-but-insufficient publish-* event-type filter fix)
- #519 (v0.3.0 alpha test plan — blocked on sdk-py reaching PyPI)
- #520 (sdk-py 0.9.0a2 manifest bump that's currently sitting unpublished)
- #521 (deeper architectural fix for the GITHUB_TOKEN propagation issue)