### PR TITLE
Add production security warnings to in-process signing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ mcp-proxy verify --key pub.pem <chain-id>
 
 ## SDK quick start
 
+> **Not for production.** The snippets below keep the signing key inside the
+> agent process. Anyone with code execution in the agent can forge receipts. For
+> real deployments, use the
+> [daemon-mediated path](https://agentreceipts.ai/getting-started/daemon-setup/),
+> where the daemon owns the key and your app only sends events over a socket.
+
 ### Go
 
 ```bash

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -31,6 +31,12 @@ go get github.com/agent-receipts/sdk-go
 
 ## Quick start
 
+> **Not for production.** This pattern keeps the signing key inside the agent
+> process. Anyone with code execution in the agent can forge receipts. For real
+> deployments, use the
+> [daemon-mediated path](https://agentreceipts.ai/getting-started/daemon-setup/),
+> where the daemon owns the key and your app only sends events over a socket.
+
 ```go
 package main
 

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -49,14 +49,15 @@ pip install agent-receipts
 
 ## Quick start
 
-> **In-process signing (below) keeps the private key in the calling process.**
-> For the strongest key isolation, run an out-of-process `agent-receipts-daemon`
-> that owns the key and the chain while your app only sends tool-call events to
-> it. If you sign client-side, deliver the signed receipts with `HttpEmitter`
-> (optionally wrapped in `WalEmitter` for at-least-once delivery — requires
-> `HttpEmitter` in its default `"sync"` mode, not `"fire-and-forget"`).
-> See [Delivering receipts](#delivering-receipts) and the
-> [Daemon Setup guide](https://agentreceipts.ai/getting-started/daemon-setup/).
+> **Not for production.** The in-process signing below keeps the signing key
+> inside the agent process. Anyone with code execution in the agent can forge
+> receipts. For real deployments, use the daemon-mediated path: run an
+> out-of-process `agent-receipts-daemon` that owns the key and the chain while
+> your app only sends tool-call events to it. If you sign client-side, deliver
+> the signed receipts with `HttpEmitter` (optionally wrapped in `WalEmitter` for
+> at-least-once delivery — requires `HttpEmitter` in its default `"sync"` mode,
+> not `"fire-and-forget"`). See [Delivering receipts](#delivering-receipts) and
+> the [Daemon Setup guide](https://agentreceipts.ai/getting-started/daemon-setup/).
 
 ### Create and sign a receipt
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -47,6 +47,12 @@ npm install @agnt-rcpt/sdk-ts
 
 ### Create and sign a receipt
 
+> **Not for production.** This pattern keeps the signing key inside the agent
+> process. Anyone with code execution in the agent can forge receipts. For real
+> deployments, use the
+> [daemon-mediated path](https://agentreceipts.ai/getting-started/daemon-setup/),
+> where the daemon owns the key and your app only sends events over a socket.
+
 ```typescript
 import {
   createReceipt,

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -5,8 +5,8 @@ description: Create, sign, and verify your first Agent Receipt.
 
 This guide walks you through creating, signing, and verifying an Agent Receipt using either the TypeScript or Python SDK.
 
-:::note[In-process API — standalone and testing use]
-The examples below use the direct SDK signing API, where the calling process holds the private key. This is the legacy in-process pattern that ADR-0010 deprecates in favour of the `agent-receipts-daemon`. For production deployments, the daemon owns the key and emitters send events over a socket — see [Daemon Setup](/getting-started/daemon-setup/).
+:::caution[Not for production]
+The examples below use the direct SDK signing API, which keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
 :::
 
 ```mermaid
@@ -36,6 +36,10 @@ npm install @agnt-rcpt/sdk-ts
 ```
 
 ### 2. Create and sign a receipt
+
+:::caution[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/).
+:::
 
 ```typescript
 import {
@@ -103,6 +107,10 @@ pip install agent-receipts
 ```
 
 ### 2. Create and sign a receipt
+
+:::caution[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/).
+:::
 
 ```python
 from agent_receipts import (

--- a/site/src/content/docs/sdk-go/overview.mdx
+++ b/site/src/content/docs/sdk-go/overview.mdx
@@ -23,6 +23,10 @@ The Go SDK provides tools for creating, signing, and verifying Agent Receipts in
 
 ## Quick example
 
+:::caution[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
+:::
+
 ```go
 package main
 

--- a/site/src/content/docs/sdk-py/overview.mdx
+++ b/site/src/content/docs/sdk-py/overview.mdx
@@ -17,6 +17,10 @@ The Python SDK (`agent-receipts`) provides tools for creating, signing, and veri
 
 ## Quick example
 
+:::caution[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
+:::
+
 ```python
 from agent_receipts import (
     CreateReceiptInput,

--- a/site/src/content/docs/sdk-ts/overview.mdx
+++ b/site/src/content/docs/sdk-ts/overview.mdx
@@ -17,6 +17,10 @@ The TypeScript SDK (`@agnt-rcpt/sdk-ts`) provides tools for creating, signing, a
 
 ## Quick example
 
+:::caution[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
+:::
+
 ```typescript
 import { createReceipt, signReceipt, generateKeyPair } from "@agnt-rcpt/sdk-ts";
 


### PR DESCRIPTION
## What

Added prominent security warnings across all SDK documentation and README files to clarify that in-process signing (where the private key lives in the agent process) is not suitable for production use. The warnings direct users to the daemon-mediated path for real deployments.

## Why

In-process signing creates a security risk: anyone with code execution in the agent process can forge receipts. This is a critical distinction that should be immediately visible to users following the quick-start guides. The current documentation presents the in-process pattern without sufficient emphasis on its limitations, which could lead to insecure deployments.

By adding `:::caution[Not for production]` blocks and updated blockquotes in all quick-start sections, we ensure users understand the security model before implementing it.

## Changes

- Updated `README.md` (root) with production warning in SDK quick start section
- Updated `sdk/py/README.md` with clarified warning about in-process signing risks
- Updated `sdk/go/README.md` with production warning before quick start example
- Updated `sdk/ts/README.md` with production warning before quick start example
- Updated `site/src/content/docs/getting-started/quick-start.mdx` with caution block and additional warnings in both TypeScript and Python sections
- Updated `site/src/content/docs/sdk-go/overview.mdx` with caution block before quick example
- Updated `site/src/content/docs/sdk-py/overview.mdx` with caution block before quick example
- Updated `site/src/content/docs/sdk-ts/overview.mdx` with caution block before quick example

All warnings consistently explain the risk and link to the daemon setup guide for production deployments.

## Checklist

- [x] No code logic changes — documentation only
- [x] No real keys or secrets in the diff
- [x] Warnings are consistent across all SDK documentation

## Security

- [x] This PR touches security documentation (in-process vs. daemon-mediated signing)
- [x] Warnings accurately describe the threat model (code execution → forged receipts)
- [x] All quick-start examples now have explicit production warnings

https://claude.ai/code/session_01PXxuaQhCEmgRjbfdxp6wRM