### PR TITLE
docs(site): refresh specification pages for v0.3.0

### DIFF
--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -216,7 +216,7 @@ type ChainVerification struct {
 ### Constants
 
 ```go
-const Version = "0.2.0"
+const Version = "0.3.0"
 
 type RiskLevel string
 const (

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -255,7 +255,7 @@ OutcomeStatus = Literal["success", "failure", "pending"]
 
 CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
-RECEIPT_VERSION: str        # "0.2.0" (receipt schema)
+RECEIPT_VERSION: str        # "0.3.0" (receipt schema)
 VERSION: str                # current package version
 ```
 

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -256,8 +256,8 @@ type OutcomeStatus = "success" | "failure" | "pending"
 
 const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 const CREDENTIAL_TYPE: readonly ["VerifiableCredential", "AgentReceipt"]
-const RECEIPT_VERSION: "0.2.0"  // receipt schema
-const VERSION: "0.6.0"          // package version
+const RECEIPT_VERSION: "0.3.0"  // receipt schema
+const VERSION: "0.9.0"          // package version
 ```
 
 ---

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -91,8 +91,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
         "gid": 20,
         "exe_path": "/Applications/Claude.app/Contents/MacOS/Claude"
       },
-      "timestamp": "2026-03-31T14:30:00Z",
-      "trusted_timestamp": null
+      "timestamp": "2026-03-31T14:30:00Z"
     },
 
     "intent": {
@@ -104,10 +103,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 
     "outcome": {
       "status": "success",
-      "error": null,
       "reversible": false,
-      "reversal_method": null,
-      "reversal_window_seconds": null,
       "state_change": {
         "before_hash": "sha256:d604f3e5a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3a9",
         "after_hash": "sha256:e7a504f6a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4ba"
@@ -117,8 +113,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
     "authorization": {
       "scopes": ["filesystem:write"],
       "granted_at": "2026-03-31T14:00:00Z",
-      "expires_at": "2026-03-31T15:00:00Z",
-      "grant_ref": null
+      "expires_at": "2026-03-31T15:00:00Z"
     },
 
     "chain": {
@@ -186,7 +181,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `peer_credential` | No | OS-attested peer process metadata captured by the daemon at the SDK↔daemon boundary (`platform`, `pid`, optional `uid`/`gid`/`exe_path`). Present only on receipts emitted through a daemon (ADR-0010); absent on direct SDK emissions. Daemon-attested, not agent-claimed. |
 | `emitter_metadata` | No | Daemon-observed emitter-side metadata. Currently a single `drop_count` field on synthetic events_dropped receipts (ADR-0010). Daemon-attested, not agent-claimed. |
 | `timestamp` | Yes | ISO 8601 datetime when the action was executed. |
-| `trusted_timestamp` | No | Base64-encoded RFC 3161 TimeStampToken, or `null`. |
+| `trusted_timestamp` | No | Base64-encoded RFC 3161 TimeStampToken. Absent (not `null`) when not present — see [Optional-field rule](#optional-field-rule). |
 
 ### `intent`
 
@@ -202,10 +197,10 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | Field | Required | Description |
 |---|---|---|
 | `status` | Yes | `success`, `failure`, or `pending`. |
-| `error` | No | Error message if `status` is `failure`. |
+| `error` | No | Error message when `status` is `failure`. Absent (not `null`) otherwise — see [Optional-field rule](#optional-field-rule). |
 | `reversible` | No | `true` if the action can be undone. |
-| `reversal_method` | No | Machine-readable reversal method (e.g. `gmail:undo_send`). |
-| `reversal_window_seconds` | No | Seconds within which reversal is possible. |
+| `reversal_method` | No | Machine-readable reversal method (e.g. `gmail:undo_send`). Absent (not `null`) when not applicable. |
+| `reversal_window_seconds` | No | Seconds within which reversal is possible. Absent (not `null`) when not applicable. |
 | `reversal_of` | No | `urn:receipt:<uuid>` of the original receipt this receipt reverses. Present only on reversal receipts. |
 | `response_hash` | No | `sha256:` prefixed hash of the tool's response (RFC 8785 canonical JSON). |
 | `state_change.before_hash` | Conditional | `sha256:` hash of state before. Required when `state_change` is present. |
@@ -218,7 +213,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `scopes` | Conditional | Authorization scopes. Required when `authorization` is present. |
 | `granted_at` | Conditional | When authorization was granted. Required when `authorization` is present. |
 | `expires_at` | No | When authorization expires. |
-| `grant_ref` | No | Reference to authorization grant (e.g. Grantex token). |
+| `grant_ref` | No | Reference to authorization grant (e.g. Grantex token). Absent (not `null`) when not applicable — see [Optional-field rule](#optional-field-rule). |
 
 ### `delegation`
 
@@ -249,6 +244,15 @@ Present when this chain was spawned by delegation from another agent. All fields
 | `verificationMethod` | Yes | DID URL of the signing key. The `did:agent:` method used in examples is an illustrative placeholder — DID resolution is not specified in the current protocol (see ADR-0007). |
 | `proofPurpose` | Yes | Must be `"assertionMethod"`. |
 | `proofValue` | Yes | Multibase-encoded (`u`-prefixed base64url, no padding) Ed25519 signature. |
+
+## Optional-field rule
+
+Spec §7.1.1 (tightened in v0.2.1) draws a hard line between required-nullable and optional fields:
+
+- **Required-nullable fields** MUST be emitted with their value, including the explicit JSON `null` literal when the value is null. The only such field is `chain.previous_receipt_hash` — `null` for the first receipt in a chain, a hash string for all subsequent receipts.
+- **Optional fields** MUST NOT be emitted when their value is null or absent. `"error": null`, `"trusted_timestamp": null`, `"grant_ref": null`, `"reversal_method": null`, and `"reversal_window_seconds": null` are all schema-invalid — omit the field entirely instead. An SDK that receives `null` on an optional field MUST normalise it to absent before canonicalising.
+
+This rule keeps all three SDKs producing byte-identical RFC 8785 canonical output for the same logical receipt, regardless of whether an optional field was set to `null` or omitted by the caller.
 
 ## JSON Schema
 

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -50,7 +50,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
   ],
   "id": "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
   "type": ["VerifiableCredential", "AgentReceipt"],
-  "version": "0.2.0",
+  "version": "0.3.0",
 
   "issuer": {
     "id": "did:agent:claude-cowork-instance-abc123",
@@ -81,6 +81,16 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
         "resource": "/tmp/old-report.pdf"
       },
       "parameters_hash": "sha256:a3f1c2d4e5b6a7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1d6",
+      "parameters_disclosure": {
+        "path": "/tmp/old-report.pdf"
+      },
+      "peer_credential": {
+        "platform": "darwin",
+        "pid": 8421,
+        "uid": 501,
+        "gid": 20,
+        "exe_path": "/Applications/Claude.app/Contents/MacOS/Claude"
+      },
       "timestamp": "2026-03-31T14:30:00Z",
       "trusted_timestamp": null
     },
@@ -135,7 +145,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `@context` | Yes | JSON-LD context. Must include the W3C VC v2 and Agent Receipt context URIs in order. |
 | `id` | Yes | Globally unique identifier. Must be `urn:receipt:<uuid>`. |
 | `type` | Yes | Must be `["VerifiableCredential", "AgentReceipt"]`. |
-| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, or `"0.2.1"`. Verifiers MUST accept all three. |
+| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, or `"0.3.0"`. Verifiers MUST accept all four. |
 | `issuer` | Yes | The agent or platform that issued the receipt. |
 | `issuanceDate` | Yes | ISO 8601 datetime when the receipt was issued. May differ from `action.timestamp`. |
 | `credentialSubject` | Yes | The receipt payload. |
@@ -171,7 +181,10 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `risk_level` | Yes | `low`, `medium`, `high`, or `critical`. |
 | `target.system` | No | The system or service acted upon. |
 | `target.resource` | No | The specific resource within the system. |
-| `parameters_hash` | No | `sha256:` prefixed hash of action parameters (RFC 8785 canonical JSON). |
+| `parameters_hash` | No | `sha256:` prefixed hash of action parameters (RFC 8785 canonical JSON). Always authoritative for parameter integrity; `parameters_disclosure` is additive metadata. |
+| `parameters_disclosure` | No | Operator-controlled disclosure of action parameters. Either the legacy flat-map (v0.2.x — `{ [key: string]: string }`) or the HPKE asymmetric encryption envelope defined by ADR-0012 (v0.3.0+). Mode is per-emitter; a receipt MUST NOT mix shapes. The envelope shape is validated by the sibling [`parameters-disclosure.schema.json`](https://github.com/agent-receipts/ar/blob/main/spec/schema/parameters-disclosure.schema.json). Operators MUST NOT place plaintext secrets or PII in the legacy flat-map form. |
+| `peer_credential` | No | OS-attested peer process metadata captured by the daemon at the SDK↔daemon boundary (`platform`, `pid`, optional `uid`/`gid`/`exe_path`). Present only on receipts emitted through a daemon (ADR-0010); absent on direct SDK emissions. Daemon-attested, not agent-claimed. |
+| `emitter_metadata` | No | Daemon-observed emitter-side metadata. Currently a single `drop_count` field on synthetic events_dropped receipts (ADR-0010). Daemon-attested, not agent-claimed. |
 | `timestamp` | Yes | ISO 8601 datetime when the action was executed. |
 | `trusted_timestamp` | No | Base64-encoded RFC 3161 TimeStampToken, or `null`. |
 
@@ -224,7 +237,8 @@ Present when this chain was spawned by delegation from another agent. All fields
 | `chain_id` | Yes | Opaque identifier grouping receipts into a chain. |
 | `sequence` | Yes | Monotonically increasing integer, starting at `1`. |
 | `previous_receipt_hash` | Yes | `sha256:` hash of previous receipt, or `null` for first in chain. |
-| `terminal` | No | `true` if this is the final receipt in the chain. Enables tail-truncation detection by verifiers — see [Receipt Chain Verification](/specification/receipt-chain-verification/#chain-integrity-verification). |
+| `terminal` | No | `true` if this is the final receipt in the chain. Enables tail-truncation detection by verifiers — see [Receipt Chain Verification](/specification/receipt-chain-verification/#chain-integrity-verification). Explicit `false` is schema-invalid; omit the field instead. |
+| `status` | No | Only meaningful alongside `terminal: true`. One of `"complete"` (issuer reached normal end-of-session) or `"interrupted"` (best-effort terminator emitted on signal or known abort path). Absent on a terminal receipt is equivalent to `"complete"`. A non-terminal receipt carrying `status` is schema-invalid. The verifier-derived value `"unknown"` (chains with no terminal) is never written on the wire. |
 
 ## Proof
 
@@ -238,4 +252,4 @@ Present when this chain was spawned by delegation from another agent. All fields
 
 ## JSON Schema
 
-A machine-readable JSON Schema (draft 2020-12) is available at [`schema/action-receipt.schema.json`](https://github.com/agent-receipts/spec/blob/main/schema/action-receipt.schema.json).
+A machine-readable JSON Schema (draft 2020-12) is available at [`spec/schema/agent-receipt.schema.json`](https://github.com/agent-receipts/ar/blob/main/spec/schema/agent-receipt.schema.json). The envelope shape of `parameters_disclosure` (v0.3.0+) is also published as a sibling schema for standalone validation: [`spec/schema/parameters-disclosure.schema.json`](https://github.com/agent-receipts/ar/blob/main/spec/schema/parameters-disclosure.schema.json).

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -100,7 +100,7 @@ sequenceDiagram
 
   E->>D: emitter frame (v, ts_emit, tool, session_id, channel, decision, input?, output?, error?) [Unix socket]
   Note over D: daemon builds receipt fields from frame
-  Note over D: capture peer_credential (platform, pid, uid, gid, exe_path)
+  Note over D: capture peer_credential (platform, pid; uid?, gid?, exe_path? — POSIX/best-effort)
   Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>(optional) encrypt input → action.parameters_disclosure (HPKE envelope)<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
   Note over D: SHA-256 of this receipt → next receipt's chain.previous_receipt_hash
   Note over D: Ed25519 sign

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -100,8 +100,8 @@ sequenceDiagram
 
   E->>D: emitter frame (v, ts_emit, tool, session_id, channel, decision, input?, output?, error?) [Unix socket]
   Note over D: daemon builds receipt fields from frame
-  Note over D: capture peer creds (uid, pid, exe_path)
-  Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
+  Note over D: capture peer_credential (platform, pid, uid, gid, exe_path)
+  Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>(optional) encrypt input → action.parameters_disclosure (HPKE envelope)<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
   Note over D: SHA-256 of this receipt → next receipt's chain.previous_receipt_hash
   Note over D: Ed25519 sign
   D->>DB: insert signed receipt

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -100,7 +100,7 @@ sequenceDiagram
 
   E->>D: emitter frame (v, ts_emit, tool, session_id, channel, decision, input?, output?, error?) [Unix socket]
   Note over D: daemon builds receipt fields from frame
-  Note over D: capture peer_credential (platform, pid; uid?, gid?, exe_path? — POSIX/best-effort)
+  Note over D: capture peer_credential (platform, pid, uid?, gid?, exe_path? — POSIX/best-effort)
   Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>(optional) encrypt input → action.parameters_disclosure (HPKE envelope)<br/>hash output → outcome.response_hash<br/>(plaintext not stored)
   Note over D: SHA-256 of this receipt → next receipt's chain.previous_receipt_hash
   Note over D: Ed25519 sign

--- a/site/src/content/docs/specification/overview.mdx
+++ b/site/src/content/docs/specification/overview.mdx
@@ -3,11 +3,19 @@ title: Specification Overview
 description: Design principles and core concepts of the Agent Receipt Protocol.
 ---
 
-import { Badge } from "@astrojs/starlight/components";
+import { Aside, Badge } from "@astrojs/starlight/components";
 
-<Badge text="v0.2.0" variant="note" /> <Badge text="Draft" variant="caution" />
+<Badge text="v0.3.0" variant="note" /> <Badge text="Draft" variant="caution" />
 
-The Agent Receipt Protocol defines a standard format for cryptographically signed records of AI agent actions. This page covers the design principles and core concepts. For the full specification, see the [spec source on GitHub](https://github.com/agent-receipts/spec).
+The Agent Receipt Protocol defines a standard format for cryptographically signed records of AI agent actions. This page covers the design principles and core concepts. For the full specification, see the [spec source on GitHub](https://github.com/agent-receipts/ar/tree/main/spec).
+
+<Aside type="note" title="What's new in v0.3.0">
+- W3C VC credential type renamed from `AIActionReceipt` to `AgentReceipt`. Schema file renamed to `agent-receipt.schema.json`.
+- `parameters_disclosure` widened to accept either the legacy flat-map shape (v0.2.x) or an HPKE asymmetric encryption envelope (ADR-0012).
+- `credentialSubject.action.peer_credential` — OS-attested peer process metadata captured by the daemon (`platform`, `pid`, optional `uid`/`gid`/`exe_path`). Daemon-attested, not agent-claimed.
+- `credentialSubject.action.emitter_metadata` — daemon-observed emitter-side metadata (currently `drop_count` for synthetic events_dropped receipts).
+- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, or `"0.3.0"`. Verifiers MUST accept all four. See the [full changelog](https://github.com/agent-receipts/ar/blob/main/spec/CHANGELOG.md).
+</Aside>
 
 ## Design principles
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -50,14 +50,16 @@ Agent Receipts are hash-chained into tamper-evident sequences. This page describ
 flowchart TD
   A[Load chain ordered by sequence] --> A2{R_0.chain.previous_receipt_hash is null?}
   A2 -->|no| Z[Chain broken]
-  A2 -->|yes| A3{R_0.chain.sequence == 1?}
-  A3 -->|no| Z
-  A3 -->|yes| B[For each receipt R_i]
-  B --> C[Verify Ed25519 signature]
+  A2 -->|yes| B[For each receipt R_i]
+  B --> CID{R_i.chain.chain_id == R_0.chain.chain_id?}
+  CID -->|no| Z2["Chain broken: chain_id mismatch"]
+  CID -->|yes| C[Verify Ed25519 signature]
   C -->|fail| Z
   C -->|pass| D[SHA-256 of canonical form — proof excluded]
   D --> E{Not last receipt?}
-  E -->|yes| F["Check R_i+1.chain.previous_receipt_hash == sha256:digest"]
+  E -->|yes| TERM{R_i.chain.terminal == true?}
+  TERM -->|yes| Z3["Chain broken: receipt after terminal"]
+  TERM -->|no| F["Check R_i+1.chain.previous_receipt_hash == sha256:digest"]
   F -->|fail| Z
   F -->|pass| G[Check sequence increments by 1]
   G -->|fail| Z
@@ -85,7 +87,7 @@ To verify a receipt chain:
    - **b.** Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of *R(i)* with the `proof` field removed.
    - **c.** If *i < n - 1*, confirm *R(i+1)*'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
 3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1. Any gap is a hard verification failure, not a warning — partial chains cannot be silently accepted.
-4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null`. (The spec mandates `chain.sequence` starts at `1` per §4.3.2, but the reference SDK verifiers only enforce `sequence ≥ 1` here and rely on the schema and issuer conformance for the exact starting value. Callers needing strict first-sequence enforcement should additionally validate against `chain.sequence == 1` on R(0) or supply `ExpectedLength`.)
+4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null`. (The spec mandates `chain.sequence` starts at `1` per §4.3.2, but the reference SDK verifiers only enforce `sequence ≥ 1` here and rely on the schema and issuer conformance for the exact starting value. Callers needing strict first-sequence enforcement should additionally validate `R(0).chain.sequence == 1` inline — schema validation alone is not sufficient because JSON Schema can only express the per-receipt `≥ 1` bound, not the position-dependent "first equals 1" rule.)
 5. Confirm every receipt shares the same `chain.chain_id` as *R(0)*. Any mismatch fails verification immediately with a `chain_id mismatch` error identifying the offending index and both values. This check is unconditional and runs independently of `previous_receipt_hash` linkage — an attacker who splices a forged hash link cannot mix receipts from two distinct chains under a single verification call.
 6. If any receipt *R(i)* carries `chain.terminal: true` and a receipt *R(i+1)* exists in the input, verification fails immediately with `receipt after terminal`. This check is unconditional — no caller parameter can suppress it.
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -82,12 +82,20 @@ To verify a receipt chain:
    - **a.** Verify the `proof` signature against the issuer's public key at `proof.verificationMethod`. Note: resolution of `proof.verificationMethod` URLs (particularly `did:agent:` identifiers) is not specified in the current protocol — verifiers must obtain public keys through out-of-band means (e.g. the daemon's published `.pub` file).
    - **b.** Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of *R(i)* with the `proof` field removed.
    - **c.** If *i < n - 1*, confirm *R(i+1)*'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
-3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1.
+3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1. Any gap is a hard verification failure, not a warning — partial chains cannot be silently accepted.
 4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null` and `chain.sequence` is `1`.
+5. Confirm every receipt shares the same `chain.chain_id` as *R(0)*. Any mismatch fails verification immediately with a `chain_id mismatch` error identifying the offending index and both values. This check is unconditional and runs independently of `previous_receipt_hash` linkage — an attacker who splices a forged hash link cannot mix receipts from two distinct chains under a single verification call.
+6. If any receipt *R(i)* carries `chain.terminal: true` and a receipt *R(i+1)* exists in the input, verification fails immediately with `receipt after terminal`. This check is unconditional — no caller parameter can suppress it.
 
 If any step fails, the chain is broken at that point. Receipts before the break may still be individually valid; receipts after are suspect.
 
-**Truncation detection.** The algorithm above detects inserted, modified, or reordered receipts, but does not detect tail truncation — a chain that ends prematurely looks identical to a normally-terminated chain. When the final receipt carries `chain.terminal: true`, verifiers SHOULD treat any chain that ends without this flag as potentially truncated. Without a terminal receipt, silently dropping the most recent events is undetectable by this algorithm alone.
+**Truncation detection.** Steps 1–6 detect inserted, modified, reordered, gapped, cross-chain-spliced, and post-terminal receipts. They do **not** detect tail truncation of an open chain — dropping the last N receipts from a non-terminal chain still produces `Valid: true`, because no in-chain field commits to the chain's total length. Three mitigations are available:
+
+- **In-band terminal marker.** When the final receipt carries `chain.terminal: true`, the receipt-after-terminal check (step 6) prevents extension. Callers MAY additionally pass `RequireTerminal` to fail verification when the final observed receipt is not explicitly terminal. The terminal receipt MAY also carry `chain.status` — `"complete"` for normal end-of-session, `"interrupted"` for best-effort terminators emitted on signal or known abort path. The verifier reports a `"complete"` / `"interrupted"` / `"unknown"` classification regardless of `RequireTerminal`. `"unknown"` is the verifier-derived label for chains with no terminal at all; issuers MUST NOT write `"unknown"` on the wire.
+- **Out-of-band witness.** Callers maintaining an external record of chain state (audit log, transparency log, signed checkpoint) MAY supply `ExpectedLength` and/or `ExpectedFinalHash` to `VerifyChain`. Verification fails when the observed chain does not match.
+- **Floor.** Tail truncation of an open (non-terminal) chain without any external witness **cannot** be detected by any mechanism in this specification.
+
+**Store trust.** Chain verification proves the integrity of the receipts the verifier is *given*; it cannot prove the verifier was given every receipt the issuer wrote. An attacker who can both delete from the store AND re-sign downstream receipts with updated `previous_receipt_hash` values (which requires the agent's signing key) can erase mid-chain history undetectably from chain verification alone. Operators who require detection of store-level tampering SHOULD layer at least one of: append-only storage (S3 Object Lock, WORM), external chain-state witnesses (per the bullet above), or periodic chain-head anchoring to a public log.
 
 ## Reversal receipts
 

--- a/site/src/content/docs/specification/receipt-chain-verification.mdx
+++ b/site/src/content/docs/specification/receipt-chain-verification.mdx
@@ -75,6 +75,8 @@ The issuer signs the canonical receipt (proof field excluded) with its Ed25519 p
 
 ## Chain integrity verification
 
+**Prerequisite.** This algorithm assumes every input receipt has already been validated against the [JSON Schema](/specification/agent-receipt-schema/#json-schema), per the end-to-end verification flow (spec §7.8 step 1). The schema enforces per-receipt invariants such as `chain.sequence` being an integer ≥ 1 and `chain.previous_receipt_hash` being either `null` or a `sha256:`-prefixed hex string. The chain algorithm below does not re-validate those constraints — chains containing schema-invalid receipts will produce undefined results.
+
 To verify a receipt chain:
 
 1. Retrieve all receipts for the chain, ordered by `chain.sequence`. Let *n* be the number of receipts.
@@ -83,7 +85,7 @@ To verify a receipt chain:
    - **b.** Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of *R(i)* with the `proof` field removed.
    - **c.** If *i < n - 1*, confirm *R(i+1)*'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
 3. For each receipt *R(i)* where *i > 0*, confirm `chain.sequence` equals *R(i-1)*'s `chain.sequence` + 1. Any gap is a hard verification failure, not a warning — partial chains cannot be silently accepted.
-4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null` and `chain.sequence` is `1`.
+4. Confirm *R(0)*'s `chain.previous_receipt_hash` is `null`. (The spec mandates `chain.sequence` starts at `1` per §4.3.2, but the reference SDK verifiers only enforce `sequence ≥ 1` here and rely on the schema and issuer conformance for the exact starting value. Callers needing strict first-sequence enforcement should additionally validate against `chain.sequence == 1` on R(0) or supply `ExpectedLength`.)
 5. Confirm every receipt shares the same `chain.chain_id` as *R(0)*. Any mismatch fails verification immediately with a `chain_id mismatch` error identifying the offending index and both values. This check is unconditional and runs independently of `previous_receipt_hash` linkage — an attacker who splices a forged hash link cannot mix receipts from two distinct chains under a single verification call.
 6. If any receipt *R(i)* carries `chain.terminal: true` and a receipt *R(i+1)* exists in the input, verification fails immediately with `receipt after terminal`. This check is unconditional — no caller parameter can suppress it.
 


### PR DESCRIPTION
## Summary

Spec v0.3.0 (AgentReceipt rename, `parameters_disclosure` envelope, `peer_credential`, `emitter_metadata`, `chain.status`) shipped in `spec/CHANGELOG.md` on 2026-05-21 and all three reference SDKs already stamp `"0.3.0"` (Go #515, TS #515, Py #515 + #494). The site was still showing v0.2.0 with no mention of the new fields. This brings the site current.

### `site/src/content/docs/specification/`

- **`overview.mdx`** — bump badge `v0.2.0` → `v0.3.0`; add an `Aside` callout summarising the v0.3.0 breaking changes and linking to `spec/CHANGELOG.md`. Also fix the dead `agent-receipts/spec` repo link (this repo merged spec into the monorepo).
- **`agent-receipt-schema.mdx`** — bump example `"version"` to `0.3.0`; add `parameters_disclosure` and `peer_credential` to the example payload; document the four new field rows (`parameters_disclosure`, `peer_credential`, `emitter_metadata`, `chain.status`); update the accepted-versions list to all four; tighten the `chain.terminal` row to note that explicit `false` is schema-invalid; fix the JSON Schema link (`action-receipt.schema.json` → `agent-receipt.schema.json`) and add the sibling `parameters-disclosure.schema.json` link.
- **`how-it-works.mdx`** — reference `peer_credential` by field name in the daemon mermaid diagram and add a line for the optional HPKE `parameters_disclosure` envelope path.
- **`receipt-chain-verification.mdx`** — add steps 5 (`chain_id` binding, unconditional, per ADR-0012 / spec §7.3.4) and 6 (receipt-after-terminal, unconditional, per spec §7.3.2) to the chain-integrity algorithm; rewrite the truncation section to cover `chain.status` (`complete` / `interrupted` / `unknown`) and to document the store-trust model and required operational mitigations (append-only storage, external witnesses, chain-head anchoring) per spec §7.3.5.

### `site/src/content/docs/sdk-{go,ts,py}/api-reference.mdx`

- Bump `Version` / `RECEIPT_VERSION` constants from `"0.2.0"` to `"0.3.0"` to match the actual SDK source. Opportunistic papercut on the TS page: correct stale package `VERSION` from `"0.6.0"` to the current `"0.9.0"`.

### Out of scope

- The protocol spec source (`spec/`) is unchanged — per `AGENTS.md`, modifying it requires explicit human approval. Note that `spec/spec/agent-receipt-spec-v0.1.md` still has front matter declaring `Version: 0.1.0, Date: 31 March 2026` even though its body uses the `AgentReceipt` rename and the CHANGELOG declares 0.3.0 shipped. The schema (`spec/schema/agent-receipt.schema.json`) and CHANGELOG are authoritative and already reflect 0.3.0; the spec body front matter is stale. Worth a separate PR to either re-version the front matter or, since the v0.3.0 changes are described mostly in the CHANGELOG and schema, fold the new fields' normative text into the spec body.
- The `sdk-go/api-reference.mdx` does not list a separate package version constant; the page version constants for Go and Py are documented as "current package version" (no literal) so no other bumps needed there.

## Test plan

- [x] `pnpm install` + `pnpm build` succeeds locally (with `rehype-mermaid` strategy temporarily swapped to `pre-mermaid` because Playwright's CDN is unreachable from the sandbox — restored before commit). All 43 pages built; both edited spec pages (`/specification/agent-receipt-schema/`, `/specification/receipt-chain-verification/`, `/specification/overview/`, `/specification/how-it-works/`) and the three SDK API reference pages built without errors.
- [ ] CI build (with `inline-svg` Mermaid strategy) passes — exercise on this PR.
- [ ] Visual review of the new `Aside` callout on `/specification/overview/`.
- [ ] Skim the new step 5 / step 6 wording on `/specification/receipt-chain-verification/` for accuracy vs spec §7.3.2 / §7.3.4 / §7.3.5.

Companion: `spec/v0.3.0` git tag is being cut against `a69a6ad` (the latest `spec/` commit, which completes the 0.3.0 changeset per `spec/CHANGELOG.md`).