### PR TITLE
Add action.idempotency_key field (v0.4.0)

### DIFF
--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -196,6 +196,13 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("wrote v030_vectors.json")
+
+	// --- v0.4.0 vectors ---
+	if err := generateV040Vectors(tsVectors.Keys); err != nil {
+		fmt.Fprintf(os.Stderr, "generate v040 vectors: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("wrote v040_vectors.json")
 }
 
 // generateV020Vectors builds and writes v020_vectors.json using the shared keypair
@@ -248,6 +255,11 @@ func generateV020Vectors(keys keysSection) error {
 		r.IssuanceDate = fixedTimestamp
 		r.CredentialSubject.Action.ID = fmt.Sprintf("act_v020_%d", i)
 		r.CredentialSubject.Action.Timestamp = fixedTimestamp
+		// Pin the protocol version: this is a *v0.2.0* fixture, so it must not
+		// drift to whatever the SDK's current Version constant is (Create stamps
+		// that). Without this, every protocol bump silently rewrites the pinned
+		// v020 vector and its signatures.
+		r.Version = "0.2.0"
 
 		s, err := receipt.Sign(r, keys.PrivateKey, "did:agent:test#key-1")
 		if err != nil {
@@ -537,6 +549,183 @@ func generateV030Vectors(keys keysSection) error {
 		return fmt.Errorf("marshal v030 vectors: %w", err)
 	}
 	return os.WriteFile("v030_vectors.json", append(outBytes, '\n'), 0644)
+}
+
+// --- v0.4.0 vector generation ---
+//
+// The v0.4.0 receipt shape adds the optional action.idempotency_key string
+// (spec §7.3.6, ADR-0019 §S5). These vectors pin two cross-SDK contracts:
+//
+//   - idempotencyKeyReceipt: a single signed receipt carrying
+//     action.idempotency_key. All three SDKs MUST canonicalise, hash, and
+//     verify it identically (the new field is just another sorted string key
+//     under RFC 8785).
+//   - duplicateIdempotencyChain: a two-receipt chain whose receipts share one
+//     idempotency_key. All three SDK chain verifiers MUST report the chain as
+//     valid (retries are legitimate) AND surface exactly one duplicate-key
+//     advisory. The warning string itself is SDK-local prose and is NOT pinned;
+//     only the count and the duplicated key value are.
+
+type v040Vectors struct {
+	Comment        string                       `json:"$comment"`
+	Version        string                       `json:"version"`
+	Keys           keysSection                  `json:"keys"`
+	Idempotency    idempotencyKeyReceiptSection `json:"idempotencyKeyReceipt"`
+	DuplicateChain duplicateChainSection        `json:"duplicateIdempotencyChain"`
+}
+
+type idempotencyKeyReceiptSection struct {
+	Description         string          `json:"description"`
+	IdempotencyKey      string          `json:"idempotencyKey"`
+	Receipt             json.RawMessage `json:"receipt"`
+	ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+	ExpectedValid       bool            `json:"expectedValid"`
+}
+
+type duplicateChainSection struct {
+	Description          string            `json:"description"`
+	DuplicateKey         string            `json:"duplicateKey"`
+	Receipts             []json.RawMessage `json:"receipts"`
+	ExpectedValid        bool              `json:"expectedValid"`
+	ExpectedWarningCount int               `json:"expectedWarningCount"`
+}
+
+func generateV040Vectors(keys keysSection) error {
+	const fixedTimestamp = "2026-05-23T00:00:00Z"
+
+	// --- single receipt carrying action.idempotency_key ---
+	const singleKey = "jsonrpc-req-7c3a9f10"
+	idemUnsigned := map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"},
+		"id":           "urn:receipt:040e0040-0000-4040-a040-000000000001",
+		"type":         []any{"VerifiableCredential", "AgentReceipt"},
+		"version":      "0.4.0",
+		"issuer":       map[string]any{"id": "did:agent:test"},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":              "act_040e0040-0000-4040-a040-000000000001",
+				"type":            "system.command.execute",
+				"risk_level":      "high",
+				"idempotency_key": singleKey,
+				"timestamp":       fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_v040_idempotency_test",
+			},
+		},
+	}
+	idemSigned, idemHash, err := signAndHashMap(idemUnsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("idempotency receipt: %w", err)
+	}
+
+	// --- two-receipt chain sharing one idempotency_key (a recorded retry) ---
+	const dupKey = "jsonrpc-req-retry-001"
+	const dupChainID = "chain_v040_duplicate_test"
+	dup1Unsigned := map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"},
+		"id":           "urn:receipt:040e0040-0000-4040-a040-000000000002",
+		"type":         []any{"VerifiableCredential", "AgentReceipt"},
+		"version":      "0.4.0",
+		"issuer":       map[string]any{"id": "did:agent:test"},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":              "act_040e0040-0000-4040-a040-000000000002",
+				"type":            "data.api.read",
+				"risk_level":      "low",
+				"idempotency_key": dupKey,
+				"timestamp":       fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "failure", "error": "upstream timeout"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              dupChainID,
+			},
+		},
+	}
+	dup1Signed, dup1Hash, err := signAndHashMap(dup1Unsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("duplicate chain receipt 1: %w", err)
+	}
+	dup2Unsigned := map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"},
+		"id":           "urn:receipt:040e0040-0000-4040-a040-000000000003",
+		"type":         []any{"VerifiableCredential", "AgentReceipt"},
+		"version":      "0.4.0",
+		"issuer":       map[string]any{"id": "did:agent:test"},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":              "act_040e0040-0000-4040-a040-000000000003",
+				"type":            "data.api.read",
+				"risk_level":      "low",
+				"idempotency_key": dupKey,
+				"timestamp":       fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              2,
+				"previous_receipt_hash": dup1Hash,
+				"chain_id":              dupChainID,
+			},
+		},
+	}
+	dup2Signed, _, err := signAndHashMap(dup2Unsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("duplicate chain receipt 2: %w", err)
+	}
+
+	// Self-check: the duplicate chain must verify as valid with exactly one
+	// idempotency warning, matching what the TS and Py SDK tests assert.
+	var r1, r2 receipt.AgentReceipt
+	if err := json.Unmarshal(dup1Signed, &r1); err != nil {
+		return fmt.Errorf("unmarshal dup receipt 1: %w", err)
+	}
+	if err := json.Unmarshal(dup2Signed, &r2); err != nil {
+		return fmt.Errorf("unmarshal dup receipt 2: %w", err)
+	}
+	res := receipt.VerifyChain([]receipt.AgentReceipt{r1, r2}, keys.PublicKey)
+	if !res.Valid {
+		return fmt.Errorf("generated duplicate chain failed verification: %s", res.Error)
+	}
+	if len(res.Warnings) != 1 {
+		return fmt.Errorf("generated duplicate chain produced %d warnings, want 1", len(res.Warnings))
+	}
+
+	out := v040Vectors{
+		Comment: "Cross-SDK v0.4.0 test vectors: pins the optional action.idempotency_key field (spec §7.3.6, ADR-0019 §S5, #480). All three SDKs MUST verify the signatures and reproduce expectedReceiptHash byte-for-byte, and MUST report the duplicate-key chain as valid with exactly one warning. Warning text is SDK-local prose and is intentionally not pinned.",
+		Version: "0.4.0",
+		Keys:    keys,
+		Idempotency: idempotencyKeyReceiptSection{
+			Description:         "Signed v0.4.0 receipt carrying action.idempotency_key. The new field is an ordinary sorted string key under RFC 8785; cross-SDK hash/sign/verify must be byte-identical.",
+			IdempotencyKey:      singleKey,
+			Receipt:             idemSigned,
+			ExpectedReceiptHash: idemHash,
+			ExpectedValid:       true,
+		},
+		DuplicateChain: duplicateChainSection{
+			Description:          "Two-receipt chain whose receipts share one action.idempotency_key — a tool call that timed out (failure) and was retried (success). Verifiers MUST report valid: true (retries are legitimate) and surface exactly one duplicate-key advisory.",
+			DuplicateKey:         dupKey,
+			Receipts:             []json.RawMessage{dup1Signed, dup2Signed},
+			ExpectedValid:        true,
+			ExpectedWarningCount: 1,
+		},
+	}
+
+	outBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal v040 vectors: %w", err)
+	}
+	return os.WriteFile("v040_vectors.json", append(outBytes, '\n'), 0644)
 }
 
 // signAndHashMap signs an unsigned-receipt JSON map with the Ed25519 PEM

--- a/cross-sdk-tests/v040_vectors.json
+++ b/cross-sdk-tests/v040_vectors.json
@@ -1,0 +1,152 @@
+{
+  "$comment": "Cross-SDK v0.4.0 test vectors: pins the optional action.idempotency_key field (spec §7.3.6, ADR-0019 §S5, #480). All three SDKs MUST verify the signatures and reproduce expectedReceiptHash byte-for-byte, and MUST report the duplicate-key chain as valid with exactly one warning. Warning text is SDK-local prose and is intentionally not pinned.",
+  "version": "0.4.0",
+  "keys": {
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAZMzh2Qtdx/p40WlXhD+gKmaTDv3rLGm6TeY7TsJUKSQ=\n-----END PUBLIC KEY-----\n",
+    "privateKey": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJqomA2cjqhLUYPhkMJyg4+A7hU8GiZtVzkN0Yz6jJPF\n-----END PRIVATE KEY-----\n"
+  },
+  "idempotencyKeyReceipt": {
+    "description": "Signed v0.4.0 receipt carrying action.idempotency_key. The new field is an ordinary sorted string key under RFC 8785; cross-SDK hash/sign/verify must be byte-identical.",
+    "idempotencyKey": "jsonrpc-req-7c3a9f10",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v1"
+      ],
+      "credentialSubject": {
+        "action": {
+          "id": "act_040e0040-0000-4040-a040-000000000001",
+          "idempotency_key": "jsonrpc-req-7c3a9f10",
+          "risk_level": "high",
+          "timestamp": "2026-05-23T00:00:00Z",
+          "type": "system.command.execute"
+        },
+        "chain": {
+          "chain_id": "chain_v040_idempotency_test",
+          "previous_receipt_hash": null,
+          "sequence": 1
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "principal": {
+          "id": "did:user:test"
+        }
+      },
+      "id": "urn:receipt:040e0040-0000-4040-a040-000000000001",
+      "issuanceDate": "2026-05-23T00:00:00Z",
+      "issuer": {
+        "id": "did:agent:test"
+      },
+      "proof": {
+        "created": "2026-05-23T00:00:00Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u-abQMKcumWX68aJLkVPIG-hG2LGxJRcjhv3pNbeSKyIOcrJoK67TyhZiTP4-1DKD4hVym7p5RPW4IQJpZNwtBA",
+        "type": "Ed25519Signature2020",
+        "verificationMethod": "did:agent:test#key-1"
+      },
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.4.0"
+    },
+    "expectedReceiptHash": "sha256:c396d4c4080359f17cdfaf5e42ae44da460a59b7573a9071e7c09b51e283f2c3",
+    "expectedValid": true
+  },
+  "duplicateIdempotencyChain": {
+    "description": "Two-receipt chain whose receipts share one action.idempotency_key — a tool call that timed out (failure) and was retried (success). Verifiers MUST report valid: true (retries are legitimate) and surface exactly one duplicate-key advisory.",
+    "duplicateKey": "jsonrpc-req-retry-001",
+    "receipts": [
+      {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "credentialSubject": {
+          "action": {
+            "id": "act_040e0040-0000-4040-a040-000000000002",
+            "idempotency_key": "jsonrpc-req-retry-001",
+            "risk_level": "low",
+            "timestamp": "2026-05-23T00:00:00Z",
+            "type": "data.api.read"
+          },
+          "chain": {
+            "chain_id": "chain_v040_duplicate_test",
+            "previous_receipt_hash": null,
+            "sequence": 1
+          },
+          "outcome": {
+            "error": "upstream timeout",
+            "status": "failure"
+          },
+          "principal": {
+            "id": "did:user:test"
+          }
+        },
+        "id": "urn:receipt:040e0040-0000-4040-a040-000000000002",
+        "issuanceDate": "2026-05-23T00:00:00Z",
+        "issuer": {
+          "id": "did:agent:test"
+        },
+        "proof": {
+          "created": "2026-05-23T00:00:00Z",
+          "proofPurpose": "assertionMethod",
+          "proofValue": "uaFnQzyQexOpaSLWziujIegXRb90G0J8xeU4SlRit9eGtdRVVWj7Eeo4CZmYtJFtd5bgnkJPZQEmckgwK56uWDw",
+          "type": "Ed25519Signature2020",
+          "verificationMethod": "did:agent:test#key-1"
+        },
+        "type": [
+          "VerifiableCredential",
+          "AgentReceipt"
+        ],
+        "version": "0.4.0"
+      },
+      {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "credentialSubject": {
+          "action": {
+            "id": "act_040e0040-0000-4040-a040-000000000003",
+            "idempotency_key": "jsonrpc-req-retry-001",
+            "risk_level": "low",
+            "timestamp": "2026-05-23T00:00:00Z",
+            "type": "data.api.read"
+          },
+          "chain": {
+            "chain_id": "chain_v040_duplicate_test",
+            "previous_receipt_hash": "sha256:67091303644f28434bcb85d387b3703b9fa5f2bc5331d18fa67026b525e1d124",
+            "sequence": 2
+          },
+          "outcome": {
+            "status": "success"
+          },
+          "principal": {
+            "id": "did:user:test"
+          }
+        },
+        "id": "urn:receipt:040e0040-0000-4040-a040-000000000003",
+        "issuanceDate": "2026-05-23T00:00:00Z",
+        "issuer": {
+          "id": "did:agent:test"
+        },
+        "proof": {
+          "created": "2026-05-23T00:00:00Z",
+          "proofPurpose": "assertionMethod",
+          "proofValue": "ubImjLpM72iaNVp3nh20YrcyzoDGfpOH4-N8uuiy-pAnUKmX5Y4R6yALXdq9emo5nkP_Kyumca08901RCvkqPDw",
+          "type": "Ed25519Signature2020",
+          "verificationMethod": "did:agent:test#key-1"
+        },
+        "type": [
+          "VerifiableCredential",
+          "AgentReceipt"
+        ],
+        "version": "0.4.0"
+      }
+    ],
+    "expectedValid": true,
+    "expectedWarningCount": 1
+  }
+}

--- a/cross-sdk-tests/v040_vectors_test.go
+++ b/cross-sdk-tests/v040_vectors_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package crosssdk_test
+
+// Test runner for cross-sdk-tests/v040_vectors.json (action.idempotency_key,
+// spec §7.3.6 / ADR-0019 §S5 / #480). Pins:
+//
+//   - Schema validation of each v0.4.0 receipt against
+//     spec/schema/agent-receipt.schema.json.
+//   - Signature verification + byte-identical receipt-hash reproduction for the
+//     receipt carrying action.idempotency_key.
+//   - The duplicate-idempotency_key chain verifies as valid with exactly one
+//     warning (retries are legitimate; spec §7.3.6).
+//
+// Gated behind the `integration` build tag like the other vector runners.
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+const v040VectorsPath = "v040_vectors.json"
+
+type v040File struct {
+	Comment string `json:"$comment"`
+	Version string `json:"version"`
+	Keys    struct {
+		PublicKey  string `json:"publicKey"`
+		PrivateKey string `json:"privateKey"`
+	} `json:"keys"`
+	Idempotency struct {
+		Description         string          `json:"description"`
+		IdempotencyKey      string          `json:"idempotencyKey"`
+		Receipt             json.RawMessage `json:"receipt"`
+		ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+		ExpectedValid       bool            `json:"expectedValid"`
+	} `json:"idempotencyKeyReceipt"`
+	DuplicateChain struct {
+		Description          string            `json:"description"`
+		DuplicateKey         string            `json:"duplicateKey"`
+		Receipts             []json.RawMessage `json:"receipts"`
+		ExpectedValid        bool              `json:"expectedValid"`
+		ExpectedWarningCount int               `json:"expectedWarningCount"`
+	} `json:"duplicateIdempotencyChain"`
+}
+
+func loadV040(t *testing.T) v040File {
+	t.Helper()
+	data, err := os.ReadFile(v040VectorsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", v040VectorsPath, err)
+	}
+	var f v040File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("parse %s: %v", v040VectorsPath, err)
+	}
+	if f.Version != "0.4.0" {
+		t.Fatalf("v040 vectors file version = %q, want 0.4.0", f.Version)
+	}
+	return f
+}
+
+// TestV040VectorsValidateAgainstSchema runs each pinned v0.4.0 receipt through
+// the spec schema, locking in that action.idempotency_key matches the schema.
+func TestV040VectorsValidateAgainstSchema(t *testing.T) {
+	schema := loadSchema(t)
+	f := loadV040(t)
+
+	receipts := []json.RawMessage{f.Idempotency.Receipt}
+	receipts = append(receipts, f.DuplicateChain.Receipts...)
+
+	for i, raw := range receipts {
+		var doc any
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("unmarshal receipt %d: %v", i, err)
+		}
+		if err := schema.Validate(doc); err != nil {
+			t.Errorf("receipt %d does not validate against agent-receipt.schema.json:\n%v", i, err)
+		}
+	}
+}
+
+// TestV040IdempotencyReceiptHashAndSignature verifies the signature and the
+// byte-identical receipt hash of the receipt carrying action.idempotency_key.
+func TestV040IdempotencyReceiptHashAndSignature(t *testing.T) {
+	f := loadV040(t)
+
+	pub, err := parseEd25519PublicPEMTest(f.Keys.PublicKey)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+
+	var asMap map[string]any
+	if err := json.Unmarshal(f.Idempotency.Receipt, &asMap); err != nil {
+		t.Fatalf("unmarshal receipt to map: %v", err)
+	}
+	proofMap, ok := asMap["proof"].(map[string]any)
+	if !ok {
+		t.Fatal("receipt missing proof")
+	}
+	proofValue, _ := proofMap["proofValue"].(string)
+	if len(proofValue) < 2 || proofValue[0] != 'u' {
+		t.Fatalf("proof.proofValue %q: missing u multibase prefix", proofValue)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(proofValue[1:])
+	if err != nil {
+		t.Fatalf("decode proofValue: %v", err)
+	}
+
+	unsigned := make(map[string]any, len(asMap)-1)
+	for k, v := range asMap {
+		if k == "proof" {
+			continue
+		}
+		unsigned[k] = v
+	}
+	canonical, err := receipt.Canonicalize(unsigned)
+	if err != nil {
+		t.Fatalf("canonicalize unsigned: %v", err)
+	}
+	if !ed25519.Verify(pub, []byte(canonical), sig) {
+		t.Errorf("signature does not verify")
+	}
+	h := sha256.Sum256([]byte(canonical))
+	got := "sha256:" + hex.EncodeToString(h[:])
+	if got != f.Idempotency.ExpectedReceiptHash {
+		t.Errorf("receipt hash\n  got:  %s\n  want: %s", got, f.Idempotency.ExpectedReceiptHash)
+	}
+}
+
+// TestV040DuplicateChainWarns confirms the shared-idempotency_key chain
+// verifies as valid and surfaces exactly one duplicate-key warning naming the
+// shared key (spec §7.3.6). This is the cross-SDK contract the TS and Python
+// runners assert against the same vector file.
+func TestV040DuplicateChainWarns(t *testing.T) {
+	f := loadV040(t)
+
+	receipts := make([]receipt.AgentReceipt, 0, len(f.DuplicateChain.Receipts))
+	for i, raw := range f.DuplicateChain.Receipts {
+		var r receipt.AgentReceipt
+		if err := json.Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal duplicate-chain receipt %d: %v", i, err)
+		}
+		receipts = append(receipts, r)
+	}
+
+	result := receipt.VerifyChain(receipts, f.Keys.PublicKey)
+	if result.Valid != f.DuplicateChain.ExpectedValid {
+		t.Errorf("chain valid = %v, want %v (broken at %d: %s)", result.Valid, f.DuplicateChain.ExpectedValid, result.BrokenAt, result.Error)
+	}
+	if len(result.Warnings) != f.DuplicateChain.ExpectedWarningCount {
+		t.Fatalf("warning count = %d, want %d: %v", len(result.Warnings), f.DuplicateChain.ExpectedWarningCount, result.Warnings)
+	}
+	if f.DuplicateChain.ExpectedWarningCount > 0 {
+		if !strings.Contains(result.Warnings[0], f.DuplicateChain.DuplicateKey) {
+			t.Errorf("warning %q does not name duplicate key %q", result.Warnings[0], f.DuplicateChain.DuplicateKey)
+		}
+	}
+}

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -58,20 +58,21 @@ const actionTypeEventsDropped = "agent_receipts.events_dropped"
 // events_dropped receipt with this count before the live receipt so the gap
 // is visible in the chain.
 type EmitterFrame struct {
-	Version      string          `json:"v"`
-	TsEmit       string          `json:"ts_emit"`
-	SessionID    string          `json:"session_id"`
-	Channel      string          `json:"channel"`
-	Tool         EmitterTool     `json:"tool"`
-	Input        json.RawMessage `json:"input,omitempty"`
-	Output       json.RawMessage `json:"output,omitempty"`
-	Error        string          `json:"error,omitempty"`
-	Decision     string          `json:"decision"`
-	DropCount    int64           `json:"drop_count,omitempty"`
-	IssuerName   string          `json:"issuer_name,omitempty"`
-	IssuerModel  string          `json:"issuer_model,omitempty"`
-	OperatorID   string          `json:"operator_id,omitempty"`
-	OperatorName string          `json:"operator_name,omitempty"`
+	Version        string          `json:"v"`
+	TsEmit         string          `json:"ts_emit"`
+	SessionID      string          `json:"session_id"`
+	Channel        string          `json:"channel"`
+	Tool           EmitterTool     `json:"tool"`
+	Input          json.RawMessage `json:"input,omitempty"`
+	Output         json.RawMessage `json:"output,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	Decision       string          `json:"decision"`
+	DropCount      int64           `json:"drop_count,omitempty"`
+	IssuerName     string          `json:"issuer_name,omitempty"`
+	IssuerModel    string          `json:"issuer_model,omitempty"`
+	OperatorID     string          `json:"operator_id,omitempty"`
+	OperatorName   string          `json:"operator_name,omitempty"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -88,8 +89,8 @@ type Pipeline struct {
 	Store    store.ReceiptStore
 	IssuerID string // e.g. "did:agent-receipts-daemon:<host>"
 	Now      func() time.Time
-	TraceLog io.Writer              // Optional trace log for testing; nil = silent
-	ErrorLog func(string, ...any)   // Optional error logger; nil = silent
+	TraceLog io.Writer            // Optional trace log for testing; nil = silent
+	ErrorLog func(string, ...any) // Optional error logger; nil = silent
 
 	// ParameterDisclosure is the historical opt-in for plaintext tool
 	// input/output in the legacy string-map shape of parameters_disclosure.
@@ -313,6 +314,9 @@ func validateFrame(f *EmitterFrame) error {
 	if f.OperatorName != "" && f.OperatorID == "" {
 		return fmt.Errorf("operator_name set without operator_id")
 	}
+	if len(f.IdempotencyKey) > maxIdentityFieldLen {
+		return fmt.Errorf("idempotency_key exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.IdempotencyKey))
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash
@@ -446,6 +450,7 @@ func (p *Pipeline) buildAndSign(
 		RiskLevel:      risk,
 		Timestamp:      now,
 		PeerCredential: peerCred,
+		IdempotencyKey: f.IdempotencyKey,
 	}
 	if hasJSONPayload(f.Input) {
 		hash, err := canonicalSHA256(f.Input)

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -147,6 +147,69 @@ func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	}
 }
 
+// TestProcess_StampsIdempotencyKey verifies the daemon copies the frame's
+// idempotency_key onto action.idempotency_key (spec §7.3.6, #480) and omits it
+// when the frame leaves it empty.
+func TestProcess_StampsIdempotencyKey(t *testing.T) {
+	build := func(t *testing.T, key string) receipt.Action {
+		t.Helper()
+		ks := newTestKeySource(t)
+		st := newTestStore(t)
+		state := chain.New("chain-1")
+		p := New(state, ks, st, "did:agent-receipts-daemon:test")
+		body, err := json.Marshal(EmitterFrame{
+			Version:        "1",
+			TsEmit:         "2026-05-23T00:00:00Z",
+			SessionID:      "s",
+			Channel:        "mcp",
+			Tool:           EmitterTool{Name: "do_thing"},
+			Decision:       "allowed",
+			IdempotencyKey: key,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := p.Process(socket.Frame{Payload: body}); err != nil {
+			t.Fatal(err)
+		}
+		chainReceipts, err := st.GetChain("chain-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(chainReceipts) != 1 {
+			t.Fatalf("got %d receipts, want 1", len(chainReceipts))
+		}
+		return chainReceipts[0].CredentialSubject.Action
+	}
+
+	t.Run("present", func(t *testing.T) {
+		if got := build(t, "jsonrpc-req-99").IdempotencyKey; got != "jsonrpc-req-99" {
+			t.Errorf("action.idempotency_key = %q, want %q", got, "jsonrpc-req-99")
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		if got := build(t, "").IdempotencyKey; got != "" {
+			t.Errorf("action.idempotency_key = %q, want empty", got)
+		}
+	})
+}
+
+// TestValidateFrame_RejectsOversizeIdempotencyKey pins the per-field cap so a
+// runaway idempotency_key cannot inflate receipts.
+func TestValidateFrame_RejectsOversizeIdempotencyKey(t *testing.T) {
+	f := &EmitterFrame{
+		Version:        "1",
+		SessionID:      "s",
+		Channel:        "mcp",
+		Tool:           EmitterTool{Name: "t"},
+		Decision:       "allowed",
+		IdempotencyKey: strings.Repeat("x", maxIdentityFieldLen+1),
+	}
+	if err := validateFrame(f); err == nil {
+		t.Error("validateFrame accepted an oversize idempotency_key; want rejection")
+	}
+}
+
 func TestProcess_OutcomeStatus(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -574,11 +637,11 @@ func TestProcess_RejectsUnrepresentableNumbers(t *testing.T) {
 // the chain mutex via deferred Rollback even when buildAndSign panics.
 type panicSigningKeySource struct{}
 
-func (panicSigningKeySource) Init() error                  { return nil }
-func (panicSigningKeySource) Teardown() error              { return nil }
-func (panicSigningKeySource) PublicKey() (string, error)   { return "", nil }
-func (panicSigningKeySource) VerificationMethod() string   { return "did:test#k1" }
-func (panicSigningKeySource) Rotate() error                { return nil }
+func (panicSigningKeySource) Init() error                { return nil }
+func (panicSigningKeySource) Teardown() error            { return nil }
+func (panicSigningKeySource) PublicKey() (string, error) { return "", nil }
+func (panicSigningKeySource) VerificationMethod() string { return "did:test#k1" }
+func (panicSigningKeySource) Rotate() error              { return nil }
 func (panicSigningKeySource) Sign(_ []byte) ([]byte, error) {
 	panic("simulated panic during signing")
 }

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -192,9 +192,28 @@ func TestEmitToContext_AllowedToolCall(t *testing.T) {
 		json.RawMessage(`{"content":"hello"}`),
 		"",
 		"allowed",
+		"jsonrpc-req-42",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+
+	// The wrapped JSON-RPC request id must reach action.idempotency_key
+	// (spec §7.3.6): proxy → emitter frame → daemon build → signed receipt.
+	s, err := store.OpenReadOnly(d.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	receipts, err := s.GetChain(d.cfg.ChainID)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	if got := receipts[0].CredentialSubject.Action.IdempotencyKey; got != "jsonrpc-req-42" {
+		t.Errorf("action.idempotency_key = %q, want %q", got, "jsonrpc-req-42")
+	}
 }
 
 // TestEmitToContext_DeniedToolCall verifies that a "denied" decision (blocked by
@@ -210,6 +229,7 @@ func TestEmitToContext_DeniedToolCall(t *testing.T) {
 		nil,
 		"blocked by policy: delete_secrets matches block rule",
 		"denied",
+		"",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
@@ -234,7 +254,7 @@ func TestEmitToContext_MultipleEvents(t *testing.T) {
 	}
 
 	for _, ev := range events {
-		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision)
+		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision, "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, len(events), 5*time.Second)
@@ -279,7 +299,7 @@ func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
 
 	start := time.Now()
 	// emitToContext logs the drop via log.Printf — that's fine for tests.
-	emitToContext(em, "srv", "noop", nil, nil, "", "allowed")
+	emitToContext(em, "srv", "noop", nil, nil, "", "allowed", "")
 	elapsed := time.Since(start)
 
 	// 25ms dial timeout + 100ms write deadline = 125ms worst-case. We allow
@@ -307,7 +327,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 
 	// nil input and output are valid: the emitter accepts them and the daemon
 	// treats them as absent. No panic, no error returned.
-	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed")
+	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed", "")
 }
 
 // TestEmitToContext_NilEmitterIsNoOp guards the nil-emitter path in serve():
@@ -317,7 +337,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 // explicit guard at the call sites is kept for clarity.
 func TestEmitToContext_NilEmitterIsNoOp(t *testing.T) {
 	// Must not panic.
-	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed")
+	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed", "")
 }
 
 // TestEmitToContext_SessionIDPropagatesToReceipts verifies the ADR-0010 OQ4
@@ -331,7 +351,7 @@ func TestEmitToContext_SessionIDPropagatesToReceipts(t *testing.T) {
 	em := newSilentEmitter(t, d.cfg.SocketPath, sid)
 
 	for i := 0; i < 3; i++ {
-		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed")
+		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed", "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 3, 5*time.Second)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -197,8 +197,9 @@ func serve() {
 	// keeps the block/pause/success emit paths identical and avoids a
 	// second `json.Marshal` per call.
 	type pendingCall struct {
-		toolName string
-		argJSON  json.RawMessage
+		toolName       string
+		argJSON        json.RawMessage
+		idempotencyKey string
 	}
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
@@ -272,8 +273,9 @@ func serve() {
 
 				pendingMu.Lock()
 				pendingCalls[jsonrpcID] = &pendingCall{
-					toolName: toolName,
-					argJSON:  argJSON,
+					toolName:       toolName,
+					argJSON:        argJSON,
+					idempotencyKey: jsonrpcID,
 				}
 				pendingMu.Unlock()
 
@@ -283,7 +285,7 @@ func serve() {
 					pendingMu.Lock()
 					delete(pendingCalls, jsonrpcID)
 					pendingMu.Unlock()
-					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied")
+					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID)
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -309,7 +311,7 @@ func serve() {
 						pendingMu.Lock()
 						delete(pendingCalls, jsonrpcID)
 						pendingMu.Unlock()
-						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied")
+						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID)
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(
@@ -373,7 +375,7 @@ func serve() {
 				if resultStr != "" && json.Valid([]byte(resultStr)) {
 					outputRaw = json.RawMessage(resultStr)
 				}
-				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed")
+				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed", pc.idempotencyKey)
 			}
 		}
 
@@ -522,17 +524,24 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 // errStr carries the error payload string (raw JSON-RPC error object JSON for
 // upstream errors, a policy message for denied calls; empty for success).
 // decision must be "allowed", "denied", or "pending".
-func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision string) {
+//
+// idempotencyKey is the wrapped JSON-RPC request id of the tool call. The
+// daemon stamps it onto action.idempotency_key (spec §7.3.6) so that retries
+// of the same logical operation share a value and auditors can tell a
+// legitimate retry from a duplicated emission. Empty when no id was present;
+// the emitter omits the field from the frame in that case.
+func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision, idempotencyKey string) {
 	if em == nil {
 		return
 	}
 	if err := em.Emit(context.Background(), emitter.Event{
-		Channel:  "mcp",
-		Tool:     emitter.Tool{Server: serverName, Name: toolName},
-		Input:    input,
-		Output:   output,
-		Error:    errStr,
-		Decision: decision,
+		Channel:        "mcp",
+		Tool:           emitter.Tool{Server: serverName, Name: toolName},
+		Input:          input,
+		Output:         output,
+		Error:          errStr,
+		Decision:       decision,
+		IdempotencyKey: idempotencyKey,
 	}); err != nil {
 		log.Printf("mcp-proxy: emitter: %v", err)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -838,7 +838,7 @@ func TestDiagnoseConfigNoApproverReturnsNotConfigured(t *testing.T) {
 
 func TestEmitToContextNilEmitterNoOp(t *testing.T) {
 	// Must not panic with nil emitter.
-	emitToContext(nil, "server", "tool", nil, nil, "", "allowed")
+	emitToContext(nil, "server", "tool", nil, nil, "", "allowed", "")
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -102,6 +102,14 @@ type Event struct {
 	IssuerModel  string
 	OperatorID   string
 	OperatorName string
+
+	// IdempotencyKey is a stable identifier for the logical operation this
+	// event represents (e.g. the wrapped JSON-RPC request id). The daemon
+	// stamps it onto action.idempotency_key so retries of the same operation
+	// share a value and auditors can distinguish a legitimate retry from a
+	// duplicated emission. Optional; omitted from the frame when empty.
+	// See spec §7.3.6 and ADR-0019 §S5.
+	IdempotencyKey string
 }
 
 // Option configures an Emitter at construction.
@@ -244,20 +252,21 @@ func (e *DaemonEmitter) SessionID() string { return e.sessionID }
 // Defined locally so the emitter does not import a daemon-internal
 // package; the wire format is the contract, not the type definition.
 type frame struct {
-	Version      string          `json:"v"`
-	TsEmit       string          `json:"ts_emit"`
-	SessionID    string          `json:"session_id"`
-	Channel      string          `json:"channel"`
-	Tool         frameTool       `json:"tool"`
-	Input        json.RawMessage `json:"input,omitempty"`
-	Output       json.RawMessage `json:"output,omitempty"`
-	Error        string          `json:"error,omitempty"`
-	Decision     string          `json:"decision"`
-	DropCount    int64           `json:"drop_count,omitempty"`
-	IssuerName   string          `json:"issuer_name,omitempty"`
-	IssuerModel  string          `json:"issuer_model,omitempty"`
-	OperatorID   string          `json:"operator_id,omitempty"`
-	OperatorName string          `json:"operator_name,omitempty"`
+	Version        string          `json:"v"`
+	TsEmit         string          `json:"ts_emit"`
+	SessionID      string          `json:"session_id"`
+	Channel        string          `json:"channel"`
+	Tool           frameTool       `json:"tool"`
+	Input          json.RawMessage `json:"input,omitempty"`
+	Output         json.RawMessage `json:"output,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	Decision       string          `json:"decision"`
+	DropCount      int64           `json:"drop_count,omitempty"`
+	IssuerName     string          `json:"issuer_name,omitempty"`
+	IssuerModel    string          `json:"issuer_model,omitempty"`
+	OperatorID     string          `json:"operator_id,omitempty"`
+	OperatorName   string          `json:"operator_name,omitempty"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 }
 
 type frameTool struct {
@@ -348,11 +357,12 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	for _, f := range [4]struct{ name, val string }{
+	for _, f := range [5]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
 		{"operator_name", operatorName},
+		{"idempotency_key", ev.IdempotencyKey},
 	} {
 		if len(f.val) > MaxIdentityFieldLen {
 			e.dropCount.Add(pendingDrops)
@@ -361,20 +371,21 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 
 	body, err := json.Marshal(frame{
-		Version:      SupportedFrameVersion,
-		TsEmit:       time.Now().UTC().Format(time.RFC3339Nano),
-		SessionID:    e.sessionID,
-		Channel:      ev.Channel,
-		Tool:         frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
-		Input:        ev.Input,
-		Output:       ev.Output,
-		Error:        ev.Error,
-		Decision:     ev.Decision,
-		DropCount:    pendingDrops,
-		IssuerName:   issuerName,
-		IssuerModel:  issuerModel,
-		OperatorID:   operatorID,
-		OperatorName: operatorName,
+		Version:        SupportedFrameVersion,
+		TsEmit:         time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID:      e.sessionID,
+		Channel:        ev.Channel,
+		Tool:           frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
+		Input:          ev.Input,
+		Output:         ev.Output,
+		Error:          ev.Error,
+		Decision:       ev.Decision,
+		DropCount:      pendingDrops,
+		IssuerName:     issuerName,
+		IssuerModel:    issuerModel,
+		OperatorID:     operatorID,
+		OperatorName:   operatorName,
+		IdempotencyKey: ev.IdempotencyKey,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/receipt/chain.go
+++ b/sdk/go/receipt/chain.go
@@ -3,6 +3,7 @@ package receipt
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 )
 
 // hashReceipt is overridable in tests so the error-return path of HashReceipt
@@ -34,6 +35,12 @@ type ChainVerification struct {
 	// ResponseHashNote is non-empty when one or more receipts carry response_hash
 	// but no response body was supplied for recomputation.
 	ResponseHashNote string `json:"response_hash_note,omitempty"`
+	// Warnings carries non-fatal advisories about the verified chain. It is
+	// populated independently of Valid — a warning never changes the
+	// verification result. Currently it surfaces duplicate action.idempotency_key
+	// values (spec §7.3.6): retries are legitimate, so duplicates are flagged for
+	// auditor review rather than treated as failures.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // classifyTerminationStatus inspects the wire form of the final receipt and
@@ -52,6 +59,43 @@ func classifyTerminationStatus(receipts []AgentReceipt) ChainStatus {
 		return ChainStatusInterrupted
 	}
 	return ChainStatusComplete
+}
+
+// duplicateIdempotencyWarnings scans the chain for non-empty
+// action.idempotency_key values that appear on more than one receipt and
+// returns a human-readable advisory for each such key (spec §7.3.6). Retries
+// are legitimate, so these are warnings, not failures. Order is deterministic:
+// warnings follow the first-seen order of each duplicated key, and the indices
+// within each warning are in chain order. Receipts that omit the key never
+// contribute. Returns nil when there are no duplicates.
+func duplicateIdempotencyWarnings(receipts []AgentReceipt) []string {
+	indices := make(map[string][]int)
+	var order []string
+	for i, r := range receipts {
+		key := r.CredentialSubject.Action.IdempotencyKey
+		if key == "" {
+			continue
+		}
+		if _, seen := indices[key]; !seen {
+			order = append(order, key)
+		}
+		indices[key] = append(indices[key], i)
+	}
+	var warnings []string
+	for _, key := range order {
+		idx := indices[key]
+		if len(idx) < 2 {
+			continue
+		}
+		parts := make([]string, len(idx))
+		for j, v := range idx {
+			parts[j] = strconv.Itoa(v)
+		}
+		warnings = append(warnings, "duplicate idempotency_key "+strconv.Quote(key)+
+			" on receipts at indices "+strings.Join(parts, ", ")+
+			" (retries are legitimate; review for double-counting)")
+	}
+	return warnings
 }
 
 // ChainVerifyOptions holds optional parameters for VerifyChain.
@@ -126,6 +170,10 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 	}
 
 	status := classifyTerminationStatus(receipts)
+
+	// Idempotency-key duplicate detection is independent of validity (spec
+	// §7.3.6) — compute it once up front so every return path can surface it.
+	warnings := duplicateIdempotencyWarnings(receipts)
 
 	results := make([]ReceiptVerification, 0, len(receipts))
 	brokenAt := -1
@@ -258,6 +306,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 				BrokenAt: i,
 				Error: "chain_id mismatch at index " + strconv.Itoa(i) +
 					`: expected "` + expectedChainID + `", got "` + observed + `"`,
+				Warnings: warnings,
 			}
 		}
 	}
@@ -286,6 +335,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 					Receipts: results,
 					BrokenAt: brokenAt,
 					Error:    errMsg,
+					Warnings: warnings,
 				}
 			}
 		}
@@ -298,6 +348,7 @@ func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVeri
 		Receipts: results,
 		BrokenAt: brokenAt,
 		Error:    loopErr,
+		Warnings: warnings,
 	}
 
 	// Response-hash verification (spec §4.3.2).

--- a/sdk/go/receipt/idempotency_test.go
+++ b/sdk/go/receipt/idempotency_test.go
@@ -1,0 +1,124 @@
+package receipt
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildChainWithKeys builds a signed, hash-linked chain whose i-th receipt
+// carries idempotencyKeys[i] on action.idempotency_key (empty = omitted).
+func buildChainWithKeys(t *testing.T, kp KeyPair, idempotencyKeys []string) []AgentReceipt {
+	t.Helper()
+	chain := make([]AgentReceipt, 0, len(idempotencyKeys))
+	var prevHash *string
+	for i, key := range idempotencyKeys {
+		unsigned := Create(CreateInput{
+			Issuer:    Issuer{ID: "did:agent:test"},
+			Principal: Principal{ID: "did:user:test"},
+			Action: Action{
+				Type:           "filesystem.file.read",
+				RiskLevel:      RiskLow,
+				IdempotencyKey: key,
+			},
+			Outcome: Outcome{Status: StatusSuccess},
+			Chain:   Chain{Sequence: i + 1, PreviousReceiptHash: prevHash, ChainID: "chain-1"},
+		})
+		signed, err := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		chain = append(chain, signed)
+		h, err := HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+	return chain
+}
+
+func TestCreateStampsIdempotencyKey(t *testing.T) {
+	r := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:alice"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow, IdempotencyKey: "req-1"},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	if r.CredentialSubject.Action.IdempotencyKey != "req-1" {
+		t.Errorf("idempotency_key = %q, want %q", r.CredentialSubject.Action.IdempotencyKey, "req-1")
+	}
+}
+
+// TestIdempotencyKeyOmittedWhenEmpty pins that an empty key serialises to an
+// absent field (omitempty), so receipts that do not set it never carry it.
+func TestIdempotencyKeyOmittedWhenEmpty(t *testing.T) {
+	r := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:alice"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	canonical, err := Canonicalize(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(canonical, "idempotency_key") {
+		t.Errorf("canonical form should omit idempotency_key when empty: %s", canonical)
+	}
+}
+
+// TestVerifyChainDuplicateIdempotencyKeyWarning verifies that a duplicate
+// idempotency_key surfaces as a warning, not a failure (spec §7.3.6).
+func TestVerifyChainDuplicateIdempotencyKeyWarning(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	// Receipts 0 and 2 share "req-A"; receipt 1 has a distinct key.
+	chain := buildChainWithKeys(t, kp, []string{"req-A", "req-B", "req-A"})
+
+	result := VerifyChain(chain, kp.PublicKey)
+	if !result.Valid {
+		t.Fatalf("duplicate idempotency_key must not invalidate the chain; broken at %d: %s", result.BrokenAt, result.Error)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	w := result.Warnings[0]
+	if !strings.Contains(w, "req-A") || !strings.Contains(w, "0") || !strings.Contains(w, "2") {
+		t.Errorf("warning should name key req-A and indices 0, 2; got %q", w)
+	}
+}
+
+// TestVerifyChainNoDuplicateNoWarning confirms that distinct (or absent) keys
+// produce no warnings.
+func TestVerifyChainNoDuplicateNoWarning(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	cases := map[string][]string{
+		"all distinct": {"req-1", "req-2", "req-3"},
+		"all absent":   {"", "", ""},
+		"mixed absent": {"req-1", "", "req-2"},
+	}
+	for name, keys := range cases {
+		t.Run(name, func(t *testing.T) {
+			chain := buildChainWithKeys(t, kp, keys)
+			result := VerifyChain(chain, kp.PublicKey)
+			if !result.Valid {
+				t.Fatalf("chain should be valid, broken at %d", result.BrokenAt)
+			}
+			if len(result.Warnings) != 0 {
+				t.Errorf("expected no warnings, got %v", result.Warnings)
+			}
+		})
+	}
+}
+
+// TestVerifyChainEmptyKeyNeverWarns pins that repeated *empty* keys (i.e.
+// absent fields) are never treated as duplicates.
+func TestVerifyChainEmptyKeyNeverWarns(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	chain := buildChainWithKeys(t, kp, []string{"", "", "", ""})
+	result := VerifyChain(chain, kp.PublicKey)
+	if len(result.Warnings) != 0 {
+		t.Errorf("absent idempotency keys must never warn, got %v", result.Warnings)
+	}
+}

--- a/sdk/go/receipt/live_emit_version_test.go
+++ b/sdk/go/receipt/live_emit_version_test.go
@@ -9,7 +9,7 @@ import "testing"
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const liveEmitVersion = "0.3.0"
+const liveEmitVersion = "0.4.0"
 
 // TestCreateStampsCrossSDKVersion asserts that Create() stamps the
 // cross-SDK-agreed literal version string. This pins the SDK's Version

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -16,7 +16,7 @@ func Context() []string { return append([]string{}, protocolContext...) }
 // CredentialType returns a copy of the credential type array.
 func CredentialType() []string { return append([]string{}, protocolCredentialType...) }
 
-const Version = "0.3.0"
+const Version = "0.4.0"
 
 // RiskLevel classifies the security risk of an action.
 type RiskLevel string
@@ -121,6 +121,13 @@ type Action struct {
 	EmitterMetadata      *EmitterMetadata    `json:"emitter_metadata,omitempty"`
 	Timestamp            string              `json:"timestamp"`
 	TrustedTimestamp     string              `json:"trusted_timestamp,omitempty"`
+	// IdempotencyKey is a stable identifier for the logical operation this
+	// action represents (e.g. a request ID). When an agent retries a tool call,
+	// the same key is stamped on every receipt for that operation so auditors
+	// can distinguish a legitimate retry from a duplicated emission. Omitted
+	// (omitempty) when no stable source exists; MUST NOT be empty when present.
+	// See spec §7.3.6 and ADR-0019 §S5.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
 // Intent captures conversation context behind the action.

--- a/sdk/py/src/agent_receipts/receipt/chain.py
+++ b/sdk/py/src/agent_receipts/receipt/chain.py
@@ -28,6 +28,44 @@ def _empty_receipts() -> list[ReceiptVerification]:
     return []
 
 
+def _empty_warnings() -> list[str]:
+    """Typed default for ChainVerification.warnings (satisfies pyright strict)."""
+    return []
+
+
+def _duplicate_idempotency_warnings(receipts: list[AgentReceipt]) -> list[str]:
+    """Return an advisory for each non-empty ``action.idempotency_key`` value
+    that appears on more than one receipt (spec §7.3.6).
+
+    Retries are legitimate, so these are warnings, not failures. Order is
+    deterministic: warnings follow the first-seen order of each duplicated key,
+    and the indices within each warning are in chain order. Receipts that omit
+    the key never contribute. Returns an empty list when there are no
+    duplicates.
+    """
+    indices: dict[str, list[int]] = {}
+    order: list[str] = []
+    for i, r in enumerate(receipts):
+        key = r.credentialSubject.action.idempotency_key
+        if not key:
+            continue
+        if key not in indices:
+            order.append(key)
+            indices[key] = []
+        indices[key].append(i)
+    warnings: list[str] = []
+    for key in order:
+        idx = indices[key]
+        if len(idx) < 2:
+            continue
+        joined = ", ".join(str(v) for v in idx)
+        warnings.append(
+            f"duplicate idempotency_key {key!r} on receipts at indices "
+            f"{joined} (retries are legitimate; review for double-counting)"
+        )
+    return warnings
+
+
 # Chain termination status values (spec §7.3.3).
 STATUS_COMPLETE = "complete"
 STATUS_INTERRUPTED = "interrupted"
@@ -65,6 +103,12 @@ class ChainVerification:
     # Non-empty when one or more receipts carry response_hash but no response
     # body was supplied for recomputation.
     response_hash_note: str = ""
+    # Non-fatal advisories about the verified chain, populated independently of
+    # ``valid`` — a warning never changes the verification result. Currently
+    # surfaces duplicate ``action.idempotency_key`` values (spec §7.3.6):
+    # retries are legitimate, so duplicates are flagged for auditor review
+    # rather than treated as failures. Empty when there are no warnings.
+    warnings: list[str] = field(default_factory=_empty_warnings)
 
 
 def verify_chain(
@@ -117,6 +161,10 @@ def verify_chain(
         return ChainVerification(valid=True, length=0, status=STATUS_UNKNOWN)
 
     status = _classify_termination_status(receipts)
+
+    # Idempotency-key duplicate detection is independent of validity (spec
+    # §7.3.6) — compute it once up front so every return path can surface it.
+    warnings = _duplicate_idempotency_warnings(receipts)
 
     results: list[ReceiptVerification] = []
     broken_at = -1
@@ -219,6 +267,7 @@ def verify_chain(
                     f"chain_id mismatch at index {i}: "
                     f"expected {quoted_expected}, got {quoted_observed}"
                 ),
+                warnings=warnings,
             )
 
     # Receipt-after-terminal integrity check (unconditional — spec §7.3.2).
@@ -243,6 +292,7 @@ def verify_chain(
                 receipts=results,
                 broken_at=broken_at,
                 error=error_msg,
+                warnings=warnings,
             )
 
     cv = ChainVerification(
@@ -252,6 +302,7 @@ def verify_chain(
         receipts=results,
         broken_at=broken_at,
         error=loop_error,
+        warnings=warnings,
     )
 
     # Response-hash verification (spec §4.3.2).

--- a/sdk/py/src/agent_receipts/receipt/create.py
+++ b/sdk/py/src/agent_receipts/receipt/create.py
@@ -95,7 +95,10 @@ def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
         action_data["emitter_metadata"] = input.action.emitter_metadata
     if input.action.trusted_timestamp is not None:
         action_data["trusted_timestamp"] = input.action.trusted_timestamp
-    if input.action.idempotency_key is not None:
+    # spec §7.3.6: idempotency_key MUST be non-empty when present. A truthy
+    # check omits both None and the empty string so we never emit a
+    # schema-invalid receipt.
+    if input.action.idempotency_key:
         action_data["idempotency_key"] = input.action.idempotency_key
 
     # Compute response_hash when a response body is supplied.

--- a/sdk/py/src/agent_receipts/receipt/create.py
+++ b/sdk/py/src/agent_receipts/receipt/create.py
@@ -46,6 +46,7 @@ class ActionInput(BaseModel):
     peer_credential: PeerCredential | None = None
     emitter_metadata: EmitterMetadata | None = None
     trusted_timestamp: str | None = None
+    idempotency_key: str | None = None
 
 
 class CreateReceiptInput(BaseModel):
@@ -94,6 +95,8 @@ def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
         action_data["emitter_metadata"] = input.action.emitter_metadata
     if input.action.trusted_timestamp is not None:
         action_data["trusted_timestamp"] = input.action.trusted_timestamp
+    if input.action.idempotency_key is not None:
+        action_data["idempotency_key"] = input.action.idempotency_key
 
     # Compute response_hash when a response body is supplied.
     if input.response_body is not None:

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -144,7 +144,7 @@ class Action(BaseModel):
     timestamp: str
     trusted_timestamp: str | None = None
 
-    idempotency_key: str | None = None
+    idempotency_key: str | None = Field(default=None, min_length=1)
     """Stable identifier for the logical operation this action represents
     (e.g. a request ID). When an agent retries a tool call, the same key is
     stamped on every receipt for that operation so auditors can distinguish a

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -24,7 +24,7 @@ CREDENTIAL_TYPE: list[str] = [
     "AgentReceipt",
 ]
 
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 
 RiskLevel = Literal["low", "medium", "high", "critical"]
 
@@ -143,6 +143,14 @@ class Action(BaseModel):
 
     timestamp: str
     trusted_timestamp: str | None = None
+
+    idempotency_key: str | None = None
+    """Stable identifier for the logical operation this action represents
+    (e.g. a request ID). When an agent retries a tool call, the same key is
+    stamped on every receipt for that operation so auditors can distinguish a
+    legitimate retry from a duplicated emission. Absent when no stable source
+    exists; MUST be a non-empty string when present. See spec §7.3.6 and
+    ADR-0019 §S5."""
 
 
 class Intent(BaseModel):

--- a/sdk/py/tests/receipt/test_idempotency.py
+++ b/sdk/py/tests/receipt/test_idempotency.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from agent_receipts.receipt.chain import verify_chain
 from agent_receipts.receipt.create import (
     ActionInput,
@@ -11,6 +14,7 @@ from agent_receipts.receipt.create import (
 from agent_receipts.receipt.hash import canonicalize, hash_receipt
 from agent_receipts.receipt.signing import sign_receipt
 from agent_receipts.receipt.types import (
+    Action,
     AgentReceipt,
     Chain,
     Issuer,
@@ -80,6 +84,36 @@ class TestIdempotencyKey:
         )
         wire = unsigned.model_dump(by_alias=True, exclude_none=True)
         assert "idempotency_key" not in canonicalize(wire)
+
+    def test_empty_key_is_omitted_by_create(self) -> None:
+        # spec §7.3.6: idempotency_key MUST be non-empty when present. An empty
+        # string passed to create_receipt is dropped, not emitted.
+        unsigned = create_receipt(
+            CreateReceiptInput(
+                issuer=Issuer(id="did:agent:test"),
+                principal=Principal(id="did:user:alice"),
+                action=ActionInput(
+                    type="filesystem.file.read",
+                    risk_level="low",
+                    idempotency_key="",
+                ),
+                outcome=Outcome(status="success"),
+                chain=Chain(sequence=1, previous_receipt_hash=None, chain_id="c"),
+            )
+        )
+        assert unsigned.credentialSubject.action.idempotency_key is None
+        wire = unsigned.model_dump(by_alias=True, exclude_none=True)
+        assert "idempotency_key" not in canonicalize(wire)
+
+    def test_empty_key_rejected_by_model(self) -> None:
+        with pytest.raises(ValidationError):
+            Action(
+                id="act_x",
+                type="filesystem.file.read",
+                risk_level="low",
+                timestamp="2026-05-23T00:00:00Z",
+                idempotency_key="",
+            )
 
     def test_duplicate_surfaces_as_warning_not_failure(self) -> None:
         # Receipts 0 and 2 share "req-A"; receipt 1 has a distinct key.

--- a/sdk/py/tests/receipt/test_idempotency.py
+++ b/sdk/py/tests/receipt/test_idempotency.py
@@ -1,0 +1,104 @@
+"""Tests for action.idempotency_key (spec §7.3.6, ADR-0019 §S5)."""
+
+from __future__ import annotations
+
+from agent_receipts.receipt.chain import verify_chain
+from agent_receipts.receipt.create import (
+    ActionInput,
+    CreateReceiptInput,
+    create_receipt,
+)
+from agent_receipts.receipt.hash import canonicalize, hash_receipt
+from agent_receipts.receipt.signing import sign_receipt
+from agent_receipts.receipt.types import (
+    AgentReceipt,
+    Chain,
+    Issuer,
+    Outcome,
+    Principal,
+)
+from tests.conftest import TEST_PRIVATE_KEY, TEST_PUBLIC_KEY
+
+
+def _build_chain_with_keys(
+    idempotency_keys: list[str | None], private_key: str
+) -> list[AgentReceipt]:
+    """Build a signed, hash-linked chain whose i-th receipt carries
+    idempotency_keys[i] on action.idempotency_key (None = omitted)."""
+    chain: list[AgentReceipt] = []
+    previous_hash: str | None = None
+    for i, key in enumerate(idempotency_keys):
+        unsigned = create_receipt(
+            CreateReceiptInput(
+                issuer=Issuer(id="did:agent:test"),
+                principal=Principal(id="did:user:test"),
+                action=ActionInput(
+                    type="filesystem.file.read",
+                    risk_level="low",
+                    idempotency_key=key,
+                ),
+                outcome=Outcome(status="success"),
+                chain=Chain(
+                    sequence=i + 1,
+                    previous_receipt_hash=previous_hash,
+                    chain_id="chain_test",
+                ),
+            )
+        )
+        signed = sign_receipt(unsigned, private_key, "did:agent:test#key-1")
+        chain.append(signed)
+        previous_hash = hash_receipt(signed)
+    return chain
+
+
+class TestIdempotencyKey:
+    def test_create_stamps_idempotency_key(self) -> None:
+        unsigned = create_receipt(
+            CreateReceiptInput(
+                issuer=Issuer(id="did:agent:test"),
+                principal=Principal(id="did:user:alice"),
+                action=ActionInput(
+                    type="filesystem.file.read",
+                    risk_level="low",
+                    idempotency_key="req-1",
+                ),
+                outcome=Outcome(status="success"),
+                chain=Chain(sequence=1, previous_receipt_hash=None, chain_id="c"),
+            )
+        )
+        assert unsigned.credentialSubject.action.idempotency_key == "req-1"
+
+    def test_omitted_when_unset(self) -> None:
+        unsigned = create_receipt(
+            CreateReceiptInput(
+                issuer=Issuer(id="did:agent:test"),
+                principal=Principal(id="did:user:alice"),
+                action=ActionInput(type="filesystem.file.read", risk_level="low"),
+                outcome=Outcome(status="success"),
+                chain=Chain(sequence=1, previous_receipt_hash=None, chain_id="c"),
+            )
+        )
+        wire = unsigned.model_dump(by_alias=True, exclude_none=True)
+        assert "idempotency_key" not in canonicalize(wire)
+
+    def test_duplicate_surfaces_as_warning_not_failure(self) -> None:
+        # Receipts 0 and 2 share "req-A"; receipt 1 has a distinct key.
+        chain = _build_chain_with_keys(["req-A", "req-B", "req-A"], TEST_PRIVATE_KEY)
+        result = verify_chain(chain, TEST_PUBLIC_KEY)
+        assert result.valid is True
+        assert len(result.warnings) == 1
+        warning = result.warnings[0]
+        assert "req-A" in warning
+        assert "0" in warning
+        assert "2" in warning
+
+    def test_no_warning_for_distinct_or_absent_keys(self) -> None:
+        for keys in (
+            ["req-1", "req-2", "req-3"],
+            [None, None, None],
+            ["req-1", None, "req-2"],
+        ):
+            chain = _build_chain_with_keys(keys, TEST_PRIVATE_KEY)
+            result = verify_chain(chain, TEST_PUBLIC_KEY)
+            assert result.valid is True
+            assert result.warnings == []

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -29,7 +29,7 @@ from agent_receipts.receipt.types import (
     Principal,
 )
 
-LIVE_EMIT_VERSION = "0.3.0"
+LIVE_EMIT_VERSION = "0.4.0"
 
 
 class TestCreateReceiptCrossSDKVersion:

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -32,7 +32,7 @@ class TestConstants:
         assert "AgentReceipt" in CREDENTIAL_TYPE
 
     def test_version(self) -> None:
-        assert VERSION == "0.3.0"
+        assert VERSION == "0.4.0"
 
 
 class TestAgentReceipt:

--- a/sdk/py/tests/test_v040_vectors.py
+++ b/sdk/py/tests/test_v040_vectors.py
@@ -1,0 +1,66 @@
+"""Cross-SDK v0.4.0 vectors (action.idempotency_key, #480).
+
+Asserts that the Python SDK reproduces the pinned ``expectedReceiptHash`` for
+the receipt carrying ``action.idempotency_key`` and agrees with Go and TS on
+the verifier semantics for a duplicate-key chain (valid + exactly one warning).
+Vectors live at ``cross-sdk-tests/v040_vectors.json``.
+
+If the hash diverges, the Python SDK has a wire-format incompatibility with Go
+(#480) and TS — almost always a Pydantic serialization / alias / omit-when-None
+issue on the new optional field.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_receipts.receipt.chain import verify_chain
+from agent_receipts.receipt.hash import hash_receipt
+from agent_receipts.receipt.signing import verify_receipt
+from agent_receipts.receipt.types import AgentReceipt
+
+VECTORS = (
+    Path(__file__).parent.parent.parent.parent / "cross-sdk-tests" / "v040_vectors.json"
+)
+
+
+def _load_vectors() -> dict:
+    with open(VECTORS, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestV040Vectors:
+    """Byte-identical reproduction + verifier agreement for v0.4.0 vectors."""
+
+    def test_idempotency_receipt_hash_matches(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["idempotencyKeyReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]
+
+    def test_idempotency_receipt_signature_verifies(self) -> None:
+        vectors = _load_vectors()
+        public_key = vectors["keys"]["publicKey"]
+        section = vectors["idempotencyKeyReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert verify_receipt(receipt, public_key) is True
+
+    def test_idempotency_key_round_trips(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["idempotencyKeyReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert (
+            receipt.credentialSubject.action.idempotency_key
+            == section["idempotencyKey"]
+        )
+
+    def test_duplicate_chain_valid_with_one_warning(self) -> None:
+        vectors = _load_vectors()
+        public_key = vectors["keys"]["publicKey"]
+        section = vectors["duplicateIdempotencyChain"]
+        receipts = [AgentReceipt.model_validate(r) for r in section["receipts"]]
+        result = verify_chain(receipts, public_key)
+        assert result.valid is section["expectedValid"]
+        assert len(result.warnings) == section["expectedWarningCount"]
+        assert section["duplicateKey"] in result.warnings[0]

--- a/sdk/ts/src/receipt/chain.ts
+++ b/sdk/ts/src/receipt/chain.ts
@@ -3,6 +3,42 @@ import { verifyReceipt } from "./signing.js";
 import type { AgentReceipt } from "./types.js";
 
 /**
+ * Scan the chain for non-empty `action.idempotency_key` values that appear on
+ * more than one receipt and return a human-readable advisory for each such key
+ * (spec §7.3.6). Retries are legitimate, so these are warnings, not failures.
+ * Order is deterministic: warnings follow the first-seen order of each
+ * duplicated key, and the indices within each warning are in chain order.
+ * Receipts that omit the key never contribute. Returns undefined when there
+ * are no duplicates so the optional `warnings` field stays absent.
+ */
+function duplicateIdempotencyWarnings(
+	receipts: AgentReceipt[],
+): string[] | undefined {
+	const indices = new Map<string, number[]>();
+	const order: string[] = [];
+	receipts.forEach((r, i) => {
+		const key = r.credentialSubject.action.idempotency_key;
+		if (!key) return;
+		const existing = indices.get(key);
+		if (existing === undefined) {
+			order.push(key);
+			indices.set(key, [i]);
+		} else {
+			existing.push(i);
+		}
+	});
+	const warnings: string[] = [];
+	for (const key of order) {
+		const idx = indices.get(key);
+		if (idx === undefined || idx.length < 2) continue;
+		warnings.push(
+			`duplicate idempotency_key ${JSON.stringify(key)} on receipts at indices ${idx.join(", ")} (retries are legitimate; review for double-counting)`,
+		);
+	}
+	return warnings.length > 0 ? warnings : undefined;
+}
+
+/**
  * Classify chain termination based purely on what the receipts claim on the
  * wire (independent of verification result). See spec §7.3.3.
  */
@@ -67,6 +103,14 @@ export interface ChainVerification {
 	responseHashNote?: string;
 	/** Non-empty when verification failed with a descriptive message. */
 	error?: string;
+	/**
+	 * Non-fatal advisories about the verified chain, populated independently of
+	 * `valid` — a warning never changes the verification result. Currently
+	 * surfaces duplicate `action.idempotency_key` values (spec §7.3.6): retries
+	 * are legitimate, so duplicates are flagged for auditor review rather than
+	 * treated as failures. Omitted when there are no warnings.
+	 */
+	warnings?: string[];
 }
 
 /**
@@ -145,6 +189,10 @@ export function verifyChain(
 	}
 
 	const status = classifyTerminationStatus(receipts);
+
+	// Idempotency-key duplicate detection is independent of validity (spec
+	// §7.3.6) — compute it once up front so every return path can surface it.
+	const warnings = duplicateIdempotencyWarnings(receipts);
 
 	const results: ReceiptVerification[] = [];
 	let brokenAt = -1;
@@ -270,6 +318,7 @@ export function verifyChain(
 				receipts: results,
 				brokenAt: i,
 				responseHashNote: undefined,
+				warnings,
 				error: `chain_id mismatch at index ${i}: expected "${expectedChainId}", got "${observedChainId}"`,
 			};
 		}
@@ -298,6 +347,7 @@ export function verifyChain(
 				receipts: results,
 				brokenAt,
 				responseHashNote: undefined,
+				warnings,
 				error,
 			};
 		}
@@ -310,6 +360,9 @@ export function verifyChain(
 		receipts: results,
 		brokenAt,
 	};
+	if (warnings !== undefined) {
+		cv.warnings = warnings;
+	}
 	if (loopError !== undefined) {
 		cv.error = loopError;
 	}

--- a/sdk/ts/src/receipt/create.ts
+++ b/sdk/ts/src/receipt/create.ts
@@ -79,6 +79,13 @@ export function createReceipt(input: CreateReceiptInput): UnsignedAgentReceipt {
 			}
 		: { ...input.chain };
 
+	// spec §7.3.6: idempotency_key MUST be non-empty when present. Drop an
+	// empty string so createReceipt never emits a schema-invalid receipt.
+	const { idempotency_key, ...restAction } = input.action;
+	const action = idempotency_key
+		? { ...restAction, idempotency_key }
+		: restAction;
+
 	return {
 		"@context": CONTEXT,
 		id: `urn:receipt:${randomUUID()}`,
@@ -89,7 +96,7 @@ export function createReceipt(input: CreateReceiptInput): UnsignedAgentReceipt {
 		credentialSubject: {
 			principal: input.principal,
 			action: {
-				...input.action,
+				...action,
 				id: `act_${randomUUID()}`,
 				timestamp: actionTimestamp,
 			},

--- a/sdk/ts/src/receipt/cross-language.test.ts
+++ b/sdk/ts/src/receipt/cross-language.test.ts
@@ -369,3 +369,63 @@ describe("cross-language: v0.3.0 vectors", () => {
 		).toBe(true);
 	});
 });
+
+interface V040Vectors {
+	version: string;
+	keys: { publicKey: string; privateKey: string };
+	idempotencyKeyReceipt: {
+		idempotencyKey: string;
+		receipt: AgentReceipt;
+		expectedReceiptHash: string;
+		expectedValid: boolean;
+	};
+	duplicateIdempotencyChain: {
+		duplicateKey: string;
+		receipts: AgentReceipt[];
+		expectedValid: boolean;
+		expectedWarningCount: number;
+	};
+}
+
+function loadV040Vectors(): V040Vectors {
+	const path = resolve(
+		currentDir,
+		"../../../../cross-sdk-tests/v040_vectors.json",
+	);
+	return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+// Cross-SDK reproduction of the v0.4.0 vectors pinned in
+// cross-sdk-tests/v040_vectors.json (#480). The TS SDK MUST hash the
+// idempotency_key receipt to the same digest as Go and Python, and its chain
+// verifier MUST flag the shared-key chain as valid with exactly one warning.
+describe("cross-language: v0.4.0 vectors", () => {
+	it("idempotency_key receipt hash matches pin", () => {
+		const v = loadV040Vectors();
+		expect(hashReceipt(v.idempotencyKeyReceipt.receipt)).toBe(
+			v.idempotencyKeyReceipt.expectedReceiptHash,
+		);
+	});
+
+	it("idempotency_key receipt verifies with shared key", () => {
+		const v = loadV040Vectors();
+		expect(
+			verifyReceipt(v.idempotencyKeyReceipt.receipt, v.keys.publicKey),
+		).toBe(true);
+	});
+
+	it("duplicate-idempotency_key chain is valid with one warning", () => {
+		const v = loadV040Vectors();
+		const result = verifyChain(
+			v.duplicateIdempotencyChain.receipts,
+			v.keys.publicKey,
+		);
+		expect(result.valid).toBe(v.duplicateIdempotencyChain.expectedValid);
+		expect(result.warnings ?? []).toHaveLength(
+			v.duplicateIdempotencyChain.expectedWarningCount,
+		);
+		expect(result.warnings?.[0]).toContain(
+			v.duplicateIdempotencyChain.duplicateKey,
+		);
+	});
+});

--- a/sdk/ts/src/receipt/idempotency.test.ts
+++ b/sdk/ts/src/receipt/idempotency.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { verifyChain } from "./chain.js";
 import { createReceipt } from "./create.js";
 import { canonicalize, hashReceipt } from "./hash.js";
+import { agentReceiptSchema } from "./schema.js";
 import { generateKeyPair, signReceipt } from "./signing.js";
 import type { AgentReceipt } from "./types.js";
 
@@ -61,6 +62,42 @@ describe("idempotency_key", () => {
 			chain: { sequence: 1, previous_receipt_hash: null, chain_id: "c" },
 		});
 		expect(canonicalize(unsigned)).not.toContain("idempotency_key");
+	});
+
+	it("drops an empty idempotency_key instead of emitting it (spec §7.3.6)", () => {
+		const unsigned = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:alice" },
+			action: {
+				type: "filesystem.file.read",
+				risk_level: "low",
+				idempotency_key: "",
+			},
+			outcome: { status: "success" },
+			chain: { sequence: 1, previous_receipt_hash: null, chain_id: "c" },
+		});
+		expect(unsigned.credentialSubject.action.idempotency_key).toBeUndefined();
+		expect(canonicalize(unsigned)).not.toContain("idempotency_key");
+	});
+
+	it("rejects an empty idempotency_key in schema validation", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:alice" },
+			action: { type: "filesystem.file.read", risk_level: "low" },
+			outcome: { status: "success" },
+			chain: { sequence: 1, previous_receipt_hash: null, chain_id: "c" },
+		});
+		const signed = signReceipt(unsigned, privateKey, "did:agent:test#key-1");
+		const bad = {
+			...signed,
+			credentialSubject: {
+				...signed.credentialSubject,
+				action: { ...signed.credentialSubject.action, idempotency_key: "" },
+			},
+		};
+		expect(agentReceiptSchema.safeParse(bad).success).toBe(false);
 	});
 
 	it("surfaces a duplicate idempotency_key as a warning, not a failure", () => {

--- a/sdk/ts/src/receipt/idempotency.test.ts
+++ b/sdk/ts/src/receipt/idempotency.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { verifyChain } from "./chain.js";
+import { createReceipt } from "./create.js";
+import { canonicalize, hashReceipt } from "./hash.js";
+import { generateKeyPair, signReceipt } from "./signing.js";
+import type { AgentReceipt } from "./types.js";
+
+// buildChainWithKeys builds a signed, hash-linked chain whose i-th receipt
+// carries idempotencyKeys[i] on action.idempotency_key (undefined = omitted).
+function buildChainWithKeys(
+	idempotencyKeys: (string | undefined)[],
+	privateKey: string,
+): AgentReceipt[] {
+	const receipts: AgentReceipt[] = [];
+	let previousHash: string | null = null;
+	idempotencyKeys.forEach((key, i) => {
+		const unsigned = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:test" },
+			action: {
+				type: "filesystem.file.read",
+				risk_level: "low",
+				...(key !== undefined && { idempotency_key: key }),
+			},
+			outcome: { status: "success" },
+			chain: {
+				sequence: i + 1,
+				previous_receipt_hash: previousHash,
+				chain_id: "chain_test",
+			},
+		});
+		const signed = signReceipt(unsigned, privateKey, "did:agent:test#key-1");
+		receipts.push(signed);
+		previousHash = hashReceipt(signed);
+	});
+	return receipts;
+}
+
+describe("idempotency_key", () => {
+	it("createReceipt stamps action.idempotency_key", () => {
+		const unsigned = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:alice" },
+			action: {
+				type: "filesystem.file.read",
+				risk_level: "low",
+				idempotency_key: "req-1",
+			},
+			outcome: { status: "success" },
+			chain: { sequence: 1, previous_receipt_hash: null, chain_id: "c" },
+		});
+		expect(unsigned.credentialSubject.action.idempotency_key).toBe("req-1");
+	});
+
+	it("omits idempotency_key from the canonical form when unset", () => {
+		const unsigned = createReceipt({
+			issuer: { id: "did:agent:test" },
+			principal: { id: "did:user:alice" },
+			action: { type: "filesystem.file.read", risk_level: "low" },
+			outcome: { status: "success" },
+			chain: { sequence: 1, previous_receipt_hash: null, chain_id: "c" },
+		});
+		expect(canonicalize(unsigned)).not.toContain("idempotency_key");
+	});
+
+	it("surfaces a duplicate idempotency_key as a warning, not a failure", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		// Receipts 0 and 2 share "req-A"; receipt 1 has a distinct key.
+		const chain = buildChainWithKeys(["req-A", "req-B", "req-A"], privateKey);
+
+		const result = verifyChain(chain, publicKey);
+		expect(result.valid).toBe(true);
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings?.[0]).toContain("req-A");
+		expect(result.warnings?.[0]).toContain("0");
+		expect(result.warnings?.[0]).toContain("2");
+	});
+
+	it("emits no warnings for distinct or absent keys", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		for (const keys of [
+			["req-1", "req-2", "req-3"],
+			[undefined, undefined, undefined],
+			["req-1", undefined, "req-2"],
+		]) {
+			const chain = buildChainWithKeys(keys, privateKey);
+			const result = verifyChain(chain, publicKey);
+			expect(result.valid).toBe(true);
+			expect(result.warnings).toBeUndefined();
+		}
+	});
+});

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -9,7 +9,7 @@ import { VERSION } from "./types.js";
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const LIVE_EMIT_VERSION = "0.3.0";
+const LIVE_EMIT_VERSION = "0.4.0";
 
 describe("createReceipt cross-SDK version invariant", () => {
 	it("stamps the cross-SDK literal version on freshly-emitted receipts", () => {

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -127,7 +127,7 @@ const actionSchema = z
 		emitter_metadata: emitterMetadataSchema.optional(),
 		timestamp: z.string(),
 		trusted_timestamp: z.string().optional(),
-		idempotency_key: z.string().optional(),
+		idempotency_key: z.string().min(1).optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -127,6 +127,7 @@ const actionSchema = z
 		emitter_metadata: emitterMetadataSchema.optional(),
 		timestamp: z.string(),
 		trusted_timestamp: z.string().optional(),
+		idempotency_key: z.string().optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/types.test.ts
+++ b/sdk/ts/src/receipt/types.test.ts
@@ -39,8 +39,8 @@ describe("receipt schema constants", () => {
 		expect(CREDENTIAL_TYPE).toEqual(["VerifiableCredential", "AgentReceipt"]);
 	});
 
-	it("has version 0.3.0", () => {
-		expect(VERSION).toBe("0.3.0");
+	it("has version 0.4.0", () => {
+		expect(VERSION).toBe("0.4.0");
 	});
 });
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -18,7 +18,7 @@ export const CREDENTIAL_TYPE = [
 	"AgentReceipt",
 ] as const;
 
-export const VERSION = "0.3.0";
+export const VERSION = "0.4.0";
 
 // --- Risk levels ---
 
@@ -129,6 +129,15 @@ export interface Action {
 	emitter_metadata?: EmitterMetadata;
 	timestamp: string;
 	trusted_timestamp?: string;
+	/**
+	 * Stable identifier for the logical operation this action represents
+	 * (e.g. a request ID). When an agent retries a tool call, the same key is
+	 * stamped on every receipt for that operation so auditors can distinguish
+	 * a legitimate retry from a duplicated emission. Omitted when no stable
+	 * source exists; MUST be a non-empty string when present.
+	 * See spec §7.3.6 and ADR-0019 §S5.
+	 */
+	idempotency_key?: string;
 }
 
 // --- Intent ---

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -140,7 +140,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `@context` | Yes | JSON-LD context. Must include the W3C VC v2 and Agent Receipt context URIs in order. |
 | `id` | Yes | Globally unique identifier. Must be `urn:receipt:<uuid>`. |
 | `type` | Yes | Must be `["VerifiableCredential", "AgentReceipt"]`. |
-| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, or `"0.3.0"`. Verifiers MUST accept all four. |
+| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, or `"0.4.0"`. Verifiers MUST accept all five. |
 | `issuer` | Yes | The agent or platform that issued the receipt. |
 | `issuanceDate` | Yes | ISO 8601 datetime when the receipt was issued. May differ from `action.timestamp`. |
 | `credentialSubject` | Yes | The receipt payload. |
@@ -182,6 +182,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `emitter_metadata` | No | Daemon-observed emitter-side metadata. Currently a single `drop_count` field on synthetic events_dropped receipts (ADR-0010). Daemon-attested, not agent-claimed. |
 | `timestamp` | Yes | ISO 8601 datetime when the action was executed. |
 | `trusted_timestamp` | No | Base64-encoded RFC 3161 TimeStampToken. Absent (not `null`) when not present — see [Optional-field rule](#optional-field-rule). |
+| `idempotency_key` | No | Stable identifier for the logical operation this action represents (e.g. a request ID). When an agent retries a tool call, the SDK or MCP proxy stamps the same `idempotency_key` on every receipt for that operation; verifiers surface duplicates across a chain as a warning, not a failure (retries are legitimate). Non-empty string when present; absent (not `null`) otherwise. Added in v0.4.0 (ADR-0019 §S5). |
 
 #### `parameters_disclosure` envelope (HPKE)
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-23
+
+### Added
+- `credentialSubject.action.idempotency_key` — optional stable identifier for the logical operation an action represents (e.g. a request ID). When an agent retries a tool call, the SDK or MCP proxy stamps the same `idempotency_key` on every receipt emitted for that operation, letting auditors distinguish a legitimate retry from a duplicated emission. MUST be a non-empty string when present; MUST NOT be `null`. The MCP proxy populates it automatically from the wrapped JSON-RPC request `id`. See spec §4.3.2, §7.3.6, and ADR-0019 §S5 (#480).
+- Spec §7.3.6: normative verifier rule — two or more receipts in a chain sharing a non-empty `idempotency_key` are surfaced as a **warning**, never a verification failure. Retries are legitimate. SDK chain verifiers expose these advisories on their verification result (Go `ChainVerification.Warnings`, TS `ChainVerification.warnings`, Python `ChainVerification.warnings`).
+
+### Changed
+- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, or `"0.4.0"`. Verifiers MUST accept all five. All new receipts SHOULD use `"0.4.0"`.
+
+### Upgrade notes
+
+**Issuers:** No action required to remain protocol-valid. To deduplicate retries, stamp a stable `action.idempotency_key` on each receipt for the same logical operation — omit the field entirely when no stable identifier is available (never emit `null` or an empty string). Upgrade to `"version": "0.4.0"` when emitting new receipts.
+
+**Verifiers:** No breaking changes. Receipts at `0.1.0`–`0.3.0` validate unchanged. Duplicate `idempotency_key` values produce an advisory warning on the verification result, not a failure.
+
 ## [0.3.0] - 2026-05-21
 
 ### Changed

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -42,8 +42,8 @@
       "description": "MUST be [\"VerifiableCredential\", \"AgentReceipt\"]."
     },
     "version": {
-      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0"],
-      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", or \"0.3.0\". Verifiers MUST accept all four."
+      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0"],
+      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", \"0.3.0\", or \"0.4.0\". Verifiers MUST accept all five."
     },
     "issuer": { "$ref": "#/$defs/issuer" },
     "issuanceDate": {
@@ -221,6 +221,11 @@
           "type": "string",
           "contentEncoding": "base64",
           "description": "Base64-encoded RFC 3161 TimeStampToken (DER encoding). Absent when not present; MUST NOT be null."
+        },
+        "idempotency_key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional stable identifier for the logical operation this action represents (e.g. a request ID). When an agent retries a tool call on timeout, the SDK or MCP proxy SHOULD stamp the same idempotency_key on every emitted receipt for that logical operation, so auditors can distinguish a legitimate retry from a duplicated emission. Verifier tooling surfaces duplicate idempotency_key values across a chain as a warning, not a failure — retries are legitimate. Absent when not applicable; MUST NOT be null or empty. See ADR-0019 §S5."
         }
       },
       "allOf": [

--- a/spec/spec/agent-receipt-spec-v0.1.md
+++ b/spec/spec/agent-receipt-spec-v0.1.md
@@ -251,6 +251,7 @@ All five `proof` fields are required even in the minimal form.
 | `action.parameters_hash` | No | `sha256:`-prefixed hash of the action parameters (RFC 8785 canonical JSON). A verifier can independently canonicalize any disclosed parameters and recompute this hash; however, this version of the spec does not define per-action-type parameter schemas, so verifiers cannot reliably determine whether the disclosed parameters are complete or expected for the action type, and mismatches may be ambiguous. See §9.9. |
 | `action.timestamp` | Yes | ISO 8601 datetime when the action was executed. |
 | `action.trusted_timestamp` | No | Base64-encoded RFC 3161 `TimeStampToken` (DER encoding, then base64). The TSA MUST timestamp the same canonical JSON (proof field removed) used for signing. If no trusted timestamp is available, this field MAY be omitted or set explicitly to `null`. See §7.7. |
+| `action.idempotency_key` | No | Stable identifier for the logical operation this action represents (e.g. a request ID). When an agent retries a tool call, the SDK or MCP proxy SHOULD stamp the same `idempotency_key` on every receipt emitted for that operation. Verifiers surface duplicate values across a chain as a warning, not a failure — retries are legitimate. MUST be a non-empty string when present; MUST NOT be `null`. See §7.3.6 and ADR-0019 §S5. |
 | `intent` | No | Context about the agent's intent at time of action. |
 | `intent.conversation_hash` | No | `sha256:` prefixed hash of the conversation context. |
 | `intent.prompt_preview` | No | Plain-text preview of the prompt that triggered the action (may be truncated). |
@@ -505,6 +506,12 @@ Operators who require detection of store-level tampering SHOULD layer at least o
 - **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.
 
 These are operational controls outside the protocol; the verifier cannot synthesize them and the spec does not mandate any specific backend. They are listed here so that compliance reviewers can match the protocol's verification contract to their operational threat model.
+
+#### 7.3.6 Idempotency key and retry deduplication
+
+When an agent retries a tool call (e.g. on timeout), the wrapping proxy or SDK may emit more than one `tool_call` receipt for the same logical operation. Without a shared identifier, an auditor cannot distinguish a legitimate retry from a duplicated emission. `action.idempotency_key` (§4.3.2) carries a stable identifier for the logical operation so that all receipts arising from one operation share a value. The SDK and MCP proxy SHOULD populate it automatically where a stable source exists (e.g. the MCP proxy derives it from the wrapped JSON-RPC request `id`).
+
+Duplicate `idempotency_key` values are **not** a verification failure. Retries are a normal, legitimate occurrence and the protocol does not attempt to suppress duplicate receipts. Verifiers MUST treat two or more receipts sharing a non-empty `idempotency_key` as a **warning** surfaced alongside the verification result, leaving `valid` unchanged. The warning lets auditors review whether the duplicates represent expected retries or unexpected double-counting. Receipts that omit `idempotency_key` never contribute to duplicate warnings.
 
 ### 7.4 Reversal receipts
 


### PR DESCRIPTION
## What

Adds the optional `action.idempotency_key` field to Agent Receipts (spec §7.3.6, ADR-0019 §S5). This field carries a stable identifier for the logical operation an action represents (e.g., a JSON-RPC request ID), allowing auditors to distinguish legitimate retries from duplicated emissions.

**Key changes:**
- Protocol version bumped to 0.4.0 across all SDKs (Go, Python, TypeScript)
- New optional `idempotency_key` field on `Action` type in all SDKs
- Chain verifier now detects and warns about duplicate idempotency keys (retries are legitimate, so duplicates surface as warnings, not failures)
- MCP proxy and daemon pipeline now capture and propagate JSON-RPC request IDs as idempotency keys
- Cross-SDK test vectors pinned in `v040_vectors.json` covering both single-receipt hash/signature verification and duplicate-key chain semantics
- Schema updated to accept v0.4.0 receipts

## Why

Idempotency keys enable:
1. **Retry safety**: When an agent retries a tool call (e.g., after timeout), the same idempotency key appears on all receipts for that operation
2. **Audit clarity**: Auditors can distinguish a legitimate retry from a duplicated emission or double-counting bug
3. **Cross-SDK interoperability**: All three SDKs canonicalize, hash, and verify the new field identically (it's just another sorted string key under RFC 8785)

The MCP proxy now extracts the JSON-RPC request ID and stamps it through the emitter frame → daemon → signed receipt pipeline, making idempotency keys available without requiring the agent to explicitly provide them.

## Checklist

- [x] Tests pass for all changed components
  - Added unit tests for idempotency key handling in all three SDKs (`idempotency_test.go`, `test_idempotency.py`, `idempotency.test.ts`)
  - Added cross-SDK vector tests (`v040_vectors_test.go`, `test_v040_vectors.py`, cross-language test in TS)
  - Daemon pipeline tests verify idempotency key propagation (`TestProcess_StampsIdempotencyKey`, `TestValidateFrame_RejectsOversizeIdempotencyKey`)
  - MCP proxy integration test verifies end-to-end flow (`TestEmitToContext_AllowedToolCall`)
- [x] Linter passes (Go vet, ruff check, biome as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass
  - Byte-identical hash reproduction for idempotency key receipt across Go, Python, TS
  - Duplicate-key chain verifier agreement: all SDKs report valid + exactly one warning
- [x] Spec changes reviewed (schema, CHANGELOG, spec document updated)

## Security

- [x] This PR touches receipt format and hashing (crypto-adjacent)
- [x] Primitives and parameters reviewed
  - Field is optional string, omitted when empty (omitempty)
  - Daemon enforces per-field size cap (`maxIdentityFieldLen`) to prevent inflation
  - Field participates in RFC 8785 canonical JSON like any other sorted string key
- [x] All inputs validated at trust boundaries
  - Daemon validates frame idempotency_key length before building receipt
  - MCP proxy extracts JSON-RPC ID (trusted source, no user input)
- [x] Edge cases tested
  - Empty/absent keys (omitted from canonical form)
  - Duplicate keys in chain (warning, not failure)
  - Oversized keys (rejected by daemon)

https://claude.ai/code/session_01T7oK33UYfER8JGM2FBENB7