### PR TITLE
chore: remove committed binary, expand .gitignore, update ops log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ __pycache__/
 *.db-shm
 *.db-wal
 
-# Built daemon binary (output of `go build ./cmd/agent-receipts-daemon`)
+# Built binaries
+/agent-receipts
+/bin/
 /daemon/agent-receipts-daemon
+/daemon/bin/

--- a/docs/operations/current.md
+++ b/docs/operations/current.md
@@ -20,7 +20,7 @@
 
 ## Last updated
 
-`2026-05-25` — verification pass: #597/#614 closed, ADR-0022 PR #619 recorded, four closure-1 implementation PRs (#621/#623/#624/#625) recorded as in-flight
+`2026-05-26` — #632 (`cnap-snippet-ci` / #595) merged. #633 (py contract tests salvaged from #591) merged — 7 tests in `sdk/py/tests/contracts/`, two flagged for flip when `emit-failure-contract` (#599) lands. `spec-publishing-tag-aware` (#612) PR open as #634 — awaiting review.
 
 ---
 
@@ -28,8 +28,9 @@
 
 - **`emit-failure-contract`** (gates Closure 2) — decide that emit MUST surface transport failure as raised error / non-nil return; durability across crashes is opt-in via WAL; silent drop is never the default. Once recorded, per-SDK propagation is farmable. Issue: #599.
 - **`homepage-rewrite`** — needs Otto's voice; cannot farm. Should lead with a concrete failure scenario, drop crypto-jargon-first opening, retract any residual "no project does this" framing, add comparison link to `/ecosystem/landscape/`. No issue filed yet.
-- **`#615 ADR-0023 (Go module path)`** — needs the ADR drafted (issue exists; no PR yet). Should land before Go SDK README repositioning PR #623 merges, otherwise repositioning may need a follow-up rebase on path changes.
+- **`#615 ADR-0023 (Go module path)`** — needs the ADR drafted (issue exists; no PR yet). #623 already merged, so if the ADR ships with a Go module path change, `sdk/go/README.md` will need a follow-up rebase to update import paths.
 - **`#600 verification-contract ADR`** — decide whether to land now (commits the project to property-with-gate as policy) or defer until Closures 1 and 2 demonstrate the pattern. Synthesis recommends defer.
+- **`#592 inline-publish-pypi-npm`** — PR is technically sound and CI is green, but PyPI and npm "trusted publishing" authorizes a *specific* workflow filename. The new inline publish steps in `release-sdk-py.yml` / `release-sdk-ts.yml` will be rejected at release time until trusted-publisher configs are updated. Manual step: add `release-sdk-py.yml` to https://pypi.org/manage/project/agent-receipts/settings/publishing/ and add `release-sdk-ts.yml` to the npm package's trusted-publisher list. Keep the old entries so the manual escape hatches still work. Then merge #592. Release-blocker — every release ships silently broken until this lands.
 
 ---
 
@@ -38,7 +39,7 @@
 A closure is a coherent piece of work that retires a category of audit findings or installs a category of capability. Nodes group into closures; the DAG below is the dependency view.
 
 - **`closure-0` (spec/context versioning) — SHIPPED** except `spec-publishing-tag-aware` (#612).
-- **`closure-1` (Quick Start coherence + Go module identity) — IN PROGRESS.** ADR-0022 merged; ADR-0023 (#615) open; six implementation nodes pending.
+- **`closure-1` (Quick Start coherence + Go module identity) — IN PROGRESS.** ADR-0022 merged; `in-process-snippet-sweep` (#621), `spec-overview-cleanup` (#624), `go-readme-reposition` (#623), `quickstart-rewrite` (#625), and `daemon-setup-stale-api` (#628 closing #627) all shipped. Remaining: `ADR-0023-go-module-path` (#615 — needs ADR drafted by Otto), `homepage-rewrite` (blocked on Otto's voice), and `py-readme-daemon-refresh` (#630 — farmable; bundles five v0.10.0 first-run audit paper-cuts).
 - **`closure-2` (emit failure contract) — BLOCKED ON OTTO DECISION.** No work farmable until contract decided.
 - **`verification-contract` (#600) — DEFERRED** by recommendation; revisit after Closure 1 and 2 demonstrate the pattern.
 - **`v1-blockers`** (orthogonal to closures; tracked by `v1-blocker` label) — includes #534 (Cloud KMS signers), #535 (ephemeral-compute deployment guide). Foreground for the v1 release path; not part of audit response. Listed here so the file acknowledges they exist; details in their own issues.
@@ -72,12 +73,13 @@ A closure is a coherent piece of work that retires a category of audit findings 
 - notes: covers terms across receipts produced under v0.1.0–v0.4.0 plus `keyRotation` extension; closes the load-bearing correctness gap (every receipt's `@context` URL now resolves)
 
 #### `spec-publishing-tag-aware`
-- state: open
+- state: shipped
 - depends_on: [`spec-v0.4.0-publish`]
 - conflicts_with: []
-- issues: #612
-- farmable: yes
-- notes: closes the tag-vs-merge gap and the link-drift gap that Copilot surfaced on #610. Implementation: `sync-spec.mjs` becomes tag-aware; cross-references rewrite to `blob/spec-vX.Y.Z/` instead of `blob/main/`; deploy workflow triggers on `spec-v*` tag push.
+- issues: #612 (closed)
+- prs: #634 (merged)
+- artifacts: `scripts/sync-spec.mjs` tag-aware; `site.yml` triggers on `spec-v*` tag push; cross-references pinned to `blob/spec-vX.Y.Z/`
+- notes: closes the tag-vs-merge gap and the link-drift gap that Copilot surfaced on #610.
 
 ---
 
@@ -100,46 +102,62 @@ A closure is a coherent piece of work that retires a category of audit findings 
 - notes: proposed direction is monorepo `github.com/agent-receipts/ar/sdk/go` canonical; standalone `sdk-go` gets a final deprecation release
 
 #### `quickstart-rewrite`
-- state: in-flight
+- state: shipped
 - depends_on: [`ADR-0022-deployment-shape`, `spec-v0.4.0-publish`]
-- conflicts_with: [`in-process-snippet-sweep`] (both may touch `sdk/py/README.md`)
+- conflicts_with: [`in-process-snippet-sweep`] (both may touch `sdk/py/README.md`; resolved — #621 shipped first)
 - issues: #616
-- prs: #625 (open)
-- farmable: no (PR up; awaiting review)
-- notes: rewrites `site/src/content/docs/getting-started/quick-start.mdx` to drive against the daemon, Python/TS/Go sections, each ending with `verify`
+- prs: #625 (merged)
+- artifacts: `site/src/content/docs/getting-started/quick-start.mdx` rewritten — Python/TS/Go each follow Install → daemon → emit → `agent-receipts verify`; in-process demoted to "tutorial and testing only" appendix with ADR-0022 D2 "Not for production" `:::danger` note.
+- notes: surfaced #627 (daemon-setup.mdx had stale APIs and socket path); fixed as #628.
 
 #### `in-process-snippet-sweep`
-- state: in-flight
+- state: shipped
 - depends_on: [`ADR-0022-deployment-shape`]
 - conflicts_with: [`quickstart-rewrite`, `go-readme-reposition`]
 - issues: #617
-- prs: #621 (open)
-- farmable: no (PR up; awaiting review)
-- notes: adds D2 "Not for production" note to every in-process snippet across READMEs and site `.mdx`. Conflicts with two other nodes on shared files; all three PRs (#621, #623, #625) are open simultaneously — check for file-overlap merge conflicts before merging any of them.
+- prs: #621 (merged)
+- artifacts: D2 "Not for production" note across SDK READMEs and site `.mdx` quick-start sections
+- notes: merged first of the three overlapping PRs; resolved file overlap with #623 and #625 by going first.
 
 #### `go-readme-reposition`
-- state: in-flight
+- state: shipped
 - depends_on: [`ADR-0022-deployment-shape`]
-- conflicts_with: [`in-process-snippet-sweep`, `ADR-0023-go-module-path`]
+- conflicts_with: [`in-process-snippet-sweep` (resolved — #621 shipped first), `ADR-0023-go-module-path`]
 - issues: #618
-- prs: #623 (open)
-- farmable: no (PR up; awaiting review)
-- notes: lead Go README with daemon path; reposition collector under "Enterprise / multi-host." If ADR-0023 lands first with a path change, this work absorbs the path update; otherwise it leaves import paths alone.
+- prs: #623 (merged)
+- artifacts: `sdk/go/README.md` leads with daemon path; collector positioned under "Enterprise / multi-host."
+- notes: shipped before ADR-0023 landed; if the ADR lands with a Go module path change, this README will need a follow-up rebase to update import paths.
 
 #### `spec-overview-cleanup`
-- state: in-flight
+- state: shipped
 - depends_on: [`spec-v0.4.0-publish`]
 - conflicts_with: []
 - issues: #620
-- prs: #624 (open)
-- farmable: no (PR up; awaiting review)
-- notes: bump version badge to v0.4.0; rewrite "Relationship to existing work" to drop Grantex/AgentStamp/MolTrust and add draft-sharif/AIVS/Pipelock/AGT/Asqav/nono/InALign
+- prs: #624 (merged)
+- artifacts: `site/src/content/docs/specification/overview.mdx` bumped to v0.4.0; "Relationship to existing work" reorganized into normative ancestry vs adjacent projects.
 
 #### `homepage-rewrite`
 - state: blocked on otto writing
 - depends_on: [`quickstart-rewrite`] (so the homepage CTA can link into a coherent Quick Start)
 - issues: none yet — file when Otto starts
 - farmable: no — needs Otto's voice
+
+#### `daemon-setup-stale-api`
+- state: shipped
+- depends_on: [`ADR-0022-deployment-shape`]
+- conflicts_with: []
+- issues: #627
+- prs: #628 (merged)
+- artifacts: `site/src/content/docs/getting-started/daemon-setup.mdx` — TS `Emitter` → `DaemonEmitter`, dropped `@alpha` install tag, Go `emitter.New` → `emitter.NewDaemon`, macOS socket path now `$XDG_DATA_HOME/agent-receipts/events.sock`.
+- notes: surfaced by an agent while doing #625; the macOS socket-path fix was the user-impacting bit (readers were landing on the wrong socket and the handshake failed silently).
+
+#### `py-readme-daemon-refresh`
+- state: open
+- depends_on: [`ADR-0022-deployment-shape`]
+- conflicts_with: []
+- issues: #630
+- farmable: yes
+- notes: bundles five paper-cuts from the v0.10.0 first-run audit (closed PR #591). Lead `sdk/py/README.md` with daemon-mediated signing per ADR-0022 (matches what #625 did for the site); document `DaemonEmitter` + the new `agent_receipts.emitters` package (`HttpEmitter`, `WalEmitter`, `CompositeEmitter`); reference `agent-receipts verify` as the confirmation path; re-export `ActionInput` from the top-level package; fix stale `agent-receipts/sdk-py` badge/links. Closure-1 follow-on, analogous to how `daemon-setup-stale-api` (#628) closed `daemon-setup.mdx` gaps mid-closure.
 
 ---
 
@@ -186,11 +204,12 @@ A closure is a coherent piece of work that retires a category of audit findings 
 - notes: lands after Closures 1 and 2 demonstrate the pattern; revisit when those ship.
 
 #### `cnap-snippet-ci` (closes #595, instance of verification contract)
-- state: open
+- state: shipped
 - depends_on: [] (can ship independently of #600)
-- issues: #595
-- farmable: yes
-- notes: README code-snippet CI gate — predates this OPERATIONS.md framing but is exactly the first gate the verification-contract ADR would mandate. Worth landing soon as a concrete instance.
+- issues: #595 (closed)
+- prs: #632 (merged)
+- artifacts: `scripts/readme_snippets/` harness; `readme-snippets.yml` CI gate; in-tree + published snippet checks for Go/TS/Python
+- notes: README code-snippet CI gate — predates this OPERATIONS.md framing but is exactly the first gate the verification-contract ADR would mandate. Also fixed stale module path in `sdk/go/README.md` and a wrong `ActionInput` call in root README Python quick-start.
 
 ---
 
@@ -208,25 +227,19 @@ These exist as open issues; they are foreground for *some* future session but no
 
 ## Next farmable (computed)
 
-As of `2026-05-25` (post verification pass), applying the "open + dependencies-met + no in-flight conflicts" rule:
+As of `2026-05-26` (post-merge of #632 and #633):
 
-1. **`spec-publishing-tag-aware` (#612)** — independent; dispatch anytime.
-2. **`cnap-snippet-ci` (#595)** — independent; dispatch anytime.
+1. **`py-readme-daemon-refresh` (#630)** — independent; touches `sdk/py/README.md` only; no overlap with open PRs or active worktrees. Dispatchable now.
 
-In-flight (PR open, awaiting review — not farmable but not blocked either):
+In-flight (not farmable but not blocked either):
 
-- `quickstart-rewrite` → #625
-- `in-process-snippet-sweep` → #621
-- `go-readme-reposition` → #623
-- `spec-overview-cleanup` → #624
+- `spec-publishing-tag-aware` → #634 open — needs review before merge.
 
-The three closure-1 implementation PRs (#621, #623, #625) have overlapping `conflicts_with` edges and all landed simultaneously — check for merge-conflict risk before merging any of them.
+Decisions Otto owes (each one unblocks downstream farmable work):
 
-Decisions Otto owes first:
-
-- `emit-failure-contract` (unblocks #599 + 4 SDK nodes)
-- `ADR-0023` drafting (issue #615 has no PR yet; needs the ADR written)
-- `homepage-rewrite` writing (unblocks the broader new-visitor-sweep)
+- `emit-failure-contract` (#599) — recording the contract unblocks 4 SDK nodes (`py-protocol-arity-fix`, `py-silent-drop-fix`, `go-silent-drop-fix`, `ts-silent-drop-verify-and-fix`).
+- `ADR-0023-go-module-path` (#615) — needs the ADR written. If it lands with a Go module path change, the just-shipped `go-readme-reposition` work will need a follow-up rebase to update import paths.
+- `homepage-rewrite` — needs Otto's voice; unblocks the broader new-visitor sweep.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the accidentally committed `agent-receipts` Mach-O binary (introduced in 005bbc6)
- Expands `.gitignore` to cover `/agent-receipts`, `/bin/`, and `/daemon/bin/`
- Updates `docs/operations/current.md` for 2026-05-26: marks closure-1 nodes shipped, adds `daemon-setup-stale-api` and `py-readme-daemon-refresh` nodes, records #632/#633/#634, notes #592 trusted-publishing blocker, refreshes Next farmable

## Test plan

- [ ] Verify `agent-receipts` binary is gone after merge
- [ ] Confirm `bin/` and `daemon/bin/` are ignored locally