### PR TITLE
Pin spec links to release tags instead of main branch

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,6 +3,12 @@ name: Site
 on:
   push:
     branches: [main]
+    # spec-v<X.Y.Z> tag pushes are the release signal for a spec version
+    # (ADR-0021 D4): tagging rebuilds the site so /spec/v<X.Y.Z>/ goes live
+    # with cross-references pinned to that tag. Path filters do not apply to
+    # tag pushes, so this fires regardless of which files the tagged commit
+    # touched.
+    tags: ["spec-v*"]
     paths: [site/**, spec/**]
   pull_request:
     branches: [main]
@@ -27,6 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # sync-spec.mjs reads spec-v<X.Y.Z> tags to decide which versions
+          # are released; the default fetch-depth: 1 checkout omits tags.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test build scripts
+        run: pnpm test
+
       - name: Install Playwright Chromium (for mermaid rendering)
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ __pycache__/
 *.db-shm
 *.db-wal
 
-# Built daemon binary (output of `go build ./cmd/agent-receipts-daemon`)
+# Built binaries
+/bin/
+/daemon/bin/
 /daemon/agent-receipts-daemon

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@9.15.9",
   "scripts": {
     "sync-spec": "node scripts/sync-spec.mjs",
+    "test": "node --test 'scripts/**/*.test.mjs'",
     "predev": "node scripts/sync-spec.mjs",
     "prebuild": "node scripts/sync-spec.mjs",
     "dev": "astro dev",

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@9.15.9",
   "scripts": {
     "sync-spec": "node scripts/sync-spec.mjs",
-    "test": "node --test 'scripts/**/*.test.mjs'",
+    "test": "node --test \"scripts/**/*.test.mjs\"",
     "predev": "node scripts/sync-spec.mjs",
     "prebuild": "node scripts/sync-spec.mjs",
     "dev": "astro dev",

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -115,6 +115,13 @@ function main() {
     .filter((v) => released.has(v))
     .sort(semverCompare);
 
+  // Clear any previously generated pages up front, before deciding what to
+  // write. This holds the "publish nothing" safe failure mode even when the
+  // version set is empty (no release tags, shallow clone, or git
+  // unavailable): a stale page from an earlier run must never survive into
+  // the build, since a wrongly-pinned page is worse than a missing one.
+  if (existsSync(outDir)) rmSync(outDir, { recursive: true });
+
   if (versions.length === 0) {
     console.warn(
       "sync-spec: no released spec versions found — a spec/v<X.Y.Z>/ directory " +
@@ -129,7 +136,6 @@ function main() {
 }
 
 function writeSpecPages(versions) {
-  if (existsSync(outDir)) rmSync(outDir, { recursive: true });
   mkdirSync(outDir, { recursive: true });
 
   const latest = versions[versions.length - 1];

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -16,7 +16,7 @@ import {
   rmSync,
 } from "node:fs";
 import { join, dirname, posix } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { execFileSync } from "node:child_process";
 
 const GITHUB_BLOB = "https://github.com/agent-receipts/ar/blob";
@@ -34,7 +34,7 @@ const GITHUB_BLOB = "https://github.com/agent-receipts/ar/blob";
 // `main`: a permanent per-version page must reference the schema and
 // taxonomy as they were at that release, so a later spec release can't
 // retroactively change what an older page links to (ADR-0021 D2).
-function rewriteRelativeLinks(body, version) {
+export function rewriteRelativeLinks(body, version) {
   const baseDir = `spec/${version}`;
   const ref = `spec-${version}`;
   return body.replace(/\]\((\.{1,2}\/[^)\s#]+)(#[^)]*)?\)/g, (m, rel, anchor) => {
@@ -71,6 +71,20 @@ function semverCompare(a, b) {
 // fetch-depth: 0 (or fetch-tags: true). If git is unavailable we return an
 // empty set rather than crash — nothing publishes, which is the safe
 // failure mode (a missing page is recoverable; a wrongly-pinned one is not).
+// Parse the output of `git tag -l` into the set of released version names
+// ("v0.4.0", …). Only exact spec-v<X.Y.Z> tags count: prerelease tags
+// (spec-v0.4.0-rc1) and other artifacts (context-v1) have no matching
+// spec/v<X.Y.Z>/ directory and must not gate publishing. Kept pure (no git
+// call) so it is unit-testable.
+export function parseReleasedTags(tagOutput) {
+  const released = new Set();
+  for (const line of tagOutput.split("\n")) {
+    const m = line.trim().match(/^spec-(v\d+\.\d+\.\d+)$/);
+    if (m) released.add(m[1]);
+  }
+  return released;
+}
+
 function releasedVersions() {
   let out;
   try {
@@ -82,12 +96,7 @@ function releasedVersions() {
     console.error(`sync-spec: unable to read git tags: ${err.message}`);
     return new Set();
   }
-  const released = new Set();
-  for (const line of out.split("\n")) {
-    const m = line.trim().match(/^spec-(v\d+\.\d+\.\d+)$/);
-    if (m) released.add(m[1]);
-  }
-  return released;
+  return parseReleasedTags(out);
 }
 
 // A version is published — appearing in the index, the per-version routes,
@@ -97,22 +106,26 @@ function releasedVersions() {
 // in-flight (drafted on a feature branch, or merged ahead of its release
 // tag). Either case is silently ignored, so we never publish a page — or a
 // link to one — before the version is actually released.
-const released = releasedVersions();
-const versions = readdirSync(specRoot, { withFileTypes: true })
-  .filter((d) => d.isDirectory() && VERSION_RE.test(d.name))
-  .map((d) => d.name)
-  .filter((v) => existsSync(join(specRoot, v, "spec.md")))
-  .filter((v) => released.has(v))
-  .sort(semverCompare);
+function main() {
+  const released = releasedVersions();
+  const versions = readdirSync(specRoot, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && VERSION_RE.test(d.name))
+    .map((d) => d.name)
+    .filter((v) => existsSync(join(specRoot, v, "spec.md")))
+    .filter((v) => released.has(v))
+    .sort(semverCompare);
 
-if (versions.length === 0) {
-  console.warn(
-    "sync-spec: no released spec versions found — a spec/v<X.Y.Z>/ directory " +
-      "publishes only once a matching spec-v<X.Y.Z> git tag exists; " +
-      "skipping /spec/ page generation",
-  );
-} else {
-  writeSpecPages(versions);
+  if (versions.length === 0) {
+    console.warn(
+      "sync-spec: no released spec versions found — a spec/v<X.Y.Z>/ directory " +
+        "publishes only once a matching spec-v<X.Y.Z> git tag exists; " +
+        "skipping /spec/ page generation",
+    );
+  } else {
+    writeSpecPages(versions);
+  }
+
+  publishContexts();
 }
 
 function writeSpecPages(versions) {
@@ -201,17 +214,17 @@ function writeSpecPages(versions) {
 // The file has no extension to match the URL receipts already reference;
 // JSON-LD validators parse on content, not MIME.
 
-const CONTEXT_VERSION_RE = /^v(\d+)$/;
-const contextSrcRoot = join(specRoot, "context");
-const contextOutRoot = join(repoRoot, "site", "public", "context");
+function publishContexts() {
+  const CONTEXT_VERSION_RE = /^v(\d+)$/;
+  const contextSrcRoot = join(specRoot, "context");
+  const contextOutRoot = join(repoRoot, "site", "public", "context");
 
-if (existsSync(contextSrcRoot)) {
+  if (!existsSync(contextSrcRoot)) return;
+
   const contextVersions = readdirSync(contextSrcRoot, { withFileTypes: true })
     .filter((d) => d.isDirectory() && CONTEXT_VERSION_RE.test(d.name))
     .map((d) => d.name)
-    .filter((v) =>
-      existsSync(join(contextSrcRoot, v, "context.jsonld")),
-    )
+    .filter((v) => existsSync(join(contextSrcRoot, v, "context.jsonld")))
     .sort((a, b) => Number(a.slice(1)) - Number(b.slice(1)));
 
   if (existsSync(contextOutRoot)) rmSync(contextOutRoot, { recursive: true });
@@ -226,4 +239,11 @@ if (existsSync(contextSrcRoot)) {
       `sync-spec: published ${contextVersions.length} JSON-LD context(s) (${contextVersions.join(", ")}) to /context/`,
     );
   }
+}
+
+// Run the publishing pipeline only when invoked directly (predev / prebuild /
+// `pnpm sync-spec`). Importing this module — e.g. from the unit tests — must
+// not touch the filesystem or shell out to git.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -249,7 +249,9 @@ function publishContexts() {
 
 // Run the publishing pipeline only when invoked directly (predev / prebuild /
 // `pnpm sync-spec`). Importing this module — e.g. from the unit tests — must
-// not touch the filesystem or shell out to git.
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+// not touch the filesystem or shell out to git. argv[1] is absent in some
+// invocation modes (e.g. `node --eval` that imports this), so guard it before
+// pathToFileURL, which would otherwise throw on undefined.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -17,8 +17,9 @@ import {
 } from "node:fs";
 import { join, dirname, posix } from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 
-const GITHUB_BLOB = "https://github.com/agent-receipts/ar/blob/main";
+const GITHUB_BLOB = "https://github.com/agent-receipts/ar/blob";
 
 // Rewrite repo-relative markdown links to absolute GitHub URLs so the
 // rendered site can resolve them. The source spec uses relative paths
@@ -28,11 +29,17 @@ const GITHUB_BLOB = "https://github.com/agent-receipts/ar/blob/main";
 // re-served under the spec page tree. GitHub is the canonical viewer
 // for the artifact files; pointing there keeps a single source of
 // truth.
+//
+// Links are pinned to the version's release tag (`spec-v<X.Y.Z>`), not
+// `main`: a permanent per-version page must reference the schema and
+// taxonomy as they were at that release, so a later spec release can't
+// retroactively change what an older page links to (ADR-0021 D2).
 function rewriteRelativeLinks(body, version) {
   const baseDir = `spec/${version}`;
+  const ref = `spec-${version}`;
   return body.replace(/\]\((\.{1,2}\/[^)\s#]+)(#[^)]*)?\)/g, (m, rel, anchor) => {
     const repoPath = posix.normalize(`${baseDir}/${rel}`);
-    return `](${GITHUB_BLOB}/${repoPath}${anchor || ""})`;
+    return `](${GITHUB_BLOB}/${ref}/${repoPath}${anchor || ""})`;
   });
 }
 
@@ -57,93 +64,130 @@ function semverCompare(a, b) {
   return 0;
 }
 
-// A version is only considered released — and only appears in the index,
-// the per-version routes, and the `latest` computation — if its spec.md
-// exists. A bare directory without spec.md is treated as in-flight or a
-// mistake and is ignored, so we never publish links to pages we haven't
-// generated.
+// The release signal for a spec version is a pushed `spec-v<X.Y.Z>` git
+// tag (ADR-0021 D4), not the mere presence of a spec/v<X.Y.Z>/ directory on
+// main. Return the set of version names ("v0.4.0", …) that have such a tag.
+// Requires tag history: a normal local clone has it; CI must check out with
+// fetch-depth: 0 (or fetch-tags: true). If git is unavailable we return an
+// empty set rather than crash — nothing publishes, which is the safe
+// failure mode (a missing page is recoverable; a wrongly-pinned one is not).
+function releasedVersions() {
+  let out;
+  try {
+    out = execFileSync("git", ["tag", "-l", "spec-v*"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    console.error(`sync-spec: unable to read git tags: ${err.message}`);
+    return new Set();
+  }
+  const released = new Set();
+  for (const line of out.split("\n")) {
+    const m = line.trim().match(/^spec-(v\d+\.\d+\.\d+)$/);
+    if (m) released.add(m[1]);
+  }
+  return released;
+}
+
+// A version is published — appearing in the index, the per-version routes,
+// and the `latest` computation — only when both its spec.md exists and a
+// matching spec-v<X.Y.Z> release tag has been pushed (ADR-0021 D4). A
+// directory without spec.md is malformed; a directory without a tag is
+// in-flight (drafted on a feature branch, or merged ahead of its release
+// tag). Either case is silently ignored, so we never publish a page — or a
+// link to one — before the version is actually released.
+const released = releasedVersions();
 const versions = readdirSync(specRoot, { withFileTypes: true })
   .filter((d) => d.isDirectory() && VERSION_RE.test(d.name))
   .map((d) => d.name)
   .filter((v) => existsSync(join(specRoot, v, "spec.md")))
+  .filter((v) => released.has(v))
   .sort(semverCompare);
 
 if (versions.length === 0) {
-  console.error("sync-spec: no spec/v<X.Y.Z>/spec.md files found");
-  process.exit(1);
+  console.warn(
+    "sync-spec: no released spec versions found — a spec/v<X.Y.Z>/ directory " +
+      "publishes only once a matching spec-v<X.Y.Z> git tag exists; " +
+      "skipping /spec/ page generation",
+  );
+} else {
+  writeSpecPages(versions);
 }
 
-if (existsSync(outDir)) rmSync(outDir, { recursive: true });
-mkdirSync(outDir, { recursive: true });
+function writeSpecPages(versions) {
+  if (existsSync(outDir)) rmSync(outDir, { recursive: true });
+  mkdirSync(outDir, { recursive: true });
 
-const latest = versions[versions.length - 1];
+  const latest = versions[versions.length - 1];
 
-for (const v of versions) {
-  const src = join(specRoot, v, "spec.md");
-  // Strip a leading H1 if present — Starlight already renders the page
-  // title from frontmatter, so leaving the spec's own H1 in place would
-  // produce two stacked headings.
-  const raw = readFileSync(src, "utf8").replace(/^#\s+.+\n+/, "");
-  const body = rewriteRelativeLinks(raw, v);
-  // Force the route slug to preserve the dots in the semver — Starlight's
-  // default slug derivation strips them ("v0.4.0" → "v040"), but ADR-0021
-  // D2 commits to /spec/v<X.Y.Z>/ as the literal canonical URL.
-  const front = [
+  for (const v of versions) {
+    const src = join(specRoot, v, "spec.md");
+    // Strip a leading H1 if present — Starlight already renders the page
+    // title from frontmatter, so leaving the spec's own H1 in place would
+    // produce two stacked headings.
+    const raw = readFileSync(src, "utf8").replace(/^#\s+.+\n+/, "");
+    const body = rewriteRelativeLinks(raw, v);
+    // Force the route slug to preserve the dots in the semver — Starlight's
+    // default slug derivation strips them ("v0.4.0" → "v040"), but ADR-0021
+    // D2 commits to /spec/v<X.Y.Z>/ as the literal canonical URL.
+    const front = [
+      "---",
+      `title: Agent Receipts Protocol — Specification ${v}`,
+      `description: Full text of the Agent Receipts Protocol Specification at ${v}.`,
+      `slug: spec/${v}`,
+      "---",
+      "",
+      "",
+    ].join("\n");
+    writeFileSync(join(outDir, `${v}.md`), front + body);
+  }
+
+  // /spec/latest/ — the mutable alias from ADR-0021 D2. Implemented as a
+  // meta-refresh redirect page so the URL bar reflects the actual version
+  // the reader lands on (auditors should be citing /spec/v<X.Y.Z>/, not
+  // /spec/latest/). No-JS / pre-redirect users still see a plain link.
+  const latestPage = [
     "---",
-    `title: Agent Receipts Protocol — Specification ${v}`,
-    `description: Full text of the Agent Receipts Protocol Specification at ${v}.`,
-    `slug: spec/${v}`,
+    `title: Agent Receipts Protocol — Specification (latest)`,
+    `description: Mutable alias for the current released spec version (${latest}).`,
+    `slug: spec/latest`,
+    "head:",
+    "  - tag: meta",
+    "    attrs:",
+    "      http-equiv: refresh",
+    `      content: "0; url=/spec/${latest}/"`,
     "---",
     "",
+    `Redirecting to the latest released spec version, [${latest}](/spec/${latest}/).`,
+    "",
+    `If you are citing the spec, please use the [permanent per-version URL](/spec/${latest}/) directly rather than this alias.`,
     "",
   ].join("\n");
-  writeFileSync(join(outDir, `${v}.md`), front + body);
+  writeFileSync(join(outDir, "latest.md"), latestPage);
+
+  const indexLines = [
+    "---",
+    "title: Agent Receipts Protocol — Spec Versions",
+    "description: Index of released Agent Receipts Protocol Specification versions.",
+    "---",
+    "",
+    "Released spec versions. Each URL below is permanent (per [ADR-0021](https://github.com/agent-receipts/ar/blob/main/docs/adr/0021-spec-and-context-versioning.md)) and links to the full text of that version.",
+    "",
+    "| Version | Status | Link |",
+    "| --- | --- | --- |",
+  ];
+  for (const v of versions) {
+    const status = v === latest ? "**current**" : "released";
+    indexLines.push(`| ${v} | ${status} | [/spec/${v}/](/spec/${v}/) |`);
+  }
+  indexLines.push("");
+  writeFileSync(join(outDir, "index.md"), indexLines.join("\n"));
+
+  console.log(
+    `sync-spec: wrote ${versions.length} version page(s) (${versions.join(", ")}); current = ${latest}`,
+  );
 }
-
-// /spec/latest/ — the mutable alias from ADR-0021 D2. Implemented as a
-// meta-refresh redirect page so the URL bar reflects the actual version
-// the reader lands on (auditors should be citing /spec/v<X.Y.Z>/, not
-// /spec/latest/). No-JS / pre-redirect users still see a plain link.
-const latestPage = [
-  "---",
-  `title: Agent Receipts Protocol — Specification (latest)`,
-  `description: Mutable alias for the current released spec version (${latest}).`,
-  `slug: spec/latest`,
-  "head:",
-  "  - tag: meta",
-  "    attrs:",
-  "      http-equiv: refresh",
-  `      content: "0; url=/spec/${latest}/"`,
-  "---",
-  "",
-  `Redirecting to the latest released spec version, [${latest}](/spec/${latest}/).`,
-  "",
-  `If you are citing the spec, please use the [permanent per-version URL](/spec/${latest}/) directly rather than this alias.`,
-  "",
-].join("\n");
-writeFileSync(join(outDir, "latest.md"), latestPage);
-
-const indexLines = [
-  "---",
-  "title: Agent Receipts Protocol — Spec Versions",
-  "description: Index of released Agent Receipts Protocol Specification versions.",
-  "---",
-  "",
-  "Released spec versions. Each URL below is permanent (per [ADR-0021](https://github.com/agent-receipts/ar/blob/main/docs/adr/0021-spec-and-context-versioning.md)) and links to the full text of that version.",
-  "",
-  "| Version | Status | Link |",
-  "| --- | --- | --- |",
-];
-for (const v of versions) {
-  const status = v === latest ? "**current**" : "released";
-  indexLines.push(`| ${v} | ${status} | [/spec/${v}/](/spec/${v}/) |`);
-}
-indexLines.push("");
-writeFileSync(join(outDir, "index.md"), indexLines.join("\n"));
-
-console.log(
-  `sync-spec: wrote ${versions.length} version page(s) (${versions.join(", ")}); current = ${latest}`,
-);
 
 // --- JSON-LD context publishing ---------------------------------------
 //

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -15,7 +15,7 @@ import {
   existsSync,
   rmSync,
 } from "node:fs";
-import { join, dirname, posix } from "node:path";
+import { join, dirname, posix, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { execFileSync } from "node:child_process";
 
@@ -251,7 +251,8 @@ function publishContexts() {
 // `pnpm sync-spec`). Importing this module — e.g. from the unit tests — must
 // not touch the filesystem or shell out to git. argv[1] is absent in some
 // invocation modes (e.g. `node --eval` that imports this), so guard it before
-// pathToFileURL, which would otherwise throw on undefined.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// pathToFileURL. resolve() ensures a relative argv[1] (e.g. `node scripts/sync-spec.mjs`)
+// is converted to an absolute path before pathToFileURL, which requires one.
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
   main();
 }

--- a/site/scripts/sync-spec.mjs
+++ b/site/scripts/sync-spec.mjs
@@ -64,13 +64,6 @@ function semverCompare(a, b) {
   return 0;
 }
 
-// The release signal for a spec version is a pushed `spec-v<X.Y.Z>` git
-// tag (ADR-0021 D4), not the mere presence of a spec/v<X.Y.Z>/ directory on
-// main. Return the set of version names ("v0.4.0", …) that have such a tag.
-// Requires tag history: a normal local clone has it; CI must check out with
-// fetch-depth: 0 (or fetch-tags: true). If git is unavailable we return an
-// empty set rather than crash — nothing publishes, which is the safe
-// failure mode (a missing page is recoverable; a wrongly-pinned one is not).
 // Parse the output of `git tag -l` into the set of released version names
 // ("v0.4.0", …). Only exact spec-v<X.Y.Z> tags count: prerelease tags
 // (spec-v0.4.0-rc1) and other artifacts (context-v1) have no matching
@@ -85,6 +78,13 @@ export function parseReleasedTags(tagOutput) {
   return released;
 }
 
+// The release signal for a spec version is a pushed `spec-v<X.Y.Z>` git
+// tag (ADR-0021 D4), not the mere presence of a spec/v<X.Y.Z>/ directory on
+// main. Return the set of version names ("v0.4.0", …) that have such a tag.
+// Requires tag history: a normal local clone has it; CI must check out with
+// fetch-depth: 0 (or fetch-tags: true). If git is unavailable we return an
+// empty set rather than crash — nothing publishes, which is the safe
+// failure mode (a missing page is recoverable; a wrongly-pinned one is not).
 function releasedVersions() {
   let out;
   try {

--- a/site/scripts/sync-spec.test.mjs
+++ b/site/scripts/sync-spec.test.mjs
@@ -49,7 +49,7 @@ test("rewriteRelativeLinks preserves anchors and normalizes ..", () => {
   );
 });
 
-test("rewriteRelativeLinks leaves absolute links untouched", () => {
+test("rewriteRelativeLinks rewrites relative links but leaves absolute URLs untouched", () => {
   const out = rewriteRelativeLinks(
     "[home](https://agentreceipts.ai) and [rel](./x.json)",
     "v0.4.0",

--- a/site/scripts/sync-spec.test.mjs
+++ b/site/scripts/sync-spec.test.mjs
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseReleasedTags, rewriteRelativeLinks } from "./sync-spec.mjs";
+
+const BLOB = "https://github.com/agent-receipts/ar/blob";
+
+test("parseReleasedTags keeps exact spec-vX.Y.Z tags", () => {
+  const set = parseReleasedTags("spec-v0.4.0\nspec-v0.5.0\n");
+  assert.deepEqual([...set].sort(), ["v0.4.0", "v0.5.0"]);
+});
+
+test("parseReleasedTags ignores prereleases, other artifacts, and noise", () => {
+  const tags = [
+    "spec-v0.4.0",
+    "spec-v0.4.0-rc1", // prerelease — no matching spec/v<X.Y.Z>/ dir
+    "spec-v1.2", // not full semver
+    "context-v1", // different artifact
+    "spec-vX.Y.Z", // non-numeric
+    "", // blank line
+    "  spec-v0.9.0  ", // surrounding whitespace tolerated
+  ].join("\n");
+  assert.deepEqual([...parseReleasedTags(tags)].sort(), ["v0.4.0", "v0.9.0"]);
+});
+
+test("parseReleasedTags returns an empty set for empty output", () => {
+  assert.equal(parseReleasedTags("").size, 0);
+});
+
+test("rewriteRelativeLinks pins cross-references to the version's release tag", () => {
+  const out = rewriteRelativeLinks(
+    "See [schema](../schema/agent-receipt.schema.json).",
+    "v0.4.0",
+  );
+  assert.equal(
+    out,
+    `See [schema](${BLOB}/spec-v0.4.0/spec/schema/agent-receipt.schema.json).`,
+  );
+});
+
+test("rewriteRelativeLinks preserves anchors and normalizes ..", () => {
+  const out = rewriteRelativeLinks(
+    "[t](../spec/taxonomy/action-types.json#risk)",
+    "v0.5.0",
+  );
+  assert.equal(
+    out,
+    `[t](${BLOB}/spec-v0.5.0/spec/spec/taxonomy/action-types.json#risk)`,
+  );
+});
+
+test("rewriteRelativeLinks leaves absolute links untouched", () => {
+  const out = rewriteRelativeLinks(
+    "[home](https://agentreceipts.ai) and [rel](./x.json)",
+    "v0.4.0",
+  );
+  assert.equal(
+    out,
+    `[home](https://agentreceipts.ai) and [rel](${BLOB}/spec-v0.4.0/spec/v0.4.0/x.json)`,
+  );
+});


### PR DESCRIPTION
## What

Refactor spec publishing to pin cross-references in spec pages to their release tag (`spec-v<X.Y.Z>`) rather than the `main` branch. This ensures that older spec versions always link to the schema and taxonomy as they existed at that release, preventing later releases from retroactively changing what older pages reference.

Additionally, gate spec version publication on the existence of a matching git release tag, not just the presence of a `spec/v<X.Y.Z>/` directory. This ensures specs only go live once formally released via tag push.

## Why

**Problem**: Currently, spec pages link to GitHub using the `main` branch reference. When a new spec version is released and the schema/taxonomy evolve, older spec pages' links now point to the newer versions of those files, breaking the immutability guarantee that auditors expect when citing a specific spec version.

**Solution**: 
1. Rewrite links to use the version's release tag (`spec-v<X.Y.Z>`) as the ref, ensuring each spec version's links are permanently pinned to the artifacts as they existed at that release (ADR-0021 D2).
2. Use `git tag -l` to determine which versions are actually released, rather than relying on directory presence. This prevents in-flight spec versions (merged on feature branches before their release tag) from being published prematurely.
3. Update CI to trigger on `spec-v*` tag pushes and fetch full tag history (`fetch-depth: 0`).

## Changes

- **sync-spec.mjs**: 
  - Export `rewriteRelativeLinks()` and `parseReleasedTags()` for testing
  - Add `releasedVersions()` function that shells out to `git tag -l` to determine released versions
  - Change `GITHUB_BLOB` from `main` to generic `blob` ref, then inject version-specific tag in link rewriting
  - Refactor main logic into `writeSpecPages()` and `publishContexts()` functions
  - Guard script execution with `import.meta.url` check so module can be imported for testing without side effects
  
- **sync-spec.test.mjs** (new):
  - Unit tests for `parseReleasedTags()` covering exact semver matching, prerelease filtering, and edge cases
  - Unit tests for `rewriteRelativeLinks()` covering tag pinning, anchor preservation, and path normalization

- **.github/workflows/site.yml**:
  - Add `tags: ["spec-v*"]` trigger so tag pushes rebuild the site
  - Set `fetch-depth: 0` to ensure CI has full tag history for `git tag -l`
  - Add `pnpm test` step to run unit tests

- **site/package.json**:
  - Add `test` script: `node --test 'scripts/**/*.test.mjs'`

## Checklist

- [x] Tests pass for all changed components (new unit tests added and pass)
- [x] No real keys or secrets in the diff
- [x] Spec changes follow ADR-0021 D2 and D4 (permanent per-version URLs, tag-based release signal)

## Security

- [x] This PR does not touch crypto, auth, or secrets handling