### PR TITLE
Upgrade SDK to v0.13.0 and add collector binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 # Built binaries
 /agent-receipts
 /bin/
+/collector/collector
 /daemon/bin/
 /daemon/agent-receipts-daemon
 /daemon/bin/

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/ar/collector
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.12.1
+	github.com/agent-receipts/ar/sdk/go v0.13.0
 	modernc.org/sqlite v1.50.1
 )
 

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.12.1 h1:FavWBocmh+hBhsZClG07ylHaXADvmZ72sp+euPN7e9M=
-github.com/agent-receipts/ar/sdk/go v0.12.1/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/agent-receipts/ar/sdk/go v0.13.0 h1:o/JDXuJrWuyyXuiei/TmC7p/8KRVsufNWS9SIPFhPJ8=
+github.com/agent-receipts/ar/sdk/go v0.13.0/go.mod h1:O4UZo83wzTJw08TsaxjEKjgmsSUq4bjYmSMQxDJTJZA=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## What

- Upgrade `github.com/agent-receipts/ar/sdk/go` from v0.12.1 to v0.13.0
- Add `/collector/collector` to `.gitignore` to exclude the built collector binary

## Why

The SDK upgrade brings in bug fixes and improvements from the latest version. Adding the collector binary to gitignore prevents accidentally committing build artifacts to the repository.

## Checklist

- [ ] Tests pass for all changed components
- [ ] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [ ] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [ ] AGENTS.md updated (if project structure changed)
- [ ] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)

https://claude.ai/code/session_018dcpyNNfrZuNBp5vfE8unN