### PR TITLE
docs: ADR-0023 — canonical Go module path

### DIFF
--- a/docs/adr/0023-canonical-go-module-path.md
+++ b/docs/adr/0023-canonical-go-module-path.md
@@ -8,7 +8,7 @@ Accepted
 
 The Go SDK is currently reachable via two distinct module paths:
 
-1. **`github.com/agent-receipts/ar/sdk/go`** — the monorepo path. This is where the SDK actively develops (current version `v0.13.0`); the site's installation docs use this path; the collector and other Go components share the same monorepo.
+1. **`github.com/agent-receipts/ar/sdk/go`** — the monorepo path. This is where the SDK is actively developed (current version `v0.13.0`); the site's installation docs use this path; the collector and other Go components share the same monorepo.
 2. **`github.com/agent-receipts/sdk-go`** — a standalone module path. This was the historical canonical path. The last published tag is `v0.1.0`. It contains `receipt`, `store`, and `taxonomy` packages but no `emitters`, no `aws` KMS adapter, no collector — it is 12 versions behind and missing the majority of current functionality. The `sdk/go` README in the monorepo still uses this import path.
 
 A new Go evaluator hitting the project's front door runs `go get github.com/agent-receipts/sdk-go` per the README, resolves the stale module, compiles a hello-world against it, and either gets confused by the missing `emitters` package or assumes that is the complete SDK. The site, meanwhile, uses the monorepo path. The two surfaces disagree.
@@ -21,7 +21,7 @@ The Go ecosystem's module-path mechanics make this a binary decision: a Go modul
 
 ### D1. The canonical Go module path is `github.com/agent-receipts/ar/sdk/go`
 
-All Go consumers of the Agent Receipts SDK use the monorepo import path. The README, the site, every example, every documentation reference, and every SDK release tag uses this path going forward.
+All Go consumers of the Agent Receipts SDK use the monorepo import path. The README, the site, every example, every documentation reference, and every SDK release tag use this path going forward.
 
 Reasoning: the monorepo is where development actively happens, where releases are cut from, where the collector and other Go components share build infrastructure, and where the SDK's current version corresponds to the project's overall surface area. The standalone module has been stale for 12 versions; promoting it to canonical now means moving the active development *to* it, which is the opposite of where the project's investment is going.
 

--- a/docs/adr/0023-canonical-go-module-path.md
+++ b/docs/adr/0023-canonical-go-module-path.md
@@ -1,0 +1,83 @@
+# ADR-0023: Canonical Go Module Path
+
+## Status
+
+Accepted
+
+## Context
+
+The Go SDK is currently reachable via two distinct module paths:
+
+1. **`github.com/agent-receipts/ar/sdk/go`** — the monorepo path. This is where the SDK actively develops (current version `v0.13.0`); the site's installation docs use this path; the collector and other Go components share the same monorepo.
+2. **`github.com/agent-receipts/sdk-go`** — a standalone module path. This was the historical canonical path. The last published tag is `v0.1.0`. It contains `receipt`, `store`, and `taxonomy` packages but no `emitters`, no `aws` KMS adapter, no collector — it is 12 versions behind and missing the majority of current functionality. The `sdk/go` README in the monorepo still uses this import path.
+
+A new Go evaluator hitting the project's front door runs `go get github.com/agent-receipts/sdk-go` per the README, resolves the stale module, compiles a hello-world against it, and either gets confused by the missing `emitters` package or assumes that is the complete SDK. The site, meanwhile, uses the monorepo path. The two surfaces disagree.
+
+Compounding: the collector module has no semver tag, so `go install github.com/agent-receipts/ar/collector/cmd/collector@latest` pins `sdk/go` to `v0.12.1` (missing `store.Exists` added at `v0.13.0`) and fails to build. The only way to run a collector today is `git clone` + workspace build. The headline distribution channel for Go tools is broken.
+
+The Go ecosystem's module-path mechanics make this a binary decision: a Go module has one canonical import path, and consumers reaching it via any other path resolve a different module. There is no graceful "both are fine" outcome; the project must pick one.
+
+## Decision
+
+### D1. The canonical Go module path is `github.com/agent-receipts/ar/sdk/go`
+
+All Go consumers of the Agent Receipts SDK use the monorepo import path. The README, the site, every example, every documentation reference, and every SDK release tag uses this path going forward.
+
+Reasoning: the monorepo is where development actively happens, where releases are cut from, where the collector and other Go components share build infrastructure, and where the SDK's current version corresponds to the project's overall surface area. The standalone module has been stale for 12 versions; promoting it to canonical now means moving the active development *to* it, which is the opposite of where the project's investment is going.
+
+### D2. `github.com/agent-receipts/sdk-go` is deprecated
+
+The standalone module receives one final release tagged `v0.1.1` (or whatever increment is appropriate) whose sole content is:
+
+1. A package-level `// Deprecated:` notice on every exported symbol, pointing at the canonical monorepo path.
+2. A README rewrite stating the module is deprecated and pointing at the monorepo.
+3. No code changes beyond the deprecation notices.
+
+After that release, no further tags are published on the standalone module. The repo remains live as a redirect target for historical references but receives no updates.
+
+### D3. The collector module is tagged independently
+
+The collector (`github.com/agent-receipts/ar/collector`) is tagged independently of `sdk/go`. The current state — collector module has no semver tags, so `@latest` pins a stale transitive dependency — is fixed by tagging the collector at its own version (e.g. `collector/v0.13.0`) on the same commit as a corresponding `sdk/go/v0.13.x` tag, with the collector's `go.mod` requiring the matching `sdk/go` version explicitly.
+
+Going forward, every release of `sdk/go` is accompanied by a matching collector tag if collector behaviour or dependencies changed; otherwise the collector tag is incremented independently when collector-only changes ship.
+
+### D4. README and site updates
+
+The `sdk/go/README.md` import paths are updated to the monorepo path. The site's installation docs (already using the monorepo path) remain canonical. Every example file in the repo using the standalone path is updated.
+
+### D5. Release-time verification
+
+After this ADR is implemented, a one-time verification step confirms:
+
+1. `go get github.com/agent-receipts/ar/sdk/go@latest` resolves to the current monorepo version.
+2. `go install github.com/agent-receipts/ar/collector/cmd/collector@latest` builds and produces a runnable collector binary against a fresh GOPATH.
+3. The hello-world in `sdk/go/README.md` compiles and runs against `@latest`.
+
+This verification is run manually as part of closing the ADR's implementation issue. Whether it graduates to a CI gate is a separate question (covered under the verification-contract ADR #600's gate catalogue).
+
+## Out of scope for this ADR
+
+- Reorganizing the broader `sdk-go` site documentation section. Independent docs work, tracked under Closure 1's Go docs reorganization issues.
+- Updating the Go README's hello-world snippet content beyond the import paths. The snippet's correctness as a code snippet is covered by the documented-snippet gate (verification-contract follow-up).
+- Migrating users on the standalone module. There likely are no production users on `sdk-go` given its 12-version-stale state, but if any external repos surface, they are handled case-by-case after the deprecation notice ships.
+
+## Consequences
+
+- `go get github.com/agent-receipts/sdk-go` continues to resolve, but emits deprecation warnings, and the docs point users away from it.
+- `go get github.com/agent-receipts/ar/sdk/go` becomes the only documented install path. Resolves cleanly to the current version.
+- `go install ...collector@latest` builds successfully. The project's Go tooling becomes installable via the headline distribution channel.
+- Persona A following the Go README hits a working install on first try. GO-P1, GO-P2, GO-P3 close.
+- The two-module-paths confusion that the audit surfaced as the worst Go first-run experience in the project no longer exists.
+
+## Implementation issues spawned by this ADR
+
+Filed as separate issues, blocked on this PR merging. Each is labeled `adr-followup`.
+
+- Update all README and example import paths from `github.com/agent-receipts/sdk-go/...` to `github.com/agent-receipts/ar/sdk/go/...`. (#636)
+- Publish the final deprecation release on `github.com/agent-receipts/sdk-go` per D2. (#637)
+- Tag the collector module independently per D3; verify `go install ...collector@latest` builds. (#638)
+- Run the D5 release-time verification and record results in the closing issue. (#639)
+
+---
+
+*Closes #615 when merged.*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0020](0020-emitter-abstraction-and-remote-receipt-delivery.md) | Emitter Abstraction and Remote Receipt Delivery | Accepted |
 | [ADR-0021](0021-spec-and-context-versioning.md) | Spec and JSON-LD Context Versioning, with Permanent Per-Version URLs | Accepted |
 | [ADR-0022](0022-canonical-deployment-shape.md) | Canonical Agent Receipts Deployment Shape (Daemon-Mediated Primary, In-Process Tutorial-Only) | Accepted |
+| [ADR-0023](0023-canonical-go-module-path.md) | Canonical Go Module Path | Accepted |
 
 ## References
 


### PR DESCRIPTION
## What

Adds ADR-0023: Canonical Go Module Path at `docs/adr/0023-canonical-go-module-path.md`.

## Why

Closes #615. The Go SDK is reachable via two conflicting module paths (`github.com/agent-receipts/sdk-go` and `github.com/agent-receipts/ar/sdk/go`). The standalone path is 12 versions stale and missing the majority of current functionality. The collector module has no semver tags, making `go install ...collector@latest` broken. This ADR records the binding decision so implementation issues can proceed unambiguously.

## Decisions recorded (D1–D5)

- **D1.** `github.com/agent-receipts/ar/sdk/go` is the canonical Go module path. All docs, READMEs, and examples use this path going forward.
- **D2.** `github.com/agent-receipts/sdk-go` receives one final deprecation release (`v0.1.1`) with `// Deprecated:` notices and a README redirect; no further tags after that.
- **D3.** The collector module (`github.com/agent-receipts/ar/collector`) is tagged independently with its own semver, fixing the broken `@latest` install.
- **D4.** `sdk/go/README.md` and all example import paths are updated to the monorepo path (implementation in #636).
- **D5.** A one-time release-time verification (three `go get`/`go install` checks) is run manually after implementation and recorded in the closing issue (tracked in #639).

## Spawned follow-up issues

- #636 — Update all README and example import paths
- #637 — Publish the final deprecation release on `github.com/agent-receipts/sdk-go`
- #638 — Tag the collector module independently; verify `go install ...collector@latest` builds
- #639 — Run D5 release-time verification and record results

## Checklist

- [x] Tests pass for all changed components — docs only, no code
- [x] No real keys or secrets in the diff
- [x] AGENTS.md updated — no structural changes

## Security

- [ ] This PR touches crypto, auth, or secrets handling (no — docs only)