### PR TITLE
hook: add --version flag

### DIFF
--- a/hook/.goreleaser.yaml
+++ b/hook/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X main.version=v{{.Version}}
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -78,7 +78,7 @@ brews:
     install: |
       bin.install "agent-receipts-hook"
     test: |
-      system "#{bin}/agent-receipts-hook"
+      system "#{bin}/agent-receipts-hook", "--version"
     # `brew outdated` and `brew livecheck` use this to detect new releases.
     # The `ar` repo ships multiple taggable components, so we can't use
     # `:github_latest` (which returns repo-wide latest). `:github_releases`

--- a/hook/cmd/agent-receipts-hook/main.go
+++ b/hook/cmd/agent-receipts-hook/main.go
@@ -19,9 +19,28 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"runtime/debug"
 
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
+
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z".
+// Falls back to the module version from Go's build info (set automatically
+// for binaries installed with `go install`), then to "dev". Mirrors the
+// resolveVersion pattern in mcp-proxy/cmd/mcp-proxy/main.go and
+// daemon/cmd/agent-receipts-daemon/main.go so operators see a useful string
+// from `--version` in any install scenario.
+var version string
+
+func resolveVersion() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}
 
 // reader maps a raw stdin payload and an env-lookup function to an
 // emitter.Event. The sessionID return value is the host-supplied session
@@ -58,7 +77,13 @@ func detect(stdin []byte, env func(string) string) string {
 
 func main() {
 	formatFlag := flag.String("format", "", "Force a specific input format (e.g. claude-code). Auto-detected when unset.")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("agent-receipts-hook %s\n", resolveVersion())
+		return
+	}
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -368,3 +368,39 @@ func TestReadClaudeCode_PreToolUseAcceptedByEmitter(t *testing.T) {
 	}
 	checkEventAcceptedByEmitter(t, ev)
 }
+
+// --- resolveVersion unit tests ---
+
+// TestResolveVersion_PrefersLDFlagInjection pins the precedence the
+// release pipeline relies on: a -ldflags "-X main.version=..." build
+// wins over both Go's build info and the "dev" fallback. Mirrors the
+// equivalent test in daemon/cmd/agent-receipts-daemon/main_test.go.
+func TestResolveVersion_PrefersLDFlagInjection(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	version = "v9.9.9-test"
+	if got, want := resolveVersion(), "v9.9.9-test"; got != want {
+		t.Errorf("resolveVersion() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveVersion_FallsBackToDevWhenUnset is the contract when neither
+// the release pipeline injected a version nor `go install` produced a
+// module version: --version must still print something useful instead of
+// an empty string. "dev" matches mcp-proxy's and daemon's behaviour.
+func TestResolveVersion_FallsBackToDevWhenUnset(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	version = ""
+	got := resolveVersion()
+	// Under `go test`, debug.ReadBuildInfo() can return either an empty
+	// or "(devel)" Main.Version depending on how the binary was invoked
+	// — both branches must yield a non-empty, sensible string. We accept
+	// either "dev" or any non-empty version-shaped value (anything that
+	// isn't the empty string the operator would never want to see).
+	if got == "" {
+		t.Error("resolveVersion() returned empty string; --version output would be empty")
+	}
+}


### PR DESCRIPTION
## What

Adds a `--version` (and `-version`) flag to `agent-receipts-hook`, mirroring the pattern already in `mcp-proxy` and `agent-receipts-daemon`:

- `hook/cmd/agent-receipts-hook/main.go` — new `var version string` + `resolveVersion()` + `flag.Bool("version", ...)` early-return in `main()`.
- `hook/.goreleaser.yaml` — `ldflags` now includes `-X main.version=v{{.Version}}` so release builds embed the tag (matches `daemon/.goreleaser.yaml`). Also tightens the brew `test:` block from a bare invocation (which read stdin and silently exited 0) to `system "#{bin}/agent-receipts-hook", "--version"` — matches the daemon formula.
- `hook/cmd/agent-receipts-hook/main_test.go` — new `TestResolveVersion_PrefersLDFlagInjection` and `TestResolveVersion_FallsBackToDevWhenUnset`, mirrors `daemon/cmd/agent-receipts-daemon/main_test.go`.

## Why

Surfaced during the v0.3.0 alpha e2e pass (#519, Section 1): `mcp-proxy --version` and `agent-receipts-daemon --version` print the tag, but `agent-receipts-hook --version` errors out with `flag provided but not defined: -version`. Operators (and our own brew-test) had no way to confirm which build of the hook was installed.

Closes #524

## Test plan

- [x] `go vet github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook` — clean
- [x] `go test github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook` — passes (including the two new `TestResolveVersion_*` cases)
- [x] `go build` succeeds; `agent-receipts-hook --version` prints `agent-receipts-hook dev`
- [x] `go run -ldflags '-X main.version=v0.11.0-alpha.1' ...` prints `agent-receipts-hook v0.11.0-alpha.1`
- [ ] Next release will exercise the goreleaser ldflags path end-to-end via the brew formula `test:` block

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (N/A — no receipt/signing/hashing changes)
- [x] AGENTS.md updated (N/A — no structural change)
- [x] Spec changes have been reviewed by a maintainer (N/A)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (no — flag-only change)
