### PR TITLE
chore(sdk/py): bump to 0.9.0a3

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,10 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.9.0a3] - 2026-05-22
+
+Re-cut as a diagnostic test of [#518](https://github.com/agent-receipts/ar/pull/518); no source changes vs `0.9.0a2`. Verifies whether the `prereleased` event-type fix is sufficient to fire `publish-py.yml`, or whether the deeper `GITHUB_TOKEN` workflow-suppression issue tracked in [#521](https://github.com/agent-receipts/ar/issues/521) still blocks publication.
+
 ## [0.9.0a2] - 2026-05-22
 
 Re-cut of the v0.3.0 pre-release after fixing the `publish-py.yml`

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.9.0a2"
+version = "0.9.0a3"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.9.0a1"
+version = "0.9.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Diagnostic re-cut. Tests whether #518's `prereleased` trigger fix is sufficient or whether #521's `GITHUB_TOKEN` suppression is the deeper blocker.

If `publish-py.yml` fires on this tag, `sdk-py` lands on PyPI and we close #522 as not-needed. If it doesn't, we merge #522 and dispatch.

No source changes vs `0.9.0a2` — manifest, lockfile, and changelog only.

Refs #519, #521, #522.