### PR TITLE
docs(site): fix stale APIs and macOS socket path in Daemon Setup

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -76,7 +76,7 @@ To run as a persistent service on macOS, use the launchd plist available at [`da
 
 ## Connect your emitters
 
-Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default on those platforms. On other platforms the Go SDK does not consult `AGENTRECEIPTS_SOCKET` — callers must pass an explicit `WithSocketPath` option; `NewDaemon()` returns an error if no socket path is provided.
+Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default. Other platforms have no platform default, but `AGENTRECEIPTS_SOCKET` (or the SDK's explicit socket-path option) still supplies one; `NewDaemon()` only errors when neither is provided.
 
 There is no in-process fallback: if the daemon is unreachable, events are dropped silently (see [Start](#start) for timeout details).
 
@@ -242,8 +242,8 @@ The most common cause is that the daemon is not running when the emitter starts.
 
 ```bash
 pgrep agent-receipts-daemon
-ls -la "${XDG_DATA_HOME:-$HOME/.local/share}/agent-receipts/events.sock"  # macOS
-ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"               # Linux
+ls -la ~/.local/share/agent-receipts/events.sock             # macOS (default fallback)
+ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"  # Linux
 ```
 
 **Socket path mismatch.**

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -63,7 +63,7 @@ The daemon listens on a Unix domain socket. The socket path depends on platform:
 
 | Platform | Default socket path |
 |----------|---------------------|
-| macOS | `$TMPDIR/agentreceipts/events.sock` (falls back to `/tmp/agentreceipts/events.sock` when `$TMPDIR` is unset) |
+| macOS | `$XDG_DATA_HOME/agent-receipts/events.sock` (falls back to `~/.local/share/agent-receipts/events.sock` when `$XDG_DATA_HOME` is unset or not an absolute path) |
 | Linux | `$XDG_RUNTIME_DIR/agentreceipts/events.sock`, falling back to `/run/agentreceipts/events.sock` |
 
 :::caution
@@ -76,7 +76,7 @@ To run as a persistent service on macOS, use the launchd plist available at [`da
 
 ## Connect your emitters
 
-Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default on those platforms. On other platforms the Go SDK does not consult `AGENTRECEIPTS_SOCKET` — callers must pass an explicit `WithSocketPath` option; `New()` returns an error if no socket path is provided.
+Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default on those platforms. On other platforms the Go SDK does not consult `AGENTRECEIPTS_SOCKET` — callers must pass an explicit `WithSocketPath` option; `NewDaemon()` returns an error if no socket path is provided.
 
 There is no in-process fallback: if the daemon is unreachable, events are dropped silently (see [Start](#start) for timeout details).
 
@@ -94,7 +94,7 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
 
-e, err := emitter.New(emitter.WithSocketPath("/path/to/events.sock"))
+e, err := emitter.NewDaemon(emitter.WithSocketPath("/path/to/events.sock"))
 if err != nil {
 	log.Fatal(err)
 }
@@ -108,34 +108,34 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
 
-e, err := emitter.New()
+e, err := emitter.NewDaemon()
 if err != nil {
 	log.Fatal(err)
 }
 ```
 
-### TypeScript SDK (v0.8.0-alpha.2)
+### TypeScript SDK
 
-Install the alpha release:
+Install:
 
 ```bash
-npm install @agnt-rcpt/sdk-ts@alpha
+npm install @agnt-rcpt/sdk-ts
 ```
 
 **Option A: explicit socket path**
 
 ```typescript
-import { Emitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
 
-const e = new Emitter({ socketPath: "/path/to/events.sock" });
+const e = new DaemonEmitter({ socketPath: "/path/to/events.sock" });
 ```
 
 **Option B: via environment variable (`AGENTRECEIPTS_SOCKET`)**
 
 ```typescript
-import { Emitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
 
-const e = new Emitter();
+const e = new DaemonEmitter();
 ```
 
 ### Python SDK
@@ -242,8 +242,8 @@ The most common cause is that the daemon is not running when the emitter starts.
 
 ```bash
 pgrep agent-receipts-daemon
-ls -la "${TMPDIR:-/tmp}/agentreceipts/events.sock"                       # macOS
-ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"  # Linux
+ls -la "${XDG_DATA_HOME:-$HOME/.local/share}/agent-receipts/events.sock"  # macOS
+ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"               # Linux
 ```
 
 **Socket path mismatch.**

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -76,7 +76,7 @@ To run as a persistent service on macOS, use the launchd plist available at [`da
 
 ## Connect your emitters
 
-Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default. Other platforms have no platform default, but `AGENTRECEIPTS_SOCKET` (or the SDK's explicit socket-path option) still supplies one; `NewDaemon()` only errors when neither is provided.
+Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default. Other platforms have no platform default, but `AGENTRECEIPTS_SOCKET` (or the SDK's explicit socket-path option, e.g. Go's `WithSocketPath`) still supplies one; the emitter constructor only errors when neither is provided.
 
 There is no in-process fallback: if the daemon is unreachable, events are dropped silently (see [Start](#start) for timeout details).
 
@@ -245,6 +245,8 @@ pgrep agent-receipts-daemon
 ls -la ~/.local/share/agent-receipts/events.sock             # macOS (default fallback)
 ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"  # Linux
 ```
+
+If you've set `AGENTRECEIPTS_SOCKET` or an absolute `XDG_DATA_HOME`, check that path instead. The macOS example above assumes the default fallback location.
 
 **Socket path mismatch.**
 If you start the daemon and an emitter on different socket paths, events are dropped. Set `AGENTRECEIPTS_SOCKET` to the same value in the daemon's environment and each emitter's environment, or rely on the platform default by not setting it in either.


### PR DESCRIPTION
Brings `site/src/content/docs/getting-started/daemon-setup.mdx` into line with the shipped SDKs and `daemon/README.md`. Surfaced by #627; the Quick Start rewrite (#625) already uses these values, this PR fixes the page that disagreed with it.

## Changes

- **TypeScript snippets** use `DaemonEmitter` (renamed from `Emitter` in `@agnt-rcpt/sdk-ts` 0.10.0 / #548). The old import no longer compiles.
- **TypeScript install** drops `@alpha`. `DaemonEmitter` ships on the default tag; `@alpha` still resolves to the older prerelease that exports the old `Emitter` name, so the documented import was broken against the pinned version.
- **Go snippets** use `emitter.NewDaemon` — the current constructor in `sdk/go/emitter`. There is no `emitter.New`.
- **macOS default socket path** moves from `$TMPDIR/agentreceipts/events.sock` to `$XDG_DATA_HOME/agent-receipts/events.sock` (fallback `~/.local/share/agent-receipts/events.sock`). This matches the daemon's actual resolver and `daemon/README.md`. `$TMPDIR` is not inherited by GUI-spawned processes on macOS, so the old path made the emitter ↔ daemon handshake fail silently (#545). Most user-impacting item in the issue.

## Papercut

- Fixed one inline reference to `New()` → `NewDaemon()` in the same paragraph as the renamed Go snippets, for consistency.
- Updated the troubleshooting `ls` example to the new macOS path.

## Acceptance criteria

- [x] TypeScript snippets use `DaemonEmitter` (not `Emitter`).
- [x] TypeScript install drops `@alpha` (plain package).
- [x] Go snippets use `emitter.NewDaemon`.
- [x] macOS default socket path matches `daemon/README.md`.
- [x] `daemon-setup.mdx` no longer contradicts the Quick Start (#625) or `daemon/README.md`.

Closes #627.