### PR TITLE
Isolate chain_id binding test by maintaining hash linkage

### DIFF
--- a/sdk/go/receipt/chain_test.go
+++ b/sdk/go/receipt/chain_test.go
@@ -1228,6 +1228,13 @@ func TestChainIDBindingRejectsCrossChainSplice(t *testing.T) {
 
 // A single off-chain receipt spliced into the middle (with signatures still
 // valid for its own chain_id) must be rejected solely on chain_id.
+//
+// Isolation note: this test confirms the chain would otherwise verify
+// cleanly; the only failure mode is the chain_id binding check. We re-sign
+// the middle receipt with a different chain_id AND re-link and re-sign the
+// trailing receipt so its previous_receipt_hash points at the middle's new
+// hash — keeping hash linkage valid so the sole invariant violated is
+// chain_id binding (not collateral hash breakage).
 func TestChainIDBindingRejectsSingleMismatchedReceipt(t *testing.T) {
 	kp, _ := GenerateKeyPair()
 	chain := buildChainWithID(t, kp, 3, "chain-A", 1, nil)
@@ -1248,6 +1255,28 @@ func TestChainIDBindingRejectsSingleMismatchedReceipt(t *testing.T) {
 		t.Fatal(err)
 	}
 	chain[1] = resigned
+
+	// Re-link the trailing receipt to the re-signed middle so hash linkage
+	// stays valid; its chain_id remains "chain-A".
+	middleHash, err := HashReceipt(resigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tail := chain[2]
+	tail.CredentialSubject.Chain.PreviousReceiptHash = &middleHash
+	resignedTail, err := Sign(UnsignedAgentReceipt{
+		Context:           tail.Context,
+		ID:                tail.ID,
+		Type:              tail.Type,
+		Version:           tail.Version,
+		Issuer:            tail.Issuer,
+		IssuanceDate:      tail.IssuanceDate,
+		CredentialSubject: tail.CredentialSubject,
+	}, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain[2] = resignedTail
 
 	result := VerifyChain(chain, kp.PublicKey)
 	if result.Valid {

--- a/sdk/py/tests/receipt/test_chain.py
+++ b/sdk/py/tests/receipt/test_chain.py
@@ -953,6 +953,13 @@ class TestChainIDBinding:
     def test_single_mismatched_receipt_in_middle_rejected(self) -> None:
         """A single off-chain receipt spliced into the middle (with a valid
         signature for its own chain_id) is rejected solely on chain_id.
+
+        Isolation note: this test confirms the chain would otherwise verify
+        cleanly; the only failure mode is the chain_id binding check. We
+        re-sign the middle receipt with a different chain_id AND re-link and
+        re-sign the trailing receipt so its previous_receipt_hash points at
+        the middle's new hash — keeping hash linkage valid so the sole
+        invariant violated is chain_id binding (not collateral hash breakage).
         """
         chain = _build_chain_with_id(3, TEST_PRIVATE_KEY, "chain-A")
         # Re-sign the middle receipt with chain_id="chain-other" so its
@@ -972,6 +979,26 @@ class TestChainIDBinding:
         )
         resigned = sign_receipt(unsigned, TEST_PRIVATE_KEY, "did:agent:test#key-1")
         chain[1] = resigned
+
+        # Re-link the trailing receipt to the re-signed middle so hash linkage
+        # stays valid; its chain_id remains "chain-A".
+        tail = chain[2]
+        tail.credentialSubject.chain.previous_receipt_hash = hash_receipt(resigned)
+        unsigned_tail = UnsignedAgentReceipt(
+            **{
+                "@context": tail.context,
+                "id": tail.id,
+                "type": tail.type,
+                "version": tail.version,
+                "issuer": tail.issuer,
+                "issuanceDate": tail.issuanceDate,
+                "credentialSubject": tail.credentialSubject,
+            }
+        )
+        resigned_tail = sign_receipt(
+            unsigned_tail, TEST_PRIVATE_KEY, "did:agent:test#key-1"
+        )
+        chain[2] = resigned_tail
 
         result = verify_chain(chain, TEST_PUBLIC_KEY)
         assert result.valid is False

--- a/sdk/ts/src/receipt/chain.test.ts
+++ b/sdk/ts/src/receipt/chain.test.ts
@@ -1010,14 +1010,19 @@ describe("verifyChain", () => {
 	});
 
 	it("chain_id binding: single mismatched receipt in the middle is rejected", () => {
+		// Isolation note: this test confirms the chain would otherwise verify
+		// cleanly; the only failure mode is the chain_id binding check. We
+		// re-sign the middle receipt with a different chain_id AND re-link and
+		// re-sign the trailing receipt so its previous_receipt_hash points at
+		// the middle's new hash — keeping hash linkage valid so the sole
+		// invariant violated is chain_id binding (not collateral hash breakage).
 		const { publicKey, privateKey } = generateKeyPair();
 		const chain = buildChainWithId(3, privateKey, "chain-A");
-		// Re-sign the middle receipt with a different chain_id so signatures
-		// still verify; the verifier must reject solely on chain_id.
+
 		const middle = chain[1];
 		if (!middle) throw new Error("test setup");
 		middle.credentialSubject.chain.chain_id = "chain-other";
-		const resigned = signReceipt(
+		const resignedMiddle = signReceipt(
 			{
 				"@context": middle["@context"],
 				id: middle.id,
@@ -1030,7 +1035,28 @@ describe("verifyChain", () => {
 			privateKey,
 			"did:agent:test#key-1",
 		);
-		chain[1] = resigned;
+		chain[1] = resignedMiddle;
+
+		// Re-link the trailing receipt to the re-signed middle so hash linkage
+		// stays valid; its chain_id remains "chain-A".
+		const tail = chain[2];
+		if (!tail) throw new Error("test setup");
+		tail.credentialSubject.chain.previous_receipt_hash =
+			hashReceipt(resignedMiddle);
+		const resignedTail = signReceipt(
+			{
+				"@context": tail["@context"],
+				id: tail.id,
+				type: tail.type,
+				version: tail.version,
+				issuer: tail.issuer,
+				issuanceDate: tail.issuanceDate,
+				credentialSubject: tail.credentialSubject,
+			},
+			privateKey,
+			"did:agent:test#key-1",
+		);
+		chain[2] = resignedTail;
 
 		const result = verifyChain(chain, publicKey);
 


### PR DESCRIPTION
## What

Updated the "single mismatched receipt in the middle is rejected" test across TypeScript, Go, and Python SDKs to maintain valid hash linkage while introducing a chain_id mismatch. The test now re-signs both the middle receipt (with a different chain_id) and the trailing receipt (to point to the middle's new hash), ensuring the only invariant violated is chain_id binding.

## Why

The original test modified the middle receipt's chain_id but didn't update the trailing receipt's `previous_receipt_hash` to point to the re-signed middle receipt's new hash. This meant the test could fail for two reasons: either the chain_id mismatch (the intended failure) or hash linkage breakage (collateral damage). 

By maintaining hash linkage validity, we isolate the test to verify that chain_id binding is enforced as the sole failure mode, making the test more precise and the verification logic's behavior clearer.

## Checklist

- [x] Tests pass for all changed components (test modifications only, no logic changes)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests updated consistently (TS, Go, Python)

## Security

- [x] This PR touches crypto and receipt verification
- [x] No changes to cryptographic primitives or parameters
- [x] Test isolation improvement strengthens verification validation