### PR TITLE
ci: verify README code snippets against the SDK artifacts

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -54,6 +54,26 @@ jobs:
           done
           [[ "$succeeded" == "true" ]] || echo "::warning::Failed to request pkg.go.dev indexing after 3 attempts"
 
+  # Release-blocking gate: the just-published Go module must satisfy the code
+  # snippets in the READMEs. Runs after sdk-go so the tag is live on the proxy;
+  # a drifted snippet turns the release red. (Pre-publish gating isn't possible
+  # here — "published" mode needs the artifact to already exist on the proxy.)
+  readme-snippets:
+    needs: sdk-go
+    if: startsWith(github.ref_name, 'sdk/go/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - name: Verify published README snippets build
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/readme_snippets/check.py \
+            --lang go --source published --version "$VERSION" \
+            README.md sdk/go/README.md
+
   hook:
     if: startsWith(github.ref_name, 'hook/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -43,3 +43,21 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: sdk/py/dist/
+
+  # Release-blocking gate: the just-published PyPI package must satisfy the code
+  # snippets in the READMEs. Runs after publish so the version is live on PyPI;
+  # a drifted snippet turns the release red. (Pre-publish gating isn't possible
+  # here — "published" mode needs the artifact to already exist on the registry.)
+  readme-snippets:
+    needs: publish
+    if: |
+      startsWith(github.ref_name, 'sdk-py-v') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Verify published README snippets type-check
+        run: python3 scripts/readme_snippets/check.py --lang py --source published README.md sdk/py/README.md

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -86,3 +86,24 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}
+
+  # Release-blocking gate: the just-published npm package must satisfy the code
+  # snippets in the READMEs. Runs after publish so the version is live on npm;
+  # a drifted snippet turns the release red. (Pre-publish gating isn't possible
+  # here — "published" mode needs the artifact to already exist on the registry.)
+  readme-snippets:
+    needs: publish
+    if: |
+      startsWith(github.ref_name, 'sdk-ts-v') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - name: Verify published README snippets type-check
+        run: python3 scripts/readme_snippets/check.py --lang ts --source published README.md sdk/ts/README.md

--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -1,0 +1,67 @@
+name: "CI: README snippets"
+
+# Compile / type-check the SDK code snippets embedded in the user-facing
+# READMEs against the in-tree SDK, so a snippet and the API it documents are
+# verified against the same commit. The release-blocking variant (against the
+# *published* artifact) lives in the publish-* workflows.
+#
+# See scripts/readme_snippets/ for the extractor and orchestrator.
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - "README.md"
+      - "sdk/go/README.md"
+      - "sdk/ts/README.md"
+      - "sdk/py/README.md"
+      - "scripts/readme_snippets/**"
+      - ".github/workflows/readme-snippets.yml"
+  pull_request:
+    branches: [main]
+    paths: *paths
+
+permissions:
+  contents: read
+
+jobs:
+  extractor-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - run: python3 scripts/readme_snippets/test_extract.py
+
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - name: Check Go snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang go --source local README.md sdk/go/README.md
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: sdk/ts/pnpm-lock.yaml
+      # The snippets resolve `@agnt-rcpt/sdk-ts` from a file: install of the
+      # in-tree package, so its dist/ must be built first.
+      - name: Build in-tree TypeScript SDK
+        working-directory: sdk/ts
+        run: pnpm install --frozen-lockfile && pnpm run build
+      - name: Check TypeScript snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang ts --source local README.md sdk/ts/README.md
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check Python snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang py --source local README.md sdk/py/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ go.work.sum
 # Local dev files
 .claude/
 .codex-worktrees/
+__pycache__/
+*.pyc
 *.db
 *.db-shm
 *.db-wal

--- a/README.md
+++ b/README.md
@@ -153,12 +153,13 @@ from agent_receipts import (
     create_receipt, generate_key_pair, sign_receipt,
     CreateReceiptInput, Issuer, Principal, Outcome, Chain,
 )
+from agent_receipts.receipt.create import ActionInput
 
 keys = generate_key_pair()
 unsigned = create_receipt(CreateReceiptInput(
     issuer=Issuer(id="did:agent:my-agent"),
     principal=Principal(id="did:user:alice"),
-    action={"type": "filesystem.file.read", "risk_level": "low"},
+    action=ActionInput(type="filesystem.file.read", risk_level="low"),
     outcome=Outcome(status="success"),
     chain=Chain(sequence=1, previous_receipt_hash=None, chain_id="chain_1"),
 ))

--- a/scripts/readme_snippets/AGENTS.md
+++ b/scripts/readme_snippets/AGENTS.md
@@ -1,0 +1,60 @@
+# readme_snippets
+
+Release-blocking check that the SDK code snippets in the user-facing READMEs
+actually compile / type-check against the SDK. Catches the recurring papercut
+(#593, #594) where a quick-start snippet calls a non-existent API, imports a
+wrong module path, or drifts behind a published rename.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `extract.py` | Pure fence extraction + per-language assembly. Unit tested. |
+| `check.py` | IO + subprocess driver: scaffolds a throwaway project and runs the compiler/type-checker. |
+| `test_extract.py` | Unit tests for `extract.py`. |
+
+## Run locally
+
+```sh
+python3 scripts/readme_snippets/test_extract.py          # unit tests
+# TypeScript local mode needs the in-tree dist built first:
+( cd sdk/ts && pnpm install && pnpm run build )
+python3 scripts/readme_snippets/check.py --lang go --source local README.md sdk/go/README.md
+python3 scripts/readme_snippets/check.py --lang ts --source local README.md sdk/ts/README.md
+python3 scripts/readme_snippets/check.py --lang py --source local README.md sdk/py/README.md
+```
+
+`--source local` builds against the in-tree SDK (used on PRs). `--source
+published [--version X.Y.Z]` builds against the released artifact (used by the
+publish-* workflows at release time).
+
+## Per-language tooling
+
+- **Go** — every snippet compiles as a non-main `package snippet` via `go build`
+  (so a block with no `func main` still builds; unused funcs are allowed, unused
+  imports/locals are not). Bare statement snippets are wrapped automatically.
+- **TypeScript** — `tsc --noEmit --strict` against the installed package.
+- **Python** — `mypy` against the installed package (`agent-receipts` ships
+  `py.typed`). Type-check only; snippets are never executed.
+
+## Authoring snippets
+
+Every fenced `go` / `typescript` / `python` block that imports the SDK is
+checked **by default** — that default is what catches drift on a newly added
+snippet without anyone remembering to annotate it. Two invisible HTML-comment
+directives override this when a block isn't standalone:
+
+```md
+<!-- snippet-check: continues -->   <!-- concatenate onto the previous checked block -->
+<!-- snippet-check: skip -->        <!-- exclude (intentionally partial pseudo-code) -->
+```
+
+Place the directive on its own line immediately above the opening fence.
+
+## Adding a README to the gate
+
+1. Add its path to the `check.py` invocations in
+   `.github/workflows/readme-snippets.yml` (and the relevant publish-* workflow
+   for the release gate).
+2. Run the local commands above and resolve any failures — prefer fixing the
+   snippet over adding a `skip`.

--- a/scripts/readme_snippets/check.py
+++ b/scripts/readme_snippets/check.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Compile / type-check the SDK code snippets embedded in the user-facing READMEs.
+
+Three failure classes this guards against, all of which have shipped before
+(see #593, #594): a snippet calls an API that never existed, imports a wrong
+module path, or drifts behind a published rename.
+
+Usage:
+    check.py --lang {go,ts,py} --source {local,published} [--version X.Y.Z]
+             [--repo-root .] [--workdir DIR] README.md [more/README.md ...]
+
+Source modes:
+    local      Build snippets against the in-tree SDK. Used on PRs so a snippet
+               and the API it documents are verified against the same commit
+               (and new, unreleased APIs are allowed).
+    published  Build against the released artifact at --version (default: read
+               from the manifest). Used at release time to catch a README that
+               has drifted from what users will actually `pip install` /
+               `npm install` / `go get`.
+
+Only the extraction/assembly logic is unit tested (see test_extract.py); this
+module is the IO + subprocess driver and is exercised end-to-end by CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import extract  # noqa: E402
+
+GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+TS_PACKAGE = "@agnt-rcpt/sdk-ts"
+PY_PACKAGE = "agent-receipts"
+
+
+def _run(cmd: list[str], cwd: str, env: dict[str, str] | None = None, retries: int = 0) -> int:
+    full_env = {**os.environ, **(env or {})}
+    for attempt in range(retries + 1):
+        print(f"  $ {' '.join(cmd)}  (cwd={cwd})", flush=True)
+        proc = subprocess.run(cmd, cwd=cwd, env=full_env)
+        if proc.returncode == 0 or attempt == retries:
+            return proc.returncode
+        wait = 2 ** (attempt + 1)
+        print(f"  command failed (rc={proc.returncode}); retrying in {wait}s", flush=True)
+        time.sleep(wait)
+    return proc.returncode
+
+
+def _collect_units(readmes: list[str], lang: str) -> list[extract.Unit]:
+    units: list[extract.Unit] = []
+    for path in readmes:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        found = extract.build_units(path, text, lang)
+        units.extend(found)
+        print(f"  {path}: {len(found)} {lang} unit(s)")
+    return units
+
+
+# --------------------------------------------------------------------------- #
+# Version resolution
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_version(lang: str, repo_root: str, override: str | None) -> str:
+    if override:
+        return override
+    if lang == "ts":
+        with open(os.path.join(repo_root, "sdk/ts/package.json"), encoding="utf-8") as fh:
+            return json.load(fh)["version"]
+    if lang == "py":
+        import re
+
+        with open(os.path.join(repo_root, "sdk/py/pyproject.toml"), encoding="utf-8") as fh:
+            for line in fh:
+                m = re.match(r'\s*version\s*=\s*"([^"]+)"', line)
+                if m:
+                    return m.group(1)
+        raise SystemExit("could not read version from sdk/py/pyproject.toml")
+    raise SystemExit(
+        "--version is required for Go published-mode checks (read it from the release tag)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Go
+# --------------------------------------------------------------------------- #
+
+
+def check_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    if not units:
+        print("  no Go units to check")
+        return 0
+
+    noncanonical = False
+    for unit in units:
+        bad = extract.go_noncanonical_imports(unit.code)
+        if bad:
+            noncanonical = True
+            for path in bad:
+                print(
+                    f"  non-canonical SDK import {path!r} ({', '.join(unit.sources)}); "
+                    f"use {GO_MODULE}"
+                )
+    if noncanonical:
+        return 1
+
+    network_retries = 4 if source == "published" else 0
+    go_mod = ["module readme-snippets\n", "go 1.26.1\n"]
+    if source == "local":
+        sdk_path = os.path.join(repo_root, "sdk", "go")
+        # Throwaway module — a local replace here is fine and never published
+        # (publish-go.yml only rejects replaces in the SDK's own go.mod).
+        go_mod.append(f"require {GO_MODULE} v0.0.0\n")
+        go_mod.append(f"replace {GO_MODULE} => {sdk_path}\n")
+    else:
+        go_mod.append(f"require {GO_MODULE} v{version}\n")
+
+    with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
+        fh.writelines(go_mod)
+
+    for n, unit in enumerate(units, start=1):
+        pkg_dir = os.path.join(workdir, f"snippet_{n:03d}")
+        os.makedirs(pkg_dir, exist_ok=True)
+        _write_unit(pkg_dir, "main.go", unit)
+
+    env = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
+    if _run(["go", "mod", "tidy"], cwd=workdir, env=env, retries=network_retries) != 0:
+        return 1
+    return _run(["go", "build", "./..."], cwd=workdir, env=env)
+
+
+# --------------------------------------------------------------------------- #
+# TypeScript
+# --------------------------------------------------------------------------- #
+
+
+def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    if not units:
+        print("  no TypeScript units to check")
+        return 0
+
+    if source == "local":
+        dep = f"file:{os.path.join(repo_root, 'sdk', 'ts')}"
+    else:
+        dep = version
+
+    package_json = {
+        "name": "readme-snippets",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: dep},
+        "devDependencies": {"typescript": "^5", "@types/node": "^22"},
+    }
+    with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+
+    tsconfig = {
+        "compilerOptions": {
+            "module": "nodenext",
+            "moduleResolution": "nodenext",
+            "target": "esnext",
+            "lib": ["esnext"],
+            "types": ["node"],
+            "strict": True,
+            "noEmit": True,
+            "skipLibCheck": True,
+        },
+        "include": ["snippets/*.ts"],
+    }
+    with open(os.path.join(workdir, "tsconfig.json"), "w", encoding="utf-8") as fh:
+        json.dump(tsconfig, fh, indent=2)
+
+    snip_dir = os.path.join(workdir, "snippets")
+    os.makedirs(snip_dir, exist_ok=True)
+    for n, unit in enumerate(units, start=1):
+        _write_unit(snip_dir, f"snippet_{n:03d}.ts", unit)
+
+    retries = 4 if source == "published" else 0
+    if _run(["npm", "install", "--no-audit", "--no-fund"], cwd=workdir, retries=retries) != 0:
+        return 1
+    return _run(["npx", "--no-install", "tsc", "--noEmit"], cwd=workdir)
+
+
+# --------------------------------------------------------------------------- #
+# Python
+# --------------------------------------------------------------------------- #
+
+
+def check_py(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    if not units:
+        print("  no Python units to check")
+        return 0
+
+    snip_dir = os.path.join(workdir, "snippets")
+    os.makedirs(snip_dir, exist_ok=True)
+    files = []
+    for n, unit in enumerate(units, start=1):
+        path = _write_unit(snip_dir, f"snippet_{n:03d}.py", unit)
+        files.append(path)
+
+    venv = os.path.join(workdir, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=workdir) != 0:
+        return 1
+    py = os.path.join(venv, "bin", "python")
+    pip_install = [py, "-m", "pip", "install", "--quiet", "--upgrade", "pip", "mypy"]
+    if _run(pip_install, cwd=workdir) != 0:
+        return 1
+
+    if source == "local":
+        target = os.path.join(repo_root, "sdk", "py")
+        retries = 0
+    else:
+        target = f"{PY_PACKAGE}=={version}"
+        retries = 4
+    if _run([py, "-m", "pip", "install", "--quiet", target], cwd=workdir, retries=retries) != 0:
+        return 1
+
+    # mypy's default errors on a missing/renamed import and on a non-existent
+    # attribute of a typed object (agent-receipts ships py.typed), catching all
+    # three drift classes without executing the snippet.
+    return _run([py, "-m", "mypy", *files], cwd=workdir)
+
+
+# --------------------------------------------------------------------------- #
+
+
+def _write_unit(dirpath: str, filename: str, unit: extract.Unit) -> str:
+    path = os.path.join(dirpath, filename)
+    header = f"// snippet sources: {', '.join(unit.sources)}" if unit.lang != "py" else f"# snippet sources: {', '.join(unit.sources)}"
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(header + "\n")
+        fh.write(unit.code)
+        if not unit.code.endswith("\n"):
+            fh.write("\n")
+    return path
+
+
+_CHECKERS = {"go": check_go, "ts": check_ts, "py": check_py}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lang", required=True, choices=["go", "ts", "py"])
+    parser.add_argument("--source", required=True, choices=["local", "published"])
+    parser.add_argument("--version", default=None)
+    parser.add_argument("--repo-root", default=os.getcwd())
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("readmes", nargs="+")
+    args = parser.parse_args(argv)
+
+    repo_root = os.path.abspath(args.repo_root)
+    readmes = [os.path.join(repo_root, r) if not os.path.isabs(r) else r for r in args.readmes]
+    readmes = [r for r in readmes if os.path.exists(r)]
+
+    print(f"Checking {args.lang} snippets ({args.source}) in:")
+    units = _collect_units(readmes, args.lang)
+    if not units:
+        print("No SDK snippets found — nothing to check.")
+        return 0
+
+    version = None
+    if args.source == "published":
+        version = _resolve_version(args.lang, repo_root, args.version)
+        print(f"  pinning to published version: {version}")
+
+    cleanup = False
+    if args.workdir:
+        workdir = os.path.abspath(args.workdir)
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = tempfile.mkdtemp(prefix="readme-snippets-")
+        cleanup = True
+
+    try:
+        rc = _CHECKERS[args.lang](units, args.source, version, repo_root, workdir)
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    if rc == 0:
+        print(f"\nAll {len(units)} {args.lang} snippet unit(s) compiled cleanly.")
+    else:
+        print(f"\nSnippet check FAILED for {args.lang} (see errors above).")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/readme_snippets/check.py
+++ b/scripts/readme_snippets/check.py
@@ -40,6 +40,7 @@ import extract  # noqa: E402
 GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
 TS_PACKAGE = "@agnt-rcpt/sdk-ts"
 PY_PACKAGE = "agent-receipts"
+MYPY_VERSION = "mypy==2.1.0"
 
 
 def _run(cmd: list[str], cwd: str, env: dict[str, str] | None = None, retries: int = 0) -> int:
@@ -144,6 +145,14 @@ def check_go(units: list[extract.Unit], source: str, version: str | None, repo_r
 # --------------------------------------------------------------------------- #
 
 
+def _read_ts_dev_deps(repo_root: str) -> dict[str, str]:
+    try:
+        with open(os.path.join(repo_root, "sdk/ts/package.json"), encoding="utf-8") as fh:
+            return json.load(fh).get("devDependencies", {})
+    except (OSError, ValueError):
+        return {}
+
+
 def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
     if not units:
         print("  no TypeScript units to check")
@@ -154,12 +163,19 @@ def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_r
     else:
         dep = version
 
+    # Type-check with the same typescript / @types/node the SDK is built with,
+    # so the gate matches the published .d.ts (newer TS type features included)
+    # instead of an arbitrary pinned major.
+    sdk_dev = _read_ts_dev_deps(repo_root)
     package_json = {
         "name": "readme-snippets",
         "private": True,
         "type": "module",
         "dependencies": {TS_PACKAGE: dep},
-        "devDependencies": {"typescript": "^5", "@types/node": "^22"},
+        "devDependencies": {
+            "typescript": sdk_dev.get("typescript", "^5"),
+            "@types/node": sdk_dev.get("@types/node", "^22"),
+        },
     }
     with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
         json.dump(package_json, fh, indent=2)
@@ -212,8 +228,9 @@ def check_py(units: list[extract.Unit], source: str, version: str | None, repo_r
     if _run([sys.executable, "-m", "venv", venv], cwd=workdir) != 0:
         return 1
     py = os.path.join(venv, "bin", "python")
-    pip_install = [py, "-m", "pip", "install", "--quiet", "--upgrade", "pip", "mypy"]
-    if _run(pip_install, cwd=workdir) != 0:
+    # Pin mypy so the gate is deterministic — a behaviour change in a future
+    # release shouldn't silently start failing (or passing) snippet checks.
+    if _run([py, "-m", "pip", "install", "--quiet", MYPY_VERSION], cwd=workdir) != 0:
         return 1
 
     if source == "local":
@@ -260,7 +277,14 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = os.path.abspath(args.repo_root)
     readmes = [os.path.join(repo_root, r) if not os.path.isabs(r) else r for r in args.readmes]
-    readmes = [r for r in readmes if os.path.exists(r)]
+    missing = [r for r in readmes if not os.path.exists(r)]
+    if missing:
+        # Fail loudly rather than silently disable the gate — a path typo or a
+        # renamed README must not quietly pass as "nothing to check".
+        print("ERROR: README path(s) not found:")
+        for r in missing:
+            print(f"  {r}")
+        return 2
 
     print(f"Checking {args.lang} snippets ({args.source}) in:")
     units = _collect_units(readmes, args.lang)

--- a/scripts/readme_snippets/check.py
+++ b/scripts/readme_snippets/check.py
@@ -116,7 +116,7 @@ def check_go(units: list[extract.Unit], source: str, version: str | None, repo_r
         return 1
 
     network_retries = 4 if source == "published" else 0
-    go_mod = ["module readme-snippets\n", "go 1.26.1\n"]
+    go_mod = ["module example.com/readme-snippets\n", "go 1.26.1\n"]
     if source == "local":
         sdk_path = os.path.join(repo_root, "sdk", "go")
         # Throwaway module — a local replace here is fine and never published
@@ -145,6 +145,12 @@ def check_go(units: list[extract.Unit], source: str, version: str | None, repo_r
 # --------------------------------------------------------------------------- #
 
 
+def _exact_version(spec: str) -> str:
+    """Strip a leading ^ / ~ range so the temp project pins an exact version."""
+    spec = spec.strip()
+    return spec[1:] if spec[:1] in "^~" else spec
+
+
 def _read_ts_dev_deps(repo_root: str) -> dict[str, str]:
     try:
         with open(os.path.join(repo_root, "sdk/ts/package.json"), encoding="utf-8") as fh:
@@ -165,7 +171,8 @@ def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_r
 
     # Type-check with the same typescript / @types/node the SDK is built with,
     # so the gate matches the published .d.ts (newer TS type features included)
-    # instead of an arbitrary pinned major.
+    # instead of an arbitrary major. Pin to exact versions (strip the ^/~ range)
+    # so resolution is deterministic and doesn't drift with registry state.
     sdk_dev = _read_ts_dev_deps(repo_root)
     package_json = {
         "name": "readme-snippets",
@@ -173,8 +180,8 @@ def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_r
         "type": "module",
         "dependencies": {TS_PACKAGE: dep},
         "devDependencies": {
-            "typescript": sdk_dev.get("typescript", "^5"),
-            "@types/node": sdk_dev.get("@types/node", "^22"),
+            "typescript": _exact_version(sdk_dev.get("typescript", "5")),
+            "@types/node": _exact_version(sdk_dev.get("@types/node", "22")),
         },
     }
     with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -208,7 +208,10 @@ def _render(lang: str, chain: list[Block]) -> str:
 # so the wrapper can suppress "declared and not used" for bare Go snippets.
 _GO_SHORT_DECL_RE = re.compile(r"^(?P<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*:=")
 _GO_VAR_DECL_RE = re.compile(r"^var\s+(?P<name>[A-Za-z_]\w*)")
-_GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:[\w.]+\s+)?"(?P<path>[^"]+)"\s*$')
+# A single-line import: captures the whole spec after `import ` (the optional
+# alias / blank identifier plus the quoted path), so it round-trips verbatim.
+_GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?P<spec>(?:[\w.]+\s+|_\s+)?"[^"]+")\s*$')
+_GO_IMPORT_BLOCK_OPEN_RE = re.compile(r"^import\s*\(\s*$")
 
 
 GO_SNIPPET_PACKAGE = "snippet"
@@ -236,27 +239,29 @@ def _render_go(code: str) -> str:
         )
         return rewritten + "\n"
 
+    # Each entry is a full import spec, kept verbatim so aliases (`foo "pkg"`),
+    # blank imports (`_ "pkg"`), and inline comments survive the rewrite.
     imports: list[str] = []
     body: list[str] = []
     lines = code.splitlines()
     i = 0
     while i < len(lines):
-        line = lines[i]
-        single = _GO_SINGLE_IMPORT_RE.match(line.strip())
+        stripped = lines[i].strip()
+        single = _GO_SINGLE_IMPORT_RE.match(stripped)
         if single:
-            imports.append(single.group("path"))
+            imports.append(single.group("spec").strip())
             i += 1
             continue
-        if re.match(r"^import\s*\(", line.strip()):
+        if _GO_IMPORT_BLOCK_OPEN_RE.match(stripped):
             i += 1
-            while i < len(lines) and ")" not in lines[i]:
-                path = lines[i].strip().strip('"')
-                if path:
-                    imports.append(path)
+            while i < len(lines) and lines[i].strip() != ")":
+                spec = lines[i].strip()
+                if spec:
+                    imports.append(spec)
                 i += 1
             i += 1  # skip the closing ")"
             continue
-        body.append(line)
+        body.append(lines[i])
         i += 1
 
     declared: list[str] = []
@@ -276,8 +281,8 @@ def _render_go(code: str) -> str:
     out: list[str] = [f"package {GO_SNIPPET_PACKAGE}", ""]
     if imports:
         out.append("import (")
-        for path in imports:
-            out.append(f'\t"{path}"')
+        for spec in imports:
+            out.append(f"\t{spec}")
         out.append(")")
         out.append("")
     out.append("func run() {")

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -1,0 +1,312 @@
+"""Extract fenced code blocks from READMEs and assemble them into compilable units.
+
+This module is pure (no IO beyond the markdown text passed in) so it can be unit
+tested without a toolchain. The companion ``check.py`` writes the units to disk
+and drives the per-language compiler / type-checker.
+
+Selection rules:
+
+* Only fenced blocks whose language is one we test (Go, TypeScript, Python) and
+  that import the SDK are checked. Everything else (``bash`` install lines,
+  illustrative output, etc.) is ignored.
+* A block is checked in isolation by default — "would this compile if a reader
+  pasted it into a fresh file against the published SDK?".
+* An HTML-comment directive on the line(s) before a fence overrides this:
+    ``<!-- snippet-check: continues -->`` concatenates the block onto the
+    previous checked block in the same README so snippets that build on earlier
+    state (store/verify follow-ons) resolve their references.
+    ``<!-- snippet-check: skip -->`` opts a block out entirely (intentionally
+    partial pseudo-code).
+  Directives are invisible in rendered markdown. Unmarked blocks are checked by
+  default, so a newly added quick-start snippet is covered without anyone
+  remembering to annotate it — which is the drift this gate exists to catch.
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from dataclasses import dataclass, field
+
+# Normalised language -> the info-strings that map to it.
+_INFO_TO_LANG = {
+    "go": "go",
+    "typescript": "ts",
+    "ts": "ts",
+    "python": "py",
+    "py": "py",
+}
+
+# A block counts as "documents the SDK" only if its body matches one of these.
+# The Go pattern deliberately matches the *wrong* module path too
+# (``agent-receipts/sdk-go`` vs the real ``agent-receipts/ar/sdk/go``) so that a
+# snippet importing a non-existent module is still selected and then fails to
+# build — that drift is exactly what we want to surface.
+_SDK_IMPORT_PATTERN = {
+    "go": re.compile(r"github\.com/agent-receipts/(?:ar/sdk/go|sdk-go)"),
+    "ts": re.compile(r"""['"]@agnt-rcpt/sdk-ts(?:/[\w-]+)?['"]"""),
+    "py": re.compile(r"\b(?:from|import)\s+agent_receipts\b"),
+}
+
+_DIRECTIVE_RE = re.compile(r"<!--\s*snippet-check:\s*(?P<directive>[\w-]+)\s*-->")
+_FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<ticks>`{3,})(?P<info>.*)$")
+
+_VALID_DIRECTIVES = {"continues", "skip"}
+
+
+@dataclass
+class Block:
+    """A single fenced code block."""
+
+    lang: str  # normalised: "go" | "ts" | "py" | raw info-string otherwise
+    code: str
+    line: int  # 1-based line number of the opening fence
+    directive: str | None = None
+
+
+@dataclass
+class Unit:
+    """A compilation unit: one or more blocks rendered into a single source file."""
+
+    lang: str  # "go" | "ts" | "py"
+    name: str
+    code: str
+    sources: list[str] = field(default_factory=list)
+
+
+def parse_blocks(text: str) -> list[Block]:
+    """Return every fenced code block in ``text`` with any attached directive.
+
+    The directive is taken from the most recent ``<!-- snippet-check: ... -->``
+    comment that appears before the fence with only blank lines in between.
+    """
+
+    blocks: list[Block] = []
+    lines = text.splitlines()
+    pending_directive: str | None = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        directive_match = _DIRECTIVE_RE.search(line)
+        if directive_match:
+            value = directive_match.group("directive").lower()
+            if value in _VALID_DIRECTIVES:
+                pending_directive = value
+            i += 1
+            continue
+
+        fence = _FENCE_RE.match(line)
+        if not fence:
+            # A non-blank, non-directive line breaks the association between a
+            # pending directive and a later fence.
+            if line.strip():
+                pending_directive = None
+            i += 1
+            continue
+
+        ticks = fence.group("ticks")
+        info = fence.group("info").strip()
+        raw_lang = info.split()[0].lower() if info else ""
+        lang = _INFO_TO_LANG.get(raw_lang, raw_lang)
+        start_line = i + 1
+
+        body: list[str] = []
+        i += 1
+        while i < len(lines):
+            close = _FENCE_RE.match(lines[i])
+            if close and close.group("ticks") == ticks and not close.group("info").strip():
+                break
+            body.append(lines[i])
+            i += 1
+
+        # Fences nested in list items are indented; strip the common leading
+        # whitespace so the snippet parses (Python especially) without changing
+        # relative indentation.
+        blocks.append(
+            Block(
+                lang=lang,
+                code=textwrap.dedent("\n".join(body)),
+                line=start_line,
+                directive=pending_directive,
+            )
+        )
+        pending_directive = None
+        i += 1
+
+    return blocks
+
+
+def _imports_sdk(lang: str, code: str) -> bool:
+    pattern = _SDK_IMPORT_PATTERN.get(lang)
+    return bool(pattern and pattern.search(code))
+
+
+def build_units(readme_label: str, text: str, lang: str) -> list[Unit]:
+    """Assemble compilation units for a single README and target language.
+
+    ``readme_label`` is a human-readable source reference (e.g. the README path),
+    used both for diagnostics and to derive stable unit names.
+    """
+
+    blocks = [b for b in parse_blocks(text) if b.lang == lang]
+
+    units: list[Unit] = []
+    chain: list[Block] = []
+
+    def flush() -> None:
+        if not chain:
+            return
+        idx = len(units) + 1
+        sources = [f"{readme_label}:{b.line}" for b in chain]
+        code = _render(lang, chain)
+        units.append(
+            Unit(lang=lang, name=f"{_safe_label(readme_label)}-{lang}-{idx}", code=code, sources=sources)
+        )
+        chain.clear()
+
+    for block in blocks:
+        if block.directive == "skip":
+            flush()
+            continue
+        if not _imports_sdk(lang, block.code):
+            # Non-SDK block (or a "continues" block that doesn't itself import
+            # the SDK but builds on one) — only keep it if it continues a chain.
+            if block.directive == "continues" and chain:
+                chain.append(block)
+            else:
+                flush()
+            continue
+        if block.directive == "continues" and chain:
+            chain.append(block)
+        else:
+            flush()
+            chain.append(block)
+
+    flush()
+    return units
+
+
+def _safe_label(label: str) -> str:
+    return re.sub(r"[^\w]+", "_", label).strip("_") or "readme"
+
+
+def _render(lang: str, chain: list[Block]) -> str:
+    if lang == "go":
+        # Go blocks are never chained (each README block is a standalone
+        # program or a bare statement snippet), so render the single block.
+        return _render_go(chain[0].code)
+    return "\n\n".join(b.code for b in chain)
+
+
+# Matches a top-level (column 0) short variable declaration or `var` declaration
+# so the wrapper can suppress "declared and not used" for bare Go snippets.
+_GO_SHORT_DECL_RE = re.compile(r"^(?P<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*:=")
+_GO_VAR_DECL_RE = re.compile(r"^var\s+(?P<name>[A-Za-z_]\w*)")
+_GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:[\w.]+\s+)?"(?P<path>[^"]+)"\s*$')
+
+
+GO_SNIPPET_PACKAGE = "snippet"
+
+
+def _render_go(code: str) -> str:
+    """Render a Go snippet as a buildable, non-main library package.
+
+    Every unit is compiled as ``package snippet`` rather than ``package main``:
+    that way a snippet that defines helper funcs but no ``main`` (e.g. the
+    collector-delivery example) still builds, and an unused ``func main`` is not
+    an error. Unused *imports* and unused *locals* remain errors, so genuine
+    drift is still caught.
+
+    Blocks that already declare a package have that line rewritten. Bare
+    statement snippets (root README quick-start) have their ``import`` lines
+    hoisted into a package shim, the remaining statements placed in a function,
+    and blank-identifier assignments appended so locally-declared values don't
+    trip Go's unused-variable error.
+    """
+
+    if re.search(r"^package\s+\w+", code, re.MULTILINE):
+        rewritten = re.sub(
+            r"^package\s+\w+", f"package {GO_SNIPPET_PACKAGE}", code.strip(), count=1, flags=re.MULTILINE
+        )
+        return rewritten + "\n"
+
+    imports: list[str] = []
+    body: list[str] = []
+    lines = code.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        single = _GO_SINGLE_IMPORT_RE.match(line.strip())
+        if single:
+            imports.append(single.group("path"))
+            i += 1
+            continue
+        if re.match(r"^import\s*\(", line.strip()):
+            i += 1
+            while i < len(lines) and ")" not in lines[i]:
+                path = lines[i].strip().strip('"')
+                if path:
+                    imports.append(path)
+                i += 1
+            i += 1  # skip the closing ")"
+            continue
+        body.append(line)
+        i += 1
+
+    declared: list[str] = []
+    for line in body:
+        stripped = line.strip()
+        short = _GO_SHORT_DECL_RE.match(stripped)
+        if short:
+            for name in short.group("names").split(","):
+                name = name.strip()
+                if name and name != "_":
+                    declared.append(name)
+            continue
+        var = _GO_VAR_DECL_RE.match(stripped)
+        if var:
+            declared.append(var.group("name"))
+
+    out: list[str] = [f"package {GO_SNIPPET_PACKAGE}", ""]
+    if imports:
+        out.append("import (")
+        for path in imports:
+            out.append(f'\t"{path}"')
+        out.append(")")
+        out.append("")
+    out.append("func run() {")
+    for line in _trim_blank_edges(body):
+        out.append("\t" + line if line.strip() else "")
+    for name in declared:
+        out.append(f"\t_ = {name}")
+    out.append("}")
+    return "\n".join(out) + "\n"
+
+
+_GO_AR_IMPORT_RE = re.compile(r'"(github\.com/agent-receipts/[^"]+)"')
+_GO_CANONICAL_PREFIX = "github.com/agent-receipts/ar/sdk/go"
+
+
+def go_noncanonical_imports(code: str) -> list[str]:
+    """Return any ``agent-receipts`` Go import paths that aren't the canonical SDK.
+
+    A stale module (``github.com/agent-receipts/sdk-go``) is still resolvable on
+    the proxy, so a wrong import path can silently *build*. This static guard
+    fails the check anyway — a documented module path must be the one users get
+    from ``go get github.com/agent-receipts/ar/sdk/go``.
+    """
+
+    bad: list[str] = []
+    for path in _GO_AR_IMPORT_RE.findall(code):
+        if path != _GO_CANONICAL_PREFIX and not path.startswith(_GO_CANONICAL_PREFIX + "/"):
+            bad.append(path)
+    return bad
+
+
+def _trim_blank_edges(lines: list[str]) -> list[str]:
+    start, end = 0, len(lines)
+    while start < end and not lines[start].strip():
+        start += 1
+    while end > start and not lines[end - 1].strip():
+        end -= 1
+    return lines[start:end]

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -192,8 +192,14 @@ def _safe_label(label: str) -> str:
 
 def _render(lang: str, chain: list[Block]) -> str:
     if lang == "go":
-        # Go blocks are never chained (each README block is a standalone
-        # program or a bare statement snippet), so render the single block.
+        # Go blocks are standalone (a full program or a bare statement snippet);
+        # concatenating two would not compile. Fail loudly rather than silently
+        # drop the tail of a chain, which would leave a snippet unchecked.
+        if len(chain) > 1:
+            srcs = ", ".join(f"line {b.line}" for b in chain)
+            raise ValueError(
+                f"Go snippets cannot use 'continues' ({srcs}); each must be standalone"
+            )
         return _render_go(chain[0].code)
     return "\n\n".join(b.code for b in chain)
 

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -90,8 +90,9 @@ def parse_blocks(text: str) -> list[Block]:
         directive_match = _DIRECTIVE_RE.search(line)
         if directive_match:
             value = directive_match.group("directive").lower()
-            if value in _VALID_DIRECTIVES:
-                pending_directive = value
+            # An unrecognised snippet-check comment breaks any pending directive
+            # rather than letting it leak onto the next fence.
+            pending_directive = value if value in _VALID_DIRECTIVES else None
             i += 1
             continue
 

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -69,6 +69,20 @@ def test_unknown_directive_ignored() -> None:
     assert block.directive is None
 
 
+def test_unknown_directive_clears_pending_directive() -> None:
+    # A valid directive followed by an invalid snippet-check comment must not
+    # leak the valid one onto the next fence.
+    text = """
+<!-- snippet-check: continues -->
+<!-- snippet-check: bogus -->
+```python
+from agent_receipts import x
+```
+"""
+    (block,) = extract.parse_blocks(text)
+    assert block.directive is None
+
+
 def test_only_sdk_importing_blocks_selected() -> None:
     text = """
 ```python

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -1,0 +1,219 @@
+"""Unit tests for the README snippet extractor.
+
+Run with: python3 -m pytest scripts/readme_snippets/test_extract.py
+(or plain `python3 scripts/readme_snippets/test_extract.py` for a quick check).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import extract  # noqa: E402
+
+
+def test_parse_blocks_normalises_language() -> None:
+    text = """
+```bash
+echo hi
+```
+
+```typescript
+const x = 1;
+```
+
+```py
+x = 1
+```
+"""
+    blocks = extract.parse_blocks(text)
+    langs = [b.lang for b in blocks]
+    assert langs == ["bash", "ts", "py"]
+
+
+def test_parse_blocks_records_line_numbers() -> None:
+    text = "line1\nline2\n```go\nfoo\n```\n"
+    (block,) = extract.parse_blocks(text)
+    assert block.line == 3
+    assert block.code == "foo"
+
+
+def test_directive_attaches_to_next_block() -> None:
+    text = """
+<!-- snippet-check: skip -->
+```python
+from agent_receipts import x
+```
+"""
+    (block,) = extract.parse_blocks(text)
+    assert block.directive == "skip"
+
+
+def test_directive_broken_by_intervening_prose() -> None:
+    text = """
+<!-- snippet-check: continues -->
+some prose here
+```python
+from agent_receipts import x
+```
+"""
+    (block,) = extract.parse_blocks(text)
+    assert block.directive is None
+
+
+def test_unknown_directive_ignored() -> None:
+    text = "<!-- snippet-check: bogus -->\n```go\nx\n```\n"
+    (block,) = extract.parse_blocks(text)
+    assert block.directive is None
+
+
+def test_only_sdk_importing_blocks_selected() -> None:
+    text = """
+```python
+print("no sdk here")
+```
+
+```python
+from agent_receipts import create_receipt
+create_receipt()
+```
+"""
+    units = extract.build_units("R.md", text, "py")
+    assert len(units) == 1
+    assert "create_receipt" in units[0].code
+
+
+def test_continues_concatenates_onto_previous() -> None:
+    text = """
+```python
+from agent_receipts import create_receipt
+receipt = create_receipt()
+```
+
+<!-- snippet-check: continues -->
+```python
+from agent_receipts import verify_receipt
+verify_receipt(receipt)
+```
+"""
+    units = extract.build_units("R.md", text, "py")
+    assert len(units) == 1
+    code = units[0].code
+    assert "create_receipt" in code and "verify_receipt" in code
+    assert len(units[0].sources) == 2
+
+
+def test_skip_excludes_block_and_breaks_chain() -> None:
+    text = """
+```python
+from agent_receipts import create_receipt
+receipt = create_receipt()
+```
+
+<!-- snippet-check: skip -->
+```python
+from agent_receipts import verify_chain
+verify_chain(receipts, key)
+```
+"""
+    units = extract.build_units("R.md", text, "py")
+    assert len(units) == 1
+    assert "verify_chain" not in units[0].code
+
+
+def test_wrong_go_module_path_is_still_selected() -> None:
+    # The buggy `sdk-go` path must be selected so the build catches it.
+    text = """
+```go
+package main
+
+import "github.com/agent-receipts/sdk-go/receipt"
+
+func main() { _ = receipt.GenerateKeyPair }
+```
+"""
+    units = extract.build_units("R.md", text, "go")
+    assert len(units) == 1
+    assert "sdk-go" in units[0].code
+
+
+def test_full_go_program_repackaged_as_library() -> None:
+    # `package main` is rewritten so a block without `func main` still builds.
+    code = 'package main\n\nimport "github.com/agent-receipts/ar/sdk/go/receipt"\n\nfunc deliver() { _ = receipt.GenerateKeyPair }'
+    text = f"```go\n{code}\n```\n"
+    (unit,) = extract.build_units("R.md", text, "go")
+    assert unit.code.startswith("package snippet")
+    assert "func deliver()" in unit.code
+    assert "package main" not in unit.code
+
+
+def test_bare_go_snippet_is_wrapped_and_suppresses_unused() -> None:
+    text = """
+```go
+import "github.com/agent-receipts/ar/sdk/go/receipt"
+
+keys, _ := receipt.GenerateKeyPair()
+unsigned := receipt.Create(receipt.CreateInput{})
+signed, _ := receipt.Sign(unsigned, keys.PrivateKey, "k")
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "go")
+    code = unit.code
+    assert code.startswith("package snippet")
+    assert "func run() {" in code
+    assert 'import (\n\t"github.com/agent-receipts/ar/sdk/go/receipt"\n)' in code
+    # Every locally declared value is referenced so Go won't reject it.
+    assert "_ = keys" in code
+    assert "_ = unsigned" in code
+    assert "_ = signed" in code
+
+
+def test_bare_go_snippet_with_import_block() -> None:
+    text = """
+```go
+import (
+	"fmt"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+fmt.Println(receipt.GenerateKeyPair())
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "go")
+    assert '"fmt"' in unit.code
+    assert '"github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
+
+
+def test_go_noncanonical_imports_flags_stale_module() -> None:
+    code = (
+        'import "github.com/agent-receipts/sdk-go/receipt"\n'
+        'import "github.com/agent-receipts/ar/sdk/go/store"\n'
+    )
+    assert extract.go_noncanonical_imports(code) == ["github.com/agent-receipts/sdk-go/receipt"]
+
+
+def test_go_noncanonical_imports_accepts_canonical() -> None:
+    code = (
+        'import "github.com/agent-receipts/ar/sdk/go"\n'
+        'import "github.com/agent-receipts/ar/sdk/go/emitter"\n'
+    )
+    assert extract.go_noncanonical_imports(code) == []
+
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -202,6 +202,28 @@ def test_go_noncanonical_imports_accepts_canonical() -> None:
     assert extract.go_noncanonical_imports(code) == []
 
 
+def test_go_continues_is_rejected_loudly() -> None:
+    text = """
+```go
+package main
+import "github.com/agent-receipts/ar/sdk/go/receipt"
+func main() { _ = receipt.GenerateKeyPair }
+```
+
+<!-- snippet-check: continues -->
+```go
+import "github.com/agent-receipts/ar/sdk/go/store"
+_ = store.Open
+```
+"""
+    try:
+        extract.build_units("R.md", text, "go")
+    except ValueError as exc:
+        assert "continues" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for chained Go snippets")
+
+
 def _run_all() -> int:
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -202,6 +202,28 @@ def test_go_noncanonical_imports_accepts_canonical() -> None:
     assert extract.go_noncanonical_imports(code) == []
 
 
+def test_single_aliased_import_preserved() -> None:
+    text = '```go\nimport rcpt "github.com/agent-receipts/ar/sdk/go/receipt"\n\nrcpt.GenerateKeyPair()\n```\n'
+    (unit,) = extract.build_units("R.md", text, "go")
+    assert 'rcpt "github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
+
+
+def test_import_block_preserves_alias_and_blank() -> None:
+    text = """
+```go
+import (
+	_ "github.com/agent-receipts/ar/sdk/go/receipt"
+	st "github.com/agent-receipts/ar/sdk/go/store"
+)
+
+st.Open("x")
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "go")
+    assert '_ "github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
+    assert 'st "github.com/agent-receipts/ar/sdk/go/store"' in unit.code
+
+
 def test_go_continues_is_rejected_loudly() -> None:
     text = """
 ```go

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -18,7 +18,7 @@
 ## Install
 
 ```sh
-go get github.com/agent-receipts/sdk-go
+go get github.com/agent-receipts/ar/sdk/go
 ```
 
 ## Packages
@@ -96,9 +96,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/agent-receipts/sdk-go/receipt"
-	"github.com/agent-receipts/sdk-go/store"
-	"github.com/agent-receipts/sdk-go/taxonomy"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+	"github.com/agent-receipts/ar/sdk/go/taxonomy"
 )
 
 func main() {

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -101,6 +101,7 @@ receipt_hash = hash_receipt(receipt)
 
 ### Verify a receipt
 
+<!-- snippet-check: continues -->
 ```python
 from agent_receipts import verify_receipt
 
@@ -110,6 +111,7 @@ print(f"Signature valid: {valid}")  # True
 
 ### Verify a chain
 
+<!-- snippet-check: continues -->
 ```python
 from agent_receipts import verify_chain
 

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -88,6 +88,7 @@ const hash = hashReceipt(receipt);
 
 ### Store and query
 
+<!-- snippet-check: continues -->
 ```typescript
 import { openStore } from "@agnt-rcpt/sdk-ts";
 
@@ -108,6 +109,7 @@ store.close();
 
 ### Verify a chain
 
+<!-- snippet-check: skip -->
 ```typescript
 import { verifyChain, verifyStoredChain } from "@agnt-rcpt/sdk-ts";
 

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -63,7 +63,7 @@ The daemon listens on a Unix domain socket. The socket path depends on platform:
 
 | Platform | Default socket path |
 |----------|---------------------|
-| macOS | `$TMPDIR/agentreceipts/events.sock` (falls back to `/tmp/agentreceipts/events.sock` when `$TMPDIR` is unset) |
+| macOS | `$XDG_DATA_HOME/agent-receipts/events.sock` (falls back to `~/.local/share/agent-receipts/events.sock` when `$XDG_DATA_HOME` is unset or not an absolute path) |
 | Linux | `$XDG_RUNTIME_DIR/agentreceipts/events.sock`, falling back to `/run/agentreceipts/events.sock` |
 
 :::caution
@@ -76,7 +76,7 @@ To run as a persistent service on macOS, use the launchd plist available at [`da
 
 ## Connect your emitters
 
-Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default on those platforms. On other platforms the Go SDK does not consult `AGENTRECEIPTS_SOCKET` — callers must pass an explicit `WithSocketPath` option; `New()` returns an error if no socket path is provided.
+Point each SDK or plugin at the daemon socket. On macOS and Linux, all components resolve a platform default socket path automatically (see the table above). Set `AGENTRECEIPTS_SOCKET` to override that default. Other platforms have no platform default, but `AGENTRECEIPTS_SOCKET` (or the SDK's explicit socket-path option, e.g. Go's `WithSocketPath`) still supplies one; the emitter constructor only errors when neither is provided.
 
 There is no in-process fallback: if the daemon is unreachable, events are dropped silently (see [Start](#start) for timeout details).
 
@@ -94,7 +94,7 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
 
-e, err := emitter.New(emitter.WithSocketPath("/path/to/events.sock"))
+e, err := emitter.NewDaemon(emitter.WithSocketPath("/path/to/events.sock"))
 if err != nil {
 	log.Fatal(err)
 }
@@ -108,34 +108,34 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
 
-e, err := emitter.New()
+e, err := emitter.NewDaemon()
 if err != nil {
 	log.Fatal(err)
 }
 ```
 
-### TypeScript SDK (v0.8.0-alpha.2)
+### TypeScript SDK
 
-Install the alpha release:
+Install:
 
 ```bash
-npm install @agnt-rcpt/sdk-ts@alpha
+npm install @agnt-rcpt/sdk-ts
 ```
 
 **Option A: explicit socket path**
 
 ```typescript
-import { Emitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
 
-const e = new Emitter({ socketPath: "/path/to/events.sock" });
+const e = new DaemonEmitter({ socketPath: "/path/to/events.sock" });
 ```
 
 **Option B: via environment variable (`AGENTRECEIPTS_SOCKET`)**
 
 ```typescript
-import { Emitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
 
-const e = new Emitter();
+const e = new DaemonEmitter();
 ```
 
 ### Python SDK
@@ -242,9 +242,11 @@ The most common cause is that the daemon is not running when the emitter starts.
 
 ```bash
 pgrep agent-receipts-daemon
-ls -la "${TMPDIR:-/tmp}/agentreceipts/events.sock"                       # macOS
+ls -la ~/.local/share/agent-receipts/events.sock             # macOS (default fallback)
 ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"  # Linux
 ```
+
+If you've set `AGENTRECEIPTS_SOCKET` or an absolute `XDG_DATA_HOME`, check that path instead. The macOS example above assumes the default fallback location.
 
 **Socket path mismatch.**
 If you start the daemon and an emitter on different socket paths, events are dropped. Set `AGENTRECEIPTS_SOCKET` to the same value in the daemon's environment and each emitter's environment, or rely on the platform default by not setting it in either.

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -1,18 +1,23 @@
 ---
 title: Quick Start
-description: Create, sign, and verify your first Agent Receipt.
+description: Emit and verify your first Agent Receipt through the agent-receipts daemon.
 ---
 
-This guide walks you through creating, signing, and verifying an Agent Receipt using either the TypeScript or Python SDK.
+This guide walks you through emitting and verifying your first Agent Receipt with the
+Python, TypeScript, or Go SDK.
 
-:::caution[Not for production]
-The examples below use the direct SDK signing API, which keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
-:::
+Agent Receipts are signed by a separate `agent-receipts-daemon` process, not by your
+application. Your code sends tool-call *events* over a local Unix socket; the daemon
+holds the Ed25519 signing key, builds the receipt, signs it, and appends it to the
+hash-chained store. The signing key never enters your process — so the audit trail
+holds up even if the agent is compromised. This is the canonical deployment shape
+([ADR-0022](https://github.com/agent-receipts/ar/blob/main/docs/adr/0022-canonical-deployment-shape.md)),
+and it is the first thing you should reach for.
 
 ```mermaid
 graph LR
-  subgraph sdk["SDK (this guide)"]
-    A[Your app code] -- "SDK API call" --> S[Agent Receipts SDK]
+  subgraph app["Your app (this guide)"]
+    A[Your app code] -- "emit event" --> S[Agent Receipts SDK]
   end
   subgraph proxy["MCP Proxy"]
     P[mcp-proxy] -- "wraps" --> M[MCP Server]
@@ -24,92 +29,214 @@ graph LR
     O[OpenClaw gateway] -- "hooks" --> T[Tools]
   end
   S & P & H & O -- "Unix socket" --> D[agent-receipts-daemon]
-  D --> DB[(receipts.db)]
+  D -- "signs + stores" --> DB[(receipts.db)]
 ```
 
-## TypeScript
-
-### 1. Install
-
-```bash
-npm install @agnt-rcpt/sdk-ts
-```
-
-### 2. Create and sign a receipt
-
-:::caution[Not for production]
-This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/).
-:::
-
-```typescript
-import {
-  createReceipt,
-  generateKeyPair,
-  signReceipt,
-  hashReceipt,
-} from "@agnt-rcpt/sdk-ts";
-
-const keys = generateKeyPair();
-
-const unsigned = createReceipt({
-  issuer: { id: "did:agent:my-agent" },
-  principal: { id: "did:user:alice" },
-  action: {
-    type: "filesystem.file.read",
-    risk_level: "low",
-    target: { system: "local", resource: "/docs/report.md" },
-  },
-  outcome: { status: "success" },
-  chain: {
-    sequence: 1,
-    previous_receipt_hash: null,
-    chain_id: "chain_session-1",
-  },
-});
-
-const receipt = signReceipt(unsigned, keys.privateKey, "did:agent:my-agent#key-1");
-const hash = hashReceipt(receipt);
-
-console.log(receipt.id);  // urn:receipt:<uuid>
-console.log(hash);        // sha256:<hex>
-```
-
-### 3. Store and query
-
-```typescript
-import { openStore } from "@agnt-rcpt/sdk-ts";
-
-const store = openStore("receipts.db");
-store.insert(receipt, hash);
-
-const chain = store.getChain("chain_session-1");
-console.log(`Chain has ${chain.length} receipt(s)`);
-
-store.close();
-```
-
-### 4. Verify a chain
-
-```typescript
-import { verifyChain } from "@agnt-rcpt/sdk-ts";
-
-const result = verifyChain(chain, keys.publicKey);
-console.log(result.valid);   // true
-console.log(result.length);  // number of receipts verified
-```
+Each SDK section below follows the same shape: **Install → Start the daemon →
+Emit a receipt → Verify.** Pick your language and work top to bottom.
 
 ## Python
 
 ### 1. Install
 
+Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setup/)
+for your platform), then the Python SDK:
+
 ```bash
 pip install agent-receipts
 ```
 
-### 2. Create and sign a receipt
+### 2. Start the daemon
 
-:::caution[Not for production]
-This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/).
+Generate the signing key once, then run the daemon. It listens on the per-OS default
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
+service installation.
+
+```bash
+agent-receipts-daemon --init   # one-time: creates the signing key
+agent-receipts-daemon          # start the daemon (leave it running)
+```
+
+### 3. Emit a receipt
+
+`DaemonEmitter` forwards the tool-call event to the daemon, which constructs, signs,
+and chains the receipt. It is fire-and-forget — start the daemon before your app.
+
+```python
+from agent_receipts import DaemonEmitter
+
+with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
+    e.emit(
+        channel="my-app",
+        tool_name="filesystem.file.read",
+        decision="allowed",
+    )
+```
+
+### 4. Verify
+
+`agent-receipts verify` reads the database directly and confirms hash linkage and
+signatures — the daemon does not need to be running.
+
+```bash
+AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
+  agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+A successful run prints the chain length and confirms the signatures are intact. If you
+started the daemon with a non-default chain id (`AGENTRECEIPTS_CHAIN_ID` / `--chain-id`)
+or overrode `AGENTRECEIPTS_DB` or `AGENTRECEIPTS_PUBLIC_KEY`, pass those same values
+here — otherwise `verify` reads the `default` chain at the default paths.
+
+## TypeScript
+
+### 1. Install
+
+Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setup/)
+for your platform), then the TypeScript SDK:
+
+```bash
+npm install @agnt-rcpt/sdk-ts
+```
+
+### 2. Start the daemon
+
+Generate the signing key once, then run the daemon. It listens on the per-OS default
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
+service installation.
+
+```bash
+agent-receipts-daemon --init   # one-time: creates the signing key
+agent-receipts-daemon          # start the daemon (leave it running)
+```
+
+### 3. Emit a receipt
+
+`DaemonEmitter` forwards the tool-call event to the daemon, which constructs, signs,
+and chains the receipt. It is fire-and-forget — start the daemon before your app.
+
+```typescript
+import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
+
+async function main() {
+  const e = new DaemonEmitter();  // uses AGENTRECEIPTS_SOCKET or the per-OS default
+  try {
+    // emit() returns an Error for caller-bug events (bad shape), null otherwise
+    const err = await e.emit({
+      channel: "my-app",
+      tool: { name: "filesystem.file.read" },
+      decision: "allowed",
+    });
+    if (err) throw err;
+  } finally {
+    e.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});
+```
+
+### 4. Verify
+
+`agent-receipts verify` reads the database directly and confirms hash linkage and
+signatures — the daemon does not need to be running.
+
+```bash
+AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
+  agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+A successful run prints the chain length and confirms the signatures are intact. If you
+started the daemon with a non-default chain id (`AGENTRECEIPTS_CHAIN_ID` / `--chain-id`)
+or overrode `AGENTRECEIPTS_DB` or `AGENTRECEIPTS_PUBLIC_KEY`, pass those same values
+here — otherwise `verify` reads the `default` chain at the default paths.
+
+## Go
+
+### 1. Install
+
+Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setup/)
+for your platform), then the Go SDK:
+
+```bash
+go get github.com/agent-receipts/ar/sdk/go
+```
+
+### 2. Start the daemon
+
+Generate the signing key once, then run the daemon. It listens on the per-OS default
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
+service installation.
+
+```bash
+agent-receipts-daemon --init   # one-time: creates the signing key
+agent-receipts-daemon          # start the daemon (leave it running)
+```
+
+### 3. Emit a receipt
+
+`NewDaemon` returns an emitter that forwards the tool-call event to the daemon, which
+constructs, signs, and chains the receipt. It is fire-and-forget — start the daemon
+before your app.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/agent-receipts/ar/sdk/go/emitter"
+)
+
+func main() {
+	e, err := emitter.NewDaemon() // uses AGENTRECEIPTS_SOCKET or the per-OS default
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = e.Close() }()
+
+	if err := e.Emit(context.Background(), emitter.Event{
+		Channel:  "my-app",
+		Tool:     emitter.Tool{Name: "filesystem.file.read"},
+		Decision: "allowed",
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+### 4. Verify
+
+`agent-receipts verify` reads the database directly and confirms hash linkage and
+signatures — the daemon does not need to be running.
+
+```bash
+AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
+  agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+A successful run prints the chain length and confirms the signatures are intact. If you
+started the daemon with a non-default chain id (`AGENTRECEIPTS_CHAIN_ID` / `--chain-id`)
+or overrode `AGENTRECEIPTS_DB` or `AGENTRECEIPTS_PUBLIC_KEY`, pass those same values
+here — otherwise `verify` reads the `default` chain at the default paths.
+
+## Appendix: in-process signing (tutorial and testing only)
+
+The SDKs can also create and sign a receipt entirely in your process, with no daemon.
+This is useful for learning the receipt API and for unit tests that should not depend
+on a running daemon.
+
+:::danger[Not for production]
+This pattern keeps the signing key inside the agent process. Anyone with code execution
+in the agent can forge receipts. For real deployments, use the daemon-mediated path
+shown above (see also [Daemon Setup](/getting-started/daemon-setup/)).
 :::
 
 ```python
@@ -117,8 +244,8 @@ from agent_receipts import (
     CreateReceiptInput,
     create_receipt,
     generate_key_pair,
-    hash_receipt,
     sign_receipt,
+    verify_receipt,
 )
 
 keys = generate_key_pair()
@@ -142,23 +269,20 @@ unsigned = create_receipt(
 )
 
 receipt = sign_receipt(unsigned, keys.private_key, "did:agent:my-agent#key-1")
-receipt_hash = hash_receipt(receipt)
+
+valid = verify_receipt(receipt, keys.public_key)
+print(f"Signature valid: {valid}")  # True
 ```
 
-### 3. Verify a chain
-
-```python
-from agent_receipts import verify_chain
-
-receipts = [receipt]  # or load from storage
-result = verify_chain(receipts, keys.public_key)
-print(result.valid)   # True
-print(result.length)  # number of receipts verified
-```
+The equivalent TypeScript and Go signing APIs are documented in each SDK README
+([TypeScript](https://github.com/agent-receipts/ar/tree/main/sdk/ts),
+[Go](https://github.com/agent-receipts/ar/tree/main/sdk/go)). The same
+"not for production" caveat applies to all of them.
 
 ## Next steps
 
 - Read the [Introduction](/) for background on the protocol
+- Follow [Daemon Setup](/getting-started/daemon-setup/) for install, socket paths, and running the daemon as a service
 - See the [Agent Receipt Schema](/specification/agent-receipt-schema/) for the full receipt structure
 - Explore the [Action Taxonomy](/specification/action-taxonomy/) to understand action types and risk levels
 - Set up `agent-receipts-hook` to capture native tool calls — see [Hook: Claude Code](/hook/claude-code/)


### PR DESCRIPTION
## Summary

Closes #595. Adds a gate that extracts the SDK quick-start snippets from the user-facing READMEs and compiles / type-checks each one, catching the recurring papercut (#593, #594) where a snippet calls a non-existent API, imports a wrong module path, or drifts behind a published rename.

**Harness — `scripts/readme_snippets/`** (dependency-free Python)
- `extract.py` (pure, 14 unit tests): parses fenced blocks, filters to SDK-importing ones, assembles compilation units. Bare Go snippets are wrapped; every Go unit builds as a non-main `package snippet` so a block without `func main` still compiles.
- `check.py`: scaffolds a throwaway project and runs `go build` / `tsc --noEmit --strict` / `mypy` against either the **in-tree** SDK (`--source local`) or the **published** artifact (`--source published`). Type-check only — snippets are never executed.
- **Default-in**: every SDK-importing block is checked, so a newly added snippet is covered without anyone remembering to annotate it. `<!-- snippet-check: continues -->` / `<!-- snippet-check: skip -->` directives handle dependent / illustrative blocks.

**CI**
- `readme-snippets.yml`: runs the in-tree check on every README-touching PR (works for new, unreleased APIs).
- `publish-{go,ts,py}.yml`: a `readme-snippets` job runs the published check at release time.

**Drift the gate caught and this PR fixes**
- `sdk/go/README.md` used the stale module path `github.com/agent-receipts/sdk-go` (install + 3 imports) instead of `github.com/agent-receipts/ar/sdk/go`. That stale module still resolves on the proxy, so `check.py` also has a static canonical-path guard.
- Root README Python quick-start passed `action={...}` (a dict) where `CreateReceiptInput` expects `ActionInput`; now uses `ActionInput(...)`, matching the sdk/py README.

## Please review carefully
- **Publish-workflow edits touch release-critical CI** (per AGENTS.md, these want explicit human review).
- **The release gate is a post-publish alarm, not a true pre-gate.** "Published" mode can only run after the artifact is live, and the publish workflows trigger on `release: published` (already non-draft). A true pre-publish block would need a draft → check → publish restructure (follow-up).
- The sdk/ts README "Verify a chain" block is `skip`'d because it references never-defined `receipts`/`publicKey` — worth making standalone someday.

## Test plan
- [x] `python3 scripts/readme_snippets/test_extract.py` — 14 extractor unit tests pass
- [x] Go / TS / Python snippet checks pass in `--source local`
- [x] Go (`v0.13.0`), TS (`0.10.0`), Python (`0.10.0`) snippet checks pass in `--source published` against live registries
- [x] Full SDK suites green via pre-push hook (Go, TS 385, Python 405, mcp-proxy)