### PR TITLE
Enforce safe socket paths, reject TCP addresses (issue #538)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ go.work.sum
 *.db
 *.db-shm
 *.db-wal
+
+# Built daemon binary (output of `go build ./cmd/agent-receipts-daemon`)
+/daemon/agent-receipts-daemon

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Refuse unsafe socket paths absent `--unsafe-socket-path`** ([#538](https://github.com/agent-receipts/ar/issues/538)). At startup the daemon now rejects a `--socket` / `AGENTRECEIPTS_SOCKET` override that resolves outside the per-platform safe set (Linux: `$XDG_RUNTIME_DIR`, `/run`, `/var/run`; macOS: `$TMPDIR`, `/var/run`, `$XDG_DATA_HOME/agent-receipts`) unless `--unsafe-socket-path` is also passed, in which case it starts, logs a `level=warn` line naming the path, and re-emits the warning every 60s. The path is canonicalized with `filepath.EvalSymlinks` before the check so a symlink escaping the safe set is judged by its real target. TCP addresses are rejected unconditionally (ADR-0010 § IPC transport). Defaults always resolve inside the safe set and are unaffected. This closes the "unsafe configuration silently accepted" gap where an override could quietly relocate the socket to a shared, world-traversable, swept directory like `/tmp`.
+
 ### Changed
 
 - **macOS default socket path moved off `$TMPDIR`** ([#545](https://github.com/agent-receipts/ar/issues/545)). The macOS default is now `$XDG_DATA_HOME/agent-receipts/events.sock` (defaulting to `~/.local/share/agent-receipts/events.sock`), co-located with `receipts.db` and the signing key. The previous `$TMPDIR/agentreceipts/events.sock` default was unreliable because launchd's per-user TMPDIR is not inherited by every spawn context — GUI-spawned MCP servers commonly saw no TMPDIR and silently landed on `/tmp` while the daemon kept the per-user path, producing a no-error / zero-receipt failure mode. HOME is preserved across every supported spawn context, eliminating the divergence. Linux defaults are unchanged. Operators upgrading from v0.11.0 or earlier on macOS must restart both the daemon and any emitter (mcp-proxy, hook); anyone relying on TMPDIR redirection should switch to `AGENTRECEIPTS_SOCKET`. See ADR-0010's 2026-05-23 entry.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -60,6 +60,7 @@ agent-receipts-daemon \
 | Flag | Env | Default |
 |---|---|---|
 | `--socket` | `AGENTRECEIPTS_SOCKET` | Linux: `$XDG_RUNTIME_DIR/agentreceipts/events.sock` (falls back to `/run/agentreceipts/events.sock`). macOS: `$XDG_DATA_HOME/agent-receipts/events.sock` (defaults to `~/.local/share/agent-receipts/events.sock`). |
+| `--unsafe-socket-path` | — | `false` — permit a `--socket` outside the per-platform safe set (see [Socket-path safety](#socket-path-safety)). |
 | `--db` | `AGENTRECEIPTS_DB` | `$XDG_DATA_HOME/agent-receipts/receipts.db` (defaults to `~/.local/share/agent-receipts/receipts.db`) |
 | `--key` | `AGENTRECEIPTS_KEY` | `$XDG_DATA_HOME/agent-receipts/signing.key` (defaults to `~/.local/share/agent-receipts/signing.key`) |
 | `--chain-id` | `AGENTRECEIPTS_CHAIN_ID` | `default` |
@@ -77,6 +78,34 @@ non-regular file at this path.
 The socket directory is created with mode `0750` if missing; the socket
 itself is `0660`. Phase 1 unprivileged installs use the per-user defaults
 (`$XDG_DATA_HOME` on macOS, `$XDG_RUNTIME_DIR` on Linux when set).
+
+### Socket-path safety
+
+The per-user runtime/data directory is what makes peer-credential capture and
+the trust boundary meaningful (ADR-0010 § IPC transport). A socket in a shared,
+world-traversable, periodically-swept directory (e.g. `/tmp`) keeps peer creds
+working but loses location privacy, and the socket file may disappear under
+load. To stop a safe default being silently abandoned by an override, the
+daemon refuses to start when `--socket` / `AGENTRECEIPTS_SOCKET` resolves
+outside the per-platform safe set:
+
+- **Linux:** under `$XDG_RUNTIME_DIR` (when set), `/run`, or `/var/run`.
+- **macOS:** under `$TMPDIR` (when set), `/var/run`, or
+  `$XDG_DATA_HOME/agent-receipts` (where the per-user default lives, alongside
+  `receipts.db` and the signing key).
+
+The path is canonicalized with `filepath.EvalSymlinks` before the check, so a
+symlink pointing out of the safe set is judged by its real target. The default
+socket path always resolves inside the safe set, so defaults are never
+rejected. TCP addresses (e.g. `127.0.0.1:9000`) are rejected unconditionally —
+the daemon speaks Unix-domain sockets only.
+
+To deliberately run on a path outside the safe set — containers with unusual
+mounts, dev experiments, the short `/tmp` path the integration tests need to
+stay within the macOS `sun_path` limit — pass `--unsafe-socket-path`. The
+daemon then starts, logs a `level=warn` line naming the path, and re-emits the
+warning every 60 seconds. The flag unblocks legitimate edge cases; it does not
+suppress the warning, and it does not override the TCP rejection.
 
 On every startup the daemon publishes the matching SPKI public key to
 `--public-key` (default `<KeyPath>.pub`, tracking any `--key` override) with

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -54,6 +54,7 @@ func main() {
 
 	initKeys := flag.Bool("init", false, "Generate a new signing key pair and exit (must not exist)")
 	showVersion := flag.Bool("version", false, "Print version and exit")
+	unsafeSocket := flag.Bool("unsafe-socket-path", false, "Permit a --socket/AGENTRECEIPTS_SOCKET path outside the per-platform safe set (logs a warning; does not override TCP rejection)")
 	flag.StringVar(&cfg.SocketPath, "socket", cfg.SocketPath, "Unix-domain socket path (env: AGENTRECEIPTS_SOCKET)")
 	flag.StringVar(&cfg.DBPath, "db", cfg.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	flag.StringVar(&cfg.KeyPath, "key", cfg.KeyPath, "Ed25519 PEM private key path, mode 0600 (env: AGENTRECEIPTS_KEY)")
@@ -90,6 +91,7 @@ func main() {
 	if cfg.PublicKeyPath == "" {
 		cfg.PublicKeyPath = daemon.DefaultPublicKeyPath(cfg.KeyPath)
 	}
+	cfg.UnsafeSocketPath = *unsafeSocket
 
 	logger := log.New(os.Stderr, "agent-receipts-daemon ", log.LstdFlags|log.Lmicroseconds)
 	cfg.Logger = logger

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -302,7 +302,13 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 	if unsafeSocket {
-		go warnUnsafeSocketPath(ctx, cfg.Logger, cfg.SocketPath, unsafeSocketWarnInterval)
+		// Bind the warning goroutine to a context cancelled when Run returns,
+		// not to the caller's ctx. A later startup error returns from Run
+		// without the caller necessarily cancelling ctx; without this the
+		// warning loop would outlive the failed start and keep logging.
+		warnCtx, cancelWarn := context.WithCancel(ctx)
+		defer cancelWarn()
+		go warnUnsafeSocketPath(warnCtx, cfg.Logger, cfg.SocketPath, unsafeSocketWarnInterval)
 	}
 
 	// Apply a restrictive process umask BEFORE opening the SQLite store so any

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -31,6 +31,12 @@ type Config struct {
 	// SocketPath is the Unix-domain socket the daemon listens on.
 	SocketPath string
 
+	// UnsafeSocketPath permits a SocketPath outside the per-platform safe set
+	// (see checkSocketPath). When false (the default), Run refuses to start on
+	// an unsafe explicit override; when true, Run starts and warns periodically.
+	// Set from --unsafe-socket-path. TCP addresses are rejected regardless.
+	UnsafeSocketPath bool
+
 	// DBPath is the SQLite receipt-store path.
 	DBPath string
 
@@ -284,6 +290,19 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	if err := validateConfig(&cfg); err != nil {
 		return err
+	}
+
+	// Enforce the safe-socket-location policy (issue #538) on the resolved
+	// path — default or explicit override — before binding. A TCP address or
+	// an unsafe override without --unsafe-socket-path refuses to start here;
+	// an unsafe override with the flag starts but warns on a 60s cadence for
+	// the daemon's lifetime.
+	unsafeSocket, err := checkSocketPath(cfg.SocketPath, cfg.UnsafeSocketPath)
+	if err != nil {
+		return err
+	}
+	if unsafeSocket {
+		go warnUnsafeSocketPath(ctx, cfg.Logger, cfg.SocketPath, unsafeSocketWarnInterval)
 	}
 
 	// Apply a restrictive process umask BEFORE opening the SQLite store so any

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -124,9 +124,13 @@ func startDaemon(t *testing.T) (cfg daemon.Config, pubPEM string, cancel func())
 	sockDir := sockettest.ShortSocketDir(t)
 	dataDir := t.TempDir()
 	cfg = daemon.Config{
-		SocketPath:           filepath.Join(sockDir, "events.sock"),
-		DBPath:               filepath.Join(dataDir, "receipts.db"),
-		KeyPath:              filepath.Join(dataDir, "signing.key"),
+		SocketPath: filepath.Join(sockDir, "events.sock"),
+		DBPath:     filepath.Join(dataDir, "receipts.db"),
+		KeyPath:    filepath.Join(dataDir, "signing.key"),
+		// ShortSocketDir lives under /tmp to stay within the 104-byte
+		// AF_UNIX sun_path limit on macOS — outside the per-platform safe
+		// set, so opt into the documented escape hatch (issue #538).
+		UnsafeSocketPath:     true,
 		PublicKeyPath:        filepath.Join(dataDir, "signing.key.pub"),
 		ChainID:              "it-chain",
 		IssuerID:             "did:agent-receipts-daemon:integration",
@@ -432,6 +436,7 @@ func TestShutdownWithIdleClient(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := daemon.Config{
 		SocketPath:           filepath.Join(sockDir, "events.sock"),
+		UnsafeSocketPath:     true, // /tmp ShortSocketDir is outside the safe set (issue #538)
 		DBPath:               filepath.Join(dataDir, "receipts.db"),
 		KeyPath:              filepath.Join(dataDir, "signing.key"),
 		ChainID:              "idle",
@@ -500,6 +505,7 @@ func TestResumesChainAfterRestart(t *testing.T) {
 	mkCfg := func() daemon.Config {
 		return daemon.Config{
 			SocketPath:           socketPath,
+			UnsafeSocketPath:     true, // /tmp ShortSocketDir is outside the safe set (issue #538)
 			DBPath:               dbPath,
 			KeyPath:              keyPath,
 			ChainID:              "resume-chain",
@@ -636,6 +642,7 @@ func TestVerifyCLIWithDaemonStopped(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := daemon.Config{
 		SocketPath:           filepath.Join(sockDir, "events.sock"),
+		UnsafeSocketPath:     true, // /tmp ShortSocketDir is outside the safe set (issue #538)
 		DBPath:               filepath.Join(dataDir, "receipts.db"),
 		KeyPath:              filepath.Join(dataDir, "signing.key"),
 		PublicKeyPath:        filepath.Join(dataDir, "signing.key.pub"),

--- a/daemon/socketpolicy.go
+++ b/daemon/socketpolicy.go
@@ -196,9 +196,14 @@ func pathWithin(target, root string) bool {
 // than only loopback variants, keeping checkSocketPath's "TCP rejected
 // unconditionally" contract honest.
 //
-// A Unix path is anchored by a path separator and short-circuits before the
-// host:port branch, and a real daemon socket is always an absolute path, so
-// this cannot misflag a legitimate configuration.
+// A Unix path containing a path separator short-circuits before the host:port
+// branch. The only Unix path that could reach that branch is a bare relative
+// filename, with no separator, that happens to be host:port-shaped with a
+// numeric port (e.g. "foo:9000"). That is not a real daemon socket
+// configuration — sockets are configured as absolute paths — so treating such
+// a value as TCP is acceptable rather than a misflag of a legitimate config.
+// (validateConfig does not enforce absoluteness; this is a statement about how
+// the daemon is configured in practice, not an invariant.)
 func looksLikeTCPAddress(s string) bool {
 	lower := strings.ToLower(s)
 	if strings.HasPrefix(lower, "tcp://") || strings.HasPrefix(lower, "tcp4://") || strings.HasPrefix(lower, "tcp6://") {

--- a/daemon/socketpolicy.go
+++ b/daemon/socketpolicy.go
@@ -104,13 +104,26 @@ func allowedSocketRoots() []string {
 // (e.g. $XDG_RUNTIME_DIR/agentreceipts → /tmp/x) is judged by its real target,
 // and so a root that is itself a symlink (e.g. /var/run → /run on Linux) still
 // matches a socket placed via the other name.
+//
+// Fails closed: if the candidate path cannot be canonicalized (a non-ENOENT
+// EvalSymlinks error such as EACCES on a component, or a symlink loop), it is
+// treated as unsafe. Otherwise an unresolvable component could mask a symlink
+// escaping the safe set. A root that cannot be canonicalized is skipped rather
+// than matched.
 func isSocketPathSafe(socketPath string) bool {
-	canon := canonicalizePath(socketPath)
+	canon, err := canonicalizePath(socketPath)
+	if err != nil {
+		return false
+	}
 	for _, root := range allowedSocketRoots() {
 		if root == "" || !filepath.IsAbs(root) {
 			continue
 		}
-		if pathWithin(canon, canonicalizePath(root)) {
+		canonRoot, err := canonicalizePath(root)
+		if err != nil {
+			continue
+		}
+		if pathWithin(canon, canonRoot) {
 			return true
 		}
 	}
@@ -121,11 +134,16 @@ func isSocketPathSafe(socketPath string) bool {
 // file itself does not exist at validation time (the listener creates it), and
 // its parent dir may not exist yet either, so EvalSymlinks cannot run on the
 // full path. We resolve the longest existing ancestor and re-append the
-// not-yet-created tail. On a non-ENOENT EvalSymlinks error (e.g. EACCES on a
-// directory we cannot traverse) we fall back to the cleaned absolute path
-// rather than guessing — a path we cannot resolve is treated as-is, and the
-// containment check then decides safe/unsafe on that literal form.
-func canonicalizePath(path string) string {
+// not-yet-created tail (which cannot itself be a symlink, since it does not
+// exist).
+//
+// A non-ENOENT EvalSymlinks error — EACCES on a directory we cannot traverse,
+// or ELOOP from a symlink cycle — is returned to the caller, which fails closed
+// (treats the path as unsafe). We deliberately do not fall back to the literal
+// unresolved path: doing so would let an unresolvable component hide a symlink
+// pointing out of the safe set, contradicting "reject invalid inputs at trust
+// boundaries, do not silently degrade".
+func canonicalizePath(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		abs = filepath.Clean(path)
@@ -136,16 +154,20 @@ func canonicalizePath(path string) string {
 		resolved, err := filepath.EvalSymlinks(cur)
 		if err == nil {
 			if remainder == "" {
-				return resolved
+				return resolved, nil
 			}
-			return filepath.Join(resolved, remainder)
+			return filepath.Join(resolved, remainder), nil
 		}
 		if !errors.Is(err, fs.ErrNotExist) {
-			return abs
+			return "", fmt.Errorf("canonicalize %q: %w", path, err)
 		}
 		parent := filepath.Dir(cur)
 		if parent == cur {
-			return abs
+			// Walked to the filesystem root without resolving any existing
+			// ancestor (only reachable if even "/" is reported missing, which
+			// does not happen in practice). abs has no resolvable symlink
+			// component in this case, so it is safe to return as-is.
+			return abs, nil
 		}
 		remainder = filepath.Join(filepath.Base(cur), remainder)
 		cur = parent

--- a/daemon/socketpolicy.go
+++ b/daemon/socketpolicy.go
@@ -227,7 +227,7 @@ func looksLikeTCPAddress(s string) bool {
 // is safe for concurrent use, so it can share cfg.Logger with the main path.
 func warnUnsafeSocketPath(ctx context.Context, logger *log.Logger, socketPath string, interval time.Duration) {
 	logger.Printf(
-		"level=warn unsafe socket path %q is outside the per-platform safe set; the daemon started only because --unsafe-socket-path was passed. Shared, world-traversable, periodically-swept directories (e.g. /tmp) defeat the per-user trust boundary (issue #538)",
+		"level=warn unsafe socket path %q is outside the per-platform safe set; startup is proceeding only because --unsafe-socket-path was passed. Shared, world-traversable, periodically-swept directories (e.g. /tmp) defeat the per-user trust boundary (issue #538)",
 		socketPath,
 	)
 	if interval <= 0 {

--- a/daemon/socketpolicy.go
+++ b/daemon/socketpolicy.go
@@ -1,0 +1,218 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// unsafeSocketWarnInterval is how often Run re-emits the unsafe-socket-path
+// warning while the daemon runs under --unsafe-socket-path. The first warning
+// fires immediately at startup; subsequent ones at this cadence so the unsafe
+// configuration stays visible in long-lived logs, not just at boot.
+const unsafeSocketWarnInterval = 60 * time.Second
+
+// checkSocketPath enforces the safe-socket-location policy from issue #538 on
+// the resolved SocketPath (default or explicit override). It distinguishes
+// three outcomes:
+//
+//   - safe path → (false, nil): start normally.
+//   - unsafe path with unsafeAllowed → (true, nil): start, but the caller must
+//     warn (see warnUnsafeSocketPath).
+//   - unsafe path without unsafeAllowed → (false, err): refuse to start.
+//
+// A TCP address is rejected unconditionally — even with unsafeAllowed — because
+// ADR-0010 § IPC transport rejects TCP loopback outright: it dissolves the
+// filesystem permission model the peer-credential trust boundary depends on.
+//
+// "Safe" means the socket resolves to a location under one of the per-platform
+// directories in allowedSocketRoots — the per-user runtime/data dirs and the
+// privileged system run dirs. A socket in a shared, world-traversable,
+// periodically-swept directory (e.g. /tmp) keeps peer-cred capture working but
+// loses location privacy and may vanish under load, silently abandoning the
+// safe default ADR-0010 specifies.
+func checkSocketPath(socketPath string, unsafeAllowed bool) (unsafe bool, err error) {
+	if looksLikeTCPAddress(socketPath) {
+		return false, fmt.Errorf(
+			"daemon: socket address %q is a TCP address; the daemon speaks Unix-domain sockets only and TCP loopback is rejected unconditionally (ADR-0010 § IPC transport). --unsafe-socket-path does not override this",
+			socketPath,
+		)
+	}
+	if isSocketPathSafe(socketPath) {
+		return false, nil
+	}
+	if unsafeAllowed {
+		return true, nil
+	}
+	return false, fmt.Errorf(
+		"daemon: socket path %q is outside the per-platform safe set [%s]; refusing to start. A socket in a shared, world-traversable, swept directory (e.g. /tmp) loses the per-user trust boundary. Move it under one of the safe directories, or pass --unsafe-socket-path to override deliberately (issue #538)",
+		socketPath, strings.Join(allowedSocketRoots(), ", "),
+	)
+}
+
+// allowedSocketRoots returns the directories an explicit socket override may
+// live under without --unsafe-socket-path, for the current platform. The
+// per-platform default socket path (see DefaultSocketPath) always resolves
+// under one of these, so defaults are never rejected:
+//
+//   - Linux: $XDG_RUNTIME_DIR (per-user, when set), /run and /var/run
+//     (privileged system installs).
+//   - macOS: $TMPDIR (per-user, when set), /var/run (system installs), and
+//     $XDG_DATA_HOME/agent-receipts (where the per-user default socket lives
+//     since issue #545 — the daemon's own private state directory, co-located
+//     with receipts.db and the signing key).
+//
+// Relative or empty env values are ignored: a non-absolute root cannot anchor
+// a containment check and per the XDG spec is invalid anyway. On Linux an unset
+// $XDG_RUNTIME_DIR means "no per-user runtime dir available" — overrides then
+// require --unsafe-socket-path unless they land under /run or /var/run (issue
+// #538 ambiguity guidance: do not synthesize a fallback).
+func allowedSocketRoots() []string {
+	switch runtime.GOOS {
+	case "linux":
+		roots := []string{"/run", "/var/run"}
+		if x := os.Getenv("XDG_RUNTIME_DIR"); x != "" && filepath.IsAbs(x) {
+			roots = append(roots, x)
+		}
+		return roots
+	case "darwin":
+		roots := []string{"/var/run"}
+		if t := os.Getenv("TMPDIR"); t != "" && filepath.IsAbs(t) {
+			roots = append(roots, t)
+		}
+		if dh := xdgDataHome(); dh != "" {
+			roots = append(roots, filepath.Join(dh, "agent-receipts"))
+		}
+		return roots
+	default:
+		return nil
+	}
+}
+
+// isSocketPathSafe reports whether socketPath canonicalizes to a location under
+// one of allowedSocketRoots. Both the candidate and each root are canonicalized
+// with EvalSymlinks before comparison so a symlink pointing out of the safe set
+// (e.g. $XDG_RUNTIME_DIR/agentreceipts → /tmp/x) is judged by its real target,
+// and so a root that is itself a symlink (e.g. /var/run → /run on Linux) still
+// matches a socket placed via the other name.
+func isSocketPathSafe(socketPath string) bool {
+	canon := canonicalizePath(socketPath)
+	for _, root := range allowedSocketRoots() {
+		if root == "" || !filepath.IsAbs(root) {
+			continue
+		}
+		if pathWithin(canon, canonicalizePath(root)) {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalizePath resolves path to an absolute, symlink-free form. The socket
+// file itself does not exist at validation time (the listener creates it), and
+// its parent dir may not exist yet either, so EvalSymlinks cannot run on the
+// full path. We resolve the longest existing ancestor and re-append the
+// not-yet-created tail. On a non-ENOENT EvalSymlinks error (e.g. EACCES on a
+// directory we cannot traverse) we fall back to the cleaned absolute path
+// rather than guessing — a path we cannot resolve is treated as-is, and the
+// containment check then decides safe/unsafe on that literal form.
+func canonicalizePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	remainder := ""
+	cur := abs
+	for {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err == nil {
+			if remainder == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, remainder)
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return abs
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return abs
+		}
+		remainder = filepath.Join(filepath.Base(cur), remainder)
+		cur = parent
+	}
+}
+
+// pathWithin reports whether target is root itself or a descendant of root.
+// Both arguments must already be absolute and cleaned (canonicalizePath output).
+func pathWithin(target, root string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// looksLikeTCPAddress reports whether s is a TCP socket address rather than a
+// Unix-domain path. It matches an explicit tcp/tcp4/tcp6 URL scheme, or a bare
+// host:port with a numeric port whose host is empty, "localhost", or an IP
+// literal (covers ":9000", "127.0.0.1:9000", "[::1]:9000", "localhost:9000").
+// Unix paths contain a path separator and never reach the host:port branch, so
+// a legitimate socket file with a colon in a directory name is not misflagged.
+func looksLikeTCPAddress(s string) bool {
+	lower := strings.ToLower(s)
+	if strings.HasPrefix(lower, "tcp://") || strings.HasPrefix(lower, "tcp4://") || strings.HasPrefix(lower, "tcp6://") {
+		return true
+	}
+	if strings.ContainsRune(s, '/') {
+		return false
+	}
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return false
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return false
+	}
+	if host == "" || strings.EqualFold(host, "localhost") {
+		return true
+	}
+	return net.ParseIP(host) != nil
+}
+
+// warnUnsafeSocketPath emits the startup warning naming an unsafe socket path,
+// then re-emits it every interval until ctx is cancelled. interval <= 0 emits
+// the startup line only (used by tests; production passes
+// unsafeSocketWarnInterval). Run launches this in its own goroutine; log.Logger
+// is safe for concurrent use, so it can share cfg.Logger with the main path.
+func warnUnsafeSocketPath(ctx context.Context, logger *log.Logger, socketPath string, interval time.Duration) {
+	logger.Printf(
+		"level=warn unsafe socket path %q is outside the per-platform safe set; the daemon started only because --unsafe-socket-path was passed. Shared, world-traversable, periodically-swept directories (e.g. /tmp) defeat the per-user trust boundary (issue #538)",
+		socketPath,
+	)
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			logger.Printf("level=warn daemon still running on unsafe socket path %q (--unsafe-socket-path)", socketPath)
+		}
+	}
+}

--- a/daemon/socketpolicy.go
+++ b/daemon/socketpolicy.go
@@ -187,12 +187,18 @@ func pathWithin(target, root string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// looksLikeTCPAddress reports whether s is a TCP socket address rather than a
-// Unix-domain path. It matches an explicit tcp/tcp4/tcp6 URL scheme, or a bare
-// host:port with a numeric port whose host is empty, "localhost", or an IP
-// literal (covers ":9000", "127.0.0.1:9000", "[::1]:9000", "localhost:9000").
-// Unix paths contain a path separator and never reach the host:port branch, so
-// a legitimate socket file with a colon in a directory name is not misflagged.
+// looksLikeTCPAddress reports whether s is a TCP-style socket address rather
+// than a Unix-domain path. It matches an explicit tcp/tcp4/tcp6 URL scheme, or
+// any bare host:port with a numeric port and no path separator — regardless of
+// host (covers ":9000", "127.0.0.1:9000", "[::1]:9000", "localhost:9000",
+// "example.com:9000"). The host is deliberately not restricted to loopback: the
+// daemon never speaks TCP, so every host:port form is rejected uniformly rather
+// than only loopback variants, keeping checkSocketPath's "TCP rejected
+// unconditionally" contract honest.
+//
+// A Unix path is anchored by a path separator and short-circuits before the
+// host:port branch, and a real daemon socket is always an absolute path, so
+// this cannot misflag a legitimate configuration.
 func looksLikeTCPAddress(s string) bool {
 	lower := strings.ToLower(s)
 	if strings.HasPrefix(lower, "tcp://") || strings.HasPrefix(lower, "tcp4://") || strings.HasPrefix(lower, "tcp6://") {
@@ -201,17 +207,12 @@ func looksLikeTCPAddress(s string) bool {
 	if strings.ContainsRune(s, '/') {
 		return false
 	}
-	host, port, err := net.SplitHostPort(s)
+	_, port, err := net.SplitHostPort(s)
 	if err != nil {
 		return false
 	}
-	if _, err := strconv.Atoi(port); err != nil {
-		return false
-	}
-	if host == "" || strings.EqualFold(host, "localhost") {
-		return true
-	}
-	return net.ParseIP(host) != nil
+	_, err = strconv.Atoi(port)
+	return err == nil
 }
 
 // warnUnsafeSocketPath emits the startup warning naming an unsafe socket path,

--- a/daemon/socketpolicy_test.go
+++ b/daemon/socketpolicy_test.go
@@ -1,0 +1,232 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// policyLogBuffer is a goroutine-safe bytes.Buffer for tests that read log output
+// while a logger writes from another goroutine (log.Logger serializes its own
+// writes, but a concurrent reader still races the buffer's internal state).
+type policyLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *policyLogBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *policyLogBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *policyLogBuffer) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf.Reset()
+}
+
+// setupSocketEnv pins every environment variable that allowedSocketRoots and
+// DefaultSocketPath consult to test-controlled temp dirs, none of which is
+// /tmp, so the safe set is deterministic across hosts. It also clears
+// AGENTRECEIPTS_SOCKET so DefaultSocketPath resolves the platform default.
+// Returns the per-platform directory a safe explicit override may live under.
+func setupSocketEnv(t *testing.T) (safeRoot string) {
+	t.Helper()
+	t.Setenv("AGENTRECEIPTS_SOCKET", "")
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	switch runtime.GOOS {
+	case "linux":
+		return os.Getenv("XDG_RUNTIME_DIR")
+	case "darwin":
+		return os.Getenv("TMPDIR")
+	default:
+		t.Skipf("socket-path policy test not meaningful on %s", runtime.GOOS)
+		return ""
+	}
+}
+
+// unsafeRoot returns a directory guaranteed to sit outside the safe set on
+// Linux and macOS regardless of the test environment.
+func unsafeRoot(t *testing.T) string {
+	t.Helper()
+	// /tmp is shared, world-traversable, and swept — the canonical unsafe
+	// location from the issue's originating incident. setupSocketEnv steers
+	// every safe root away from /tmp, so this is reliably rejected.
+	return filepath.Join("/tmp", "agent-receipts-538-"+t.Name())
+}
+
+func TestCheckSocketPath_DefaultIsSafe(t *testing.T) {
+	setupSocketEnv(t)
+	def := DefaultSocketPath()
+	if def == "" {
+		t.Fatal("DefaultSocketPath returned empty; test env did not resolve a default")
+	}
+	unsafe, err := checkSocketPath(def, false)
+	if err != nil {
+		t.Fatalf("default socket path %q rejected: %v", def, err)
+	}
+	if unsafe {
+		t.Errorf("default socket path %q flagged unsafe; defaults must always be safe", def)
+	}
+}
+
+func TestCheckSocketPath_AllowedExplicitPath(t *testing.T) {
+	safeRoot := setupSocketEnv(t)
+	p := filepath.Join(safeRoot, "agentreceipts", "events.sock")
+	unsafe, err := checkSocketPath(p, false)
+	if err != nil {
+		t.Fatalf("explicit safe path %q rejected: %v", p, err)
+	}
+	if unsafe {
+		t.Errorf("explicit safe path %q flagged unsafe", p)
+	}
+}
+
+func TestCheckSocketPath_RejectsUnsafeWithoutFlag(t *testing.T) {
+	setupSocketEnv(t)
+	p := filepath.Join(unsafeRoot(t), "events.sock")
+	unsafe, err := checkSocketPath(p, false)
+	if err == nil {
+		t.Fatalf("unsafe path %q accepted without --unsafe-socket-path", p)
+	}
+	if unsafe {
+		t.Error("unsafe=true should not be returned alongside a refusal error")
+	}
+	if !strings.Contains(err.Error(), "unsafe-socket-path") {
+		t.Errorf("error should name the escape hatch flag, got: %v", err)
+	}
+}
+
+func TestCheckSocketPath_AcceptsUnsafeWithFlag(t *testing.T) {
+	setupSocketEnv(t)
+	p := filepath.Join(unsafeRoot(t), "events.sock")
+	unsafe, err := checkSocketPath(p, true)
+	if err != nil {
+		t.Fatalf("unsafe path %q rejected even with --unsafe-socket-path: %v", p, err)
+	}
+	if !unsafe {
+		t.Error("unsafe path with flag should report unsafe=true so the caller warns")
+	}
+}
+
+func TestCheckSocketPath_RejectsTCPUnconditionally(t *testing.T) {
+	setupSocketEnv(t)
+	for _, addr := range []string{
+		"127.0.0.1:9000",
+		"localhost:9000",
+		":9000",
+		"[::1]:9000",
+		"tcp://127.0.0.1:9000",
+	} {
+		// Even with --unsafe-socket-path, TCP must be refused (ADR-0010).
+		for _, unsafeAllowed := range []bool{false, true} {
+			unsafe, err := checkSocketPath(addr, unsafeAllowed)
+			if err == nil {
+				t.Errorf("TCP address %q accepted (unsafeAllowed=%v); ADR-0010 rejects TCP", addr, unsafeAllowed)
+			}
+			if unsafe {
+				t.Errorf("TCP address %q returned unsafe=true; should be a hard error", addr)
+			}
+		}
+	}
+}
+
+func TestLooksLikeTCPAddress(t *testing.T) {
+	tcp := []string{"127.0.0.1:9000", "localhost:9000", ":9000", "[::1]:9000", "tcp://127.0.0.1:9000", "TCP://10.0.0.1:1"}
+	for _, s := range tcp {
+		if !looksLikeTCPAddress(s) {
+			t.Errorf("looksLikeTCPAddress(%q) = false, want true", s)
+		}
+	}
+	unixPaths := []string{
+		"/run/agentreceipts/events.sock",
+		"/tmp/x/events.sock",
+		"events.sock",
+		"./events.sock",
+		"/var/run/foo:bar/events.sock", // colon in a dir name, but has a separator
+	}
+	for _, s := range unixPaths {
+		if looksLikeTCPAddress(s) {
+			t.Errorf("looksLikeTCPAddress(%q) = true, want false (unix path)", s)
+		}
+	}
+}
+
+// TestCheckSocketPath_SymlinkOutOfSafeSet covers the issue's symlink edge case:
+// a path whose parent dir is a symlink pointing out of the safe set must be
+// judged by its real target, not its apparent location.
+func TestCheckSocketPath_SymlinkOutOfSafeSet(t *testing.T) {
+	safeRoot := setupSocketEnv(t)
+	outside := t.TempDir() // a fresh dir not under any safe root
+	link := filepath.Join(safeRoot, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	p := filepath.Join(link, "events.sock")
+	unsafe, err := checkSocketPath(p, false)
+	if err == nil {
+		t.Fatalf("symlink %q escaping the safe set was accepted: real target %q is unsafe", p, outside)
+	}
+	if unsafe {
+		t.Error("unsafe=true should not accompany a refusal error")
+	}
+}
+
+func TestWarnUnsafeSocketPath_StartupAndPeriodic(t *testing.T) {
+	var buf policyLogBuffer
+	logger := log.New(&buf, "", 0)
+
+	// Startup-only: interval <= 0 emits exactly one line and returns.
+	warnUnsafeSocketPath(context.Background(), logger, "/tmp/x.sock", 0)
+	if got := strings.Count(buf.String(), "level=warn"); got != 1 {
+		t.Fatalf("startup-only warn emitted %d lines, want 1: %q", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "/tmp/x.sock") {
+		t.Errorf("startup warning does not name the path: %q", buf.String())
+	}
+
+	// Periodic: a short interval must produce re-emissions beyond the startup
+	// line, then stop promptly when ctx is cancelled.
+	buf.Reset()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		warnUnsafeSocketPath(ctx, logger, "/tmp/x.sock", time.Millisecond)
+		close(done)
+	}()
+	// Wait until at least the startup line plus a couple of ticks have landed.
+	deadline := time.After(2 * time.Second)
+	for {
+		if strings.Count(buf.String(), "level=warn") >= 3 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected >=3 warn lines from periodic re-emission, got: %q", buf.String())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("warnUnsafeSocketPath did not return after ctx cancellation")
+	}
+}

--- a/daemon/socketpolicy_test.go
+++ b/daemon/socketpolicy_test.go
@@ -40,10 +40,14 @@ func (s *policyLogBuffer) Reset() {
 }
 
 // setupSocketEnv pins every environment variable that allowedSocketRoots and
-// DefaultSocketPath consult to test-controlled temp dirs, none of which is
-// /tmp, so the safe set is deterministic across hosts. It also clears
-// AGENTRECEIPTS_SOCKET so DefaultSocketPath resolves the platform default.
-// Returns the per-platform directory a safe explicit override may live under.
+// DefaultSocketPath consult to unique, test-controlled temp dirs, so the safe
+// set is deterministic and host-independent rather than relying on whatever
+// $XDG_RUNTIME_DIR / $TMPDIR the runner happens to set. (On Unix t.TempDir()
+// itself usually lives under /tmp, but each is a distinct subdirectory, so the
+// unsafeRoot path below — a different /tmp subdir — is never inside a safe
+// root.) It also clears AGENTRECEIPTS_SOCKET so DefaultSocketPath resolves the
+// platform default. Returns the per-platform directory a safe explicit override
+// may live under.
 func setupSocketEnv(t *testing.T) (safeRoot string) {
 	t.Helper()
 	t.Setenv("AGENTRECEIPTS_SOCKET", "")
@@ -67,8 +71,9 @@ func setupSocketEnv(t *testing.T) (safeRoot string) {
 func unsafeRoot(t *testing.T) string {
 	t.Helper()
 	// /tmp is shared, world-traversable, and swept — the canonical unsafe
-	// location from the issue's originating incident. setupSocketEnv steers
-	// every safe root away from /tmp, so this is reliably rejected.
+	// location from the issue's originating incident. setupSocketEnv pins the
+	// safe roots to distinct temp subdirectories, so this sibling /tmp path is
+	// never inside one and is reliably rejected.
 	return filepath.Join("/tmp", "agent-receipts-538-"+t.Name())
 }
 

--- a/daemon/socketpolicy_test.go
+++ b/daemon/socketpolicy_test.go
@@ -139,6 +139,7 @@ func TestCheckSocketPath_RejectsTCPUnconditionally(t *testing.T) {
 		":9000",
 		"[::1]:9000",
 		"tcp://127.0.0.1:9000",
+		"example.com:9000", // non-IP hostname must also be rejected as TCP
 	} {
 		// Even with --unsafe-socket-path, TCP must be refused (ADR-0010).
 		for _, unsafeAllowed := range []bool{false, true} {
@@ -154,7 +155,7 @@ func TestCheckSocketPath_RejectsTCPUnconditionally(t *testing.T) {
 }
 
 func TestLooksLikeTCPAddress(t *testing.T) {
-	tcp := []string{"127.0.0.1:9000", "localhost:9000", ":9000", "[::1]:9000", "tcp://127.0.0.1:9000", "TCP://10.0.0.1:1"}
+	tcp := []string{"127.0.0.1:9000", "localhost:9000", ":9000", "[::1]:9000", "tcp://127.0.0.1:9000", "TCP://10.0.0.1:1", "example.com:9000", "db.internal:5432"}
 	for _, s := range tcp {
 		if !looksLikeTCPAddress(s) {
 			t.Errorf("looksLikeTCPAddress(%q) = false, want true", s)

--- a/daemon/socketpolicy_test.go
+++ b/daemon/socketpolicy_test.go
@@ -189,6 +189,31 @@ func TestCheckSocketPath_SymlinkOutOfSafeSet(t *testing.T) {
 	}
 }
 
+// TestCheckSocketPath_SymlinkLoopFailsClosed pins the fail-closed contract: a
+// path the daemon cannot canonicalize (here a symlink cycle, which yields ELOOP
+// rather than ENOENT) must be treated as unsafe, even though its apparent
+// location is under a safe root. A previous version fell back to the literal
+// unresolved path and would have judged this safe.
+func TestCheckSocketPath_SymlinkLoopFailsClosed(t *testing.T) {
+	safeRoot := setupSocketEnv(t)
+	loopA := filepath.Join(safeRoot, "loopA")
+	loopB := filepath.Join(safeRoot, "loopB")
+	if err := os.Symlink(loopB, loopA); err != nil {
+		t.Fatalf("symlink loopA: %v", err)
+	}
+	if err := os.Symlink(loopA, loopB); err != nil {
+		t.Fatalf("symlink loopB: %v", err)
+	}
+	p := filepath.Join(loopA, "events.sock")
+	unsafe, err := checkSocketPath(p, false)
+	if err == nil {
+		t.Fatalf("unresolvable path %q (symlink loop) was accepted; must fail closed", p)
+	}
+	if unsafe {
+		t.Error("unsafe=true should not accompany a refusal error")
+	}
+}
+
 func TestWarnUnsafeSocketPath_StartupAndPeriodic(t *testing.T) {
 	var buf policyLogBuffer
 	logger := log.New(&buf, "", 0)

--- a/daemon/tests_framework.go
+++ b/daemon/tests_framework.go
@@ -57,13 +57,13 @@ func (b *syncBuffer) String() string {
 // reader observing a closed done can read daemonErr without further
 // synchronisation.
 type DaemonFixture struct {
-	Config    Config
-	PublicKey string // PEM-encoded public key
-	cancel    func()
-	done      chan struct{} // closed when daemon Run returns
-	daemonErr error         // result of Run; read only after done is closed
-	traceBuf  *syncBuffer
-	repoRoot  string
+	Config     Config
+	PublicKey  string // PEM-encoded public key
+	cancel     func()
+	done       chan struct{} // closed when daemon Run returns
+	daemonErr  error         // result of Run; read only after done is closed
+	traceBuf   *syncBuffer
+	repoRoot   string
 	emitTSPath string
 	emitPyPath string
 }
@@ -77,9 +77,13 @@ func StartDaemon(t *testing.T) *DaemonFixture {
 	dataDir := t.TempDir()
 
 	cfg := Config{
-		SocketPath:           filepath.Join(sockDir, "events.sock"),
-		DBPath:               filepath.Join(dataDir, "receipts.db"),
-		KeyPath:              filepath.Join(dataDir, "signing.key"),
+		SocketPath: filepath.Join(sockDir, "events.sock"),
+		DBPath:     filepath.Join(dataDir, "receipts.db"),
+		KeyPath:    filepath.Join(dataDir, "signing.key"),
+		// ShortSocketDir lives under /tmp to stay within the 104-byte
+		// AF_UNIX sun_path limit on macOS — outside the per-platform safe
+		// set, so opt into the documented escape hatch (issue #538).
+		UnsafeSocketPath:     true,
 		PublicKeyPath:        filepath.Join(dataDir, "signing.key.pub"),
 		ChainID:              "test-chain",
 		IssuerID:             "did:agent-receipts-daemon:test",

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -75,7 +75,11 @@ type testDaemonHandle struct {
 func startTestDaemon(t *testing.T, dir string) *testDaemonHandle {
 	t.Helper()
 	cfg := daemon.Config{
-		SocketPath:           filepath.Join(dir, "events.sock"),
+		SocketPath: filepath.Join(dir, "events.sock"),
+		// shortSocketDirEmitter lives under /tmp to stay within the 104-byte
+		// AF_UNIX sun_path limit on macOS — outside the daemon's per-platform
+		// safe set, so opt into the documented escape hatch (issue #538).
+		UnsafeSocketPath:     true,
 		DBPath:               filepath.Join(dir, "receipts.db"),
 		KeyPath:              filepath.Join(dir, "signing.key"),
 		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -89,7 +89,11 @@ type daemonHandle struct {
 func startDaemon(t *testing.T, dir string) *daemonHandle {
 	t.Helper()
 	cfg := daemon.Config{
-		SocketPath:           filepath.Join(dir, "events.sock"),
+		SocketPath: filepath.Join(dir, "events.sock"),
+		// The temp dir lives under /tmp to stay within the 104-byte AF_UNIX
+		// sun_path limit on macOS — outside the daemon's per-platform safe
+		// set, so opt into the documented escape hatch (issue #538).
+		UnsafeSocketPath:     true,
 		DBPath:               filepath.Join(dir, "receipts.db"),
 		KeyPath:              filepath.Join(dir, "signing.key"),
 		PublicKeyPath:        filepath.Join(dir, "signing.key.pub"),


### PR DESCRIPTION
## What

Add socket-path safety validation to the daemon startup. The daemon now:

1. **Rejects unsafe socket paths by default** — `--socket` / `AGENTRECEIPTS_SOCKET` must resolve under per-platform safe directories (Linux: `$XDG_RUNTIME_DIR`, `/run`, `/var/run`; macOS: `$TMPDIR`, `/var/run`, `$XDG_DATA_HOME/agent-receipts`), or the daemon refuses to start.

2. **Rejects TCP addresses unconditionally** — even with `--unsafe-socket-path`, TCP loopback addresses are forbidden per ADR-0010 § IPC transport (the daemon speaks Unix-domain sockets only).

3. **Permits deliberate overrides with `--unsafe-socket-path`** — when passed, unsafe paths are allowed but the daemon warns on startup and every 60 seconds for the lifetime of the process.

4. **Canonicalizes paths before checking** — symlinks are resolved with `filepath.EvalSymlinks`, so a symlink pointing out of the safe set is judged by its real target, not its apparent location. Fails closed: unresolvable paths (permission errors, symlink loops) are treated as unsafe.

## Why

Issue #538 identified that a socket in a shared, world-traversable, periodically-swept directory (e.g. `/tmp`) defeats the per-user trust boundary that peer-credential capture depends on. The safe default socket path always resolves under a per-user runtime/data directory, but an explicit override could silently abandon that safety. This change prevents that by enforcing the safe-socket-location policy at startup, with a documented escape hatch for legitimate use cases (containers with unusual mounts, dev experiments, integration tests that need short paths to stay within the 104-byte `AF_UNIX sun_path` limit on macOS).

## Implementation

- **`socketpolicy.go`** (new): Core validation logic
  - `checkSocketPath()`: Main entry point; distinguishes safe paths, unsafe paths with flag, and rejected paths (TCP or unsafe without flag)
  - `allowedSocketRoots()`: Per-platform safe directory list
  - `isSocketPathSafe()`: Canonicalization and containment check
  - `canonicalizePath()`: Resolves symlinks, handling non-existent socket files
  - `pathWithin()`: Checks if a path is under a root
  - `looksLikeTCPAddress()`: Detects TCP addresses (bare `host:port`, `tcp://` scheme)
  - `warnUnsafeSocketPath()`: Emits startup and periodic warnings

- **`socketpolicy_test.go`** (new): Comprehensive test coverage
  - Default paths are safe
  - Explicit safe paths are allowed
  - Unsafe paths are rejected without flag, allowed with flag
  - TCP addresses rejected unconditionally
  - Symlink edge cases (escape, loops) fail closed
  - Warning emission (startup-only vs. periodic)

- **`daemon.go`**: Integrate validation into `Run()`
  - Add `UnsafeSocketPath` config field
  - Call `checkSocketPath()` before binding the socket
  - Launch warning goroutine if unsafe path is permitted

- **`cmd/agent-receipts-daemon/main.go`**: Add `--unsafe-socket-path` flag

- **Test fixtures** (`tests_framework.go`, `integration_test.go`, `emitter_test.go`): Set `UnsafeSocketPath: true` since they use short socket paths under `/tmp` to stay within the `sun_path` limit

- **Documentation** (`README.md`, `CHANGELOG.md`): Explain the policy, safe directories, and escape hatch

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (integration tests updated to opt into escape hatch)

## Security

- [x] This PR is itself a security hardening (closes the "unsafe configuration silently accepted" gap from issue #538). It adds no new attack surface: the only new input is the `--unsafe-socket-path` flag, validation fails closed on unresolvable paths, and TCP addresses are rejected unconditionally regardless of the flag. A self-review confirmed there is no path-canonicalization bypass (`..` traversal and symlink escapes are resolved before the containment check) and that the default socket path always remains inside the safe set.