### PR TITLE
test(sdk/py): strip null optionals in v020 cross-language verify path (#510)

### DIFF
--- a/sdk/py/tests/test_cross_language_go.py
+++ b/sdk/py/tests/test_cross_language_go.py
@@ -8,9 +8,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from agent_receipts.receipt.chain import verify_chain
-from agent_receipts.receipt.hash import canonicalize, hash_receipt, sha256
+from agent_receipts.receipt.hash import (
+    _strip_optional_nulls,
+    canonicalize,
+    hash_receipt,
+    sha256,
+)
 from agent_receipts.receipt.signing import generate_key_pair, verify_receipt
 from agent_receipts.receipt.types import AgentReceipt
 
@@ -144,7 +150,8 @@ class TestV020Vectors:
 
         vectors = _load_v020_vectors()
         public_key_pem = vectors["keys"]["publicKey"]
-        receipt = dict(vectors["parametersDisclosureReceipt"]["receipt"])
+        section = vectors["parametersDisclosureReceipt"]
+        receipt: dict[str, Any] = dict(section["receipt"])
 
         proof = receipt.pop("proof")
         proof_value = proof["proofValue"]
@@ -153,7 +160,18 @@ class TestV020Vectors:
         sig_b64 += "=" * ((4 - len(sig_b64) % 4) % 4)
         signature = base64.urlsafe_b64decode(sig_b64)
 
-        canonical = canonicalize(receipt).encode("utf-8")
+        # Mirror verify_receipt: strip null optional fields (ADR-0009 Rule 2)
+        # and re-insert the required-nullable previous_receipt_hash, so the
+        # canonical bytes match what the production verify path would feed
+        # into Ed25519. Without this, a future v0.2.x vector with an explicit
+        # null on any optional field would diverge silently.
+        stripped: dict[str, Any] = _strip_optional_nulls(receipt)
+        cs: dict[str, Any] = stripped.setdefault("credentialSubject", {})
+        chain: dict[str, Any] = cs.setdefault("chain", {})
+        if "previous_receipt_hash" not in chain:
+            chain["previous_receipt_hash"] = None
+
+        canonical = canonicalize(stripped).encode("utf-8")
         key = load_pem_public_key(public_key_pem.encode("ascii"))
         assert isinstance(key, Ed25519PublicKey)
         verified = True


### PR DESCRIPTION
## Summary

Fixes #510.

The Go-signed v0.2.x `parametersDisclosureReceipt` cross-language test in `sdk/py/tests/test_cross_language_go.py::test_parameters_disclosure_receipt_verifies` was canonicalizing the raw fixture dict without applying ADR-0009 Rule 2 (strip nulls from optional fields), so its canonical bytes could diverge from what production `verify_receipt` produces.

Today the test passes by coincidence — the only null in the current fixture is the required-nullable `chain.previous_receipt_hash`, and no other optional fields are explicitly null. A future v0.2.x vector with explicit null on any optional field would silently verify against bytes the production code never produced.

## Fix

Mirror `verify_receipt` (sdk/py/src/agent_receipts/receipt/signing.py:108-124) in the test:

1. Apply `_strip_optional_nulls(receipt)` (the same module-private helper that `hash_receipt` uses for plain-dict inputs, and that `test_canonicalization_vectors.py` already imports the same way).
2. Re-insert `chain.previous_receipt_hash = None` if absent (required-nullable per ADR-0009).
3. Then `canonicalize`.

The companion `test_parameters_disclosure_receipt_hash_matches_go` already routes through `hash_receipt(dict)`, which strips nulls internally — no fix needed there.

## Out of scope (follow-ups worth filing)

- The strip + re-insert dance now lives in three places (signing.py, hash.py, this test). A small public helper like `prepare_canonical_dict(receipt) -> dict` would let all three share one implementation.
- Optional regression fixture with an explicit-null optional field — would require regenerating the Go-side `cross-sdk-tests/v020_vectors.json`.

## Test plan

- [x] `uv run pytest tests/test_cross_language_go.py -v` — 16/16 pass, including the two refactored v0.2.0 tests
- [x] `uv run pytest` — full Python SDK suite: 401 passed, 5 skipped
- [x] `uv run ruff check` — clean
- [x] `uv run pyright src tests/test_cross_language_go.py` — 140 errors (down from 147 baseline; the explicit `dict[str, Any]` annotation incidentally tightened types for several downstream operations)
- [x] Pre-push hook ran full suite cleanly