### PR TITLE
ci(collector): add CI workflow and align sdk/go to v0.12.1 (closes #533)

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -1,0 +1,41 @@
+name: "CI: collector"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "collector/**"
+      - "sdk/go/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "collector/**"
+      - "sdk/go/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: collector
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./cmd/collector
+
+      # -race because the in-memory and SQLite stores carry concurrency
+      # invariants exercised by TestInMemoryStore_ConcurrentInserts and
+      # TestSQLiteStore_ConcurrentInserts.
+      - name: Test
+        run: go test -race ./... -v

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/collector
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.11.0
+	github.com/agent-receipts/ar/sdk/go v0.12.1
 	modernc.org/sqlite v1.50.1
 )
 

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
-github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.12.1 h1:FavWBocmh+hBhsZClG07ylHaXADvmZ72sp+euPN7e9M=
+github.com/agent-receipts/ar/sdk/go v0.12.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Summary

Closes the last open Definition-of-Done item in #533 (reference HTTP collector). The collector implementation itself already landed in #537; this wires it into CI and aligns its dependency pin with the other Go modules.

- **`.github/workflows/collector.yml`** — path-filtered CI (`collector/**` + `sdk/go/**`, since the collector links `sdk/go` via the repo-root `go.work`), modeled on `mcp-proxy.yml`. Runs `go vet`, `go build ./cmd/collector`, and `go test -race ./...`. `-race` because the in-memory and SQLite stores carry concurrency invariants exercised by the `ConcurrentInserts` tests.
- **`collector/go.mod` → `sdk/go v0.12.1`** — matches daemon/mcp-proxy/hook (bumped in #549–#551). Harmless under `go.work` (the workspace overrides the require), but keeps release / `go install` resolution outside the workspace consistent across modules. `go mod tidy` dropped the stale `v0.11.0` `go.sum` entries; the new hashes are byte-identical to those in `mcp-proxy/go.sum` and `daemon/go.sum`.

## #533 Definition of Done

All items now satisfied (the implementation from #537 covered the rest):

- [x] `collector/` module with `cmd/collector` binary
- [x] All four status codes (201/409/400/5xx) covered by tests
- [x] SQLite + in-memory backends behind a `Store` interface
- [x] `/healthz` returns 200 when the store is reachable
- [x] Graceful shutdown verified (`TestServer_Run_GracefulShutdown` drives the real `Run` ctx-cancel path that `signal.NotifyContext(SIGTERM)` triggers)
- [x] README documents the trust model and references ADR-0020
- [x] Module added to `go.work` and CI workflow

## Test plan

- [x] `go build ./...` (collector)
- [x] `go vet ./...` (collector)
- [x] `go test -race ./...` (collector) — passes
- [ ] New `CI: collector` workflow runs green on this PR

## Notes

- This adds a *new* workflow rather than modifying any existing one.
- No `release-collector.yml` is included: the README frames the collector as a reference service, not a published artifact, so a release workflow is out of scope here.

https://claude.ai/code/session_01ULX2otk5tyiyejCd5sxSjr