### PR TITLE
docs: fix root README TS and Go quick-start snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,17 @@ go get github.com/agent-receipts/ar/sdk/go
 ```
 
 ```go
-import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+import "github.com/agent-receipts/ar/sdk/go/receipt"
 
-r, _ := receipt.New(receipt.WithAction("tool_call", payload))
-signed, _ := r.Sign(privateKey)
+keys, _ := receipt.GenerateKeyPair()
+unsigned := receipt.Create(receipt.CreateInput{
+    Issuer:    receipt.Issuer{ID: "did:agent:my-agent"},
+    Principal: receipt.Principal{ID: "did:user:alice"},
+    Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow},
+    Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+    Chain:     receipt.Chain{Sequence: 1, ChainID: "chain_1"},
+})
+signed, _ := receipt.Sign(unsigned, keys.PrivateKey, "did:agent:my-agent#key-1")
 ```
 
 ### TypeScript
@@ -112,10 +119,21 @@ npm install @agnt-rcpt/sdk-ts
 ```
 
 ```typescript
-import { Receipt } from "@agnt-rcpt/sdk-ts";
+import {
+  createReceipt,
+  generateKeyPair,
+  signReceipt,
+} from "@agnt-rcpt/sdk-ts";
 
-const receipt = await Receipt.create({ action: "tool_call", payload });
-const signed = await receipt.sign(privateKey);
+const keys = generateKeyPair();
+const unsigned = createReceipt({
+  issuer: { id: "did:agent:my-agent" },
+  principal: { id: "did:user:alice" },
+  action: { type: "filesystem.file.read", risk_level: "low" },
+  outcome: { status: "success" },
+  chain: { sequence: 1, previous_receipt_hash: null, chain_id: "chain_1" },
+});
+const signed = signReceipt(unsigned, keys.privateKey, "did:agent:my-agent#key-1");
 ```
 
 ### Python


### PR DESCRIPTION
## Summary

Same paper-cut as the Python snippet in #593, applied to the TS and Go quick-start snippets in the root README. Both reference a fictional `Receipt` class that does not exist in either SDK.

**TypeScript** — README previously showed:
```typescript
import { Receipt } from "@agnt-rcpt/sdk-ts";
await Receipt.create(...);
await receipt.sign(privateKey);
```
`@agnt-rcpt/sdk-ts` exports `createReceipt`, `signReceipt`, `generateKeyPair`, etc. There is no `Receipt` symbol — the import fails at module-load time.

**Go** — README previously showed:
```go
r, _ := receipt.New(receipt.WithAction("tool_call", payload))
signed, _ := r.Sign(privateKey)
```
`sdk/go/receipt` provides `Create(CreateInput) UnsignedAgentReceipt` and the package-level `Sign(unsigned, privateKeyPEM, verificationMethod) (AgentReceipt, error)`. There is no `New`, no `WithAction` functional option, and `Sign` is not a method on a receipt value — it takes three required args.

Both snippets now mirror the Python shape: generate a key pair, build a full `Create…Input` struct (Issuer / Principal / Action / Outcome / Chain), then sign with a verification method DID.

## Verification

- Go snippet compiles against the in-tree SDK (`go build`).
- TS snippet type-checks against the in-tree SDK under `tsc --strict`.

## Follow-up worth tracking

Three identical bugs slipping through three releases is the signal that there's no gate here. Suggest a release-blocking CI job that extracts every fenced code block from `README.md` (and SDK READMEs) and tries to build/type-check it against the *published* artifact — same idea as the P0-1 item in the audit synthesis. Happy to open a tracking issue if useful.