### PR TITLE
docs(adr): add ADR-0021 — spec and JSON-LD context versioning

### DIFF
--- a/docs/adr/0021-spec-and-context-versioning.md
+++ b/docs/adr/0021-spec-and-context-versioning.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0021-spec-and-context-versioning.md
+++ b/docs/adr/0021-spec-and-context-versioning.md
@@ -6,14 +6,15 @@ Proposed
 
 ## Context
 
-The Agent Receipts spec text promises permanent per-version URLs
-("subsequent versions will be published at distinct, permanent URLs; this URL
-is frozen at v0.2.1 and will not change"). The project does not currently
-honor that promise. The JSON-LD `@context` URL embedded in every receipt
-produced by the SDKs (`https://agentreceipts.ai/context/v1`) returns 404 —
-every receipt currently in existence references a context document that does
-not resolve. The W3C VC data model the receipt envelope is built on
-(ADR-0003) requires `@context` URLs to resolve.
+Five spec versions have shipped (v0.1.0 through v0.4.0, latest 2026-05-23)
+but no canonical per-version URL is published on the live site for any of
+them — `https://agentreceipts.ai/spec/v0.4.0/` and equivalents return 404.
+More consequentially, the JSON-LD `@context` URL embedded in every receipt
+produced by the SDKs (`https://agentreceipts.ai/context/v1`) also returns
+404, so every receipt currently in existence references a context document
+that does not resolve. The W3C VC data model the receipt envelope is built
+on (ADR-0003) requires `@context` URLs to resolve; the live correctness
+issue is therefore receipt-level, not just docs-level.
 
 The living-spec file `spec/spec/agent-receipt-spec-v0.1.md` has frontmatter
 claiming `Version: 0.1.0` but contains features released as recently as

--- a/docs/adr/0021-spec-and-context-versioning.md
+++ b/docs/adr/0021-spec-and-context-versioning.md
@@ -6,209 +6,145 @@ Proposed
 
 ## Context
 
-The Agent Receipts spec text promises permanent per-version URLs ("subsequent
-versions will be published at distinct, permanent URLs; this URL is frozen at
-v0.2.1 and will not change"). The project does not currently honor that
-promise. Five released spec versions (v0.1.0, v0.2.0, v0.2.1, v0.3.0, v0.4.0)
-have no canonical URL on the live site. The JSON-LD `@context` URL embedded
-in every receipt produced by the SDKs (`https://agentreceipts.ai/context/v1`)
-returns 404, meaning every receipt currently in existence references a context
-document that does not resolve.
+The Agent Receipts spec text promises permanent per-version URLs
+("subsequent versions will be published at distinct, permanent URLs; this URL
+is frozen at v0.2.1 and will not change"). The project does not currently
+honor that promise. The JSON-LD `@context` URL embedded in every receipt
+produced by the SDKs (`https://agentreceipts.ai/context/v1`) returns 404 —
+every receipt currently in existence references a context document that does
+not resolve. The W3C VC data model the receipt envelope is built on
+(ADR-0003) requires `@context` URLs to resolve.
 
-A site audit on 2026-05-24 found:
+The living-spec file `spec/spec/agent-receipt-spec-v0.1.md` has frontmatter
+claiming `Version: 0.1.0` but contains features released as recently as
+v0.4.0. The frontmatter is stale; the file's actual content corresponds to
+v0.4.0.
 
-- `https://agentreceipts.ai/spec/v0.2.1/` returns 404 (SITE-P7).
-- `https://agentreceipts.ai/context/v1` returns 404.
-- Current spec source is a single living file
-  (`spec/spec/agent-receipt-spec-v0.1.md`), not version-per-file.
-- That file's frontmatter claims `Version: 0.1.0` but its content includes
-  features released as recently as v0.4.0 (`idempotency_key`,
-  `chain.terminal` / `chain.status`, `outcome.response_hash`, `unknown`
-  action-type fallback). The frontmatter is stale and the file's actual
-  content corresponds to v0.4.0.
-- No JSON-LD context document exists in the repo.
-- Five spec versions have shipped (latest: v0.4.0, 2026-05-23) with no
-  versioned URLs published for any of them.
-
-The W3C Verifiable Credentials Data Model the receipt envelope is built on
-(ADR-0003) requires `@context` URLs to resolve to valid JSON-LD context
-documents. A receipt validator that strictly processes JSON-LD against an
-Agent Receipt today fails on context resolution. This is a correctness issue,
-not just a documentation gap. The cross-SDK conformance suite has apparently
-been getting away with not strictly validating JSON-LD, since every receipt
-it produces references an unresolvable context URL.
-
-This ADR records the decision to operate a spec release pipeline that makes
-the spec text's promise true, and specifies the versioning model for both
-the spec and the JSON-LD context.
+At this stage of the project — early days, v0.4.0 is current, nobody is
+citing per-version spec URLs in the wild — the proportionate response is to
+fix the live correctness issue and establish forward-only conventions, not
+to reconstruct four historical spec versions from git history for canonical
+republication.
 
 ## Decision
 
-The seven sub-decisions D1–D7 below collectively constitute the decision.
+### D1. Forward-only per-version spec files, starting at v0.4.0
 
-### D1. Spec is versioned per file, in the repo, under `spec/`
+The current living-spec file is migrated to `spec/v0.4.0/spec.md`, with
+frontmatter corrected to `Version: 0.4.0`. The legacy path
+`spec/spec/agent-receipt-spec-v0.1.md` is deleted after migration.
 
-The source of truth for spec version `vX.Y.Z` is `spec/v<X.Y.Z>/spec.md` in
-the repo. Each version is immutable once tagged. Editorial corrections to a
-released version are not made in place; they are made by releasing a new
-version with a CHANGELOG entry noting the correction.
+From v0.4.0 onward, each released spec version is its own immutable file at
+`spec/v<X.Y.Z>/spec.md`. Editorial corrections to a released version are not
+made in place; they are made by releasing a new version with a CHANGELOG
+entry noting the correction.
 
-The current single-file living spec (`spec/spec/agent-receipt-spec-v0.1.md`)
-is migrated: its current contents — which actually correspond to v0.4.0, not
-the v0.1.0 its frontmatter claims — become `spec/v0.4.0/spec.md`, with
-frontmatter corrected to `Version: 0.4.0`. The legacy path is deleted after
-migration.
+Earlier released versions (v0.1.0–v0.3.0) are not backfilled. They remain
+accessible via git tags and CHANGELOG entries. No canonical URLs are
+published for them. If a citation need arises later, the version can be
+reconstructed and published at that point; until then, this is not work the
+project should pay for.
 
-Earlier released versions (v0.1.0, v0.2.0, v0.2.1, v0.3.0) are reconstructed
-from git history and placed at `spec/v<X.Y.Z>/spec.md`. Where git history
-does not cleanly identify a "this commit is the v0.X release" state, the
-closest commit to the release date is used and a note recorded in the
-backfill issue.
+### D2. Permanent per-version URLs, from v0.4.0 onward
 
-### D2. Permanent per-version URLs
-
-Every released spec version is published at
+Every released spec version from v0.4.0 onward is published at
 `https://agentreceipts.ai/spec/v<X.Y.Z>/` and that URL is permanent. Once
 published, the URL MUST NOT be repurposed, redirected to a different version,
 or returned as 404 except during deploy windows.
 
-`https://agentreceipts.ai/spec/latest/` is a mutable alias pointing at the
-current version. Receipts and the conformance suite MUST NOT reference
-`/spec/latest/`; only versioned URLs.
+`https://agentreceipts.ai/spec/latest/` is a mutable site-only alias
+pointing at the current version. No `spec/latest/` directory exists in the
+repo. Receipts and the conformance suite MUST NOT reference `/spec/latest/`;
+only versioned URLs.
 
-A `https://agentreceipts.ai/spec/` index page lists all released versions,
-marks the current one, and links to each.
+A `https://agentreceipts.ai/spec/` index page lists released versions
+(initially just v0.4.0) and marks the current one. The index grows as new
+versions land.
 
 ### D3. JSON-LD context is versioned independently, by JSON-LD term changes only
 
 The JSON-LD context lives at `https://agentreceipts.ai/context/v<N>` where
 `<N>` is an integer (`1`, `2`, `3`, …), not a semver string. This URL form
-(no trailing slash, no `v<N>/` directory) matches the form already referenced
-in every released spec version's `@context` array.
+matches the form already referenced in every released spec version's
+`@context` array.
 
-The context version bumps when and only when JSON-LD term definitions change
-in a way that would alter how a receipt validates. Renaming a field is a
-context bump. Adding a new optional field whose JSON-LD term is already
-implied by existing definitions is not. Adding a new field that requires its
-own term definition is.
+The context version bumps when and only when JSON-LD term definitions
+change in a way that would alter how a receipt validates. Adding a new
+optional field whose JSON-LD term is already implied by existing definitions
+is not a bump. Renaming a field, or adding a field that requires its own
+term definition, is.
 
 The spec version and the context version are independent. Multiple spec
-versions may share one context version. The current state is: all five
-released spec versions reference `@context: https://agentreceipts.ai/context/v1`.
-This ADR is responsible for authoring v1 and ensuring it correctly defines
-the terms used across all five spec versions, including any field renames
-introduced in v0.3.0 and v0.4.0.
+versions may share one context version. The current state is: every shipped
+receipt across v0.1.0–v0.4.0 references
+`@context: https://agentreceipts.ai/context/v1`, and that URL 404s. v1 is
+authored as part of this ADR's implementation, defining the terms needed
+across receipts produced under those spec versions. The source lives at
+`spec/context/v<N>/context.jsonld` in the repo.
 
-If a future spec version introduces a JSON-LD term change, that spec
-version's `@context` array changes to reference the new context version
-(e.g. `v2`). The old context URL remains permanent.
+If a future spec version introduces a JSON-LD term change, it references a
+new context version (e.g. `v2`); the old context URL remains permanent.
 
-The context document is authored as part of this ADR's implementation. The
-source lives at `spec/context/v<N>/context.jsonld` in the repo.
+### D4. Lightweight tag-driven publishing
 
-### D4. Release pipeline
-
-Spec releases are tag-driven. Tagging `spec-v<X.Y.Z>` triggers a workflow
-that:
-
-1. Verifies `spec/v<X.Y.Z>/spec.md` exists in the repo.
-2. Renders the spec markdown to a site page at
-   `site/src/content/docs/spec/v<X.Y.Z>.mdx`.
-3. Updates the site `/spec/latest/` alias (redirect) to point at the new
-   version. This is the public URL alias only; no `spec/latest/` directory
-   exists in the repo.
-4. Updates the `/spec/` index page to list the new version.
-5. Validates that every `@context` URL referenced in the new spec resolves
-   on the live site (fail-build if not).
-6. Deploys.
-
-Context releases are tag-driven similarly: tagging `context-v<N>` publishes
+Tagging `spec-v<X.Y.Z>` causes the site build to publish that version at
+`https://agentreceipts.ai/spec/v<X.Y.Z>/`. Tagging `context-v<N>` publishes
 `spec/context/v<N>/context.jsonld` at `https://agentreceipts.ai/context/v<N>`.
 
-The workflow specs live at `.github/workflows/spec-release.yml` and
-`.github/workflows/context-release.yml`.
+The implementation is a site-build step, not a separate CI gate. The
+project does not yet need fail-build conformance machinery for a single
+context document and a single canonical spec version. If later experience
+shows drift between the published context and SDK output, a conformance
+check can be added.
 
-### D5. Retroactive tagging for existing versions
+### D5. Deprecation policy
 
-After D1's backfill, the existing five spec versions are tagged retroactively
-(`spec-v0.1.0` through `spec-v0.4.0`) on the commit that landed the
-backfilled file. This validates the pipeline on past data: if it can't
-publish the five existing versions, it can't publish the next one.
-
-Context v1 is tagged once the context document is authored and validated
-against the conformance suite (D6).
-
-### D6. Conformance validates `@context` resolution
-
-The cross-SDK conformance suite is updated to assert that every receipt it
-produces has `@context` URLs that resolve to valid JSON-LD on the live site,
-not just URLs that look correct as strings. This closes the loop: the bug
-this ADR exists to fix becomes a property the project tests.
-
-If conformance fails for a context URL, the release pipeline (D4) fails the
-build. The project cannot ship a spec version that references a context
-document the live site cannot serve.
-
-### D7. Deprecation policy for old versions
-
-Released spec and context versions are kept reachable indefinitely. There is
-no "old enough to remove" threshold; every citation must remain valid.
-
-If a released version contains a defect (e.g. the multibase encoding
-inconsistency in v0.2.1 §4.2), the defect is not patched in place. A new
-version is released with the correction. The defective version remains
-reachable as a historical artifact. The `/spec/` index marks defective
-versions and points to the version that resolves the defect.
+Released spec and context versions are kept reachable indefinitely. There
+is no "old enough to remove" threshold. Defects are fixed by releasing a
+new version with a CHANGELOG entry; the defective version remains reachable
+as a historical artifact. The `/spec/` index marks defective versions, if
+any, and points to the version that resolves the defect.
 
 ## Out of scope for this ADR
 
+- Backfilling spec versions v0.1.0–v0.3.0 as canonical URLs. Explicitly
+  deferred per D1.
+- A live-network `@context` resolution check in the cross-SDK conformance
+  suite. Explicitly deferred per D4.
 - Updating downstream pages (Overview, schema, verification, Article 12
-  one-pager) to reflect v0.4.0. Tracked in follow-up issues; depends on this
-  ADR landing.
-- Authoring an SDK release pipeline analogous to the spec pipeline.
-  Different scope, similar shape.
-- The site content-drift CI gate from the site audit. Adjacent; tracked
-  separately.
+  one-pager) to reflect v0.4.0. Independent docs work; file when prioritized.
+- An SDK release pipeline analogous to the spec pipeline. Different scope.
 
 ## Consequences
 
-- The spec text's permanent-URL promise becomes operational reality rather
-  than aspirational language. Citations of `https://agentreceipts.ai/spec/v0.2.1/`
-  and every other released version will resolve.
-- Every receipt in existence — past and future — references a `@context` URL
-  that resolves to a valid JSON-LD document. Strict JSON-LD validators no
-  longer reject Agent Receipts on context-resolution failure.
-- The release pipeline (D4) makes it structurally hard to ship a spec
-  version whose context URL does not resolve, since the build fails before
-  deploy. This converts a class of correctness bug into a CI failure.
+- Every receipt in existence references a `@context` URL that resolves to a
+  valid JSON-LD document. SDK receipts pass strict JSON-LD validation. This
+  is the primary outcome.
+- From v0.4.0 onward, the spec text's permanent-URL promise becomes
+  operational reality. Citations of `https://agentreceipts.ai/spec/v0.4.0/`
+  and every later release will resolve.
+- Citations of pre-v0.4.0 spec URLs (e.g. `/spec/v0.2.1/`) continue to 404.
+  Acceptable given the project's current adoption stage; revisitable if
+  external citation pressure appears.
+- The living-spec file is gone. The next spec version is drafted as its
+  own file under `spec/v<NEXT>/spec.md`.
 - The repo gains a `spec/v<X.Y.Z>/` directory per release and a
-  `spec/context/v<N>/` directory per context version. The legacy living-file
-  path is removed. The repo holds no `spec/latest/` directory; "latest" is
-  a site-only alias.
-- Spec and context versions evolve independently. A spec-only release (e.g.
-  a clarification that does not change JSON-LD terms) ships with no context
-  bump. A context bump (rare, term-level changes only) is independent of
-  whatever spec is current at the time.
-- The cross-SDK conformance suite gains a live-network dependency on the
-  deployed site for `@context` resolution checks. CI must tolerate transient
-  network failures by retrying, not by skipping the check.
-- Defective released versions remain published as historical artifacts.
-  Auditors verifying receipts produced under a defective spec version can
-  still resolve the exact spec text the receipt was signed against.
+  `spec/context/v<N>/` directory per context version. No `spec/latest/`
+  directory; "latest" is a site-only alias.
+- Spec and context versions evolve independently. A spec-only release ships
+  with no context bump. A context bump (rare) is independent of whatever
+  spec is current.
 
 ## Implementation issues spawned by this ADR
 
 Filed as separate issues, blocked on the PR that merges this ADR. Each is
 labeled `adr-followup`.
 
-- Backfill spec versions v0.1.0 through v0.4.0 from git history (D1, D5).
-- Author JSON-LD context v1 covering terms across all five spec versions (D3).
-- Build `spec-release` and `context-release` GitHub Actions workflows (D4).
-- Update conformance suite to validate `@context` URL resolution (D6).
-- Publish `/spec/` index page (D2).
-- Update Article 12 one-pager for v0.4.0 schema and publish at canonical URL
-  (downstream).
-- Update Overview, schema, verification pages to v0.4.0 (downstream).
+- Author JSON-LD context v1 covering terms across receipts produced under
+  v0.1.0–v0.4.0 (D3).
+- Migrate the living spec to `spec/v0.4.0/spec.md` and publish at
+  `https://agentreceipts.ai/spec/v0.4.0/` (D1, D2, D4).
+- Publish the `/spec/` index page listing v0.4.0+ (D2).
 
 ---
 

--- a/docs/adr/0021-spec-and-context-versioning.md
+++ b/docs/adr/0021-spec-and-context-versioning.md
@@ -42,7 +42,9 @@ This ADR records the decision to operate a spec release pipeline that makes
 the spec text's promise true, and specifies the versioning model for both
 the spec and the JSON-LD context.
 
-## Decisions
+## Decision
+
+The seven sub-decisions D1–D7 below collectively constitute the decision.
 
 ### D1. Spec is versioned per file, in the repo, under `spec/`
 
@@ -112,7 +114,9 @@ that:
 1. Verifies `spec/v<X.Y.Z>/spec.md` exists in the repo.
 2. Renders the spec markdown to a site page at
    `site/src/content/docs/spec/v<X.Y.Z>.mdx`.
-3. Updates `spec/latest/` alias to point at the new version.
+3. Updates the site `/spec/latest/` alias (redirect) to point at the new
+   version. This is the public URL alias only; no `spec/latest/` directory
+   exists in the repo.
 4. Updates the `/spec/` index page to list the new version.
 5. Validates that every `@context` URL referenced in the new spec resolves
    on the live site (fail-build if not).
@@ -179,8 +183,8 @@ versions and points to the version that resolves the defect.
   deploy. This converts a class of correctness bug into a CI failure.
 - The repo gains a `spec/v<X.Y.Z>/` directory per release and a
   `spec/context/v<N>/` directory per context version. The legacy living-file
-  path is removed. Contributors editing the current draft do so against
-  `spec/latest/` working copy conventions established by the backfill issue.
+  path is removed. The repo holds no `spec/latest/` directory; "latest" is
+  a site-only alias.
 - Spec and context versions evolve independently. A spec-only release (e.g.
   a clarification that does not change JSON-LD terms) ships with no context
   bump. A context bump (rare, term-level changes only) is independent of

--- a/docs/adr/0021-spec-and-context-versioning.md
+++ b/docs/adr/0021-spec-and-context-versioning.md
@@ -1,0 +1,211 @@
+# ADR-0021: Spec and JSON-LD Context Versioning, with Permanent Per-Version URLs
+
+## Status
+
+Proposed
+
+## Context
+
+The Agent Receipts spec text promises permanent per-version URLs ("subsequent
+versions will be published at distinct, permanent URLs; this URL is frozen at
+v0.2.1 and will not change"). The project does not currently honor that
+promise. Five released spec versions (v0.1.0, v0.2.0, v0.2.1, v0.3.0, v0.4.0)
+have no canonical URL on the live site. The JSON-LD `@context` URL embedded
+in every receipt produced by the SDKs (`https://agentreceipts.ai/context/v1`)
+returns 404, meaning every receipt currently in existence references a context
+document that does not resolve.
+
+A site audit on 2026-05-24 found:
+
+- `https://agentreceipts.ai/spec/v0.2.1/` returns 404 (SITE-P7).
+- `https://agentreceipts.ai/context/v1` returns 404.
+- Current spec source is a single living file
+  (`spec/spec/agent-receipt-spec-v0.1.md`), not version-per-file.
+- That file's frontmatter claims `Version: 0.1.0` but its content includes
+  features released as recently as v0.4.0 (`idempotency_key`,
+  `chain.terminal` / `chain.status`, `outcome.response_hash`, `unknown`
+  action-type fallback). The frontmatter is stale and the file's actual
+  content corresponds to v0.4.0.
+- No JSON-LD context document exists in the repo.
+- Five spec versions have shipped (latest: v0.4.0, 2026-05-23) with no
+  versioned URLs published for any of them.
+
+The W3C Verifiable Credentials Data Model the receipt envelope is built on
+(ADR-0003) requires `@context` URLs to resolve to valid JSON-LD context
+documents. A receipt validator that strictly processes JSON-LD against an
+Agent Receipt today fails on context resolution. This is a correctness issue,
+not just a documentation gap. The cross-SDK conformance suite has apparently
+been getting away with not strictly validating JSON-LD, since every receipt
+it produces references an unresolvable context URL.
+
+This ADR records the decision to operate a spec release pipeline that makes
+the spec text's promise true, and specifies the versioning model for both
+the spec and the JSON-LD context.
+
+## Decisions
+
+### D1. Spec is versioned per file, in the repo, under `spec/`
+
+The source of truth for spec version `vX.Y.Z` is `spec/v<X.Y.Z>/spec.md` in
+the repo. Each version is immutable once tagged. Editorial corrections to a
+released version are not made in place; they are made by releasing a new
+version with a CHANGELOG entry noting the correction.
+
+The current single-file living spec (`spec/spec/agent-receipt-spec-v0.1.md`)
+is migrated: its current contents — which actually correspond to v0.4.0, not
+the v0.1.0 its frontmatter claims — become `spec/v0.4.0/spec.md`, with
+frontmatter corrected to `Version: 0.4.0`. The legacy path is deleted after
+migration.
+
+Earlier released versions (v0.1.0, v0.2.0, v0.2.1, v0.3.0) are reconstructed
+from git history and placed at `spec/v<X.Y.Z>/spec.md`. Where git history
+does not cleanly identify a "this commit is the v0.X release" state, the
+closest commit to the release date is used and a note recorded in the
+backfill issue.
+
+### D2. Permanent per-version URLs
+
+Every released spec version is published at
+`https://agentreceipts.ai/spec/v<X.Y.Z>/` and that URL is permanent. Once
+published, the URL MUST NOT be repurposed, redirected to a different version,
+or returned as 404 except during deploy windows.
+
+`https://agentreceipts.ai/spec/latest/` is a mutable alias pointing at the
+current version. Receipts and the conformance suite MUST NOT reference
+`/spec/latest/`; only versioned URLs.
+
+A `https://agentreceipts.ai/spec/` index page lists all released versions,
+marks the current one, and links to each.
+
+### D3. JSON-LD context is versioned independently, by JSON-LD term changes only
+
+The JSON-LD context lives at `https://agentreceipts.ai/context/v<N>` where
+`<N>` is an integer (`1`, `2`, `3`, …), not a semver string. This URL form
+(no trailing slash, no `v<N>/` directory) matches the form already referenced
+in every released spec version's `@context` array.
+
+The context version bumps when and only when JSON-LD term definitions change
+in a way that would alter how a receipt validates. Renaming a field is a
+context bump. Adding a new optional field whose JSON-LD term is already
+implied by existing definitions is not. Adding a new field that requires its
+own term definition is.
+
+The spec version and the context version are independent. Multiple spec
+versions may share one context version. The current state is: all five
+released spec versions reference `@context: https://agentreceipts.ai/context/v1`.
+This ADR is responsible for authoring v1 and ensuring it correctly defines
+the terms used across all five spec versions, including any field renames
+introduced in v0.3.0 and v0.4.0.
+
+If a future spec version introduces a JSON-LD term change, that spec
+version's `@context` array changes to reference the new context version
+(e.g. `v2`). The old context URL remains permanent.
+
+The context document is authored as part of this ADR's implementation. The
+source lives at `spec/context/v<N>/context.jsonld` in the repo.
+
+### D4. Release pipeline
+
+Spec releases are tag-driven. Tagging `spec-v<X.Y.Z>` triggers a workflow
+that:
+
+1. Verifies `spec/v<X.Y.Z>/spec.md` exists in the repo.
+2. Renders the spec markdown to a site page at
+   `site/src/content/docs/spec/v<X.Y.Z>.mdx`.
+3. Updates `spec/latest/` alias to point at the new version.
+4. Updates the `/spec/` index page to list the new version.
+5. Validates that every `@context` URL referenced in the new spec resolves
+   on the live site (fail-build if not).
+6. Deploys.
+
+Context releases are tag-driven similarly: tagging `context-v<N>` publishes
+`spec/context/v<N>/context.jsonld` at `https://agentreceipts.ai/context/v<N>`.
+
+The workflow specs live at `.github/workflows/spec-release.yml` and
+`.github/workflows/context-release.yml`.
+
+### D5. Retroactive tagging for existing versions
+
+After D1's backfill, the existing five spec versions are tagged retroactively
+(`spec-v0.1.0` through `spec-v0.4.0`) on the commit that landed the
+backfilled file. This validates the pipeline on past data: if it can't
+publish the five existing versions, it can't publish the next one.
+
+Context v1 is tagged once the context document is authored and validated
+against the conformance suite (D6).
+
+### D6. Conformance validates `@context` resolution
+
+The cross-SDK conformance suite is updated to assert that every receipt it
+produces has `@context` URLs that resolve to valid JSON-LD on the live site,
+not just URLs that look correct as strings. This closes the loop: the bug
+this ADR exists to fix becomes a property the project tests.
+
+If conformance fails for a context URL, the release pipeline (D4) fails the
+build. The project cannot ship a spec version that references a context
+document the live site cannot serve.
+
+### D7. Deprecation policy for old versions
+
+Released spec and context versions are kept reachable indefinitely. There is
+no "old enough to remove" threshold; every citation must remain valid.
+
+If a released version contains a defect (e.g. the multibase encoding
+inconsistency in v0.2.1 §4.2), the defect is not patched in place. A new
+version is released with the correction. The defective version remains
+reachable as a historical artifact. The `/spec/` index marks defective
+versions and points to the version that resolves the defect.
+
+## Out of scope for this ADR
+
+- Updating downstream pages (Overview, schema, verification, Article 12
+  one-pager) to reflect v0.4.0. Tracked in follow-up issues; depends on this
+  ADR landing.
+- Authoring an SDK release pipeline analogous to the spec pipeline.
+  Different scope, similar shape.
+- The site content-drift CI gate from the site audit. Adjacent; tracked
+  separately.
+
+## Consequences
+
+- The spec text's permanent-URL promise becomes operational reality rather
+  than aspirational language. Citations of `https://agentreceipts.ai/spec/v0.2.1/`
+  and every other released version will resolve.
+- Every receipt in existence — past and future — references a `@context` URL
+  that resolves to a valid JSON-LD document. Strict JSON-LD validators no
+  longer reject Agent Receipts on context-resolution failure.
+- The release pipeline (D4) makes it structurally hard to ship a spec
+  version whose context URL does not resolve, since the build fails before
+  deploy. This converts a class of correctness bug into a CI failure.
+- The repo gains a `spec/v<X.Y.Z>/` directory per release and a
+  `spec/context/v<N>/` directory per context version. The legacy living-file
+  path is removed. Contributors editing the current draft do so against
+  `spec/latest/` working copy conventions established by the backfill issue.
+- Spec and context versions evolve independently. A spec-only release (e.g.
+  a clarification that does not change JSON-LD terms) ships with no context
+  bump. A context bump (rare, term-level changes only) is independent of
+  whatever spec is current at the time.
+- The cross-SDK conformance suite gains a live-network dependency on the
+  deployed site for `@context` resolution checks. CI must tolerate transient
+  network failures by retrying, not by skipping the check.
+- Defective released versions remain published as historical artifacts.
+  Auditors verifying receipts produced under a defective spec version can
+  still resolve the exact spec text the receipt was signed against.
+
+## Implementation issues spawned by this ADR
+
+Filed as separate issues, blocked on the PR that merges this ADR. Each is
+labeled `adr-followup`.
+
+- Backfill spec versions v0.1.0 through v0.4.0 from git history (D1, D5).
+- Author JSON-LD context v1 covering terms across all five spec versions (D3).
+- Build `spec-release` and `context-release` GitHub Actions workflows (D4).
+- Update conformance suite to validate `@context` URL resolution (D6).
+- Publish `/spec/` index page (D2).
+- Update Article 12 one-pager for v0.4.0 schema and publish at canonical URL
+  (downstream).
+- Update Overview, schema, verification pages to v0.4.0 (downstream).
+
+---
+
+*Closes #596 when merged.*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,7 +34,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0018](0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md) | Signer Abstraction and Cloud-Agnostic KeyProvider Design | Accepted |
 | [ADR-0019](0019-protocol-integrity-gaps-and-mitigations.md) | Protocol Integrity Gaps and Mitigations | Proposed |
 | [ADR-0020](0020-emitter-abstraction-and-remote-receipt-delivery.md) | Emitter Abstraction and Remote Receipt Delivery | Accepted |
-| [ADR-0021](0021-spec-and-context-versioning.md) | Spec and JSON-LD Context Versioning, with Permanent Per-Version URLs | Proposed |
+| [ADR-0021](0021-spec-and-context-versioning.md) | Spec and JSON-LD Context Versioning, with Permanent Per-Version URLs | Accepted |
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0018](0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md) | Signer Abstraction and Cloud-Agnostic KeyProvider Design | Accepted |
 | [ADR-0019](0019-protocol-integrity-gaps-and-mitigations.md) | Protocol Integrity Gaps and Mitigations | Proposed |
 | [ADR-0020](0020-emitter-abstraction-and-remote-receipt-delivery.md) | Emitter Abstraction and Remote Receipt Delivery | Accepted |
+| [ADR-0021](0021-spec-and-context-versioning.md) | Spec and JSON-LD Context Versioning, with Permanent Per-Version URLs | Proposed |
 
 ## References
 


### PR DESCRIPTION
## What

Adds `docs/adr/0021-spec-and-context-versioning.md` and indexes it in `docs/adr/README.md`. Decision-only: no code, no pipeline changes, no spec edits.

The ADR records five sub-decisions (D1–D5):

- **D1** — Forward-only per-version spec files, starting at v0.4.0. Living spec migrates to `spec/v0.4.0/spec.md`. v0.1.0–v0.3.0 are **not** backfilled.
- **D2** — Permanent URLs from v0.4.0 onward at `https://agentreceipts.ai/spec/v<X.Y.Z>/`. `/spec/latest/` is a site-only mutable alias; no `spec/latest/` directory in repo.
- **D3** — JSON-LD context versioned independently at `https://agentreceipts.ai/context/v<N>`. v1 is authored to cover terms used across receipts produced under v0.1.0–v0.4.0.
- **D4** — Lightweight tag-driven site-build publishing. No fail-build CI gate; premature for one context doc.
- **D5** — Released versions kept reachable indefinitely; defects fixed by new releases, not in-place patches.

## Why

The spec text already promises permanent per-version URLs. A 2026-05-24 site audit found the project does not honor that promise:

- The `@context` URL embedded in every SDK-produced receipt (`https://agentreceipts.ai/context/v1`) returns 404. Every receipt in existence references an unresolvable context document. This is a correctness issue under the W3C VC data model (ADR-0003), not just a docs gap.
- The living spec file's frontmatter claims `Version: 0.1.0` but its content matches v0.4.0.
- Five spec versions (v0.1.0–v0.4.0) have shipped without canonical URLs.

The ADR is intentionally trimmed for early-days proportion: fix the live correctness bug (authoring `/context/v1`), establish forward-only conventions for v0.4.0 onward, and explicitly defer backfilling of historical versions until external citation pressure appears.

## Implementation issues spawned by this ADR

Three issues, all labeled `adr-followup`, blocked on this PR:

- #603 — Author JSON-LD context v1 (D3) — the load-bearing correctness fix
- #609 — Migrate living spec to `spec/v0.4.0/spec.md` and publish at canonical URL (D1, D2, D4)
- #606 — Publish `/spec/` index page listing v0.4.0+ (D2)

Closed as superseded by the trim: #602, #604, #605, #607, #608.

## Checklist

- [x] Tests pass for all changed components (no code changes; docs-only)
- [x] Linter passes (n/a; docs-only)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (n/a; no receipt format / signing / hashing change)
- [x] AGENTS.md updated (n/a; no project structure change)
- [x] Spec changes have been reviewed by a maintainer (n/a; no spec edits — this is an ADR about how spec versioning will work)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (no — decision-only ADR)

Closes #596 when merged.