### PR TITLE
ci: trigger Python/TS SDK suites on cross-sdk-tests and spec changes (#474)

### DIFF
--- a/.github/workflows/sdk-py.yml
+++ b/.github/workflows/sdk-py.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "sdk/py/**"
+      - "cross-sdk-tests/**"
   pull_request:
     branches: [main]
     paths:
       - "sdk/py/**"
+      - "cross-sdk-tests/**"
 
 permissions:
   contents: read

--- a/.github/workflows/sdk-py.yml
+++ b/.github/workflows/sdk-py.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "sdk/py/**"
       - "cross-sdk-tests/**"
+      - "spec/**"
   pull_request:
     branches: [main]
     paths:
       - "sdk/py/**"
       - "cross-sdk-tests/**"
+      - "spec/**"
 
 permissions:
   contents: read

--- a/.github/workflows/sdk-ts.yml
+++ b/.github/workflows/sdk-ts.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "sdk/ts/**"
+      - "cross-sdk-tests/**"
   pull_request:
     branches: [main]
     paths:
       - "sdk/ts/**"
+      - "cross-sdk-tests/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes the CI-enforcement gap for the cross-SDK conformance suite (#474). The conformance vectors and round-trip matrix already exist and pass across all three SDKs, but two of the three SDK workflows didn't re-run their conformance tests when the shared inputs changed.

- `sdk-py.yml` / `sdk-ts.yml` were path-filtered to `sdk/py/**` / `sdk/ts/**` only, so editing a shared vector under `cross-sdk-tests/` would **not** re-run the Python/TS conformance suites that consume it — leaving the guard unenforced for two of three SDKs. `sdk-go.yml` already triggered on `cross-sdk-tests/**`. Both workflows now trigger on `cross-sdk-tests/**`.
- `sdk-py.yml` additionally now triggers on `spec/**`: `sdk/py/tests/test_spec_schema.py` reads `spec/schema/agent-receipt.schema.json` and globs `spec/examples/*.json` at runtime, so a spec-only change previously skipped the Python schema-conformance test. `sdk-go.yml` already triggers on `spec/**`. `sdk-ts.yml` is intentionally left out — its `spec/` references are inlined fixtures, not runtime file reads.

No source/test code changed; this is CI trigger wiring only (6 lines across 2 workflow files).

### Why these triggers have teeth
The Python and TS suites read the shared files at runtime, and both workflows run the full suite (`uv run pytest -v`, `pnpm run test`):
- `sdk/py/tests/test_canonicalization_vectors.py`, `test_cross_language_go.py`, `test_v030_vectors.py` → `cross-sdk-tests/*.json`
- `sdk/ts/src/receipt/canonicalization-vectors.test.ts`, `cross-language.test.ts` → `cross-sdk-tests/*.json`
- `sdk/py/tests/test_spec_schema.py` → `spec/schema/*`, `spec/examples/*`

## Context: #474 was already substantively complete
- Shared conformance vectors with canonical bytes + SHA-256 hashes (`cross-sdk-tests/canonicalization_vectors.json`) verified identically by Go (`TestCanonVectors`, `TestReceiptHashVectors`), Python, and TS.
- 6-direction round-trip matrix all green (TS↔Go, TS↔Py, Py↔Go), incl. `TestCrossLanguagePySignatureVerifiesInGo`.
- Python `eventType`/"attest" naming already removed (#502); ADR-0019 § S1 marks it fixed.

This PR is the remaining CI-enforcement piece; issue #474 is closed.

## Test plan
- [x] Local run before push: Go integration green, Python 65 passed, TS 67 passed, cross-sdk-tests spec validation green
- [x] YAML validated for both workflows

https://claude.ai/code/session_01Wpr71N5zq1Y7vjxkEDy6LR