### PR TITLE
chore(release): prep v0.3.0 stable SDK cuts

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -9,6 +9,10 @@ This file starts at 0.6.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.11.0] - 2026-05-22
+
+First stable release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280). Graduates `0.11.0-alpha.1` after the end-to-end alpha pass in [#519](https://github.com/agent-receipts/ar/issues/519). No source changes since `0.11.0-alpha.1`; see that entry below for the full v0.3.0 surface.
+
 ## [0.11.0-alpha.1] - 2026-05-22
 
 First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280).

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -9,6 +9,10 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
+## [0.9.0] - 2026-05-22
+
+First stable release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280). Graduates `0.9.0a3` after the end-to-end alpha pass in [#519](https://github.com/agent-receipts/ar/issues/519). No source changes since `0.9.0a3`; see the `0.9.0a1` entry below for the full v0.3.0 surface.
+
 ## [0.9.0a3] - 2026-05-22
 
 Re-cut as a diagnostic test of [#518](https://github.com/agent-receipts/ar/pull/518); no source changes vs `0.9.0a2`. Verifies whether the `prereleased` event-type fix is sufficient to fire `publish-py.yml`, or whether the deeper `GITHUB_TOKEN` workflow-suppression issue tracked in [#521](https://github.com/agent-receipts/ar/issues/521) still blocks publication.

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.9.0a3"
+version = "0.9.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.9.0a3"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -9,11 +9,15 @@ This file starts at 0.5.0; earlier releases are recorded only in git history.
 A repo-wide effort to auto-generate changelogs from Conventional Commits is
 tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
-## [Unreleased]
+## [0.9.0] - 2026-05-22
+
+First stable release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#280](https://github.com/agent-receipts/ar/issues/280). Graduates `0.9.0-alpha.1` after the end-to-end alpha pass in [#519](https://github.com/agent-receipts/ar/issues/519).
 
 ### Added
 
 - **Forensic disclosure API re-exported from package root** ([#526](https://github.com/agent-receipts/ar/issues/526)) — `encryptDisclosure`, `decryptDisclosure`, `generateForensicKeyPair`, `DisclosureEnvelope`, `DisclosureRecipient`, and `ForensicKeyPair` are now importable from `@agnt-rcpt/sdk-ts` directly, not just from `@agnt-rcpt/sdk-ts/receipt`. Brings the headline v0.3.0 forensic-disclosure API in line with the other top-level re-exports (`createReceipt`, `signReceipt`, `verifyReceipt`, etc.).
+
+No source changes since `0.9.0-alpha.1` other than the root re-export above. See the `0.9.0-alpha.1` entry below for the full v0.3.0 surface.
 
 ## [0.9.0-alpha.1] - 2026-05-22
 

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.9.0-alpha.1",
+	"version": "0.9.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## Summary

- Bumps `sdk/ts/package.json` from `0.9.0-alpha.1` → `0.9.0` and `sdk/py/pyproject.toml` from `0.9.0a3` → `0.9.0` so `scripts/release.sh sdk-ts 0.9.0` and `scripts/release.sh sdk-py 0.9.0` will pass the manifest-version preflight check.
- Adds `[0.9.0]` / `[0.11.0]` CHANGELOG entries to all three SDKs pointing at the alpha entries for the full v0.3.0 surface (HPKE envelope `parameters_disclosure`, daemon-attested `peer_credential` / `emitter_metadata`).
- `sdk/py/uv.lock` regenerated by `uv sync` for the new version.

## Why now

Phase 5 of the v0.3.0 release plan ([#280](https://github.com/agent-receipts/ar/issues/280)). End-to-end alpha validation passed in [#519](https://github.com/agent-receipts/ar/issues/519), with the three small follow-ups ([#524](https://github.com/agent-receipts/ar/issues/524), [#525](https://github.com/agent-receipts/ar/issues/525), [#526](https://github.com/agent-receipts/ar/issues/526)) all landed via [#527](https://github.com/agent-receipts/ar/pull/527) and [#528](https://github.com/agent-receipts/ar/pull/528).

## Test plan

- [x] `pnpm typecheck && pnpm test && pnpm build` from `sdk/ts/` (298/298 pass)
- [x] `uv sync --frozen --all-extras && uv run pytest` from `sdk/py/` (323 pass, 5 skipped)
- [x] `go vet ./... && go test ./...` from `sdk/go/`
- [ ] After merge, run `scripts/release.sh` for sdk-go 0.11.0 / sdk-ts 0.9.0 / sdk-py 0.9.0 in parallel