### PR TITLE
chore(deps): bump sdk/go to v0.11.0 in mcp-proxy, daemon, hook

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/daemon
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.11.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1 h1:i5PUMr4nee0SKp4t2XWLmVriCUTgFu0QMAr4d//ww1Y=
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
+github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.11.0
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -1,7 +1,7 @@
 github.com/agent-receipts/ar/daemon v0.9.1 h1:C8OyE04+mymOlWBIWsFeNqYNord/udkLmy8QIJJDfBw=
 github.com/agent-receipts/ar/daemon v0.9.1/go.mod h1:aboC9nI890QcajbomkWAOUXBa3BeQ9KocdA+y8+WOv8=
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1 h1:i5PUMr4nee0SKp4t2XWLmVriCUTgFu0QMAr4d//ww1Y=
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
+github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/agent-receipts/ar/daemon v0.9.1
-	github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.11.0
 	github.com/google/uuid v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,7 +1,7 @@
 github.com/agent-receipts/ar/daemon v0.9.1 h1:C8OyE04+mymOlWBIWsFeNqYNord/udkLmy8QIJJDfBw=
 github.com/agent-receipts/ar/daemon v0.9.1/go.mod h1:aboC9nI890QcajbomkWAOUXBa3BeQ9KocdA+y8+WOv8=
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1 h1:i5PUMr4nee0SKp4t2XWLmVriCUTgFu0QMAr4d//ww1Y=
-github.com/agent-receipts/ar/sdk/go v0.11.0-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
+github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Summary

- Bumps `github.com/agent-receipts/ar/sdk/go` from `v0.11.0-alpha.1` to the stable `v0.11.0` in `mcp-proxy/go.mod`, `daemon/go.mod`, and `hook/go.mod` (plus `go.sum` updates from `go mod tidy`).
- Mirrors the alpha consumer-bump [#517](https://github.com/agent-receipts/ar/pull/517) for the stable cut.
- Required gate for Phase 5 Wave B (binary stables): the per-binary `release-*.yml` workflows tag and publish whatever sdk/go version is pinned at the time of the tag push, so the stable binaries should depend on the stable SDK.

## Why now

Phase 5 of the v0.3.0 release plan ([#280](https://github.com/agent-receipts/ar/issues/280)). Wave A SDK stables just landed (sdk-go `v0.11.0` on Go proxy, sdk-ts `0.9.0` on npm, sdk-py `0.9.0` on PyPI). After this PR merges, I'll run `scripts/release.sh` for mcp-proxy 0.11.0 / daemon 0.12.0 / hook 0.11.0.

## Test plan

- [x] `GOWORK=off go vet ./... && GOWORK=off go test ./...` from `hook/` (clean)
- [x] `GOWORK=off go vet ./... && GOWORK=off go test -race ./...` from `daemon/` (clean — same flags `release.sh daemon` uses)
- [x] `go vet ./... && go test ./...` from `mcp-proxy/` (clean under the repo-root `go.work`, which is what `release.sh mcp-proxy` uses)
- [ ] Per-module CI (`CI: mcp-proxy`, `CI: daemon`, `CI: hook`) green on the PR

## Note

mcp-proxy's `daemon v0.9.1` test-only dependency is unchanged here. It needs `*receipt.DisclosureEnvelope` from sdk/go v0.11.0 but daemon v0.9.1 still uses `map[string]string`, so the daemon test-import would not compile standalone — but the repo-root `go.work` masks daemon to the in-tree version (which is v0.3.0-shape), and that's what `release.sh mcp-proxy` uses. A follow-up PR will bump that dep once daemon v0.12.0 stable is on the Go proxy.