### PR TITLE
sdk/ts: re-export RECEIPT_VERSION and disclosure API from root

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,6 +9,12 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [Unreleased]
+
+### Added
+
+- **Forensic disclosure API re-exported from package root** ([#526](https://github.com/agent-receipts/ar/issues/526)) — `encryptDisclosure`, `decryptDisclosure`, `generateForensicKeyPair`, `DisclosureEnvelope`, `DisclosureRecipient`, and `ForensicKeyPair` are now importable from `@agnt-rcpt/sdk-ts` directly, not just from `@agnt-rcpt/sdk-ts/receipt`. Brings the headline v0.3.0 forensic-disclosure API in line with the other top-level re-exports (`createReceipt`, `signReceipt`, `verifyReceipt`, etc.).
+
 ## [0.9.0-alpha.1] - 2026-05-22
 
 First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -13,6 +13,14 @@ export {
 	verifyChain,
 } from "./receipt/chain.js";
 export { type CreateReceiptInput, createReceipt } from "./receipt/create.js";
+export {
+	type DisclosureEnvelope,
+	type DisclosureRecipient,
+	decryptDisclosure,
+	encryptDisclosure,
+	type ForensicKeyPair,
+	generateForensicKeyPair,
+} from "./receipt/disclosure.js";
 export { canonicalize, hashReceipt, sha256 } from "./receipt/hash.js";
 export {
 	generateKeyPair,


### PR DESCRIPTION
## Summary

Combined fix for two ergonomic re-export papercuts in `sdk/ts/src/index.ts`, both surfaced by the v0.3.0 alpha e2e pass (#519).

**#526 — disclosure API at root (the actual change in this PR)**

The HPKE forensic-disclosure API (`encryptDisclosure`, `decryptDisclosure`, `generateForensicKeyPair`, `DisclosureEnvelope`, `DisclosureRecipient`, `ForensicKeyPair`) was exported from `sdk/ts/src/receipt/disclosure.ts` and re-exported from `sdk/ts/src/receipt/index.ts`, but not from the package root. Adds the same re-export block to `sdk/ts/src/index.ts` so the headline v0.3.0 forensic-disclosure API is importable from `@agnt-rcpt/sdk-ts` directly, matching the existing top-level pattern for `createReceipt`, `signReceipt`, `verifyReceipt`, etc. Non-breaking addition.

**#525 — `RECEIPT_VERSION` alias (already resolved upstream)**

While investigating I found `RECEIPT_VERSION` is already exported at line 63 of `sdk/ts/src/index.ts` (added in #503 alongside the disclosure types). Root `VERSION` still resolves to the SDK package version (`0.9.0-alpha.1`, generated into the gitignored `src/version.ts` by `scripts/sync-version.mjs`); root `RECEIPT_VERSION` resolves to the spec version (`0.3.0`) from `receipt/types.ts`. This matches the Python aliasing pattern and option 2 in #525, so no code change is needed — closing the issue from this PR.

Closes #525
Closes #526

## What

- `sdk/ts/src/index.ts`: add `export { ... } from "./receipt/disclosure.js"` block (6 symbols).
- `sdk/ts/CHANGELOG.md`: new `[Unreleased]` section noting the root re-export.

## Why

The dashboard / openclaw consumers, and anyone reaching for the v0.3.0 disclosure API by reflex (`import { encryptDisclosure } from "@agnt-rcpt/sdk-ts"`), should not have to know about the `/receipt` sub-path. Closing this gap before the v0.9.0 stable cut makes the headline feature discoverable from the package root.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (biome — 39 files, no fixes)
- [x] `pnpm test` clean (15 files, 298 tests)
- [x] `pnpm build` succeeds; `dist/index.d.ts` re-exports all 7 new symbols (verified via grep)
- [x] Pre-push lefthook ran ts-typecheck + ts-test

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (biome)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (n/a — pure re-export, no receipt/signing/hash change)
- [ ] AGENTS.md updated (n/a — no structural change)
- [ ] Spec changes have been reviewed by a maintainer (n/a)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no. Pure module re-export; no behaviour change to any of the disclosure functions themselves.