### PR TITLE
chore(hook): bump sdk/go to v0.12.1-alpha.1

### DIFF
--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.11.0
+require github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,6 +2,8 @@ github.com/agent-receipts/ar/daemon v0.9.1 h1:C8OyE04+mymOlWBIWsFeNqYNord/udkLmy
 github.com/agent-receipts/ar/daemon v0.9.1/go.mod h1:aboC9nI890QcajbomkWAOUXBa3BeQ9KocdA+y8+WOv8=
 github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
 github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1 h1:SBUr08S6QWGseROX40TMln1CiAsK5fA9/4zcu5qduPo=
+github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
The hook uses `emitter.NewDaemon` introduced in PR #548, but `go.mod` still pinned `sdk/go v0.11.0` which predates it. The release build with `GOWORK=off` therefore failed to compile.

Bumps to `v0.12.1-alpha.1` which includes both the socket path fix (#545) and the `NewDaemon` rename (#548).

**Why this is needed now:** `hook/v0.11.1-alpha.1` release CI failed with `undefined: emitter.NewDaemon`. This unblocks re-releasing the hook alpha for E2E socket path testing on macOS.