### PR TITLE
fix(sdk/go): PeerCredential.UID/GID *uint32 so root identity survives omitempty

### DIFF
--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -415,6 +415,7 @@ type v030Vectors struct {
 	Keys           keysSection                  `json:"keys"`
 	Envelope       envelopeReceiptSection       `json:"parametersDisclosureEnvelopeReceipt"`
 	DaemonAttested daemonAttestedReceiptSection `json:"peerCredentialEmitterMetadataReceipt"`
+	RootCred       daemonAttestedReceiptSection `json:"peerCredentialRootReceipt"`
 }
 
 type envelopeReceiptSection struct {
@@ -525,6 +526,45 @@ func generateV030Vectors(keys keysSection) error {
 		return fmt.Errorf("daemon-attested receipt: %w", err)
 	}
 
+	// --- peer_credential root receipt (uid=0, gid=0) ---
+	// Exercises the *uint32 fix for issue #511: root process identity (UID 0)
+	// must serialise as `"uid":0` in all three SDKs, not be silently dropped by
+	// omitempty.
+	rootUnsigned := map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"},
+		"id":           "urn:receipt:030e0030-0000-4030-a030-000000000003",
+		"type":         []any{"VerifiableCredential", "AgentReceipt"},
+		"version":      "0.3.0",
+		"issuer":       map[string]any{"id": "did:agent:test"},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":         "act_030e0030-0000-4030-a030-000000000003",
+				"type":       "system.command.execute",
+				"risk_level": "high",
+				"peer_credential": map[string]any{
+					"platform": "linux",
+					"pid":      1,
+					"uid":      0,
+					"gid":      0,
+					"exe_path": "/sbin/init",
+				},
+				"timestamp": fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_v030_root_test",
+			},
+		},
+	}
+	rootSigned, rootHash, err := signAndHashMap(rootUnsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("root peer-cred receipt: %w", err)
+	}
+
 	out := v030Vectors{
 		Comment: "Cross-SDK v0.3.0 test vectors: pins (a) the HPKE envelope shape of action.parameters_disclosure (ADR-0012 amendment 2026-05-18, spec PR #496) and (b) the daemon-attested action.peer_credential / action.emitter_metadata fields (ADR-0010). All three SDKs MUST verify the signatures and reproduce expectedReceiptHash byte-for-byte. Envelope bytes come from spec/test-vectors/disclosure-envelope/vectors.json vector-1 (RFC 9180 §A.1.1 ikmE encrypting to RFC 7748 §6.1 Alice).",
 		Version: "0.3.0",
@@ -540,6 +580,12 @@ func generateV030Vectors(keys keysSection) error {
 			Description:         "Signed v0.3.0 receipt exercising the daemon-attested typed fields: action.peer_credential (linux POSIX peer metadata) and action.emitter_metadata.drop_count (synthetic events_dropped semantics per ADR-0010).",
 			Receipt:             daemonSigned,
 			ExpectedReceiptHash: daemonHash,
+			ExpectedValid:       true,
+		},
+		RootCred: daemonAttestedReceiptSection{
+			Description:         "Signed v0.3.0 receipt with peer_credential.uid=0 and gid=0 (root). Pins that the zero value is present on the wire (`\"uid\":0`) and not silently dropped by omitempty — fixes issue #511.",
+			Receipt:             rootSigned,
+			ExpectedReceiptHash: rootHash,
 			ExpectedValid:       true,
 		},
 	}

--- a/cross-sdk-tests/v030_vectors.json
+++ b/cross-sdk-tests/v030_vectors.json
@@ -120,5 +120,59 @@
     },
     "expectedReceiptHash": "sha256:fa9a68dd07b63999ab27252b7da0e9fa7d004ef385ba80c3bc43ff8cc4d53420",
     "expectedValid": true
+  },
+  "peerCredentialRootReceipt": {
+    "description": "Signed v0.3.0 receipt with peer_credential.uid=0 and gid=0 (root). Pins that the zero value is present on the wire (`\"uid\":0`) and not silently dropped by omitempty — fixes issue #511.",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v1"
+      ],
+      "credentialSubject": {
+        "action": {
+          "id": "act_030e0030-0000-4030-a030-000000000003",
+          "peer_credential": {
+            "exe_path": "/sbin/init",
+            "gid": 0,
+            "pid": 1,
+            "platform": "linux",
+            "uid": 0
+          },
+          "risk_level": "high",
+          "timestamp": "2026-05-21T00:00:00Z",
+          "type": "system.command.execute"
+        },
+        "chain": {
+          "chain_id": "chain_v030_root_test",
+          "previous_receipt_hash": null,
+          "sequence": 1
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "principal": {
+          "id": "did:user:test"
+        }
+      },
+      "id": "urn:receipt:030e0030-0000-4030-a030-000000000003",
+      "issuanceDate": "2026-05-21T00:00:00Z",
+      "issuer": {
+        "id": "did:agent:test"
+      },
+      "proof": {
+        "created": "2026-05-21T00:00:00Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "ugcXVEWlRGvNuxDRMJxqaTGeK05e-PhMdA2FUnNyEFfMF20jNvW65FOqWbKvqcyE2pPFpfz_OsEHAY9SLTkQUAg",
+        "type": "Ed25519Signature2020",
+        "verificationMethod": "did:agent:test#key-1"
+      },
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.3.0"
+    },
+    "expectedReceiptHash": "sha256:cf09160414fdea640fbc1350c9b469b4649de5d2d074d31db1975f2c4def69bb",
+    "expectedValid": true
   }
 }

--- a/cross-sdk-tests/v030_vectors_test.go
+++ b/cross-sdk-tests/v030_vectors_test.go
@@ -62,6 +62,12 @@ type v030File struct {
 		ExpectedReceiptHash string          `json:"expectedReceiptHash"`
 		ExpectedValid       bool            `json:"expectedValid"`
 	} `json:"peerCredentialEmitterMetadataReceipt"`
+	RootCred struct {
+		Description         string          `json:"description"`
+		Receipt             json.RawMessage `json:"receipt"`
+		ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+		ExpectedValid       bool            `json:"expectedValid"`
+	} `json:"peerCredentialRootReceipt"`
 }
 
 func loadV030(t *testing.T) v030File {
@@ -93,6 +99,7 @@ func TestV030VectorsValidateAgainstSchema(t *testing.T) {
 	}{
 		{"parametersDisclosureEnvelopeReceipt", f.Envelope.Receipt},
 		{"peerCredentialEmitterMetadataReceipt", f.DaemonAttested.Receipt},
+		{"peerCredentialRootReceipt", f.RootCred.Receipt},
 	}
 
 	for _, c := range cases {
@@ -128,6 +135,7 @@ func TestV030ReceiptHashAndSignature(t *testing.T) {
 	}{
 		{"parametersDisclosureEnvelopeReceipt", f.Envelope.Receipt, f.Envelope.ExpectedReceiptHash},
 		{"peerCredentialEmitterMetadataReceipt", f.DaemonAttested.Receipt, f.DaemonAttested.ExpectedReceiptHash},
+		{"peerCredentialRootReceipt", f.RootCred.Receipt, f.RootCred.ExpectedReceiptHash},
 	}
 
 	for _, c := range cases {

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -318,9 +318,13 @@ func TestPeerCredCaptured(t *testing.T) {
 	if pc.PID != wantPID {
 		t.Errorf("peer_credential.pid = %d, want %d (OS-attested pid of test process)", pc.PID, wantPID)
 	}
-	wantUID := uint32(os.Getuid())
-	if pc.UID != wantUID {
-		t.Errorf("peer_credential.uid = %d, want %d", pc.UID, wantUID)
+	wantUID := uint32(os.Geteuid())
+	if pc.UID == nil || *pc.UID != wantUID {
+		t.Errorf("peer_credential.uid = %v, want %d", pc.UID, wantUID)
+	}
+	wantGID := uint32(os.Getegid())
+	if pc.GID == nil || *pc.GID != wantGID {
+		t.Errorf("peer_credential.gid = %v, want %d", pc.GID, wantGID)
 	}
 
 	switch pc.Platform {

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -428,13 +428,7 @@ func (p *Pipeline) buildAndSign(
 	// daemon vouches for these values via signature; they are present only on
 	// receipts emitted through the daemon and absent on direct-SDK emissions
 	// (where the SDK has no privileged channel to attest peer identity).
-	peerCred := &receipt.PeerCredential{
-		Platform: peer.Platform,
-		PID:      peer.PID,
-		UID:      peer.UID,
-		GID:      peer.GID,
-		ExePath:  peer.ExePath,
-	}
+	peerCred := buildPeerCred(peer)
 
 	// Risk derives from the taxonomy. Daemon-constructed action types like
 	// "mcp_proxy.github.list_repos" do not match any built-in entry, so
@@ -554,17 +548,11 @@ func (p *Pipeline) buildAndSignDropReceipt(
 		},
 		Principal: receipt.Principal{ID: "did:user:unknown"},
 		Action: receipt.Action{
-			Type:      actionTypeEventsDropped,
-			ToolName:  "events_dropped",
-			RiskLevel: receipt.RiskLow,
-			Timestamp: now,
-			PeerCredential: &receipt.PeerCredential{
-				Platform: peer.Platform,
-				PID:      peer.PID,
-				UID:      peer.UID,
-				GID:      peer.GID,
-				ExePath:  peer.ExePath,
-			},
+			Type:           actionTypeEventsDropped,
+			ToolName:       "events_dropped",
+			RiskLevel:      receipt.RiskLow,
+			Timestamp:      now,
+			PeerCredential: buildPeerCred(peer),
 			EmitterMetadata: &receipt.EmitterMetadata{
 				DropCount: dropCount,
 			},
@@ -577,6 +565,27 @@ func (p *Pipeline) buildAndSignDropReceipt(
 		},
 	}, now)
 }
+
+// buildPeerCred converts a socket.PeerCred into a receipt.PeerCredential. UID
+// and GID use pointer semantics so root (uid=0 / gid=0) serialises as
+// `"uid":0` rather than being silently dropped by omitempty. On platforms with
+// no POSIX UID/GID concept (anything other than linux/darwin today), both
+// fields are left nil — the absent-field semantics the spec prescribes for
+// Windows and similar platforms.
+func buildPeerCred(peer socket.PeerCred) *receipt.PeerCredential {
+	pc := &receipt.PeerCredential{
+		Platform: peer.Platform,
+		PID:      peer.PID,
+		ExePath:  peer.ExePath,
+	}
+	if peer.Platform == "linux" || peer.Platform == "darwin" {
+		pc.UID = ptrUint32(peer.UID)
+		pc.GID = ptrUint32(peer.GID)
+	}
+	return pc
+}
+
+func ptrUint32(v uint32) *uint32 { return &v }
 
 // signAndHash builds, signs, and hashes one receipt. It is the common tail
 // shared by buildAndSign and buildAndSignDropReceipt — both construct a

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -79,6 +79,66 @@ func sampleFrame(t *testing.T) socket.Frame {
 	}
 }
 
+// TestBuildPeerCred covers the pointer-semantics of buildPeerCred: POSIX
+// platforms must set UID/GID to non-nil pointers (including for zero/root),
+// and non-POSIX platforms must leave both nil.
+func TestBuildPeerCred(t *testing.T) {
+	cases := []struct {
+		name     string
+		peer     socket.PeerCred
+		wantUID  *uint32
+		wantGID  *uint32
+		wantNil  bool
+	}{
+		{
+			name:    "linux non-root",
+			peer:    socket.PeerCred{Platform: "linux", PID: 42, UID: 1000, GID: 1000},
+			wantUID: ptrUint32(1000),
+			wantGID: ptrUint32(1000),
+		},
+		{
+			name:    "linux root (uid=0 must not be dropped)",
+			peer:    socket.PeerCred{Platform: "linux", PID: 1, UID: 0, GID: 0},
+			wantUID: ptrUint32(0),
+			wantGID: ptrUint32(0),
+		},
+		{
+			name:    "darwin",
+			peer:    socket.PeerCred{Platform: "darwin", PID: 99, UID: 501, GID: 20},
+			wantUID: ptrUint32(501),
+			wantGID: ptrUint32(20),
+		},
+		{
+			name:    "non-POSIX platform (no UID concept)",
+			peer:    socket.PeerCred{Platform: "windows", PID: 7, UID: 0, GID: 0},
+			wantNil: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := buildPeerCred(tc.peer)
+			if pc == nil {
+				t.Fatal("buildPeerCred returned nil")
+			}
+			if tc.wantNil {
+				if pc.UID != nil {
+					t.Errorf("UID = %v, want nil on non-POSIX platform", pc.UID)
+				}
+				if pc.GID != nil {
+					t.Errorf("GID = %v, want nil on non-POSIX platform", pc.GID)
+				}
+				return
+			}
+			if pc.UID == nil || *pc.UID != *tc.wantUID {
+				t.Errorf("UID = %v, want %d", pc.UID, *tc.wantUID)
+			}
+			if pc.GID == nil || *pc.GID != *tc.wantGID {
+				t.Errorf("GID = %v, want %d", pc.GID, *tc.wantGID)
+			}
+		})
+	}
+}
+
 func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)
@@ -114,7 +174,7 @@ func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	if pc == nil {
 		t.Fatal("PeerCredential nil; daemon must record OS-attested peer cred on every live receipt")
 	}
-	if pc.Platform != "linux" || pc.PID != 4242 || pc.UID != 1000 {
+	if pc.Platform != "linux" || pc.PID != 4242 || pc.UID == nil || *pc.UID != 1000 {
 		t.Errorf("peer attestation not recorded: %#v", pc)
 	}
 	if pc.ExePath != "/usr/bin/mcp-proxy" {

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,14 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`PeerCredential.UID` and `PeerCredential.GID` are now `*uint32`** ([#511](https://github.com/agent-receipts/ar/issues/511)). Callers that read these fields directly must dereference the pointer and guard against `nil` (nil = platform has no POSIX UID concept).
+
+### Fixed
+
+- **`PeerCredential.UID` and `PeerCredential.GID` now use `*uint32`** ([#511](https://github.com/agent-receipts/ar/issues/511)). The previous `uint32` with `omitempty` silently dropped UID=0 / GID=0 (root), making a root-emitted receipt indistinguishable from a Windows receipt where UIDs have no meaning. A nil pointer now means "no POSIX UID concept"; a non-nil pointer to zero correctly serialises as `"uid":0`. Cross-SDK test vector `peerCredentialRootReceipt` added to `v030_vectors.json` to pin the zero-value wire form.
+
 ### Changed
 
 - **`emitter.DefaultSocketPath()` macOS default is now HOME-based** ([#545](https://github.com/agent-receipts/ar/issues/545)). macOS resolves to `$XDG_DATA_HOME/agent-receipts/events.sock` (defaulting to `~/.local/share/agent-receipts/events.sock`) instead of `$TMPDIR/agentreceipts/events.sock`. TMPDIR is not inherited by GUI-spawned subprocesses (e.g., MCP servers launched by Claude Desktop), which broke the daemon ↔ emitter handshake silently. HOME is preserved across every supported spawn context, so both sides of the IPC now resolve to the same path regardless of how they were started. Linux defaults are unchanged. AGENTRECEIPTS_SOCKET continues to take precedence — users who relied on TMPDIR redirection on macOS should switch to it.
@@ -31,7 +39,7 @@ First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#
 ### Added
 
 - **`EncryptDisclosure` / `DecryptDisclosure` / `GenerateForensicKeyPair`** ([#468](https://github.com/agent-receipts/ar/pull/468)) — RFC 9180 HPKE base-mode helpers (DHKEM(X25519) + HKDF-SHA256 + AES-256-GCM) via `cloudflare/circl`.
-- **`Action.PeerCredential` struct** — typed OS-attested peer process metadata. Field widths match POSIX (`int32` for PID, `uint32` for UID/GID).
+- **`Action.PeerCredential` struct** — typed OS-attested peer process metadata. Field widths match POSIX (`int32` for PID, `uint32` for UID/GID; amended to `*uint32` in [#511](https://github.com/agent-receipts/ar/issues/511) — see Unreleased).
 - **`Action.EmitterMetadata` struct** — daemon-observed emitter-side metadata, currently `DropCount`.
 - **Cross-SDK live-emit invariant test** ([#515](https://github.com/agent-receipts/ar/pull/515)).
 
@@ -39,10 +47,6 @@ First pre-release of the v0.3.0 spec migration (ADR-0012 Phase A). Tracked in [#
 
 - **`Version` constant bumped from `"0.2.0"` to `"0.3.0"`** ([#515](https://github.com/agent-receipts/ar/pull/515)).
 - Legacy v0.2.x flat-map `parameters_disclosure` receipts no longer round-trip through `receipt.AgentReceipt`. Verifiers ingesting legacy receipts must use `map[string]any` — pattern in `sdk/go/receipt/canonicalization_vectors_test.go::TestParametersDisclosureReceipt`.
-
-### Known issues
-
-- `PeerCredential.UID` and `PeerCredential.GID` are `uint32` with `omitempty`, silently dropping UID=0 / GID=0 (root). Tracked in [#511](https://github.com/agent-receipts/ar/issues/511).
 
 ## [0.10.0] - 2026-05-19
 

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -90,15 +90,16 @@ type ActionTarget struct {
 // receipt.
 //
 // Field widths follow POSIX: PID is int32 (signed pid_t, -1 is a valid
-// sentinel); UID/GID are uint32 (unsigned uid_t/gid_t). UID, GID, and ExePath
-// are POSIX-only or best-effort and use omitempty so non-POSIX daemons can
-// omit them.
+// sentinel); UID/GID are *uint32 (pointer so that uid=0 / gid=0 — the root
+// identity — serialise as `"uid":0` rather than absent). A nil pointer means
+// the platform has no UID/GID concept (e.g. Windows); ExePath uses omitempty
+// for the same reason.
 type PeerCredential struct {
-	Platform string `json:"platform"`
-	PID      int32  `json:"pid"`
-	UID      uint32 `json:"uid,omitempty"`
-	GID      uint32 `json:"gid,omitempty"`
-	ExePath  string `json:"exe_path,omitempty"`
+	Platform string  `json:"platform"`
+	PID      int32   `json:"pid"`
+	UID      *uint32 `json:"uid,omitempty"`
+	GID      *uint32 `json:"gid,omitempty"`
+	ExePath  string  `json:"exe_path,omitempty"`
 }
 
 // EmitterMetadata holds daemon-observed emitter-side metadata (ADR-0010).

--- a/sdk/py/tests/test_v030_vectors.py
+++ b/sdk/py/tests/test_v030_vectors.py
@@ -11,8 +11,11 @@ values for the v0.3.0 cross-SDK test vectors at
 - ``peerCredentialEmitterMetadataReceipt`` — receipt exercising the new
   daemon-attested typed fields ``action.peer_credential`` and
   ``action.emitter_metadata.drop_count``.
+- ``peerCredentialRootReceipt`` — receipt with ``peer_credential.uid=0`` and
+  ``gid=0`` (root). Pins that zero values are present on the wire as
+  ``"uid":0`` rather than being dropped — fixes issue #511.
 
-If either hash diverges, the Python SDK has a wire-format incompatibility
+If any hash diverges, the Python SDK has a wire-format incompatibility
 with Go (#468/#499) and TS (#472/#503) — almost always a Pydantic
 serialization / alias / omit-when-None issue.
 """
@@ -66,5 +69,20 @@ class TestV030Vectors:
         vectors = _load_vectors()
         public_key = vectors["keys"]["publicKey"]
         section = vectors["peerCredentialEmitterMetadataReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert verify_receipt(receipt, public_key) is True
+
+    def test_root_receipt_hash_matches(self) -> None:
+        """peer_credential uid=0/gid=0 (root) receipt hashes identically."""
+        vectors = _load_vectors()
+        section = vectors["peerCredentialRootReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]
+
+    def test_root_receipt_signature_verifies(self) -> None:
+        """Go-signed root peer_credential receipt verifies under the Python SDK."""
+        vectors = _load_vectors()
+        public_key = vectors["keys"]["publicKey"]
+        section = vectors["peerCredentialRootReceipt"]
         receipt = AgentReceipt.model_validate(section["receipt"])
         assert verify_receipt(receipt, public_key) is True

--- a/sdk/ts/src/receipt/cross-language.test.ts
+++ b/sdk/ts/src/receipt/cross-language.test.ts
@@ -121,6 +121,7 @@ interface V030Vectors {
 	keys: { publicKey: string; privateKey: string };
 	parametersDisclosureEnvelopeReceipt: V030VectorEntry;
 	peerCredentialEmitterMetadataReceipt: V030VectorEntry;
+	peerCredentialRootReceipt: V030VectorEntry;
 }
 
 function loadV030Vectors(): V030Vectors {
@@ -366,6 +367,20 @@ describe("cross-language: v0.3.0 vectors", () => {
 				v.peerCredentialEmitterMetadataReceipt.receipt,
 				v.keys.publicKey,
 			),
+		).toBe(true);
+	});
+
+	it("peer_credential root receipt (uid=0) hash matches pin", () => {
+		const v = loadV030Vectors();
+		expect(hashReceipt(v.peerCredentialRootReceipt.receipt)).toBe(
+			v.peerCredentialRootReceipt.expectedReceiptHash,
+		);
+	});
+
+	it("peer_credential root receipt (uid=0) verifies with shared key", () => {
+		const v = loadV030Vectors();
+		expect(
+			verifyReceipt(v.peerCredentialRootReceipt.receipt, v.keys.publicKey),
 		).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- **Wire-affecting bug fix**: `PeerCredential.UID` and `PeerCredential.GID` were `uint32` with `omitempty`. Go's `omitempty` drops zero values, so a root process (UID 0) produced a receipt with `uid` absent — indistinguishable from a Windows peer where UIDs don't apply. Changed both to `*uint32`: `nil` = no POSIX UID concept; non-nil pointer to 0 serialises as `"uid":0`.
- **Daemon `buildPeerCred` helper** sets UID/GID pointers on `linux`/`darwin` and leaves them `nil` on other platforms. Both `buildAndSign` and `buildAndSignDropReceipt` share the helper (two former inline constructions replaced).
- **New cross-SDK test vector** `peerCredentialRootReceipt` in `v030_vectors.json` pins `uid=0, gid=0` wire form. The Go harness and generator are updated; TS and Py SDKs already emit `"uid":0` correctly per their existing schemas (no changes needed there — verified by the vector).

## Impact

Receipts emitted by root-owned processes (`uid=0`, `gid=0`) previously omitted `uid`/`gid` on the wire. After this fix they emit `"uid":0,"gid":0`. This is a correctness fix for an existing audit-trail gap: the whole point of `peer_credential` is OS-attested "who ran this", and silently degrading root to "no UID concept" defeats that for the container/sudo/root-shell case most likely to need auditing.

The existing `peerCredentialEmitterMetadataReceipt` vector (`uid=1000`) is unaffected — non-zero values serialised correctly before and continue to do so.

## Files changed

| File | Change |
|------|--------|
| `sdk/go/receipt/types.go` | `UID`/`GID` `uint32` → `*uint32`; updated comment |
| `daemon/internal/pipeline/build.go` | `buildPeerCred` + `ptrUint32` helpers; both PeerCredential construction sites simplified |
| `daemon/internal/pipeline/build_test.go` | Dereference `*pc.UID` in assertion |
| `daemon/integration_test.go` | Dereference `*pc.UID` in assertion |
| `cross-sdk-tests/cmd/generate-vectors/main.go` | `RootCred` field in `v030Vectors`; root receipt generation in `generateV030Vectors` |
| `cross-sdk-tests/v030_vectors.json` | New `peerCredentialRootReceipt` vector (regenerated) |
| `cross-sdk-tests/v030_vectors_test.go` | Root receipt added to both schema-validation and hash/signature test cases |
| `sdk/go/CHANGELOG.md` | Remove known-issue note from 0.11.0-alpha.1; add fix entry in Unreleased |

Fixes #511