### PR TITLE
docs(site): document v0.3.0 HPKE disclosure envelope on spec pages

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -34,7 +34,7 @@ pnpm preview   # preview production build
 
 ## Related repos
 
-- [agent-receipts/spec](https://github.com/agent-receipts/spec) — protocol specification
+- [agent-receipts/spec](https://github.com/agent-receipts/ar/tree/main/spec) — protocol specification
 - [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) — TypeScript SDK
 - [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) — Python SDK
 - [agent-receipts/openclaw](https://github.com/agent-receipts/openclaw) — OpenClaw plugin

--- a/site/README.md
+++ b/site/README.md
@@ -51,7 +51,7 @@ Sidebar order is controlled by `astro.config.mjs`, not by file naming.
 
 | Repository | Description |
 |:---|:---|
-| [agent-receipts/spec](https://github.com/agent-receipts/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
+| [agent-receipts/spec](https://github.com/agent-receipts/ar/tree/main/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
 | [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
 | [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -125,7 +125,7 @@ Implementations may escalate but must not downgrade risk levels.
 
 ## Repositories
 
-- **spec** (https://github.com/agent-receipts/spec): Protocol specification, JSON Schema, action taxonomy
+- **spec** (https://github.com/agent-receipts/ar/tree/main/spec): Protocol specification, JSON Schema, action taxonomy
 - **sdk-ts** (https://github.com/agent-receipts/ar/tree/main/sdk/ts): TypeScript SDK — create, sign, verify receipts
 - **sdk-py** (https://github.com/agent-receipts/ar/tree/main/sdk/py): Python SDK — create, sign, verify receipts
 - **openclaw** (https://github.com/agent-receipts/openclaw): OpenClaw plugin for automatic receipt generation
@@ -134,5 +134,5 @@ Implementations may escalate but must not downgrade risk levels.
 
 - Documentation: https://agentreceipts.ai
 - Specification: https://agentreceipts.ai/specification/overview/
-- JSON Schema: https://github.com/agent-receipts/spec/blob/main/schema/agent-receipt.schema.json
+- JSON Schema: https://github.com/agent-receipts/ar/blob/main/spec/schema/agent-receipt.schema.json
 - GitHub org: https://github.com/agent-receipts

--- a/site/src/content/docs/specification/action-taxonomy.mdx
+++ b/site/src/content/docs/specification/action-taxonomy.mdx
@@ -5,7 +5,7 @@ description: Standardized action types organized by domain with default risk lev
 
 The Action Taxonomy is a hierarchical vocabulary of action types, organized by domain. Each action type has a default risk level. Implementations may escalate risk levels based on context but must not downgrade them.
 
-The canonical machine-readable taxonomy is defined in [`spec/taxonomy/action-types.json`](https://github.com/agent-receipts/spec/blob/main/spec/taxonomy/action-types.json).
+The canonical machine-readable taxonomy is defined in [`spec/spec/taxonomy/action-types.json`](https://github.com/agent-receipts/ar/blob/main/spec/spec/taxonomy/action-types.json).
 
 ## Filesystem
 

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -177,11 +177,45 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `target.system` | No | The system or service acted upon. |
 | `target.resource` | No | The specific resource within the system. |
 | `parameters_hash` | No | `sha256:` prefixed hash of action parameters (RFC 8785 canonical JSON). Always authoritative for parameter integrity; `parameters_disclosure` is additive metadata. |
-| `parameters_disclosure` | No | Operator-controlled disclosure of action parameters. Either the legacy flat-map (v0.2.x — `{ [key: string]: string }`) or the HPKE asymmetric encryption envelope defined by ADR-0012 (v0.3.0+). Mode is per-emitter; a receipt MUST NOT mix shapes. The envelope shape is validated by the sibling [`parameters-disclosure.schema.json`](https://github.com/agent-receipts/ar/blob/main/spec/schema/parameters-disclosure.schema.json). Operators MUST NOT place plaintext secrets or PII in the legacy flat-map form. |
+| `parameters_disclosure` | No | Operator-controlled disclosure of action parameters. Either the legacy flat-map (v0.2.x — `{ [key: string]: string }`) or the HPKE asymmetric encryption envelope defined by ADR-0012 (v0.3.0+). Mode is per-emitter; a receipt MUST NOT mix shapes. See [`parameters_disclosure` envelope (HPKE)](#parameters_disclosure-envelope-hpke) for the envelope shape and an example. Operators MUST NOT place plaintext secrets or PII in the legacy flat-map form. |
 | `peer_credential` | No | OS-attested peer process metadata captured by the daemon at the SDK↔daemon boundary (`platform`, `pid`, optional `uid`/`gid`/`exe_path`). Present only on receipts emitted through a daemon (ADR-0010); absent on direct SDK emissions. Daemon-attested, not agent-claimed. |
 | `emitter_metadata` | No | Daemon-observed emitter-side metadata. Currently a single `drop_count` field on synthetic events_dropped receipts (ADR-0010). Daemon-attested, not agent-claimed. |
 | `timestamp` | Yes | ISO 8601 datetime when the action was executed. |
 | `trusted_timestamp` | No | Base64-encoded RFC 3161 TimeStampToken. Absent (not `null`) when not present — see [Optional-field rule](#optional-field-rule). |
+
+#### `parameters_disclosure` envelope (HPKE)
+
+`parameters_hash` is always authoritative for parameter integrity. `parameters_disclosure` is optional, additive metadata that lets an operator make the underlying parameters recoverable. It takes one of two shapes — mode is per-emitter, and a single receipt MUST NOT mix them:
+
+- **Legacy flat-map** (v0.2.x) — `{ [key: string]: string }` of operator-redacted plaintext, as shown in the full receipt example above. Operators MUST NOT place plaintext secrets or PII here.
+- **HPKE envelope** (v0.3.0+, ADR-0012) — the parameters are encrypted to a forensic recipient so they never appear in plaintext on the wire. This is the headline v0.3.0 disclosure mode.
+
+The v1 envelope is HPKE base mode (RFC 9180) with ciphersuite KEM = DHKEM(X25519, HKDF-SHA256), KDF = HKDF-SHA256, AEAD = AES-256-GCM. Both the HPKE `info` and AEAD `aad` are the empty string; there is no `nonce` field (HPKE single-shot derives it internally). The plaintext is the RFC 8785 canonical JSON of the parameters object — top-level strings, numbers, and arrays are not valid plaintext; wrap them in an object.
+
+| Field | Required | Description |
+|---|---|---|
+| `v` | Yes | Envelope schema version. The JSON string `"1"` (not the number `1`). Any change to the field set, encoding, or ciphersuite is a future `"2"`. |
+| `alg` | Yes | Ciphersuite tag. Exactly `"hpke-x25519-hkdf-sha256-aes-256-gcm"` — no whitespace or case variation. |
+| `recipients` | Yes | Array of recipient descriptors. Exactly one entry in v1 (multi-recipient is reserved for a future envelope version). |
+| `recipients[].kid` | Yes | Recipient public-key identifier — either an ADR-0007 `did:key` URL with an encryption-key fragment (e.g. `did:key:z6Mk…#enc-1`) or a `sha256:<hex>` fingerprint. An index only; not itself authenticated. |
+| `recipients[].enc` | Yes | HPKE encapsulated key (RFC 9180 §4.1) — the 32-byte X25519 ephemeral public key as 43 unpadded base64url characters. |
+| `ct` | Yes | AEAD ciphertext including the 16-byte GCM tag, as unpadded base64url (no `=`, `+`, or `/`). |
+
+```json
+"parameters_disclosure": {
+  "v": "1",
+  "alg": "hpke-x25519-hkdf-sha256-aes-256-gcm",
+  "recipients": [
+    {
+      "kid": "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1",
+      "enc": "N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE"
+    }
+  ],
+  "ct": "YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM"
+}
+```
+
+This envelope decrypts to `{"command":"echo \"build complete\""}` for the holder of the recipient key. It is byte-for-byte the first conformance vector in [`spec/test-vectors/disclosure-envelope/vectors.json`](https://github.com/agent-receipts/ar/blob/main/spec/test-vectors/disclosure-envelope/vectors.json), which all three SDKs reproduce. The envelope shape is validated by the sibling [`parameters-disclosure.schema.json`](https://github.com/agent-receipts/ar/blob/main/spec/schema/parameters-disclosure.schema.json) (also inlined as `$defs/parametersDisclosureEnvelope` in the main schema so single-file validators resolve it without external refs).
 
 ### `intent`
 


### PR DESCRIPTION
## Summary

Closes #553. Most of that issue's checklist (overview badge, schema version enum/example, `peer_credential`/`emitter_metadata`, `proofValue` encoding) was already shipped by #531. This PR closes the remaining gaps after verifying every spec page against the source of truth in `spec/`.

- **Schema page** — The HPKE `parameters_disclosure` envelope (the headline v0.3.0 disclosure mode) was documented only by *reference* to the sibling schema, so an external verifier reading the public spec page alone couldn't implement it — an explicit #553 acceptance criterion. Added an inline field table (`v`, `alg`, `recipients[].kid/enc`, `ct`) plus ciphersuite/encoding notes and a worked example that is **byte-for-byte the first conformance vector** in `spec/test-vectors/disclosure-envelope/vectors.json` (decrypts to `{"command":"echo \"build complete\""}`). Cross-linked from the action-field table.
- **Action Taxonomy page** — Fixed a broken source link that pointed at a non-existent `agent-receipts/spec` repo; now points at `agent-receipts/ar/.../spec/spec/taxonomy/action-types.json`.
- **Opportunistic papercut** — The same dead-`agent-receipts/spec`-repo link appeared in `site/README.md`, `site/AGENTS.md`, and `site/public/llms-full.txt` (including a dead blob link to the JSON Schema). Repointed all at the `/ar` monorepo, matching how the sibling `sdk-ts`/`sdk-py` links are already written.

## Commits

- `99973be` — document v0.3.0 HPKE disclosure envelope + taxonomy link fix (the #553 work)
- `2563bd8` — repoint stale `agent-receipts/spec` links across `site/`

## Verification

- Envelope field table and example independently reviewed against `spec/schema/parameters-disclosure.schema.json`, the inline `$defs/parametersDisclosureEnvelope`, and `spec/test-vectors/disclosure-envelope/vectors.json` — all fields, required flags, and byte values match.
- Cross-link anchor `#parameters_disclosure-envelope-hpke` confirmed against `github-slugger` output for the heading.
- No version-number drift across Overview, Schema, How It Works, and code examples; taxonomy content matches `spec/spec/taxonomy/action-types.json` (no new domains since v0.2.1).

> Note: I couldn't run a full local `pnpm build` — it renders mermaid via Playwright/Chromium, and the browser download is blocked by the sandbox network policy (fails on `receipt-chain-verification.mdx`, untouched here). Astro content-sync (which parses/validates all MDX) passed; the edited `.mdx` files contain no mermaid. CI will exercise the full build.

## Out of scope

The broader "Ecosystem"/"Related repos" table staleness (e.g. `site` listed as its own repo when this is the `/ar` monorepo) is left for a separate cleanup.

## Test plan

- [ ] CI site build passes (Astro + mermaid render)
- [ ] Spot-check rendered Schema page: HPKE envelope subsection renders, action-table cross-link resolves to it
- [ ] Spot-check the repointed links resolve on GitHub

https://claude.ai/code/session_01JSudt1p74kWgmZXj8vY41u