### PR TITLE
feat(store): add cheap Exists() primitive; rewire collector hot paths

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -53,10 +53,17 @@ Structural validation only. The collector returns 400 when:
   `credentialSubject.action.type`, or `proof.proofValue`
 - The body contains more than one JSON object
 
-Unknown JSON fields are accepted and persisted verbatim. ADR-0020 makes the
-collector a forward-compat sink: a future SDK shipping a new field MUST NOT
-require every collector to upgrade first. Anything that parses and has the
-four minimal fields above is accepted regardless of signature validity.
+This list is the deliberate minimum, not an oversight. Full JSON-schema
+conformance, signature verification, taxonomy correctness, and chain
+linkage are the auditor's responsibility — not the collector's. The
+collector's contract under ADR-0020 is "store what arrived, idempotently";
+anything stricter would couple SDK upgrades to collector upgrades and
+defeat the forward-compat-sink design.
+
+Unknown JSON fields are accepted and persisted verbatim. A future SDK
+shipping a new field MUST NOT require every collector to upgrade first.
+Anything that parses and has the four minimal fields above is accepted
+regardless of signature validity.
 
 Wire bytes are stored verbatim, not a re-marshal of the Go struct, so an
 auditor can later re-canonicalise and verify the agent's signature against

--- a/collector/server.go
+++ b/collector/server.go
@@ -166,8 +166,13 @@ func (h *receiptHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// Reject trailing data after the receipt. A second JSON value in the
 	// body almost always indicates a client bug; better to surface it than
-	// silently store the first one.
-	if dec.More() {
+	// silently store the first one. Decoder.More() is unreliable at the
+	// top level (it returns false when the next non-whitespace byte is `]`
+	// or `}`, so `{...} ]` would slip past), so attempt a second Decode and
+	// require io.EOF — anything else (a parsed value, a syntax error,
+	// stray bytes) means the body wasn't a single JSON object.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); err != io.EOF {
 		writeError(w, http.StatusBadRequest, "request body must contain exactly one JSON object")
 		return
 	}

--- a/collector/server.go
+++ b/collector/server.go
@@ -156,8 +156,12 @@ func (h *receiptHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var ar receipt.AgentReceipt
 	dec := json.NewDecoder(bytes.NewReader(rawBody))
 	if err := dec.Decode(&ar); err != nil {
+		// encoding/json's error text leaks internal Go struct field names
+		// and types ("cannot unmarshal X into Go struct field
+		// AgentReceipt.foo of type Y"), so the wire body stays generic;
+		// the detailed error is preserved in the structured log.
 		h.log.Warn("receipt rejected: malformed json", slog.Any("err", err))
-		writeError(w, http.StatusBadRequest, "malformed receipt: invalid JSON")
+		writeError(w, http.StatusBadRequest, "malformed receipt")
 		return
 	}
 	// Reject trailing data after the receipt. A second JSON value in the

--- a/collector/server_test.go
+++ b/collector/server_test.go
@@ -213,6 +213,30 @@ func TestServer_PostReceipt_400TrailingData(t *testing.T) {
 	}
 }
 
+func TestServer_PostReceipt_400TrailingCloseBracket(t *testing.T) {
+	// Regression: json.Decoder.More() returns false when the next
+	// non-whitespace byte is ']' or '}', so a naive More-based trailing-data
+	// guard accepts `{...receipt...} ]`. The Decode-until-io.EOF check
+	// rejects it correctly.
+	h, store := newTestHandler(t)
+	r := signedTestReceipt("urn:receipt:srv:trailing-bracket")
+	encoded, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := append(encoded, []byte(` ]`)...)
+	rec := postReceipt(t, h, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "exactly one") {
+		t.Fatalf("body %q does not mention the trailing-data check", rec.Body.String())
+	}
+	if store.Len() != 0 {
+		t.Fatalf("store mutated on 400: %d entries", store.Len())
+	}
+}
+
 func TestServer_PostReceipt_400MissingFields(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/collector/sqlite_store.go
+++ b/collector/sqlite_store.go
@@ -38,9 +38,9 @@ func OpenSQLiteStore(path string) (*SQLiteStore, error) {
 func (s *SQLiteStore) Insert(r receipt.AgentReceipt, rawJSON []byte, receiptHash string) error {
 	// Cheap path: if the id already exists, return ErrDuplicate without
 	// attempting an INSERT. Handles the common HttpEmitter-retry case.
-	if existing, err := s.inner.GetByID(r.ID); err != nil {
+	if exists, err := s.inner.Exists(r.ID); err != nil {
 		return fmt.Errorf("lookup existing receipt: %w", err)
-	} else if existing != nil {
+	} else if exists {
 		return ErrDuplicate
 	}
 
@@ -60,7 +60,7 @@ func (s *SQLiteStore) Insert(r receipt.AgentReceipt, rawJSON []byte, receiptHash
 		if isPrimaryKeyViolation(err) {
 			return ErrDuplicate
 		}
-		if collided, lookupErr := s.inner.GetByID(r.ID); lookupErr == nil && collided != nil {
+		if exists, lookupErr := s.inner.Exists(r.ID); lookupErr == nil && exists {
 			return ErrDuplicate
 		}
 		return fmt.Errorf("insert receipt: %w", err)
@@ -83,11 +83,11 @@ func isPrimaryKeyViolation(err error) bool {
 }
 
 func (s *SQLiteStore) Exists(id string) (bool, error) {
-	r, err := s.inner.GetByID(id)
+	ok, err := s.inner.Exists(id)
 	if err != nil {
 		return false, fmt.Errorf("lookup receipt: %w", err)
 	}
-	return r != nil, nil
+	return ok, nil
 }
 
 func (s *SQLiteStore) Close() error {

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -353,6 +353,22 @@ func (s *Store) GetByID(id string) (*receipt.AgentReceipt, error) {
 	return &r, nil
 }
 
+// Exists reports whether a receipt with the given id is present without
+// loading or unmarshalling the receipt body. Hot-path callers that only need
+// a presence check (duplicate detection on insert, /healthz reachability
+// probes) should prefer this over GetByID, which pays the full JSON decode.
+func (s *Store) Exists(id string) (bool, error) {
+	var one int
+	err := s.db.QueryRow("SELECT 1 FROM receipts WHERE id = ? LIMIT 1", id).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("exists (id=%s): %w", id, err)
+	}
+	return true, nil
+}
+
 // GetChain retrieves all receipts in a chain, ordered by sequence.
 func (s *Store) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 	rows, err := s.db.Query(

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -19,6 +19,24 @@ func setupStore(t *testing.T) *Store {
 	return s
 }
 
+func mustKeyPair(t *testing.T) receipt.KeyPair {
+	t.Helper()
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	return kp
+}
+
+func mustHashReceipt(t *testing.T, r receipt.AgentReceipt) string {
+	t.Helper()
+	h, err := receipt.HashReceipt(r)
+	if err != nil {
+		t.Fatalf("hash receipt: %v", err)
+	}
+	return h
+}
+
 func makeSignedReceipt(t *testing.T, kp receipt.KeyPair, seq int, chainID string, prevHash *string) receipt.AgentReceipt {
 	t.Helper()
 	unsigned := receipt.Create(receipt.CreateInput{
@@ -37,9 +55,9 @@ func makeSignedReceipt(t *testing.T, kp receipt.KeyPair, seq int, chainID string
 
 func TestInsertAndGetByID(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
@@ -70,9 +88,9 @@ func TestGetByIDNotFound(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
 	}
@@ -109,12 +127,12 @@ func TestExistsAfterClose(t *testing.T) {
 
 func TestGetChain(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -137,12 +155,12 @@ func TestGetChain(t *testing.T) {
 
 func TestGetByChainSequence(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := s.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -163,9 +181,9 @@ func TestGetByChainSequence(t *testing.T) {
 
 func TestGetByChainSequence_NotFound(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
 	}
@@ -191,14 +209,14 @@ func TestGetByChainSequence_NotFound(t *testing.T) {
 
 func TestDistinctChainIDs(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// Two chains, "chain-b" written before "chain-a" to confirm sorted output.
 	for _, chainID := range []string{"chain-b", "chain-a"} {
 		var prevHash *string
 		for i := 1; i <= 2; i++ {
 			r := makeSignedReceipt(t, kp, i, chainID, prevHash)
-			h, _ := receipt.HashReceipt(r)
+			h := mustHashReceipt(t, r)
 			if err := s.Insert(r, h); err != nil {
 				t.Fatal(err)
 			}
@@ -248,9 +266,9 @@ func TestGetChainTail_Empty(t *testing.T) {
 
 func TestGetChainTail_SingleRow(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +290,7 @@ func TestGetChainTail_SingleRow(t *testing.T) {
 
 func TestGetChainTail_HighestSequence(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// Insert 1..5 in non-monotonic order to confirm the query orders by sequence,
 	// not insertion order.
@@ -280,7 +298,7 @@ func TestGetChainTail_HighestSequence(t *testing.T) {
 	hashes := make(map[int]string, len(insertOrder))
 	for _, seq := range insertOrder {
 		r := makeSignedReceipt(t, kp, seq, "chain-1", nil)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := s.Insert(r, h); err != nil {
 			t.Fatalf("insert seq=%d: %v", seq, err)
 		}
@@ -304,15 +322,15 @@ func TestGetChainTail_HighestSequence(t *testing.T) {
 
 func TestGetChainTail_MultiChainIsolation(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	rA := makeSignedReceipt(t, kp, 7, "chain-A", nil)
-	hA, _ := receipt.HashReceipt(rA)
+	hA := mustHashReceipt(t, rA)
 	if err := s.Insert(rA, hA); err != nil {
 		t.Fatal(err)
 	}
 	rB := makeSignedReceipt(t, kp, 2, "chain-B", nil)
-	hB, _ := receipt.HashReceipt(rB)
+	hB := mustHashReceipt(t, rB)
 	if err := s.Insert(rB, hB); err != nil {
 		t.Fatal(err)
 	}
@@ -344,10 +362,10 @@ func TestGetChainTail_MultiChainIsolation(t *testing.T) {
 
 func TestQueryReceipts(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	s.Insert(r, h)
 
 	chainID := "chain-1"
@@ -371,11 +389,11 @@ func TestQueryReceipts(t *testing.T) {
 
 func TestStats(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", nil)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		s.Insert(r, h)
 	}
 
@@ -393,9 +411,9 @@ func TestStats(t *testing.T) {
 
 func TestInsertDuplicateReceiptID(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	if err := s.Insert(r, h); err != nil {
 		t.Fatal(err)
@@ -408,17 +426,17 @@ func TestInsertDuplicateReceiptID(t *testing.T) {
 
 func TestInsertDuplicateChainSequence(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	r1 := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h1, _ := receipt.HashReceipt(r1)
+	h1 := mustHashReceipt(t, r1)
 	if err := s.Insert(r1, h1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Different receipt (new ID) but same chain_id + sequence.
 	r2 := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h2, _ := receipt.HashReceipt(r2)
+	h2 := mustHashReceipt(t, r2)
 	err := s.Insert(r2, h2)
 	if err == nil {
 		t.Fatal("expected error on duplicate chain_id + sequence")
@@ -427,7 +445,7 @@ func TestInsertDuplicateChainSequence(t *testing.T) {
 
 func TestQueryReceiptsOrdering(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// Insert three receipts with timestamps a few seconds apart by
 	// stamping them post-Create (Create sets the Action.Timestamp to now).
@@ -452,7 +470,7 @@ func TestQueryReceiptsOrdering(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		h, _ := receipt.HashReceipt(signed)
+		h := mustHashReceipt(t, signed)
 		if err := s.Insert(signed, h); err != nil {
 			t.Fatal(err)
 		}
@@ -485,7 +503,7 @@ func TestQueryReceiptsOrdering(t *testing.T) {
 
 func TestQueryReceiptsNoDefaultLimit(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// A small batch here proves the integration path; the real regression guard
 	// for the removed 10k cap is TestBuildQueryReceiptsSQLNoLimit in
@@ -493,7 +511,7 @@ func TestQueryReceiptsNoDefaultLimit(t *testing.T) {
 	const n = 5
 	for i := 1; i <= n; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", nil)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := s.Insert(r, h); err != nil {
 			t.Fatalf("insert %d: %v", i, err)
 		}
@@ -521,7 +539,7 @@ func TestQueryReceiptsNoDefaultLimit(t *testing.T) {
 
 func TestQueryReceiptsDescSequenceTiebreaker(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// Two receipts share the same timestamp but differ in sequence.
 	// With NewestFirst the one with the higher sequence must come first.
@@ -542,7 +560,7 @@ func TestQueryReceiptsDescSequenceTiebreaker(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		h, _ := receipt.HashReceipt(signed)
+		h := mustHashReceipt(t, signed)
 		if err := s.Insert(signed, h); err != nil {
 			t.Fatal(err)
 		}
@@ -565,7 +583,7 @@ func TestQueryReceiptsDescSequenceTiebreaker(t *testing.T) {
 
 func TestQueryReceiptsAscSequenceTiebreaker(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	sharedTS := "2024-06-01T12:00:00Z"
 	for _, seq := range []int{2, 1} { // insert in reverse to confirm ordering is by SQL not insertion
@@ -584,7 +602,7 @@ func TestQueryReceiptsAscSequenceTiebreaker(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		h, _ := receipt.HashReceipt(signed)
+		h := mustHashReceipt(t, signed)
 		if err := s.Insert(signed, h); err != nil {
 			t.Fatal(err)
 		}
@@ -607,11 +625,11 @@ func TestQueryReceiptsAscSequenceTiebreaker(t *testing.T) {
 
 func TestQueryReceiptsCombinedFilters(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	// Insert a receipt we can filter on.
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	s.Insert(r, h)
 
 	actionType := "filesystem.file.read"
@@ -876,11 +894,11 @@ func TestOpenReadOnlyVerifiesExistingChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := rw.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -926,9 +944,9 @@ func TestOpenReadOnlyRejectsWrites(t *testing.T) {
 	}
 	t.Cleanup(func() { ro.Close() })
 
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 	// We deliberately don't pin a specific SQLite error string here — the
 	// driver's wording around read-only rejection has shifted between
 	// modernc.org/sqlite versions, and the behaviour we actually care about
@@ -948,11 +966,11 @@ func TestOpenReadOnlyConcurrentWithWriter(t *testing.T) {
 	}
 	t.Cleanup(func() { rw.Close() })
 
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	var prevHash *string
 	for i := 1; i <= 2; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		if err := rw.Insert(r, h); err != nil {
 			t.Fatal(err)
 		}
@@ -988,12 +1006,12 @@ func TestOpenReadOnlyRejectsMemoryAndEmpty(t *testing.T) {
 
 func TestVerifyStoredChain(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 
 	var prevHash *string
 	for i := 1; i <= 3; i++ {
 		r := makeSignedReceipt(t, kp, i, "chain-1", prevHash)
-		h, _ := receipt.HashReceipt(r)
+		h := mustHashReceipt(t, r)
 		s.Insert(r, h)
 		prevHash = &h
 	}
@@ -1016,7 +1034,7 @@ func TestInsertRaw_PreservesUnknownFields(t *testing.T) {
 	// behaviour by injecting an unknown field into the raw bytes and
 	// asserting it survives the store round-trip.
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-raw", nil)
 
 	rJSON, err := json.Marshal(r)
@@ -1057,7 +1075,10 @@ func TestInsertRaw_PreservesUnknownFields(t *testing.T) {
 	if err := s.db.QueryRow("SELECT receipt_hash FROM receipts WHERE id = ?", r.ID).Scan(&storedHash); err != nil {
 		t.Fatalf("select stored hash: %v", err)
 	}
-	want, _ := receipt.HashRawReceipt([]byte(stored))
+	want, err := receipt.HashRawReceipt([]byte(stored))
+	if err != nil {
+		t.Fatalf("hash raw receipt: %v", err)
+	}
 	if storedHash != want {
 		t.Fatalf("stored receipt_hash = %s; HashRawReceipt(stored bytes) = %s; want equal", storedHash, want)
 	}
@@ -1070,9 +1091,9 @@ func TestInsertRaw_RejectsMismatchedID(t *testing.T) {
 	// a different ID — silent corruption that is lethal at audit time.
 	// InsertRaw must refuse the insert.
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-mismatch", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	err := s.InsertRaw(r, []byte(`{"id":"different","raw":"bytes"}`), h)
 	if err == nil {
@@ -1095,9 +1116,9 @@ func TestInsertRaw_AcceptsRawWithoutID(t *testing.T) {
 	// reflects r.ID and GetByID still works by struct id. This documents
 	// the boundary of validateRawReceipt's checks.
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-noid", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	raw := []byte(`{"raw":"without-id-field"}`)
 	if err := s.InsertRaw(r, raw, h); err != nil {
@@ -1120,9 +1141,9 @@ func TestInsertRaw_RejectsMismatchedChainOrSequence(t *testing.T) {
 	// the UNIQUE index on the indexed columns cannot catch. InsertRaw must
 	// reject both mismatch modes.
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 7, "chain-honest", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	cases := []struct {
 		name string
@@ -1160,9 +1181,9 @@ func TestInsertRaw_RejectsMismatchedChainOrSequence(t *testing.T) {
 
 func TestInsertRaw_RejectsInvalidPayloads(t *testing.T) {
 	s := setupStore(t)
-	kp, _ := receipt.GenerateKeyPair()
+	kp := mustKeyPair(t)
 	r := makeSignedReceipt(t, kp, 1, "chain-bad", nil)
-	h, _ := receipt.HashReceipt(r)
+	h := mustHashReceipt(t, r)
 
 	cases := []struct {
 		name string

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -68,6 +68,45 @@ func TestGetByIDNotFound(t *testing.T) {
 	}
 }
 
+func TestExists(t *testing.T) {
+	s := setupStore(t)
+	kp, _ := receipt.GenerateKeyPair()
+	r := makeSignedReceipt(t, kp, 1, "chain-1", nil)
+	h, _ := receipt.HashReceipt(r)
+	if err := s.Insert(r, h); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := s.Exists(r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("expected Exists to report present receipt as true")
+	}
+
+	ok, err = s.Exists("urn:never:inserted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("expected Exists to report absent receipt as false")
+	}
+}
+
+func TestExistsAfterClose(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := s.Exists("anything"); err == nil {
+		t.Error("expected Exists to surface an error on a closed store")
+	}
+}
+
 func TestGetChain(t *testing.T) {
 	s := setupStore(t)
 	kp, _ := receipt.GenerateKeyPair()


### PR DESCRIPTION
Closes #546.

## What

- `sdk/go/store` gains `Exists(id string) (bool, error)`, backed by `SELECT 1 FROM receipts WHERE id = ? LIMIT 1`. No JSON decode of the receipt body.
- `collector/SQLiteStore.Exists` and the duplicate-detection branches in `collector/SQLiteStore.Insert` (cheap path + chain-uniqueness re-lookup fallback) now delegate to `inner.Exists` instead of `GetByID`.
- `collector/server.go` 400 path on `json.Decoder.Decode` now returns a generic `"malformed receipt"` wire body; the detailed `encoding/json` error stays in the structured log.
- `collector/README.md` "Validation scope" section spells out that the four-field bar is the deliberate minimum — full schema, signature, and chain conformance are the auditor's job under ADR-0020.

## Why

Review of #537 surfaced that `collector/SQLiteStore.Insert` and `Exists` both called `GetByID`, which unmarshals the full `receipt_json` blob just to answer "is this row present?". `/healthz` and every HttpEmitter-retry insert paid that decode cost. There was no cheap existence primitive on `sdk/go/store` for consumers to use.

`encoding/json`'s decoder errors mention internal Go struct field names and types (e.g. `"cannot unmarshal X into Go struct field AgentReceipt.foo of type Y"`). Echoing that to the wire leaks implementation detail without helping the client debug; the structured log keeps the full text for operators.

## Checklist

- [x] Tests pass for all changed components (`sdk/go`, `collector`, `mcp-proxy`, `hook`, `daemon`, `cross-sdk-tests` all green)
- [x] Linter passes (`go vet ./...` clean across all modules)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (receipt format / signing / hashing unchanged — N/A but verified anyway)
- [ ] AGENTS.md updated (no structural change)
- [ ] Spec changes have been reviewed by a maintainer (no spec change)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no. The decoder-error sanitization is a defense-in-depth tweak (no PII or secret was ever in the leaked text, only Go type names), not a fix for a security finding.

## Out of scope

- No paging/iteration primitive on `sdk/go/store` — explicitly deferred in #546.
- `validateReceiptStructure` itself is unchanged; only its README documentation was loosened.