### PR TITLE
docs: update Go SDK README for daemon-mediated signing

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -25,17 +25,69 @@ go get github.com/agent-receipts/sdk-go
 
 | Package | Description |
 |---------|-------------|
+| `emitter` | Daemon-socket client: forwards tool-call events to a local `agent-receipts-daemon`, which holds the signing key and constructs, signs, and chains the receipt |
 | `receipt` | Create, sign (Ed25519), verify, and hash-chain Action Receipts (W3C Verifiable Credentials) |
 | `taxonomy` | Built-in action type registry (15 types), tool call classification, custom mappings |
 | `store` | SQLite-backed receipt persistence, query, stats, and chain verification |
+| `emitters` | Signed-receipt delivery to a remote collector (`HttpEmitter`, `CompositeEmitter`, `BufferingEmitter`, `WALEmitter`) |
 
 ## Quick start
 
+The canonical deployment shape is **daemon-mediated signing**: your app sends
+tool-call events to a local `agent-receipts-daemon` over a Unix socket, and the
+daemon holds the Ed25519 signing key and constructs, signs, and chains the
+receipt. Keeping the key out of the agent process is what makes a receipt
+evidence rather than a self-reported claim — anything with code execution in
+your app cannot reach the key or forge receipts.
+
+Start the daemon, then emit events from your app:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/agent-receipts/sdk-go/emitter"
+)
+
+func main() {
+	// The daemon owns the signing key and the chain. Construct the emitter
+	// once; it uses AGENTRECEIPTS_SOCKET or the per-OS default socket path.
+	e, err := emitter.NewDaemon()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer e.Close()
+
+	// Forward one tool-call event. The daemon canonicalises, signs, and
+	// persists the receipt — the SDK does no crypto here.
+	err = e.Emit(context.Background(), emitter.Event{
+		Channel:  "my-app",
+		Tool:     emitter.Tool{Name: "filesystem.file.read"},
+		Decision: "allowed",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+`emitter.Emit` is fire-and-forget: if the daemon is unreachable the event is
+dropped (logged at debug level), so start the daemon before your app. See the
+[Daemon Setup guide](https://agentreceipts.ai/getting-started/daemon-setup/) for
+running the daemon and verifying the chain.
+
+## In-process signing (tutorial and testing only)
+
 > **Not for production.** This pattern keeps the signing key inside the agent
 > process. Anyone with code execution in the agent can forge receipts. For real
-> deployments, use the
-> [daemon-mediated path](https://agentreceipts.ai/getting-started/daemon-setup/),
-> where the daemon owns the key and your app only sends events over a socket.
+> deployments, use the [daemon-mediated path](#quick-start).
+
+The `receipt`, `taxonomy`, and `store` packages let you create, sign, verify,
+and persist receipts entirely in-process. This is useful as a learning aid and
+in tests, where holding the key in the calling process is acceptable.
 
 ```go
 package main
@@ -99,6 +151,48 @@ func main() {
 	fmt.Printf("Receipt %s stored\n", signed.ID)
 }
 ```
+
+## Enterprise / multi-host: collector delivery
+
+Use the `emitters` package when the agent host and the receipt-storage host
+differ, or when you are aggregating receipts from multiple agents across
+multiple hosts. Unlike the daemon emitter (which forwards *unsigned events* for
+daemon-side signing), `emitters` deliver *already-signed* `receipt.AgentReceipt`
+values — sign client-side (or accept pre-signed receipts), then POST them to a
+deployed `agent-receipts-collector`.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/agent-receipts/sdk-go/emitters"
+	"github.com/agent-receipts/sdk-go/receipt"
+)
+
+func deliver(signed receipt.AgentReceipt) {
+	e, err := emitters.NewHTTP(emitters.HttpEmitterConfig{
+		Endpoint: "https://collector.example.com/receipts",
+		Auth:     emitters.BearerAuth{Token: os.Getenv("AGENTRECEIPTS_TOKEN")},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Emit takes a fully signed, already-chained receipt.
+	if err := e.Emit(context.Background(), signed); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+`HttpEmitter` defaults to the `"sync"` strategy (at-least-once up to the retry
+budget). For batching, fan-out, or write-ahead durability across collector
+outages, compose it with `BufferingEmitter`, `CompositeEmitter`, or
+`WALEmitter` from the same package.
 
 ## License
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -49,7 +49,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/agent-receipts/sdk-go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
 
 func main() {
@@ -169,8 +169,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/agent-receipts/sdk-go/emitters"
-	"github.com/agent-receipts/sdk-go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/emitters"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 func deliver(signed receipt.AgentReceipt) {

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -2,10 +2,10 @@
 
 # sdk-go
 
-### Go SDK for the Action Receipts protocol
+### Go SDK for the Agent Receipts protocol
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 
 **Cryptographically signed audit trails for AI agent actions.**
 
@@ -26,7 +26,7 @@ go get github.com/agent-receipts/sdk-go
 | Package | Description |
 |---------|-------------|
 | `emitter` | Daemon-socket client: forwards tool-call events to a local `agent-receipts-daemon`, which holds the signing key and constructs, signs, and chains the receipt |
-| `receipt` | Create, sign (Ed25519), verify, and hash-chain Action Receipts (W3C Verifiable Credentials) |
+| `receipt` | Create, sign (Ed25519), verify, and hash-chain Agent Receipts (W3C Verifiable Credentials) |
 | `taxonomy` | Built-in action type registry (15 types), tool call classification, custom mappings |
 | `store` | SQLite-backed receipt persistence, query, stats, and chain verification |
 | `emitters` | Signed-receipt delivery to a remote collector (`HttpEmitter`, `CompositeEmitter`, `BufferingEmitter`, `WALEmitter`) |


### PR DESCRIPTION
## What

Updated the Go SDK README to reflect the canonical deployment architecture: daemon-mediated signing via the `emitter` package, with in-process signing relegated to tutorial/testing only. Added comprehensive quick-start examples, clarified the security model, and documented the `emitters` package for multi-host collector delivery.

## Why

The README previously presented in-process signing as the primary pattern, which is a security anti-pattern for production (the signing key lives in the agent process where code execution can forge receipts). This update:

1. **Establishes the correct security model**: daemon-mediated signing keeps the Ed25519 key out of the agent process, making receipts cryptographic evidence rather than self-reported claims
2. **Provides actionable guidance**: new developers see the daemon pattern first with a working code example
3. **Documents the full SDK surface**: adds the `emitter` and `emitters` packages to the package table and explains their roles
4. **Clarifies use cases**: separates learning/testing (in-process) from production (daemon or collector delivery)
5. **Updates Go version requirement**: bumps from 1.22+ to 1.26+ to reflect current toolchain support

## Changes

- Renamed "Action Receipts" → "Agent Receipts" throughout
- Added `emitter` and `emitters` packages to the package table with descriptions
- Restructured quick-start section:
  - New "daemon-mediated signing" section as the primary pattern with working example
  - Moved in-process signing to "In-process signing (tutorial and testing only)" with security warning
  - Added "Enterprise / multi-host: collector delivery" section with `emitters` example
- Updated Go version badge from 1.22+ to 1.26+

## Checklist

- [x] No code changes (documentation only)
- [x] No real keys or secrets in the diff
- [x] Examples are syntactically correct and follow SDK conventions

## Security

- [x] This PR does not touch crypto, auth, or secrets handling (documentation clarification only)

https://claude.ai/code/session_01K4Qf9stCs3mQG9WKLCDEQW