### PR TITLE
chore(deps): bump sdk/go to v0.12.1 in daemon, mcp-proxy, hook

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/daemon
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.12.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
-github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1 h1:SBUr08S6QWGseROX40TMln1CiAsK5fA9/4zcu5qduPo=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.12.1 h1:FavWBocmh+hBhsZClG07ylHaXADvmZ72sp+euPN7e9M=
+github.com/agent-receipts/ar/sdk/go v0.12.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.12.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -1,9 +1,7 @@
 github.com/agent-receipts/ar/daemon v0.9.1 h1:C8OyE04+mymOlWBIWsFeNqYNord/udkLmy8QIJJDfBw=
 github.com/agent-receipts/ar/daemon v0.9.1/go.mod h1:aboC9nI890QcajbomkWAOUXBa3BeQ9KocdA+y8+WOv8=
-github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
-github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1 h1:SBUr08S6QWGseROX40TMln1CiAsK5fA9/4zcu5qduPo=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.12.1 h1:FavWBocmh+hBhsZClG07ylHaXADvmZ72sp+euPN7e9M=
+github.com/agent-receipts/ar/sdk/go v0.12.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/agent-receipts/ar/daemon v0.9.1
-	github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.12.1
 	github.com/google/uuid v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,9 +1,7 @@
 github.com/agent-receipts/ar/daemon v0.9.1 h1:C8OyE04+mymOlWBIWsFeNqYNord/udkLmy8QIJJDfBw=
 github.com/agent-receipts/ar/daemon v0.9.1/go.mod h1:aboC9nI890QcajbomkWAOUXBa3BeQ9KocdA+y8+WOv8=
-github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
-github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1 h1:SBUr08S6QWGseROX40TMln1CiAsK5fA9/4zcu5qduPo=
-github.com/agent-receipts/ar/sdk/go v0.12.1-alpha.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.12.1 h1:FavWBocmh+hBhsZClG07ylHaXADvmZ72sp+euPN7e9M=
+github.com/agent-receipts/ar/sdk/go v0.12.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Promotes the sdk/go dependency from `v0.12.1-alpha.1` to the stable `v0.12.1` in all three dependents.

## Changes
- `daemon/go.mod`: `sdk/go v0.12.1-alpha.1` → `v0.12.1`
- `mcp-proxy/go.mod`: `sdk/go v0.12.1-alpha.1` → `v0.12.1`
- `hook/go.mod`: `sdk/go v0.12.1-alpha.1` → `v0.12.1`

## What's in sdk/go v0.12.1
- macOS socket path fix: daemon socket now resolves to `$HOME/.local/share/agent-receipts/events.sock` instead of `$TMPDIR/agentreceipts/events.sock` (fixes GUI-spawned subprocess breakage, #547)
- HttpEmitter + Emitter interface (#548)

E2E verified: receipts land correctly from both Claude Code (hook) and Claude Desktop (mcp-proxy) after this fix.