### PR TITLE
fix(site): sort blog sidebar by date descending

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -170,16 +170,16 @@ export default defineConfig({
               slug: "blog/agent-security-tooling-landscape-may-2026",
             },
             {
-              label: "Agent Security Tooling Landscape — April 2026",
-              slug: "blog/agent-security-tooling-landscape-april-2026",
+              label: "The audit boundary belongs outside the agent",
+              slug: "blog/daemon-process-separation",
             },
             {
               label: "OpenClaw Plugin: How It Works",
               slug: "blog/openclaw-plugin-deep-dive",
             },
             {
-              label: "The audit boundary belongs outside the agent",
-              slug: "blog/daemon-process-separation",
+              label: "Agent Security Tooling Landscape — April 2026",
+              slug: "blog/agent-security-tooling-landscape-april-2026",
             },
           ],
         },


### PR DESCRIPTION
Moves "The audit boundary belongs outside the agent" (May 18) above "OpenClaw Plugin" (Apr 27) and "April 2026 Landscape" (Apr 16) in the sidebar so posts appear newest-first.