### PR TITLE
fix(sdk/py): reject empty EmitterMetadata construction (#509)

### DIFF
--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -111,6 +111,32 @@ class EmitterMetadata(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _check_not_empty(self) -> EmitterMetadata:
+        """Reject all-None construction so ``EmitterMetadata()`` is never silent.
+
+        Every field on this model is optional, so Pydantic happily builds an
+        empty instance. The instance then serializes to ``{}`` and, because
+        ``exclude_none=True`` only strips the inner None, the empty dict
+        survives canonicalization and perturbs the receipt hash (see
+        https://github.com/agent-receipts/ar/issues/509). No legitimate use
+        of empty ``EmitterMetadata`` exists, so we fail fast at construction.
+
+        Fires on both direct construction and ``model_validate`` paths;
+        ``model_construct`` still bypasses by Pydantic design, but that
+        method is an opt-in escape hatch for callers that already promise
+        validity. ``type(self).model_fields`` is the class-level accessor —
+        the instance form ``self.model_fields`` is deprecated in Pydantic
+        v2.11+.
+        """
+        if all(getattr(self, name) is None for name in type(self).model_fields):
+            msg = (
+                "EmitterMetadata requires at least one non-None field; "
+                "omit the field entirely instead of passing an empty instance"
+            )
+            raise ValueError(msg)
+        return self
+
 
 class Action(BaseModel):
     model_config = ConfigDict(populate_by_name=True)

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -1,5 +1,8 @@
 """Tests for receipt types and constants."""
 
+import pytest
+from pydantic import ValidationError
+
 from agent_receipts.receipt.hash import hash_receipt
 from agent_receipts.receipt.types import (
     CONTEXT,
@@ -182,6 +185,20 @@ class TestEmitterMetadata:
     def test_default_is_none(self) -> None:
         receipt = make_receipt()
         assert receipt.credentialSubject.action.emitter_metadata is None
+
+    def test_rejects_all_none_construction(self) -> None:
+        # Every field on EmitterMetadata is optional, so a bare ``EmitterMetadata()``
+        # would otherwise serialize to ``{}`` and perturb the canonical hash
+        # (issue #509). The validator must reject this at construction time.
+        with pytest.raises(ValidationError, match="requires at least one non-None"):
+            EmitterMetadata()
+
+    def test_rejects_empty_dict_deserialization(self) -> None:
+        # The deserialization path must also reject ``{}`` so a JSON receipt
+        # carrying ``"emitter_metadata": {}`` cannot be silently rehydrated
+        # into the same hash-perturbing instance the constructor refuses.
+        with pytest.raises(ValidationError, match="requires at least one non-None"):
+            EmitterMetadata.model_validate({})
 
     def test_round_trip_drop_count(self) -> None:
         receipt = make_receipt()


### PR DESCRIPTION
Closes #509.

## Problem

`EmitterMetadata` (`sdk/py/src/agent_receipts/receipt/types.py`) has one field, `drop_count: int | None = None`. Constructing `EmitterMetadata()` with no args and attaching it to an Action silently serialized to `"emitter_metadata": {}` in the canonical hash:

```
base hash:                 sha256:ebe87587…29fa
with EmitterMetadata():    sha256:7a8c859c…459d   (different — empty {} counted)
```

`model_dump(exclude_none=True)` strips the inner `None` but the outer empty dict survives canonicalization. Behaviour matched Go's `*EmitterMetadata{}` with `omitempty` (no cross-SDK incompatibility) but was a Python footgun because the constructor was callable with no required args.

## Fix

Approach **(a)** from the issue: add a `model_validator(mode="after")` on `EmitterMetadata` that rejects all-None construction at the source. Picked over (b) `create_receipt` skipping the field and (c) docs only because:

- catches every construction site, not just one code path
- mirrors the existing `Chain._check_status_implies_terminal` validator pattern in the same file
- the issue states no legitimate use of empty `EmitterMetadata` exists

The validator iterates `type(self).model_fields` generically rather than naming `drop_count`, so it stays correct if new optional fields are added later. `type(self).model_fields` (class form) is used because `self.model_fields` (instance form) is deprecated in Pydantic v2.11+.

## Tests

Two new tests in `sdk/py/tests/receipt/test_types.py`:

- `test_rejects_all_none_construction` — direct `EmitterMetadata()` raises `ValidationError`.
- `test_rejects_empty_dict_deserialization` — `EmitterMetadata.model_validate({})` also raises, so the deserialization path is pinned and a future refactor (e.g. switching to `mode="before"`) cannot silently relax it.

Existing canonical-hash and round-trip tests for `EmitterMetadata(drop_count=...)` continue to pass.

## Backwards compatibility — call out for reviewers

The validator also rejects `{}` on `model_validate`. **Intentional**: any persisted receipt with `"emitter_metadata": {}` was signed over a hash that already included the spurious `{}`, so its signature is already wrong; surfacing that on load rather than silently re-canonicalizing is the safer behaviour. If known persisted receipts in this shape exist anywhere (dashboard ingest store, mcp-proxy audit.db), please flag — we should write a migration note before merging.

Direct SDK emitters do not produce this shape (no caller in this repo constructs `EmitterMetadata()` empty), and Go emitter frames set `DropCount` via the in-process counter loop, never bare instances.

## Action items from issue

- [x] Pick approach (a)
- [x] Implement in `sdk/py/src/agent_receipts/receipt/types.py`
- [x] Add test (construction + deserialization paths)
- [ ] Apply same pattern to `PeerCredential` — **skipped**; `platform` and `pid` are required, so the analogous footgun doesn't exist today. If those ever become optional this needs revisiting.
- [x] Link the fix PR back to the issue (above)

## Verification

- `uv run pytest` — 403 passed / 5 skipped
- `uv run ruff check .` — clean
- `uv run pyright src` — clean
- Pre-push hook ran the full Python SDK suite