### PR TITLE
feat(spec): add JSON-LD context v1

### DIFF
--- a/spec/context/v1/context.jsonld
+++ b/spec/context/v1/context.jsonld
@@ -267,6 +267,41 @@
           "@type": "xsd:string"
         }
       }
+    },
+
+    "keyRotation": {
+      "@id": "ar:keyRotation",
+      "@context": {
+        "@protected": true,
+        "event_type": {
+          "@id": "ar:rotation_event_type",
+          "@type": "xsd:string"
+        },
+        "new_public_key": {
+          "@id": "ar:new_public_key",
+          "@type": "xsd:string"
+        },
+        "old_key_fingerprint": {
+          "@id": "ar:old_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "new_key_fingerprint": {
+          "@id": "ar:new_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "old_algorithm": {
+          "@id": "ar:old_algorithm",
+          "@type": "xsd:string"
+        },
+        "new_algorithm": {
+          "@id": "ar:new_algorithm",
+          "@type": "xsd:string"
+        },
+        "signed_with": {
+          "@id": "ar:rotation_signed_with",
+          "@type": "xsd:string"
+        }
+      }
     }
   }
 }

--- a/spec/context/v1/context.jsonld
+++ b/spec/context/v1/context.jsonld
@@ -1,0 +1,269 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "ar": "https://agentreceipts.ai/vocab#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "AgentReceipt": "ar:AgentReceipt",
+    "AIActionReceipt": "ar:AgentReceipt",
+    "AIAgent": "ar:AIAgent",
+    "HumanPrincipal": "ar:HumanPrincipal",
+    "OrganizationPrincipal": "ar:OrganizationPrincipal",
+
+    "version": {
+      "@id": "ar:version",
+      "@type": "xsd:string"
+    },
+
+    "issuanceDate": {
+      "@id": "ar:issuanceDate",
+      "@type": "xsd:dateTime"
+    },
+
+    "name": "https://schema.org/name",
+    "operator": {
+      "@id": "ar:operator",
+      "@type": "@id"
+    },
+    "model": {
+      "@id": "ar:model",
+      "@type": "xsd:string"
+    },
+    "session_id": {
+      "@id": "ar:session_id",
+      "@type": "xsd:string"
+    },
+
+    "principal": {
+      "@id": "ar:principal",
+      "@type": "@id"
+    },
+
+    "action": {
+      "@id": "ar:action",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "risk_level": {
+          "@id": "ar:risk_level",
+          "@type": "xsd:string"
+        },
+        "target": {
+          "@id": "ar:target",
+          "@context": {
+            "@protected": true,
+            "system": {
+              "@id": "ar:target_system",
+              "@type": "xsd:string"
+            },
+            "resource": {
+              "@id": "ar:target_resource",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "parameters_hash": {
+          "@id": "ar:parameters_hash",
+          "@type": "xsd:string"
+        },
+        "parameters_disclosure": {
+          "@id": "ar:parameters_disclosure",
+          "@type": "@json"
+        },
+        "peer_credential": {
+          "@id": "ar:peer_credential",
+          "@context": {
+            "@protected": true,
+            "platform": {
+              "@id": "ar:peer_platform",
+              "@type": "xsd:string"
+            },
+            "pid": {
+              "@id": "ar:peer_pid",
+              "@type": "xsd:integer"
+            },
+            "uid": {
+              "@id": "ar:peer_uid",
+              "@type": "xsd:integer"
+            },
+            "gid": {
+              "@id": "ar:peer_gid",
+              "@type": "xsd:integer"
+            },
+            "exe_path": {
+              "@id": "ar:peer_exe_path",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "emitter_metadata": {
+          "@id": "ar:emitter_metadata",
+          "@context": {
+            "@protected": true,
+            "drop_count": {
+              "@id": "ar:emitter_drop_count",
+              "@type": "xsd:integer"
+            }
+          }
+        },
+        "timestamp": {
+          "@id": "ar:action_timestamp",
+          "@type": "xsd:dateTime"
+        },
+        "trusted_timestamp": {
+          "@id": "ar:trusted_timestamp",
+          "@type": "xsd:string"
+        },
+        "idempotency_key": {
+          "@id": "ar:idempotency_key",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "intent": {
+      "@id": "ar:intent",
+      "@context": {
+        "@protected": true,
+        "conversation_hash": {
+          "@id": "ar:conversation_hash",
+          "@type": "xsd:string"
+        },
+        "prompt_preview": {
+          "@id": "ar:prompt_preview",
+          "@type": "xsd:string"
+        },
+        "prompt_preview_truncated": {
+          "@id": "ar:prompt_preview_truncated",
+          "@type": "xsd:boolean"
+        },
+        "reasoning_hash": {
+          "@id": "ar:reasoning_hash",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "outcome": {
+      "@id": "ar:outcome",
+      "@context": {
+        "@protected": true,
+        "status": {
+          "@id": "ar:status",
+          "@type": "xsd:string"
+        },
+        "error": {
+          "@id": "ar:error",
+          "@type": "xsd:string"
+        },
+        "reversible": {
+          "@id": "ar:reversible",
+          "@type": "xsd:boolean"
+        },
+        "reversal_method": {
+          "@id": "ar:reversal_method",
+          "@type": "xsd:string"
+        },
+        "reversal_window_seconds": {
+          "@id": "ar:reversal_window_seconds",
+          "@type": "xsd:integer"
+        },
+        "reversal_of": {
+          "@id": "ar:reversal_of",
+          "@type": "@id"
+        },
+        "state_change": {
+          "@id": "ar:state_change",
+          "@context": {
+            "@protected": true,
+            "before_hash": {
+              "@id": "ar:before_hash",
+              "@type": "xsd:string"
+            },
+            "after_hash": {
+              "@id": "ar:after_hash",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "response_hash": {
+          "@id": "ar:response_hash",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "authorization": {
+      "@id": "ar:authorization",
+      "@context": {
+        "@protected": true,
+        "scopes": {
+          "@id": "ar:scopes",
+          "@container": "@set",
+          "@type": "xsd:string"
+        },
+        "granted_at": {
+          "@id": "ar:granted_at",
+          "@type": "xsd:dateTime"
+        },
+        "expires_at": {
+          "@id": "ar:expires_at",
+          "@type": "xsd:dateTime"
+        },
+        "grant_ref": {
+          "@id": "ar:grant_ref",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "delegation": {
+      "@id": "ar:delegation",
+      "@context": {
+        "@protected": true,
+        "parent_chain_id": {
+          "@id": "ar:parent_chain_id",
+          "@type": "xsd:string"
+        },
+        "parent_receipt_id": {
+          "@id": "ar:parent_receipt_id",
+          "@type": "@id"
+        },
+        "delegator": {
+          "@id": "ar:delegator",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "chain": {
+      "@id": "ar:chain",
+      "@context": {
+        "@protected": true,
+        "sequence": {
+          "@id": "ar:sequence",
+          "@type": "xsd:integer"
+        },
+        "previous_receipt_hash": {
+          "@id": "ar:previous_receipt_hash",
+          "@type": "xsd:string"
+        },
+        "chain_id": {
+          "@id": "ar:chain_id",
+          "@type": "xsd:string"
+        },
+        "terminal": {
+          "@id": "ar:terminal",
+          "@type": "xsd:boolean"
+        },
+        "status": {
+          "@id": "ar:chain_status",
+          "@type": "xsd:string"
+        }
+      }
+    }
+  }
+}

--- a/spec/context/v1/context.jsonld
+++ b/spec/context/v1/context.jsonld
@@ -45,8 +45,14 @@
       "@id": "ar:action",
       "@context": {
         "@protected": true,
-        "id": "@id",
-        "type": "@type",
+        "id": {
+          "@id": "ar:action_id",
+          "@type": "xsd:string"
+        },
+        "type": {
+          "@id": "ar:action_type",
+          "@type": "xsd:string"
+        },
         "risk_level": {
           "@id": "ar:risk_level",
           "@type": "xsd:string"

--- a/spec/context/v1/context.jsonld
+++ b/spec/context/v1/context.jsonld
@@ -24,8 +24,7 @@
 
     "name": "https://schema.org/name",
     "operator": {
-      "@id": "ar:operator",
-      "@type": "@id"
+      "@id": "ar:operator"
     },
     "model": {
       "@id": "ar:model",
@@ -37,8 +36,7 @@
     },
 
     "principal": {
-      "@id": "ar:principal",
-      "@type": "@id"
+      "@id": "ar:principal"
     },
 
     "action": {
@@ -239,8 +237,7 @@
           "@type": "@id"
         },
         "delegator": {
-          "@id": "ar:delegator",
-          "@type": "@id"
+          "@id": "ar:delegator"
         }
       }
     },


### PR DESCRIPTION
## What

Adds `spec/context/v1/context.jsonld` — the JSON-LD context document referenced by every receipt's `@context` array across spec versions v0.1.0 through v0.4.0. The URL `https://agentreceipts.ai/context/v1` has been 404ing since inception, leaving every receipt in existence with an unresolvable context. This file is the source that gets published there.

Closes #603. Implements [ADR-0021](https://github.com/agent-receipts/ar/blob/main/docs/adr/0021-spec-and-context-versioning.md) D3.

## Design notes

- **JSON-LD 1.1, `@protected: true` throughout.** Locks term definitions and catches accidental redefinitions in any downstream context.
- **Two type aliases for the v0.3.0 VC rename.** Both `AgentReceipt` and the legacy `AIActionReceipt` map to `ar:AgentReceipt`, so pre-rename receipts still type-resolve correctly.
- **`parameters_disclosure` uses `@type: @json`** to cover both the v0.2.x flat-map and the v0.3.0+ HPKE envelope shape without committing to either at the JSON-LD layer. (Validation of the actual shape is the schema's job, not the context's.)
- **All version-specific additions have explicit term definitions** with appropriate `xsd:` types:
  - v0.4.0: `idempotency_key`
  - v0.3.0: `peer_credential` (with nested `platform`, `pid`, `uid`, `gid`, `exe_path`), `emitter_metadata` (with `drop_count`)
  - Earlier: `chain.terminal`, `chain.status`, `outcome.response_hash`, `outcome.reversal_of`
- **Nested scoped contexts** (`action`, `outcome`, `chain`, `intent`, `authorization`, `delegation`) keep term namespaces local. Notably, `status` resolves distinctly inside `outcome` (`ar:status`) vs `chain` (`ar:chain_status`) — same JSON key, different IRIs.

## Validation

`jsonld.expand()` was run against all nine example receipts under `spec/examples/`. All nine expand cleanly with terms resolving to the `ar:` vocabulary:

```
  full-receipt.json:                       OK (36 vocab terms)
  minimal-receipt.json:                    OK (12 vocab terms)
  chain-receipt-1.json:                    OK (16 vocab terms)
  chain-receipt-2.json:                    OK (22 vocab terms)
  chain-receipt-3.json:                    OK (18 vocab terms)
  delegation-receipt.json:                 OK (20 vocab terms)
  parameters-disclosure-receipt.json:      OK (30 vocab terms)
  v0-2-response-hash-receipt.json:         OK (18 vocab terms)
  v0-2-terminal-chain-receipt-3.json:      OK (18 vocab terms)
```

Validation script (drop into a tmp dir with `npm install jsonld`):

```js
import { readFileSync } from 'node:fs';
import jsonld from 'jsonld';

const ctxDoc = JSON.parse(readFileSync('spec/context/v1/context.jsonld', 'utf8'));
const customLoader = async (url) => {
  if (url === 'https://agentreceipts.ai/context/v1') {
    return { contextUrl: null, documentUrl: url, document: ctxDoc };
  }
  return jsonld.documentLoaders.node()(url);
};

for (const f of /* every spec/examples/*.json */) {
  const r = JSON.parse(readFileSync('spec/examples/' + f, 'utf8'));
  const exp = await jsonld.expand(r, { documentLoader: customLoader });
  // assert at least one ar: vocab term resolved
}
```

## Publishing

Per ADR-0021 D3 and D4, this file gets published at `https://agentreceipts.ai/context/v1` by a separate site-side step. PR #610 establishes the analogous per-version *spec* publishing pattern; the context publishing follows the same shape and can land in a small follow-up (or be folded into #610 if reviewers prefer one PR).

## Post-merge action

Once published, tag `context-v1` per ADR-0021 D5 (release-action; not pushed from this branch).

## Checklist

- [x] Tests pass for all changed components (no SDK changes)
- [x] Linter passes (n/a — single JSON file)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (no receipt format / signing / hashing change)
- [x] AGENTS.md updated (n/a — new artifact under spec/, conventions unchanged)
- [x] Spec changes have been reviewed by a maintainer (spec **text** unchanged; this is the JSON-LD context that resolves the @context URL)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (no — context resolution is metadata, not signing input)

Closes #603.