### PR TITLE
ci: publish PyPI and npm inline from release workflows (fix #521)

### DIFF
--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -1,16 +1,9 @@
 name: Publish SDK (Python) to PyPI
 
 on:
-  release:
-    # `prereleased` covers alpha/beta tags (e.g. sdk-py-v0.9.0a1); `published`
-    # covers stable releases. GitHub fires only one of the two per release
-    # creation depending on the prerelease flag, so we need both listed to
-    # publish every release shape we tag.
-    types: [published, prereleased]
-  # Manual escape hatch for cases where the release event does not propagate
-  # (e.g. release-sdk-py.yml created the GitHub Release via GITHUB_TOKEN,
-  # which suppresses downstream workflow triggers — see #521). Dispatching
-  # from `main` publishes whatever version pyproject.toml currently has.
+  # Manual escape hatch — dispatch from `main` publishes whatever version
+  # pyproject.toml currently has. Normal releases go through release-sdk-py.yml
+  # which publishes inline (see #521 for why the two-step pipeline was broken).
   workflow_dispatch:
 
 permissions:
@@ -23,12 +16,9 @@ defaults:
 
 jobs:
   publish:
-    # Tag-triggered releases: any sdk-py-v* tag. Manual dispatch: only from
-    # `main` — dispatch from a feature branch could publish unreviewed code
-    # to PyPI under whatever pyproject.toml version that branch has.
-    if: |
-      startsWith(github.ref_name, 'sdk-py-v') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    # Only allow dispatch from main — dispatching from a feature branch could
+    # publish unreviewed code to PyPI.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -1,23 +1,22 @@
 name: Publish SDK (TypeScript) to npm
 
 on:
-  # Manual escape hatch — dispatch from `main` publishes whatever version
-  # package.json currently has. Normal releases go through release-sdk-ts.yml
-  # which publishes inline (see #521 for why the two-step pipeline was broken).
+  # Manual escape hatch — dispatch from `main` to verify the build is clean.
+  # This workflow cannot publish to npm: the npm trusted publisher is configured
+  # for release-sdk-ts.yml, not this file. To publish manually, either push a
+  # sdk-ts-v* tag (triggers release-sdk-ts.yml) or temporarily re-add this
+  # workflow as a trusted publisher at https://www.npmjs.com/package/@agnt-rcpt/sdk-ts.
   workflow_dispatch:
 
 permissions:
   contents: read
-  id-token: write
 
 defaults:
   run:
     working-directory: sdk/ts
 
 jobs:
-  publish:
-    # Only allow dispatch from main — dispatching from a feature branch could
-    # publish unreviewed code to npm.
+  verify:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
@@ -31,53 +30,8 @@ jobs:
           node-version: "24"
           cache: "pnpm"
           cache-dependency-path: sdk/ts/pnpm-lock.yaml
-          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm test
       - run: pnpm run build
-
-      # Pre-release versions go to a non-default dist-tag so they don't
-      # clobber `latest` for users on the stable line.
-      - name: Determine npm dist-tag
-        id: dist_tag
-        shell: bash
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          CORE="${PKG_VERSION%%+*}"
-          if [[ "$CORE" == *-* ]]; then
-            PRE="${CORE#*-}"
-            if [[ "$PRE" =~ ^([A-Za-z]+) ]]; then
-              TAG_NAME="${BASH_REMATCH[1],,}"
-            else
-              TAG_NAME="prerelease"
-            fi
-            echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to npm
-        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}
-
-  # Release-blocking gate: the just-published npm package must satisfy the code
-  # snippets in the READMEs. Runs after publish so the version is live on npm;
-  # a drifted snippet turns the release red. (Pre-publish gating isn't possible
-  # here — "published" mode needs the artifact to already exist on the registry.)
-  readme-snippets:
-    needs: publish
-    if: |
-      startsWith(github.ref_name, 'sdk-ts-v') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "24"
-      - name: Verify published README snippets type-check
-        run: python3 scripts/readme_snippets/check.py --lang ts --source published README.md sdk/ts/README.md

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -1,12 +1,9 @@
 name: Publish SDK (TypeScript) to npm
 
 on:
-  release:
-    # `prereleased` covers alpha/beta tags (e.g. sdk-ts-v0.9.0-alpha.1);
-    # `published` covers stable releases. GitHub fires only one of the two
-    # per release creation depending on the prerelease flag, so we need
-    # both listed to publish every release shape we tag.
-    types: [published, prereleased]
+  # Manual escape hatch — dispatch from `main` publishes whatever version
+  # package.json currently has. Normal releases go through release-sdk-ts.yml
+  # which publishes inline (see #521 for why the two-step pipeline was broken).
   workflow_dispatch:
 
 permissions:
@@ -19,18 +16,13 @@ defaults:
 
 jobs:
   publish:
-    # Tag-triggered releases: any sdk-ts-v* tag. Manual dispatch: only from
-    # `main` — dispatch from a feature branch could publish unreviewed code
-    # to npm under whatever package.json version that branch has.
-    if: |
-      startsWith(github.ref_name, 'sdk-ts-v') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    # Only allow dispatch from main — dispatching from a feature branch could
+    # publish unreviewed code to npm.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
 
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
@@ -42,30 +34,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
-
-      - name: Verify release tag matches package.json version
-        if: github.event_name == 'release'
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Release tag sdk-ts-v${TAG_VERSION} does not match package.json version ${PKG_VERSION}"
-            exit 1
-          fi
-
       - run: pnpm run typecheck
       - run: pnpm test
       - run: pnpm run build
 
       # Pre-release versions go to a non-default dist-tag so they don't
-      # clobber `latest` for users on the stable line. Two-phase logic:
-      #   1. Strip SemVer build metadata (after '+'); if a '-' remains
-      #      anywhere in the core version, this is a pre-release.
-      #   2. Extract a leading [A-Za-z]+ identifier from the pre-release
-      #      portion (lowercased). Falls back to `prerelease` if the
-      #      identifier is purely numeric or otherwise unparseable —
-      #      never falls through to `latest`, which would defeat the
-      #      whole purpose.
+      # clobber `latest` for users on the stable line.
       - name: Determine npm dist-tag
         id: dist_tag
         shell: bash

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -83,6 +83,8 @@ jobs:
   readme-snippets:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -48,6 +49,8 @@ jobs:
       - run: uv run ruff format --check .
       - run: uv run pytest
 
+      - run: uv build
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +59,6 @@ jobs:
           # up as "latest" on the GitHub Releases page.
           # Covers SemVer pre-releases (e.g. v0.9.0-beta.1, *-*) and PEP 440
           # pre-release suffixes (e.g. v0.9.0a1, v0.9.0rc1 — matched by [abc][0-9]).
-          # publish-py.yml (triggered on release publish) handles PyPI publication.
           PRERELEASE_ARG=()
           CORE="${SDK_PY_VERSION%%+*}"
           if [[ "$CORE" == *-* ]] || [[ "$CORE" =~ [0-9]+(a|b|rc)[0-9]+$ ]]; then
@@ -66,3 +68,7 @@ jobs:
             --title "sdk-py ${SDK_PY_VERSION}" \
             --generate-notes \
             "${PRERELEASE_ARG[@]}"
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: sdk/py/dist/

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -59,16 +59,34 @@ jobs:
           # up as "latest" on the GitHub Releases page.
           # Covers SemVer pre-releases (e.g. v0.9.0-beta.1, *-*) and PEP 440
           # pre-release suffixes (e.g. v0.9.0a1, v0.9.0rc1 — matched by [abc][0-9]).
+          # Skip creation if the release already exists so reruns after a
+          # failed publish step don't abort before reaching PyPI.
           PRERELEASE_ARG=()
           CORE="${SDK_PY_VERSION%%+*}"
           if [[ "$CORE" == *-* ]] || [[ "$CORE" =~ [0-9]+(a|b|rc)[0-9]+$ ]]; then
             PRERELEASE_ARG+=(--prerelease)
           fi
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "sdk-py ${SDK_PY_VERSION}" \
-            --generate-notes \
-            "${PRERELEASE_ARG[@]}"
+          if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "sdk-py ${SDK_PY_VERSION}" \
+              --generate-notes \
+              "${PRERELEASE_ARG[@]}"
+          fi
 
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: sdk/py/dist/
+
+  # Release-blocking gate: the just-published package must satisfy the code
+  # snippets in the READMEs. Runs after publish so the version is live on PyPI;
+  # a drifted snippet turns the release red.
+  readme-snippets:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - name: Verify published README snippets type-check
+        run: python3 scripts/readme_snippets/check.py --lang py --source published README.md sdk/py/README.md

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -85,3 +85,20 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}
+
+  # Release-blocking gate: the just-published npm package must satisfy the code
+  # snippets in the READMEs. Runs after publish so the version is live on npm;
+  # a drifted snippet turns the release red.
+  readme-snippets:
+    needs: release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - name: Verify published README snippets type-check
+        run: python3 scripts/readme_snippets/check.py --lang ts --source published README.md sdk/ts/README.md

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -96,6 +96,8 @@ jobs:
   readme-snippets:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -57,14 +57,18 @@ jobs:
         run: |
           # Mark pre-release tags (e.g. v0.9.0-alpha.1) so they don't show
           # up as "latest" on the GitHub Releases page.
+          # Skip creation if the release already exists so reruns after a
+          # failed publish step don't abort before reaching npm.
           PRERELEASE_ARG=()
           if [[ "${SDK_TS_VERSION}" == *-* ]]; then
             PRERELEASE_ARG+=(--prerelease)
           fi
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "sdk-ts ${SDK_TS_VERSION}" \
-            --generate-notes \
-            "${PRERELEASE_ARG[@]}"
+          if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "sdk-ts ${SDK_TS_VERSION}" \
+              --generate-notes \
+              "${PRERELEASE_ARG[@]}"
+          fi
 
       - name: Determine npm dist-tag
         id: dist_tag

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -29,6 +30,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
           cache-dependency-path: sdk/ts/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
 
       - name: Prepare version
         run: |
@@ -55,7 +57,6 @@ jobs:
         run: |
           # Mark pre-release tags (e.g. v0.9.0-alpha.1) so they don't show
           # up as "latest" on the GitHub Releases page.
-          # publish-ts.yml (triggered on release publish) handles npm publication.
           PRERELEASE_ARG=()
           if [[ "${SDK_TS_VERSION}" == *-* ]]; then
             PRERELEASE_ARG+=(--prerelease)
@@ -64,3 +65,23 @@ jobs:
             --title "sdk-ts ${SDK_TS_VERSION}" \
             --generate-notes \
             "${PRERELEASE_ARG[@]}"
+
+      - name: Determine npm dist-tag
+        id: dist_tag
+        shell: bash
+        run: |
+          CORE="${SDK_TS_VERSION%%+*}"
+          if [[ "$CORE" == *-* ]]; then
+            PRE="${CORE#*-}"
+            if [[ "$PRE" =~ ^([A-Za-z]+) ]]; then
+              TAG_NAME="${BASH_REMATCH[1],,}"
+            else
+              TAG_NAME="prerelease"
+            fi
+            echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}


### PR DESCRIPTION
## What

Collapses the two-step release → publish pipeline for the Python and TypeScript SDKs into a single workflow each.

## Why

`GITHUB_TOKEN`-created releases suppress downstream workflow triggers (GitHub Actions safeguard documented in #521). This meant `publish-py.yml` and `publish-ts.yml` **never fired automatically** — every release since the automation was introduced has silently required manual intervention to actually reach PyPI and npm.

Discovered today when `sdk-py v0.10.0` and `sdk-ts v0.10.0` were tagged but not published; both had to be dispatched manually.

## Changes

**`release-sdk-py.yml`**
- Add `id-token: write` permission (OIDC for PyPI trusted publishing)
- Add `uv build` step (before creating the GitHub release)
- Add `pypa/gh-action-pypi-publish` step (after creating the GitHub release)
- Remove stale comment pointing at `publish-py.yml`

**`release-sdk-ts.yml`**
- Add `id-token: write` permission (OIDC for npm provenance)
- Add `registry-url` to `actions/setup-node` (required for npm auth)
- Add dist-tag determination step (mirrors `publish-ts.yml` logic, using `$SDK_TS_VERSION` which is already verified to match `package.json`)
- Add `npm publish --access public --provenance` step
- Remove stale comment pointing at `publish-ts.yml`

**`publish-py.yml` / `publish-ts.yml`**
- Remove dead `release:` trigger (it never fired for `GITHUB_TOKEN`-created releases)
- Reduce to `workflow_dispatch`-only manual fallbacks with a clarifying comment
- Tighten `if:` condition to `github.ref == 'refs/heads/main'` only

## Testing

Can only be validated end-to-end on the next real release tag. The individual steps are identical to what `publish-py.yml` and `publish-ts.yml` already run successfully (used for manual recovery of v0.10.0 today).