### PR TITLE
Add release automation for collector binary

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -1,0 +1,71 @@
+name: "Release: collector"
+
+on:
+  push:
+    tags:
+      - "collector/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release and push to the Homebrew tap. Configure at:
+    # https://github.com/agent-receipts/ar/settings/environments
+    environment: release-collector
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      # GoReleaser can't parse the prefixed tag `collector/vX.Y.Z` as semver.
+      # Create a local lightweight `vX.Y.Z` tag at the same commit so
+      # GoReleaser computes a clean .Version; this tag is never pushed.
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#collector/}"
+          echo "COLLECTOR_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          git tag "${VERSION}" HEAD
+
+      # Single GoReleaser run: builds, archives, pushes Homebrew formula.
+      # Release creation + binary upload happen in the next step with `gh`
+      # so the same dist/ artifacts (and therefore matching SHA256s) are
+      # used for both the formula and the release assets — re-running
+      # GoReleaser would produce different tar hashes.
+      - name: Build and publish Homebrew formula
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=validate,announce
+          workdir: collector
+        env:
+          GORELEASER_CURRENT_TAG: ${{ env.COLLECTOR_VERSION }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Disable the Go workspace so builds resolve from collector/go.mod
+          # (published sdk/go) rather than the in-tree ./sdk/go module.
+          GOWORK: off
+
+      - name: Create GitHub release with binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mark pre-release tags (e.g. v0.13.0-alpha.1) so they don't show
+          # up as "latest" on the GitHub Releases page.
+          PRERELEASE_ARG=()
+          if [[ "${COLLECTOR_VERSION}" == *-* ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "collector ${COLLECTOR_VERSION}" \
+            --generate-notes \
+            "${PRERELEASE_ARG[@]}" \
+            collector/dist/*.tar.gz \
+            collector/dist/checksums.txt

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -57,27 +57,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Mark pre-release tags (e.g. v0.13.0-alpha.1) so they don't show
-          # up as "latest" on the GitHub Releases page.
-          PRERELEASE_ARG=()
+          # Mark pre-release tags (e.g. v0.13.0-alpha.1) as prerelease so they
+          # don't show up as "latest" on the GitHub Releases page. Pass an
+          # explicit boolean on both paths so the edit path also *clears*
+          # prerelease for a stable tag whose release was pre-created as a
+          # prerelease (an omitted flag would leave the existing state).
+          PRERELEASE=false
           if [[ "${COLLECTOR_VERSION}" == *-* ]]; then
-            PRERELEASE_ARG+=(--prerelease)
+            PRERELEASE=true
           fi
           # Create the release if it doesn't already exist (e.g. pre-created
-          # for release notes), then upload assets either way. If it already
-          # exists, normalise title and prerelease flag — a pre-created release
-          # may be missing --prerelease, which would cause a pre-release tag to
-          # appear as the latest stable release. Idempotent so a re-run after a
-          # partial failure doesn't error on an existing release.
+          # for release notes), then upload assets either way. Idempotent so a
+          # re-run after a partial failure doesn't error on an existing release.
           if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
             gh release edit "${GITHUB_REF_NAME}" \
               --title "collector ${COLLECTOR_VERSION}" \
-              "${PRERELEASE_ARG[@]}"
+              --prerelease="${PRERELEASE}"
           else
             gh release create "${GITHUB_REF_NAME}" \
               --title "collector ${COLLECTOR_VERSION}" \
               --generate-notes \
-              "${PRERELEASE_ARG[@]}"
+              --prerelease="${PRERELEASE}"
           fi
           gh release upload "${GITHUB_REF_NAME}" \
             collector/dist/*.tar.gz \

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -63,9 +63,23 @@ jobs:
           if [[ "${COLLECTOR_VERSION}" == *-* ]]; then
             PRERELEASE_ARG+=(--prerelease)
           fi
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "collector ${COLLECTOR_VERSION}" \
-            --generate-notes \
-            "${PRERELEASE_ARG[@]}" \
+          # Create the release if it doesn't already exist (e.g. pre-created
+          # for release notes), then upload assets either way. If it already
+          # exists, normalise title and prerelease flag — a pre-created release
+          # may be missing --prerelease, which would cause a pre-release tag to
+          # appear as the latest stable release. Idempotent so a re-run after a
+          # partial failure doesn't error on an existing release.
+          if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" \
+              --title "collector ${COLLECTOR_VERSION}" \
+              "${PRERELEASE_ARG[@]}"
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "collector ${COLLECTOR_VERSION}" \
+              --generate-notes \
+              "${PRERELEASE_ARG[@]}"
+          fi
+          gh release upload "${GITHUB_REF_NAME}" \
             collector/dist/*.tar.gz \
-            collector/dist/checksums.txt
+            collector/dist/checksums.txt \
+            --clobber

--- a/collector/.gitignore
+++ b/collector/.gitignore
@@ -1,0 +1,6 @@
+# GoReleaser build output
+dist/
+
+# LICENSE is copied from the repo root by a GoReleaser `before` hook
+# so archives can include it without path traversal gymnastics.
+LICENSE

--- a/collector/.goreleaser.yaml
+++ b/collector/.goreleaser.yaml
@@ -1,0 +1,94 @@
+version: 2
+
+project_name: collector
+
+# Disable the Go workspace so GoReleaser resolves dependencies strictly from
+# collector/go.mod (published versions) rather than the in-tree ./sdk/go module
+# wired up by the repo-root go.work. Without this, the released binary would
+# link the in-tree sdk/go instead of the published version `go install` users
+# resolve.
+env:
+  - GOWORK=off
+
+before:
+  hooks:
+    - go mod download
+    - sh -c "cp ../LICENSE LICENSE"
+
+builds:
+  - id: collector
+    main: ./cmd/collector
+    binary: collector
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version=v{{.Version}}
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+
+# GitHub release is created outside GoReleaser (against the prefixed tag
+# `collector/vX.Y.Z`). GoReleaser only builds archives and publishes the
+# Homebrew formula; the workflow uploads binaries with `gh`.
+release:
+  disable: true
+
+brews:
+  - name: collector
+    # `auto` skips the formula bump PR when the release version contains a
+    # pre-release suffix (e.g. v0.13.0-alpha.1). The Homebrew tap stays
+    # locked to the latest stable collector until a non-pre-release tag is
+    # cut, so `brew install agent-receipts/tap/collector` keeps giving users
+    # a non-alpha build during soak periods.
+    skip_upload: auto
+    repository:
+      owner: agent-receipts
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      # Push the formula to a feature branch, then open a PR against
+      # main. Without an explicit branch, GoReleaser pushes to the
+      # default branch (main) and tries to open a main→main PR, which
+      # the GitHub API rejects — so the formula sneaks onto main and
+      # skips the `brew audit` gate.
+      branch: "bump-{{.ProjectName}}-{{.Version}}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+    directory: Formula
+    url_template: "https://github.com/agent-receipts/ar/releases/download/collector%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/agent-receipts/ar/tree/main/collector"
+    description: "Agent Receipts reference HTTP collector — append-only signed-receipt sink"
+    license: "Apache-2.0"
+    commit_author:
+      name: agent-receipts-bot
+      email: bot@agentreceipts.ai
+    commit_msg_template: "chore(collector): bump to v{{ .Version }}"
+    install: |
+      bin.install "collector"
+    test: |
+      system "#{bin}/collector", "--version"
+    # `brew outdated` and `brew livecheck` use this to detect new releases.
+    # The `ar` repo ships multiple taggable components, so we can't use
+    # `:github_latest` (which returns repo-wide latest). `:github_releases`
+    # scans all releases; regex extracts version from the `collector/vX.Y.Z`
+    # tag prefix.
+    custom_block: |
+      livecheck do
+        url "https://github.com/agent-receipts/ar"
+        strategy :github_releases
+        regex(/^collector\/v?(\d+(?:\.\d+)+)$/i)
+      end


### PR DESCRIPTION
## What

Add GoReleaser configuration and GitHub Actions workflow to automate building, archiving, and releasing the collector binary across multiple platforms (macOS/Linux, amd64/arm64). Includes automated Homebrew formula updates via the agent-receipts/homebrew-tap repository.

## Why

This enables consistent, reproducible releases of the collector binary with:
- Cross-platform builds (darwin/linux, amd64/arm64)
- Automated Homebrew formula management with pre-release handling
- Proper dependency resolution using published SDK versions rather than in-tree modules
- GitHub release creation with checksums and generated release notes
- Protection rules via deployment environments to gate release access

The workflow is triggered by tags matching `collector/v*` pattern, allowing multiple releasable components in the same repository.

## Checklist

- [x] No real keys or secrets in the diff
- [x] Configuration follows GoReleaser v2 conventions
- [x] Homebrew formula uses correct URL template with tag prefix
- [x] Pre-release detection and handling implemented
- [x] GOWORK disabled to ensure published SDK dependency resolution

## Security

- [x] This PR does not touch crypto, auth, or secrets handling
- [x] HOMEBREW_TAP_TOKEN is injected via GitHub Actions secrets (not in diff)
- [x] Release environment provides protection rules for access control