### PR TITLE
feat(daemon): verify-event subcommand for pipeline-provenance evidence

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -203,6 +203,84 @@ Exit codes are stable for scripting:
 | `1` | No receipt at the requested sequence (or empty store) |
 | `2` | Usage error (bad flags, ambiguous chain, unreadable DB) |
 
+## Read interface: `agent-receipts verify-event`
+
+`verify` answers "is this chain internally consistent?". `verify-event` answers
+the narrower question that turns out to matter most for trust: **was this
+specific receipt produced by the documented `emitter → daemon → chain`
+pipeline, or written to the store by some other path?** It composes the chain
+checks (signature, hash linkage, sequence contiguity) with the daemon-captured
+`peer_credential` (ADR-0010 § Permissions and trust) that makes the audit
+meaningful — the agent's self-asserted identity is untrusted; peer attestation
+is what is load-bearing.
+
+```sh
+# A single receipt by id:
+agent-receipts verify-event --id urn:receipt:...
+
+# The most recent receipt in the chain:
+agent-receipts verify-event --chain-head
+
+# Every receipt issued in a trailing window (e.g. post-incident triage):
+agent-receipts verify-event --since 10m --json
+
+# Pin the expected emitter(s) — mismatches warn, they do not fail:
+agent-receipts verify-event --chain-head \
+  --emitter-allowlist /usr/bin/mcp-proxy,/usr/bin/openclaw
+```
+
+Exactly one selector (`--id`, `--chain-head`, `--since`) is required. Like the
+other read commands it opens the store **read-only**, so it is safe to run
+against a live daemon's database or a forensic snapshot, and it never emits —
+unlike `doctor`'s synthetic round-trip, this is a cheap historical read.
+
+It runs six checks per receipt, each reported with a structured pass / fail /
+warn / n/a status:
+
+1. **Signature** — the Ed25519 signature verifies under the supplied public key.
+2. **Hash linkage** — the receipt chains back to the daemon's startup baseline
+   and is reachable from the chain head (any break anywhere taints it).
+3. **Peer credential present** — the daemon-captured `peer_credential` is
+   present and well-formed. Receipts predating peer-credential capture are
+   flagged `n/a` ("predates peer-credential evidence"), **not failed**.
+4. **Emitter identity** — the captured `exe_path` matches the operator
+   `--emitter-allowlist`. This is operator policy, not protocol: a mismatch
+   **warns**, it never fails. With no allowlist configured the observed path is
+   surfaced informationally.
+5. **Schema version** — the receipt's schema version is one this verifier
+   understands (compatible by major version).
+6. **Chain context** — the receipt's sequence position is contiguous with its
+   neighbours (no gap immediately before or after).
+
+The verdict distinguishes the two cases operators currently cannot tell apart:
+
+- **VERIFIED — pipeline-provenance confirmed**: crypto holds *and* the
+  peer-credential evidence shows the documented pipeline produced it.
+- **VERIFIED (cryptographically) — no pipeline-provenance evidence**: crypto
+  holds but there is no peer credential. This is the state a receipt written
+  directly to SQLite (or emitted before peer-credential capture) produces.
+
+What it deliberately does **not** check: whether the audited action actually
+happened in the world (no protocol can attest to that), and whether the emitter
+binary is trustworthy beyond its `exe_path` matching the allowlist (binary
+integrity attestation is a separate, ADR-grade decision).
+
+Use cases: forensic snapshot review, post-incident triage (`--since`), and a CI
+gate on a known-good receipt — gate on exit `0` to require provenance, or
+accept `0` and `3` alike to require only cryptographic validity.
+
+Exit codes are stable for scripting:
+
+| Code | Meaning |
+|---|---|
+| `0` | Verified **and** pipeline-provenance confirmed |
+| `1` | A check failed — the receipt is suspect, investigate |
+| `2` | Usage error (bad flags, no/ambiguous selector, unreadable DB or key) |
+| `3` | Verifies cryptographically but lacks peer-credential evidence |
+
+When a selector resolves to multiple receipts (`--since`), the process exit code
+is the worst case across them (`1` outranks `3`, which outranks `0`).
+
 ## Wire protocol
 
 SOCK_STREAM Unix-domain socket (uniform across Linux and macOS — see

--- a/daemon/cmd/agent-receipts/main.go
+++ b/daemon/cmd/agent-receipts/main.go
@@ -10,14 +10,16 @@ import (
 	"github.com/agent-receipts/ar/daemon/internal/listcli"
 	"github.com/agent-receipts/ar/daemon/internal/showcli"
 	"github.com/agent-receipts/ar/daemon/internal/verifycli"
+	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
 )
 
 const usage = `Usage: agent-receipts <command> [flags]
 
 Commands:
-  list     List recent receipts from the store.
-  show     Print the full fields of a single receipt by sequence number.
-  verify   Verify a stored chain's signatures and hash links.
+  list          List recent receipts from the store.
+  show          Print the full fields of a single receipt by sequence number.
+  verify        Verify a stored chain's signatures and hash links.
+  verify-event  Verify one historical receipt's end-to-end pipeline provenance.
 
 Run 'agent-receipts <command> -h' for command-specific flags.
 `
@@ -34,6 +36,8 @@ func main() {
 		os.Exit(showcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
 	case "verify":
 		os.Exit(verifycli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
+	case "verify-event":
+		os.Exit(verifyeventcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
 	case "-h", "--help", "help":
 		fmt.Fprint(os.Stdout, usage)
 		os.Exit(verifycli.ExitOK)

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -1,0 +1,624 @@
+// Package verifyeventcli implements the `agent-receipts verify-event`
+// subcommand: end-to-end pipeline-provenance evidence for a single historical
+// receipt. Where `verify` answers "is this chain internally consistent?",
+// verify-event answers the narrower question that matters most for trust: "was
+// this specific receipt produced by the path ADR-0010 describes — emitter →
+// daemon → chain — as opposed to being written to SQLite by some other path?"
+//
+// It composes the existing chain checks (signature, hash linkage, sequence
+// contiguity — #479) with the daemon-captured peer credential (#511) that
+// ADR-0010 § Permissions and trust calls the load-bearing evidence: the agent's
+// self-asserted identity is untrusted; peer attestation is what makes the audit
+// meaningful. verify-event is the verifier-side counterpart that actually uses
+// that field.
+//
+// Deliberately narrow scope: it does NOT attest that the audited action
+// happened in the world (no protocol can), nor that the emitter binary is
+// trustworthy beyond its exe_path matching an operator allowlist. Binary
+// integrity attestation is a separate, ADR-grade decision.
+//
+// The store is opened read-only so verify-event is safe to run against a live
+// daemon's database or a forensic snapshot, and it never emits — unlike
+// `doctor`'s synthetic round-trip, this is a cheap historical read.
+//
+// Logic lives here, away from cmd/agent-receipts/main.go, so tests can drive
+// the subcommand directly with captured I/O without shelling out to a binary.
+package verifyeventcli
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// Exit codes are part of the CLI contract — CI gates and triage scripts pivot
+// on them. Keep these stable.
+//
+// ExitNoProvenance (3) is the distinction the Max incident exposed and the
+// reason this subcommand exists: a receipt can verify cryptographically yet
+// carry no evidence that it traversed the documented pipeline. A CI gate that
+// requires provenance treats 3 as a failure; one that only requires
+// cryptographic validity treats 0 and 3 alike. Splitting them into separate
+// codes is what lets operators choose.
+const (
+	ExitOK           = 0 // verified AND pipeline-provenance confirmed
+	ExitVerifyFailed = 1 // a check failed — the receipt is suspect, investigate
+	ExitUsageError   = 2 // bad flags / unreadable DB or key / no receipt selected
+	ExitNoProvenance = 3 // verifies cryptographically but lacks peer-credential evidence
+)
+
+// checkStatus is the outcome of one provenance check.
+type checkStatus string
+
+const (
+	statusPass checkStatus = "pass" // check held
+	statusFail checkStatus = "fail" // check failed — receipt is suspect
+	statusWarn checkStatus = "warn" // operator-policy concern, not a protocol failure
+	statusNA   checkStatus = "n/a"  // check could not run (e.g. evidence absent by design)
+)
+
+// check is one structured provenance check result.
+type check struct {
+	Name   string      `json:"name"`
+	Status checkStatus `json:"status"`
+	Detail string      `json:"detail,omitempty"`
+}
+
+// verdict is the per-receipt provenance conclusion.
+type verdict string
+
+const (
+	verdictConfirmed    verdict = "verified_provenance_confirmed"   // crypto holds and the pipeline produced it
+	verdictNoProvenance verdict = "verified_no_provenance_evidence" // crypto holds but no peer-credential evidence
+	verdictFailed       verdict = "failed"                          // a check failed — suspect
+)
+
+// eventResult is the full verify-event result for one receipt.
+type eventResult struct {
+	ReceiptID string  `json:"receipt_id"`
+	ChainID   string  `json:"chain_id"`
+	Sequence  int     `json:"sequence"`
+	Checks    []check `json:"checks"`
+	Verdict   verdict `json:"verdict"`
+}
+
+// jsonOutput wraps the per-receipt results for --json. A wrapper (rather than a
+// bare array) leaves room to grow without breaking parsers that key off
+// "results".
+type jsonOutput struct {
+	Results []eventResult `json:"results"`
+}
+
+// Run executes the verify-event subcommand with the given args (sans the
+// program name and "verify-event" token), writing human-readable output to
+// stdout and diagnostics to stderr. Returns one of the Exit* constants.
+//
+// envLookup is split out so tests can inject a deterministic environment. Pass
+// os.Getenv for the production caller.
+func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string) int {
+	if envLookup == nil {
+		envLookup = os.Getenv
+	}
+	envOr := func(key, fallback string) string {
+		if v := envLookup(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+
+	keyPath := envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
+	defaultPubKey := envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath))
+
+	fs := flag.NewFlagSet("verify-event", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: agent-receipts verify-event (--id <id> | --chain-head | --since <dur>) [flags]")
+		fmt.Fprintln(stderr, "\nVerify that a specific historical receipt was produced by the documented")
+		fmt.Fprintln(stderr, "emitter→daemon→chain pipeline, not written to the store by another path.")
+		fmt.Fprintln(stderr, "\nExactly one selector is required:")
+		fmt.Fprintln(stderr, "  --id <id>       a single receipt by its receipt id")
+		fmt.Fprintln(stderr, "  --chain-head    the most recent receipt in the chain")
+		fmt.Fprintln(stderr, "  --since <dur>   every receipt issued within the trailing window (e.g. 10m, 24h)")
+		fmt.Fprintln(stderr, "\nFlags:")
+		fs.PrintDefaults()
+		fmt.Fprintln(stderr, "\nExit codes: 0 verified+provenance, 1 check failed, 2 usage error, 3 verified but no provenance evidence")
+	}
+	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
+	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	chainID := fs.String("chain-id", envLookup("AGENTRECEIPTS_CHAIN_ID"), "Chain id to read from (env: AGENTRECEIPTS_CHAIN_ID); required only when --chain-head/--since and the store holds more than one chain")
+	id := fs.String("id", "", "Select the receipt with this receipt id")
+	chainHead := fs.Bool("chain-head", false, "Select the most recent receipt in the chain")
+	since := fs.String("since", "", "Select every receipt issued within the trailing duration window (e.g. 10m, 24h)")
+	allowlistRaw := fs.String("emitter-allowlist", envLookup("AGENTRECEIPTS_EMITTER_ALLOWLIST"), "Comma-separated exe_path allowlist of expected emitters (env: AGENTRECEIPTS_EMITTER_ALLOWLIST); mismatches warn, never fail")
+	asJSON := fs.Bool("json", false, "Emit machine-readable JSON instead of human-readable text")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitUsageError
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "agent-receipts verify-event: unexpected positional argument(s): %v (use a selector flag)\n", fs.Args())
+		return ExitUsageError
+	}
+
+	// Exactly one selector. Zero is the common scripting mistake (operator
+	// forgot what to verify); more than one is ambiguous.
+	selectors := 0
+	if *id != "" {
+		selectors++
+	}
+	if *chainHead {
+		selectors++
+	}
+	if *since != "" {
+		selectors++
+	}
+	if selectors == 0 {
+		fmt.Fprintln(stderr, "agent-receipts verify-event: a selector is required (--id, --chain-head, or --since)")
+		return ExitUsageError
+	}
+	if selectors > 1 {
+		fmt.Fprintln(stderr, "agent-receipts verify-event: selectors --id, --chain-head and --since are mutually exclusive")
+		return ExitUsageError
+	}
+
+	if *dbPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts verify-event: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		return ExitUsageError
+	}
+	if *pubKeyPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts verify-event: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived)")
+		return ExitUsageError
+	}
+
+	pubPEM, err := os.ReadFile(*pubKeyPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify-event: read public key: %v\n", err)
+		return ExitUsageError
+	}
+	// Validate key shape upfront so a malformed key surfaces as a usage error
+	// rather than being routed through per-receipt signature failures, which
+	// would falsely implicate the receipts.
+	if err := validatePublicKeyPEM(pubPEM); err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify-event: invalid public key at %s: %v\n", *pubKeyPath, err)
+		return ExitUsageError
+	}
+
+	allowlist := parseAllowlist(*allowlistRaw)
+
+	s, err := store.OpenReadOnly(*dbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify-event: open store: %v\n", err)
+		return ExitUsageError
+	}
+	defer s.Close()
+
+	targets, code := resolveTargets(s, *id, *chainHead, *since, *chainID, stderr)
+	if code != ExitOK {
+		return code
+	}
+
+	// Verify each distinct chain once, then read per-receipt results out of the
+	// cached ChainVerification — VerifyChain is O(n) in signatures, so this
+	// avoids re-verifying the chain once per target when --since matches several.
+	chainCache := map[string]chainCtx{}
+	results := make([]eventResult, 0, len(targets))
+	for _, t := range targets {
+		ctx, ok := chainCache[t.chainID]
+		if !ok {
+			chain, err := s.GetChain(t.chainID)
+			if err != nil {
+				fmt.Fprintf(stderr, "agent-receipts verify-event: read chain %q: %v\n", t.chainID, err)
+				return ExitUsageError
+			}
+			cv := receipt.VerifyChain(chain, string(pubPEM))
+			ctx = chainCtx{chain: chain, cv: cv, indexByID: indexByID(chain)}
+			chainCache[t.chainID] = ctx
+		}
+		idx, ok := ctx.indexByID[t.receiptID]
+		if !ok {
+			// The receipt resolved from the store but is absent from its own
+			// chain load — only possible under concurrent deletion or a store
+			// inconsistency. Treat as a usage-level read error, not a verdict.
+			fmt.Fprintf(stderr, "agent-receipts verify-event: receipt %q not found in chain %q\n", t.receiptID, t.chainID)
+			return ExitUsageError
+		}
+		results = append(results, evaluate(ctx, idx, allowlist))
+	}
+
+	if *asJSON {
+		return writeJSON(stdout, stderr, results)
+	}
+	writeHuman(stdout, results)
+	return exitCode(results)
+}
+
+// chainCtx caches a loaded chain and its single verification pass.
+type chainCtx struct {
+	chain     []receipt.AgentReceipt
+	cv        receipt.ChainVerification
+	indexByID map[string]int
+}
+
+// target is one selected receipt awaiting verification.
+type target struct {
+	receiptID string
+	chainID   string
+}
+
+// resolveTargets turns the chosen selector into the set of receipts to verify.
+// Exactly one of id / chainHead / since is set (the caller enforces this).
+func resolveTargets(s *store.Store, id string, chainHead bool, since, chainID string, stderr io.Writer) ([]target, int) {
+	switch {
+	case id != "":
+		r, err := s.GetByID(id)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: read receipt %q: %v\n", id, err)
+			return nil, ExitUsageError
+		}
+		if r == nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: no receipt with id %q\n", id)
+			return nil, ExitUsageError
+		}
+		return []target{{receiptID: r.ID, chainID: r.CredentialSubject.Chain.ChainID}}, ExitOK
+
+	case chainHead:
+		resolved, code := resolveChainID(s, chainID, stderr)
+		if code != ExitOK {
+			return nil, code
+		}
+		r, err := s.GetChainTailReceipt(resolved)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: read chain head %q: %v\n", resolved, err)
+			return nil, ExitUsageError
+		}
+		if r == nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: chain %q holds no receipts\n", resolved)
+			return nil, ExitUsageError
+		}
+		return []target{{receiptID: r.ID, chainID: resolved}}, ExitOK
+
+	default: // since
+		d, err := time.ParseDuration(since)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: invalid --since duration %q: %v\n", since, err)
+			return nil, ExitUsageError
+		}
+		if d <= 0 {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: --since must be positive, got %q\n", since)
+			return nil, ExitUsageError
+		}
+		cutoff := time.Now().UTC().Add(-d).Format(time.RFC3339)
+		q := store.Query{After: &cutoff}
+		if chainID != "" {
+			q.ChainID = &chainID
+		}
+		rs, err := s.QueryReceipts(q)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: query receipts: %v\n", err)
+			return nil, ExitUsageError
+		}
+		if len(rs) == 0 {
+			fmt.Fprintf(stderr, "agent-receipts verify-event: no receipts issued within %s\n", since)
+			return nil, ExitUsageError
+		}
+		targets := make([]target, len(rs))
+		for i, r := range rs {
+			targets[i] = target{receiptID: r.ID, chainID: r.CredentialSubject.Chain.ChainID}
+		}
+		return targets, ExitOK
+	}
+}
+
+// resolveChainID mirrors showcli: an explicit chain id is used verbatim;
+// otherwise the sole chain is used silently and ambiguity is a usage error.
+func resolveChainID(s *store.Store, requested string, stderr io.Writer) (string, int) {
+	if requested != "" {
+		return requested, ExitOK
+	}
+	chains, err := s.DistinctChainIDs()
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts verify-event: enumerate chains: %v\n", err)
+		return "", ExitUsageError
+	}
+	switch len(chains) {
+	case 0:
+		fmt.Fprintln(stderr, "agent-receipts verify-event: store holds no receipts")
+		return "", ExitUsageError
+	case 1:
+		return chains[0], ExitOK
+	default:
+		fmt.Fprintf(stderr, "agent-receipts verify-event: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
+		for _, c := range chains {
+			fmt.Fprintf(stderr, "  %s\n", c)
+		}
+		return "", ExitUsageError
+	}
+}
+
+// evaluate runs the six provenance checks for the receipt at chain index idx
+// and derives its verdict.
+func evaluate(ctx chainCtx, idx int, allowlist []string) eventResult {
+	r := ctx.chain[idx]
+	checks := []check{
+		checkSignature(ctx.cv, idx),
+		checkHashLinkage(ctx.cv, idx),
+		checkPeerPresent(r),
+		checkEmitterIdentity(r, allowlist),
+		checkSchemaVersion(r),
+		checkChainContext(ctx.cv, idx),
+	}
+	return eventResult{
+		ReceiptID: r.ID,
+		ChainID:   r.CredentialSubject.Chain.ChainID,
+		Sequence:  r.CredentialSubject.Chain.Sequence,
+		Checks:    checks,
+		Verdict:   deriveVerdict(checks),
+	}
+}
+
+// checkSignature reports whether the target receipt's Ed25519 signature
+// verifies under the supplied public key (check #1).
+func checkSignature(cv receipt.ChainVerification, idx int) check {
+	if cv.Receipts[idx].SignatureValid {
+		return check{Name: "signature", Status: statusPass, Detail: "Ed25519 signature verifies"}
+	}
+	return check{Name: "signature", Status: statusFail, Detail: "signature does not verify under the supplied public key"}
+}
+
+// checkHashLinkage reports whether the target is anchored in an unbroken chain:
+// every link from the daemon's startup baseline (index 0, previous_receipt_hash
+// nil) up to the chain head must hold (check #2). A break before the target
+// means it does not chain back to the baseline; a break after means it is not
+// reachable from a trustworthy head. Either way the target's provenance is
+// suspect, so the whole chain's linkage must be intact.
+func checkHashLinkage(cv receipt.ChainVerification, idx int) check {
+	firstBreak := -1
+	for j := range cv.Receipts {
+		if !cv.Receipts[j].HashLinkValid {
+			firstBreak = j
+			break
+		}
+	}
+	if firstBreak == -1 {
+		return check{Name: "hash linkage", Status: statusPass, Detail: "chains back to the startup baseline and is reachable from the chain head"}
+	}
+	switch {
+	case firstBreak <= idx:
+		return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt does not chain back to the startup baseline", firstBreak)}
+	default:
+		return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt is not reachable from a trustworthy chain head", firstBreak)}
+	}
+}
+
+// checkPeerPresent reports on the daemon-captured peer credential (check #3).
+// Absent is NOT a failure: receipts predating peer-credential capture verify
+// cryptographically but carry no pipeline-provenance evidence (n/a). Present
+// but malformed IS a failure — corrupt evidence is worse than none.
+func checkPeerPresent(r receipt.AgentReceipt) check {
+	pc := r.CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		return check{Name: "peer credential", Status: statusNA, Detail: "receipt predates peer-credential evidence; pipeline-provenance verification not available"}
+	}
+	if pc.Platform == "" {
+		return check{Name: "peer credential", Status: statusFail, Detail: "peer credential present but malformed: missing platform"}
+	}
+	if (pc.Platform == "linux" || pc.Platform == "darwin") && (pc.UID == nil || pc.GID == nil) {
+		return check{Name: "peer credential", Status: statusFail, Detail: fmt.Sprintf("peer credential present but malformed: %s peer without uid/gid", pc.Platform)}
+	}
+	return check{Name: "peer credential", Status: statusPass, Detail: fmt.Sprintf("daemon-attested %s peer (pid %d)", pc.Platform, pc.PID)}
+}
+
+// checkEmitterIdentity compares the captured exe_path against an operator
+// allowlist (check #4). This is operator policy, not protocol: a mismatch warns
+// (it never fails), and with no allowlist configured the observed path is
+// surfaced informationally. An absent peer credential or unresolved exe_path
+// leaves nothing to check.
+func checkEmitterIdentity(r receipt.AgentReceipt, allowlist []string) check {
+	pc := r.CredentialSubject.Action.PeerCredential
+	if pc == nil {
+		return check{Name: "emitter identity", Status: statusNA, Detail: "no peer credential; emitter identity not checked"}
+	}
+	if pc.ExePath == "" {
+		return check{Name: "emitter identity", Status: statusNA, Detail: "no exe_path captured; emitter identity not checked"}
+	}
+	if len(allowlist) == 0 {
+		return check{Name: "emitter identity", Status: statusNA, Detail: fmt.Sprintf("no emitter allowlist configured; observed exe_path %s", pc.ExePath)}
+	}
+	for _, allowed := range allowlist {
+		if pc.ExePath == allowed {
+			return check{Name: "emitter identity", Status: statusPass, Detail: fmt.Sprintf("exe_path %s matches the emitter allowlist", pc.ExePath)}
+		}
+	}
+	return check{Name: "emitter identity", Status: statusWarn, Detail: fmt.Sprintf("exe_path %s is not in the emitter allowlist [%s]", pc.ExePath, strings.Join(allowlist, ", "))}
+}
+
+// checkSchemaVersion reports whether the receipt's schema version is one this
+// verifier understands (check #5). Compatibility is by major version: a
+// matching major is compatible (a differing minor/patch is noted but not
+// failed); a differing or missing major is a failure, since the verifier cannot
+// assert anything about a schema it does not model.
+func checkSchemaVersion(r receipt.AgentReceipt) check {
+	if r.Version == "" {
+		return check{Name: "schema version", Status: statusFail, Detail: "receipt carries no schema version"}
+	}
+	known := majorVersion(receipt.Version)
+	got := majorVersion(r.Version)
+	if got == "" {
+		return check{Name: "schema version", Status: statusFail, Detail: fmt.Sprintf("unparseable schema version %q", r.Version)}
+	}
+	if got != known {
+		return check{Name: "schema version", Status: statusFail, Detail: fmt.Sprintf("schema version %s is not known to this verifier (understands %s.x)", r.Version, known)}
+	}
+	if r.Version != receipt.Version {
+		return check{Name: "schema version", Status: statusPass, Detail: fmt.Sprintf("schema version %s is compatible with this verifier's %s", r.Version, receipt.Version)}
+	}
+	return check{Name: "schema version", Status: statusPass, Detail: fmt.Sprintf("schema version %s", r.Version)}
+}
+
+// checkChainContext reports that the target's sequence position is contiguous
+// with its neighbours (check #6, cross-checking #479): no gap immediately
+// before (the target's own sequence relative to its predecessor) and none
+// immediately after (its successor's sequence).
+func checkChainContext(cv receipt.ChainVerification, idx int) check {
+	if !cv.Receipts[idx].SequenceValid {
+		return check{Name: "chain context", Status: statusFail, Detail: fmt.Sprintf("sequence gap at or before index %d", idx)}
+	}
+	if idx+1 < len(cv.Receipts) && !cv.Receipts[idx+1].SequenceValid {
+		return check{Name: "chain context", Status: statusFail, Detail: fmt.Sprintf("sequence gap immediately after index %d", idx)}
+	}
+	return check{Name: "chain context", Status: statusPass, Detail: "sequence position is contiguous with its neighbours"}
+}
+
+// deriveVerdict reduces the six checks to a provenance conclusion. Any failed
+// check makes the receipt suspect. Otherwise the peer-credential check decides:
+// present (pass) means the pipeline produced it; absent (n/a) means it verifies
+// cryptographically but carries no provenance evidence. Warnings (emitter
+// allowlist) never downgrade a confirmed verdict — they are operator policy.
+func deriveVerdict(checks []check) verdict {
+	peerAbsent := false
+	for _, c := range checks {
+		if c.Status == statusFail {
+			return verdictFailed
+		}
+		if c.Name == "peer credential" && c.Status == statusNA {
+			peerAbsent = true
+		}
+	}
+	if peerAbsent {
+		return verdictNoProvenance
+	}
+	return verdictConfirmed
+}
+
+// exitCode reduces all per-receipt verdicts to a single process exit code,
+// reporting the worst case: any failure outranks any missing-provenance, which
+// outranks confirmed.
+func exitCode(results []eventResult) int {
+	code := ExitOK
+	for _, r := range results {
+		switch r.Verdict {
+		case verdictFailed:
+			return ExitVerifyFailed
+		case verdictNoProvenance:
+			code = ExitNoProvenance
+		}
+	}
+	return code
+}
+
+func writeHuman(stdout io.Writer, results []eventResult) {
+	for _, r := range results {
+		fmt.Fprintf(stdout, "Receipt %s (chain %s, seq %d):\n", r.ReceiptID, r.ChainID, r.Sequence)
+		for _, c := range r.Checks {
+			fmt.Fprintf(stdout, "  [%-4s] %s", strings.ToUpper(string(c.Status)), c.Name)
+			if c.Detail != "" {
+				fmt.Fprintf(stdout, " — %s", c.Detail)
+			}
+			fmt.Fprintln(stdout)
+		}
+		fmt.Fprintf(stdout, "  => %s\n", verdictLine(r.Verdict))
+	}
+}
+
+func verdictLine(v verdict) string {
+	switch v {
+	case verdictConfirmed:
+		return "VERIFIED — pipeline-provenance confirmed"
+	case verdictNoProvenance:
+		return "VERIFIED (cryptographically) — no pipeline-provenance evidence"
+	default:
+		return "FAILED — receipt is suspect; investigate"
+	}
+}
+
+func writeJSON(stdout, stderr io.Writer, results []eventResult) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(jsonOutput{Results: results}); err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			return exitCode(results)
+		}
+		fmt.Fprintf(stderr, "agent-receipts verify-event: encode JSON: %v\n", err)
+		return ExitUsageError
+	}
+	return exitCode(results)
+}
+
+// indexByID maps each receipt's id to its position in the chain slice.
+func indexByID(chain []receipt.AgentReceipt) map[string]int {
+	m := make(map[string]int, len(chain))
+	for i, r := range chain {
+		m[r.ID] = i
+	}
+	return m
+}
+
+// parseAllowlist splits a comma-separated exe_path list, trimming whitespace
+// and dropping empties, and returns a sorted, de-duplicated slice.
+func parseAllowlist(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// majorVersion returns the leading numeric component of a dotted version
+// string ("0.4.0" → "0"), or "" if there is no leading component.
+func majorVersion(v string) string {
+	if i := strings.IndexByte(v, '.'); i >= 0 {
+		return v[:i]
+	}
+	return v
+}
+
+// validatePublicKeyPEM rejects PEM bytes that don't decode to an Ed25519 SPKI
+// public key, so a malformed key surfaces as a usage error rather than being
+// routed through per-receipt signature failures (which would falsely implicate
+// the receipts).
+func validatePublicKeyPEM(pubPEM []byte) error {
+	block, _ := pem.Decode(pubPEM)
+	if block == nil {
+		return errors.New("PEM decode failed (no PUBLIC KEY block)")
+	}
+	if block.Type != "PUBLIC KEY" {
+		return fmt.Errorf("PEM block type is %q, want PUBLIC KEY", block.Type)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse SPKI public key: %w", err)
+	}
+	if _, ok := parsed.(ed25519.PublicKey); !ok {
+		return fmt.Errorf("public key is %T, want ed25519.PublicKey", parsed)
+	}
+	return nil
+}

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -227,7 +227,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 				return ExitUsageError
 			}
 			cv := receipt.VerifyChain(chain, string(pubPEM))
-			ctx = chainCtx{chain: chain, cv: cv, indexByID: indexByID(chain)}
+			ctx = chainCtx{chain: chain, cv: cv, indexByID: indexByID(chain), firstLinkBreak: firstLinkBreak(cv)}
 			chainCache[t.chainID] = ctx
 		}
 		idx, ok := ctx.indexByID[t.receiptID]
@@ -248,11 +248,14 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	return exitCode(results)
 }
 
-// chainCtx caches a loaded chain and its single verification pass.
+// chainCtx caches a loaded chain and its single verification pass, plus the
+// index of the first hash-linkage break (-1 if none) computed once so a
+// multi-target --since batch doesn't rescan the chain per receipt.
 type chainCtx struct {
-	chain     []receipt.AgentReceipt
-	cv        receipt.ChainVerification
-	indexByID map[string]int
+	chain          []receipt.AgentReceipt
+	cv             receipt.ChainVerification
+	indexByID      map[string]int
+	firstLinkBreak int
 }
 
 // target is one selected receipt awaiting verification.
@@ -357,7 +360,7 @@ func evaluate(ctx chainCtx, idx int, allowlist []string) eventResult {
 	r := ctx.chain[idx]
 	checks := []check{
 		checkSignature(ctx.cv, idx),
-		checkHashLinkage(ctx.cv, idx),
+		checkHashLinkage(ctx.firstLinkBreak, idx),
 		checkPeerPresent(r),
 		checkEmitterIdentity(r, allowlist),
 		checkSchemaVersion(r),
@@ -381,29 +384,32 @@ func checkSignature(cv receipt.ChainVerification, idx int) check {
 	return check{Name: "signature", Status: statusFail, Detail: "signature does not verify under the supplied public key"}
 }
 
+// firstLinkBreak returns the index of the first receipt whose hash link does
+// not hold, or -1 if the whole chain's linkage is intact.
+func firstLinkBreak(cv receipt.ChainVerification) int {
+	for j := range cv.Receipts {
+		if !cv.Receipts[j].HashLinkValid {
+			return j
+		}
+	}
+	return -1
+}
+
 // checkHashLinkage reports whether the target is anchored in an unbroken chain:
 // every link from the daemon's startup baseline (index 0, previous_receipt_hash
 // nil) up to the chain head must hold (check #2). A break before the target
 // means it does not chain back to the baseline; a break after means it is not
 // reachable from a trustworthy head. Either way the target's provenance is
-// suspect, so the whole chain's linkage must be intact.
-func checkHashLinkage(cv receipt.ChainVerification, idx int) check {
-	firstBreak := -1
-	for j := range cv.Receipts {
-		if !cv.Receipts[j].HashLinkValid {
-			firstBreak = j
-			break
-		}
-	}
+// suspect, so the whole chain's linkage must be intact. firstBreak is the
+// chain's first broken-link index (-1 if none), precomputed once per chain.
+func checkHashLinkage(firstBreak, idx int) check {
 	if firstBreak == -1 {
 		return check{Name: "hash linkage", Status: statusPass, Detail: "chains back to the startup baseline and is reachable from the chain head"}
 	}
-	switch {
-	case firstBreak <= idx:
+	if firstBreak <= idx {
 		return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt does not chain back to the startup baseline", firstBreak)}
-	default:
-		return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt is not reachable from a trustworthy chain head", firstBreak)}
 	}
+	return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt is not reachable from a trustworthy chain head", firstBreak)}
 }
 
 // checkPeerPresent reports on the daemon-captured peer credential (check #3).

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -78,6 +78,18 @@ type check struct {
 	Detail string      `json:"detail,omitempty"`
 }
 
+// Check names are constants so verdict logic keys off an identifier rather than
+// a presentation string — renaming a check can't silently change which check
+// deriveVerdict treats as the peer-credential signal.
+const (
+	checkSignatureName       = "signature"
+	checkHashLinkageName     = "hash linkage"
+	checkPeerCredentialName  = "peer credential"
+	checkEmitterIdentityName = "emitter identity"
+	checkSchemaVersionName   = "schema version"
+	checkChainContextName    = "chain context"
+)
+
 // verdict is the per-receipt provenance conclusion.
 type verdict string
 
@@ -227,7 +239,13 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 				return ExitUsageError
 			}
 			cv := receipt.VerifyChain(chain, string(pubPEM))
-			ctx = chainCtx{chain: chain, cv: cv, indexByID: indexByID(chain), firstLinkBreak: firstLinkBreak(cv)}
+			ctx = chainCtx{
+				chain:          chain,
+				cv:             cv,
+				indexByID:      indexByID(chain),
+				firstLinkBreak: firstLinkBreak(cv),
+				structuralErr:  structuralErr(cv),
+			}
 			chainCache[t.chainID] = ctx
 		}
 		idx, ok := ctx.indexByID[t.receiptID]
@@ -248,14 +266,16 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	return exitCode(results)
 }
 
-// chainCtx caches a loaded chain and its single verification pass, plus the
-// index of the first hash-linkage break (-1 if none) computed once so a
-// multi-target --since batch doesn't rescan the chain per receipt.
+// chainCtx caches a loaded chain and its single verification pass, plus values
+// derived from it once so a multi-target --since batch doesn't recompute them
+// per receipt: the first hash-linkage break (-1 if none) and any whole-chain
+// structural-integrity error not already attributed to a per-receipt check.
 type chainCtx struct {
 	chain          []receipt.AgentReceipt
 	cv             receipt.ChainVerification
 	indexByID      map[string]int
 	firstLinkBreak int
+	structuralErr  string
 }
 
 // target is one selected receipt awaiting verification.
@@ -364,7 +384,7 @@ func evaluate(ctx chainCtx, idx int, allowlist []string) eventResult {
 		checkPeerPresent(r),
 		checkEmitterIdentity(r, allowlist),
 		checkSchemaVersion(r),
-		checkChainContext(ctx.cv, idx),
+		checkChainContext(ctx.cv, ctx.structuralErr, idx),
 	}
 	return eventResult{
 		ReceiptID: r.ID,
@@ -379,9 +399,9 @@ func evaluate(ctx chainCtx, idx int, allowlist []string) eventResult {
 // verifies under the supplied public key (check #1).
 func checkSignature(cv receipt.ChainVerification, idx int) check {
 	if cv.Receipts[idx].SignatureValid {
-		return check{Name: "signature", Status: statusPass, Detail: "Ed25519 signature verifies"}
+		return check{Name: checkSignatureName, Status: statusPass, Detail: "Ed25519 signature verifies"}
 	}
-	return check{Name: "signature", Status: statusFail, Detail: "signature does not verify under the supplied public key"}
+	return check{Name: checkSignatureName, Status: statusFail, Detail: "signature does not verify under the supplied public key"}
 }
 
 // firstLinkBreak returns the index of the first receipt whose hash link does
@@ -404,30 +424,37 @@ func firstLinkBreak(cv receipt.ChainVerification) int {
 // chain's first broken-link index (-1 if none), precomputed once per chain.
 func checkHashLinkage(firstBreak, idx int) check {
 	if firstBreak == -1 {
-		return check{Name: "hash linkage", Status: statusPass, Detail: "chains back to the startup baseline and is reachable from the chain head"}
+		return check{Name: checkHashLinkageName, Status: statusPass, Detail: "chains back to the startup baseline and is reachable from the chain head"}
 	}
 	if firstBreak <= idx {
-		return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt does not chain back to the startup baseline", firstBreak)}
+		return check{Name: checkHashLinkageName, Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt does not chain back to the startup baseline", firstBreak)}
 	}
-	return check{Name: "hash linkage", Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt is not reachable from a trustworthy chain head", firstBreak)}
+	return check{Name: checkHashLinkageName, Status: statusFail, Detail: fmt.Sprintf("broken hash link at index %d — receipt is not reachable from a trustworthy chain head", firstBreak)}
 }
 
 // checkPeerPresent reports on the daemon-captured peer credential (check #3).
 // Absent is NOT a failure: receipts predating peer-credential capture verify
 // cryptographically but carry no pipeline-provenance evidence (n/a). Present
-// but malformed IS a failure — corrupt evidence is worse than none.
+// but malformed IS a failure — corrupt evidence is worse than none. A
+// recognized platform (linux/darwin — the only kinds the daemon captures) must
+// carry uid/gid; an unrecognized platform is reported n/a rather than confirmed,
+// since the verifier cannot interpret its peer-credential semantics and must not
+// vouch for provenance it can't validate.
 func checkPeerPresent(r receipt.AgentReceipt) check {
 	pc := r.CredentialSubject.Action.PeerCredential
 	if pc == nil {
-		return check{Name: "peer credential", Status: statusNA, Detail: "receipt predates peer-credential evidence; pipeline-provenance verification not available"}
+		return check{Name: checkPeerCredentialName, Status: statusNA, Detail: "receipt predates peer-credential evidence; pipeline-provenance verification not available"}
 	}
 	if pc.Platform == "" {
-		return check{Name: "peer credential", Status: statusFail, Detail: "peer credential present but malformed: missing platform"}
+		return check{Name: checkPeerCredentialName, Status: statusFail, Detail: "peer credential present but malformed: missing platform"}
 	}
-	if (pc.Platform == "linux" || pc.Platform == "darwin") && (pc.UID == nil || pc.GID == nil) {
-		return check{Name: "peer credential", Status: statusFail, Detail: fmt.Sprintf("peer credential present but malformed: %s peer without uid/gid", pc.Platform)}
+	if pc.Platform != "linux" && pc.Platform != "darwin" {
+		return check{Name: checkPeerCredentialName, Status: statusNA, Detail: fmt.Sprintf("unrecognized peer platform %q; cannot interpret peer-credential semantics, pipeline-provenance not verifiable", pc.Platform)}
 	}
-	return check{Name: "peer credential", Status: statusPass, Detail: fmt.Sprintf("daemon-attested %s peer (pid %d)", pc.Platform, pc.PID)}
+	if pc.UID == nil || pc.GID == nil {
+		return check{Name: checkPeerCredentialName, Status: statusFail, Detail: fmt.Sprintf("peer credential present but malformed: %s peer without uid/gid", pc.Platform)}
+	}
+	return check{Name: checkPeerCredentialName, Status: statusPass, Detail: fmt.Sprintf("daemon-attested %s peer (pid %d)", pc.Platform, pc.PID)}
 }
 
 // checkEmitterIdentity compares the captured exe_path against an operator
@@ -438,20 +465,20 @@ func checkPeerPresent(r receipt.AgentReceipt) check {
 func checkEmitterIdentity(r receipt.AgentReceipt, allowlist []string) check {
 	pc := r.CredentialSubject.Action.PeerCredential
 	if pc == nil {
-		return check{Name: "emitter identity", Status: statusNA, Detail: "no peer credential; emitter identity not checked"}
+		return check{Name: checkEmitterIdentityName, Status: statusNA, Detail: "no peer credential; emitter identity not checked"}
 	}
 	if pc.ExePath == "" {
-		return check{Name: "emitter identity", Status: statusNA, Detail: "no exe_path captured; emitter identity not checked"}
+		return check{Name: checkEmitterIdentityName, Status: statusNA, Detail: "no exe_path captured; emitter identity not checked"}
 	}
 	if len(allowlist) == 0 {
-		return check{Name: "emitter identity", Status: statusNA, Detail: fmt.Sprintf("no emitter allowlist configured; observed exe_path %s", pc.ExePath)}
+		return check{Name: checkEmitterIdentityName, Status: statusNA, Detail: fmt.Sprintf("no emitter allowlist configured; observed exe_path %s", pc.ExePath)}
 	}
 	for _, allowed := range allowlist {
 		if pc.ExePath == allowed {
-			return check{Name: "emitter identity", Status: statusPass, Detail: fmt.Sprintf("exe_path %s matches the emitter allowlist", pc.ExePath)}
+			return check{Name: checkEmitterIdentityName, Status: statusPass, Detail: fmt.Sprintf("exe_path %s matches the emitter allowlist", pc.ExePath)}
 		}
 	}
-	return check{Name: "emitter identity", Status: statusWarn, Detail: fmt.Sprintf("exe_path %s is not in the emitter allowlist [%s]", pc.ExePath, strings.Join(allowlist, ", "))}
+	return check{Name: checkEmitterIdentityName, Status: statusWarn, Detail: fmt.Sprintf("exe_path %s is not in the emitter allowlist [%s]", pc.ExePath, strings.Join(allowlist, ", "))}
 }
 
 // checkSchemaVersion reports whether the receipt's schema version is one this
@@ -461,34 +488,61 @@ func checkEmitterIdentity(r receipt.AgentReceipt, allowlist []string) check {
 // assert anything about a schema it does not model.
 func checkSchemaVersion(r receipt.AgentReceipt) check {
 	if r.Version == "" {
-		return check{Name: "schema version", Status: statusFail, Detail: "receipt carries no schema version"}
+		return check{Name: checkSchemaVersionName, Status: statusFail, Detail: "receipt carries no schema version"}
 	}
 	known := majorVersion(receipt.Version)
 	got := majorVersion(r.Version)
 	if got == "" {
-		return check{Name: "schema version", Status: statusFail, Detail: fmt.Sprintf("unparseable schema version %q", r.Version)}
+		return check{Name: checkSchemaVersionName, Status: statusFail, Detail: fmt.Sprintf("unparseable schema version %q", r.Version)}
 	}
 	if got != known {
-		return check{Name: "schema version", Status: statusFail, Detail: fmt.Sprintf("schema version %s is not known to this verifier (understands %s.x)", r.Version, known)}
+		return check{Name: checkSchemaVersionName, Status: statusFail, Detail: fmt.Sprintf("schema version %s is not known to this verifier (understands %s.x)", r.Version, known)}
 	}
 	if r.Version != receipt.Version {
-		return check{Name: "schema version", Status: statusPass, Detail: fmt.Sprintf("schema version %s is compatible with this verifier's %s", r.Version, receipt.Version)}
+		return check{Name: checkSchemaVersionName, Status: statusPass, Detail: fmt.Sprintf("schema version %s is compatible with this verifier's %s", r.Version, receipt.Version)}
 	}
-	return check{Name: "schema version", Status: statusPass, Detail: fmt.Sprintf("schema version %s", r.Version)}
+	return check{Name: checkSchemaVersionName, Status: statusPass, Detail: fmt.Sprintf("schema version %s", r.Version)}
 }
 
 // checkChainContext reports that the target's sequence position is contiguous
 // with its neighbours (check #6, cross-checking #479): no gap immediately
 // before (the target's own sequence relative to its predecessor) and none
-// immediately after (its successor's sequence).
-func checkChainContext(cv receipt.ChainVerification, idx int) check {
+// immediately after (its successor's sequence). It also surfaces whole-chain
+// structural-integrity violations that the per-receipt signature/hash/sequence
+// booleans don't capture — chain_id splice, receipt-after-terminal, or a
+// chain.status schema invariant (spec §7.3.2–7.3.4) — via structuralErr, so a
+// chain VerifyChain rejected can't yield an all-pass, provenance-confirmed
+// verdict.
+func checkChainContext(cv receipt.ChainVerification, structuralErr string, idx int) check {
 	if !cv.Receipts[idx].SequenceValid {
-		return check{Name: "chain context", Status: statusFail, Detail: fmt.Sprintf("sequence gap at or before index %d", idx)}
+		return check{Name: checkChainContextName, Status: statusFail, Detail: fmt.Sprintf("sequence gap at or before index %d", idx)}
 	}
 	if idx+1 < len(cv.Receipts) && !cv.Receipts[idx+1].SequenceValid {
-		return check{Name: "chain context", Status: statusFail, Detail: fmt.Sprintf("sequence gap immediately after index %d", idx)}
+		return check{Name: checkChainContextName, Status: statusFail, Detail: fmt.Sprintf("sequence gap immediately after index %d", idx)}
 	}
-	return check{Name: "chain context", Status: statusPass, Detail: "sequence position is contiguous with its neighbours"}
+	if structuralErr != "" {
+		return check{Name: checkChainContextName, Status: statusFail, Detail: "chain integrity violation: " + structuralErr}
+	}
+	return check{Name: checkChainContextName, Status: statusPass, Detail: "sequence position is contiguous with its neighbours"}
+}
+
+// structuralErr returns a whole-chain integrity error that VerifyChain reports
+// via cv.Valid/cv.Error but the per-receipt signature/hash/sequence booleans do
+// not reflect — chain_id mismatch, receipt-after-terminal, or a chain.status
+// schema invariant. It returns "" when the chain verifies, or when the failure
+// is already attributable to a per-receipt check (so the dedicated signature /
+// hash linkage / chain-context-sequence checks own the report and this doesn't
+// double-count). Computed once per chain.
+func structuralErr(cv receipt.ChainVerification) string {
+	if cv.Valid {
+		return ""
+	}
+	for _, rv := range cv.Receipts {
+		if !rv.SignatureValid || !rv.HashLinkValid || !rv.SequenceValid {
+			return ""
+		}
+	}
+	return cv.Error
 }
 
 // deriveVerdict reduces the six checks to a provenance conclusion. Any failed
@@ -502,7 +556,7 @@ func deriveVerdict(checks []check) verdict {
 		if c.Status == statusFail {
 			return verdictFailed
 		}
-		if c.Name == "peer credential" && c.Status == statusNA {
+		if c.Name == checkPeerCredentialName && c.Status == statusNA {
 			peerAbsent = true
 		}
 	}

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -599,12 +599,15 @@ func parseAllowlist(raw string) []string {
 }
 
 // majorVersion returns the leading numeric component of a dotted version
-// string ("0.4.0" → "0"), or "" if there is no leading component.
+// string ("0.4.0" → "0"). It requires the dotted form: a string with no '.'
+// (e.g. "0" or "garbage") is not a valid schema version and returns "", so
+// checkSchemaVersion rejects it as unparseable rather than treating a bare
+// major as compatible.
 func majorVersion(v string) string {
 	if i := strings.IndexByte(v, '.'); i >= 0 {
 		return v[:i]
 	}
-	return v
+	return ""
 }
 
 // validatePublicKeyPEM rejects PEM bytes that don't decode to an Ed25519 SPKI

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -139,7 +139,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	}
 	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
-	chainID := fs.String("chain-id", envLookup("AGENTRECEIPTS_CHAIN_ID"), "Chain id to read from (env: AGENTRECEIPTS_CHAIN_ID); required only when --chain-head/--since and the store holds more than one chain")
+	chainID := fs.String("chain-id", envLookup("AGENTRECEIPTS_CHAIN_ID"), "Chain id (env: AGENTRECEIPTS_CHAIN_ID); with --chain-head it selects the chain (required only if the store holds more than one); with --since it is an optional filter (default: all chains)")
 	id := fs.String("id", "", "Select the receipt with this receipt id")
 	chainHead := fs.Bool("chain-head", false, "Select the most recent receipt in the chain")
 	since := fs.String("since", "", "Select every receipt issued within the trailing duration window (e.g. 10m, 24h)")

--- a/daemon/internal/verifyeventcli/verify_event_test.go
+++ b/daemon/internal/verifyeventcli/verify_event_test.go
@@ -438,7 +438,7 @@ func TestVerifyEvent_AmbiguousChainIsUsageError(t *testing.T) {
 	// Two chains in one store; --chain-head with no --chain-id is ambiguous.
 	dbPath, pubKeyPath, _ := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
 	// Append a second chain to the same DB.
-	appendChain(t, dbPath, pubKeyPath, dir, "chain-2")
+	appendChain(t, dbPath, "chain-2")
 
 	code, _, stderr := runOnce(t, []string{
 		"--db", dbPath, "--public-key", pubKeyPath, "--chain-head",
@@ -451,10 +451,11 @@ func TestVerifyEvent_AmbiguousChainIsUsageError(t *testing.T) {
 	}
 }
 
-// appendChain adds a second single-receipt chain to an existing DB, signed by
-// the key already written at pubKeyPath's sibling (regenerated here — the
-// verify only needs the chain to exist for the ambiguity check).
-func appendChain(t *testing.T, dbPath, pubKeyPath, dir, chainID string) {
+// appendChain adds a second single-receipt chain to an existing DB so the store
+// holds more than one chain. It signs with a throwaway key because the
+// ambiguity check that consumes this fixture fires during chain resolution,
+// before any signature is verified.
+func appendChain(t *testing.T, dbPath, chainID string) {
 	t.Helper()
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/daemon/internal/verifyeventcli/verify_event_test.go
+++ b/daemon/internal/verifyeventcli/verify_event_test.go
@@ -34,6 +34,7 @@ type recSpec struct {
 	peer          *receipt.PeerCredential // nil = no peer credential (legacy receipt)
 	breakPrevHash bool                    // stamp a bogus previous_receipt_hash to break linkage at this receipt
 	version       string                  // override the schema version ("" = SDK default)
+	terminal      bool                    // mark this receipt chain.terminal: true
 }
 
 // buildStore writes a daemon-shaped DB containing a signed chain built from
@@ -85,8 +86,9 @@ func buildStore(t *testing.T, dir, chainID string, specs []recSpec) (dbPath, pub
 				RiskLevel:      receipt.RiskLow,
 				PeerCredential: spec.peer,
 			},
-			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
-			Chain:   receipt.Chain{Sequence: seq, PreviousReceiptHash: linkHash, ChainID: chainID},
+			Outcome:  receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:    receipt.Chain{Sequence: seq, PreviousReceiptHash: linkHash, ChainID: chainID},
+			Terminal: spec.terminal,
 		})
 		if spec.version != "" {
 			unsigned.Version = spec.version
@@ -317,6 +319,62 @@ func TestVerifyEvent_MalformedSchemaVersion_Fails(t *testing.T) {
 	c := findCheck(t, decodeJSON(t, stdout).Results[0], "schema version")
 	if c.Status != statusFail || !strings.Contains(c.Detail, "unparseable") {
 		t.Errorf("schema version = %q (%s), want fail/unparseable", c.Status, c.Detail)
+	}
+}
+
+// A receipt-after-terminal violation makes VerifyChain reject the whole chain
+// without tripping any per-receipt signature/hash/sequence boolean. verify-event
+// must still fail it (via chain context) rather than confirming provenance.
+func TestVerifyEvent_ReceiptAfterTerminal_Fails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy"), terminal: true},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")}, // follows a terminal receipt — spec §7.3.2 violation
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+		"--json",
+	})
+	if code != ExitVerifyFailed {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitVerifyFailed, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if r.Verdict != verdictFailed {
+		t.Errorf("verdict = %q, want %q", r.Verdict, verdictFailed)
+	}
+	c := findCheck(t, r, "chain context")
+	if c.Status != statusFail || !strings.Contains(c.Detail, "chain integrity violation") {
+		t.Errorf("chain context = %q (%s), want fail with chain-integrity detail", c.Status, c.Detail)
+	}
+}
+
+// A peer credential with an unrecognized platform can't be interpreted, so it is
+// reported n/a (no provenance evidence) rather than confirmed.
+func TestVerifyEvent_UnknownPeerPlatform_NoProvenance(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: &receipt.PeerCredential{Platform: "plan9", PID: 7}},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+		"--json",
+	})
+	if code != ExitNoProvenance {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitNoProvenance, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if r.Verdict != verdictNoProvenance {
+		t.Errorf("verdict = %q, want %q", r.Verdict, verdictNoProvenance)
+	}
+	c := findCheck(t, r, "peer credential")
+	if c.Status != statusNA || !strings.Contains(c.Detail, "unrecognized peer platform") {
+		t.Errorf("peer credential = %q (%s), want n/a with unrecognized-platform detail", c.Status, c.Detail)
 	}
 }
 

--- a/daemon/internal/verifyeventcli/verify_event_test.go
+++ b/daemon/internal/verifyeventcli/verify_event_test.go
@@ -297,6 +297,29 @@ func TestVerifyEvent_UnknownSchemaVersion_Fails(t *testing.T) {
 	}
 }
 
+// A schema version without a dotted form ("0") is malformed, not a compatible
+// bare major: it must fail explicitly as unparseable.
+func TestVerifyEvent_MalformedSchemaVersion_Fails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy"), version: "0"},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+		"--json",
+	})
+	if code != ExitVerifyFailed {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitVerifyFailed, stderr)
+	}
+	c := findCheck(t, decodeJSON(t, stdout).Results[0], "schema version")
+	if c.Status != statusFail || !strings.Contains(c.Detail, "unparseable") {
+		t.Errorf("schema version = %q (%s), want fail/unparseable", c.Status, c.Detail)
+	}
+}
+
 // --chain-head selects the most recent receipt; with one chain present no
 // --chain-id is needed.
 func TestVerifyEvent_ChainHeadSelector(t *testing.T) {

--- a/daemon/internal/verifyeventcli/verify_event_test.go
+++ b/daemon/internal/verifyeventcli/verify_event_test.go
@@ -1,0 +1,479 @@
+package verifyeventcli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+func u32(v uint32) *uint32 { return &v }
+
+// linuxPeer is a well-formed daemon-captured peer credential for an emitter at
+// the given exe_path.
+func linuxPeer(exePath string) *receipt.PeerCredential {
+	return &receipt.PeerCredential{
+		Platform: "linux",
+		PID:      4242,
+		UID:      u32(1000),
+		GID:      u32(1000),
+		ExePath:  exePath,
+	}
+}
+
+// recSpec describes one receipt to lay down in a fixture chain.
+type recSpec struct {
+	peer          *receipt.PeerCredential // nil = no peer credential (legacy receipt)
+	breakPrevHash bool                    // stamp a bogus previous_receipt_hash to break linkage at this receipt
+	version       string                  // override the schema version ("" = SDK default)
+}
+
+// buildStore writes a daemon-shaped DB containing a signed chain built from
+// specs (1-indexed sequence), and returns the db path, the matching public-key
+// path, and the receipt ids in chain order.
+func buildStore(t *testing.T, dir, chainID string, specs []recSpec) (dbPath, pubKeyPath string, ids []string) {
+	t.Helper()
+
+	dbPath = filepath.Join(dir, "receipts.db")
+	pubKeyPath = filepath.Join(dir, "signing.key.pub")
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	if err := os.WriteFile(pubKeyPath, pubPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var prevHash *string
+	for i, spec := range specs {
+		seq := i + 1
+		linkHash := prevHash
+		if spec.breakPrevHash {
+			bogus := "0000000000000000000000000000000000000000000000000000000000000000"
+			linkHash = &bogus
+		}
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				Type:           "filesystem.file.read",
+				RiskLevel:      receipt.RiskLow,
+				PeerCredential: spec.peer,
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: seq, PreviousReceiptHash: linkHash, ChainID: chainID},
+		})
+		if spec.version != "" {
+			unsigned.Version = spec.version
+		}
+		signed, err := receipt.Sign(unsigned, privPEM, "did:test#k1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := receipt.HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, signed.ID)
+		// The next receipt links to the actual hash of this one, so a
+		// breakPrevHash break is isolated to the receipt that carries it.
+		prevHash = &h
+	}
+	return dbPath, pubKeyPath, ids
+}
+
+func runOnce(t *testing.T, args []string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	// Empty env so the test never inherits real AGENTRECEIPTS_* values.
+	code = Run(args, &out, &errb, func(string) string { return "" })
+	return code, out.String(), errb.String()
+}
+
+// findCheck returns the named check from a result's check slice.
+func findCheck(t *testing.T, r eventResult, name string) check {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no %q check in result for %s", name, r.ReceiptID)
+	return check{}
+}
+
+func decodeJSON(t *testing.T, s string) jsonOutput {
+	t.Helper()
+	var out jsonOutput
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		t.Fatalf("decode JSON output: %v\noutput was:\n%s", err, s)
+	}
+	return out
+}
+
+// Well-formed receipt with full peer credential, emitter on the allowlist:
+// VERIFIED with pipeline-provenance confirmed.
+func TestVerifyEvent_FullPeerCred_ProvenanceConfirmed(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[1],
+		"--emitter-allowlist", "/usr/bin/mcp-proxy",
+		"--json",
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	out := decodeJSON(t, stdout)
+	if len(out.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(out.Results))
+	}
+	r := out.Results[0]
+	if r.Verdict != verdictConfirmed {
+		t.Errorf("verdict = %q, want %q", r.Verdict, verdictConfirmed)
+	}
+	for _, name := range []string{"signature", "hash linkage", "peer credential", "schema version", "chain context"} {
+		if c := findCheck(t, r, name); c.Status != statusPass {
+			t.Errorf("check %q = %q, want pass (%s)", name, c.Status, c.Detail)
+		}
+	}
+	if c := findCheck(t, r, "emitter identity"); c.Status != statusPass {
+		t.Errorf("emitter identity = %q, want pass (%s)", c.Status, c.Detail)
+	}
+}
+
+// Receipt without peer credential (predates peer-cred capture): verifies
+// cryptographically but is flagged as lacking pipeline-provenance evidence.
+func TestVerifyEvent_NoPeerCred_NoProvenanceEvidence(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: nil},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+	})
+	if code != ExitNoProvenance {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitNoProvenance, stderr)
+	}
+	if !strings.Contains(stdout, "no pipeline-provenance evidence") {
+		t.Errorf("stdout = %q, expected the no-provenance verdict line", stdout)
+	}
+	if !strings.Contains(stdout, "predates peer-credential evidence") {
+		t.Errorf("stdout = %q, expected the legacy peer-credential explanation", stdout)
+	}
+}
+
+// Receipt whose captured exe_path is not on the operator allowlist: a warning,
+// not a failure — provenance is still confirmed.
+func TestVerifyEvent_MismatchedExePath_WarnsNotFails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/tmp/rogue-writer")},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+		"--emitter-allowlist", "/usr/bin/mcp-proxy,/usr/bin/openclaw",
+		"--json",
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d — exe_path mismatch must not fail (stderr=%s)", code, ExitOK, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if r.Verdict != verdictConfirmed {
+		t.Errorf("verdict = %q, want %q (mismatch is operator policy, not a failure)", r.Verdict, verdictConfirmed)
+	}
+	if c := findCheck(t, r, "emitter identity"); c.Status != statusWarn {
+		t.Errorf("emitter identity = %q, want warn (%s)", c.Status, c.Detail)
+	}
+}
+
+// Receipt in a chain with broken hash linkage: FAILED — suspect.
+func TestVerifyEvent_BrokenLinkage_Fails(t *testing.T) {
+	dir := t.TempDir()
+	// Receipt 2 carries a bogus previous_receipt_hash, breaking linkage there.
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy"), breakPrevHash: true},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[1],
+		"--json",
+	})
+	if code != ExitVerifyFailed {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitVerifyFailed, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if r.Verdict != verdictFailed {
+		t.Errorf("verdict = %q, want %q", r.Verdict, verdictFailed)
+	}
+	if c := findCheck(t, r, "hash linkage"); c.Status != statusFail {
+		t.Errorf("hash linkage = %q, want fail (%s)", c.Status, c.Detail)
+	}
+}
+
+// A break downstream of the target still fails the target: it is no longer
+// reachable from a trustworthy chain head.
+func TestVerifyEvent_DownstreamBreak_FailsTarget(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy"), breakPrevHash: true},
+	})
+
+	code, _, _ := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+	})
+	if code != ExitVerifyFailed {
+		t.Fatalf("exit = %d, want %d (a downstream break must taint the head's reachability)", code, ExitVerifyFailed)
+	}
+}
+
+// Receipt whose schema version the verifier does not understand: FAILED.
+func TestVerifyEvent_UnknownSchemaVersion_Fails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy"), version: "99.0.0"},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--id", ids[0],
+		"--json",
+	})
+	if code != ExitVerifyFailed {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitVerifyFailed, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if c := findCheck(t, r, "schema version"); c.Status != statusFail {
+		t.Errorf("schema version = %q, want fail (%s)", c.Status, c.Detail)
+	}
+}
+
+// --chain-head selects the most recent receipt; with one chain present no
+// --chain-id is needed.
+func TestVerifyEvent_ChainHeadSelector(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-head",
+		"--json",
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	r := decodeJSON(t, stdout).Results[0]
+	if r.ReceiptID != ids[2] {
+		t.Errorf("chain-head selected %s, want the tail %s", r.ReceiptID, ids[2])
+	}
+}
+
+// --since verifies every receipt in the trailing window; a mix of confirmed and
+// legacy receipts yields the worst-case exit code (no-provenance here).
+func TestVerifyEvent_SinceSelector_WorstCaseExit(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, _ := buildStore(t, dir, "chain-1", []recSpec{
+		{peer: linuxPeer("/usr/bin/mcp-proxy")},
+		{peer: nil}, // legacy: no provenance evidence
+	})
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--since", "24h",
+		"--json",
+	})
+	if code != ExitNoProvenance {
+		t.Fatalf("exit = %d, want %d (worst case across the window; stderr=%s)", code, ExitNoProvenance, stderr)
+	}
+	out := decodeJSON(t, stdout)
+	if len(out.Results) != 2 {
+		t.Fatalf("got %d results, want 2 (whole window)", len(out.Results))
+	}
+}
+
+func TestVerifyEvent_NoSelectorIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, _ := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
+
+	code, _, stderr := runOnce(t, []string{"--db", dbPath, "--public-key", pubKeyPath})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "selector is required") {
+		t.Errorf("stderr = %q, expected a 'selector is required' diagnostic", stderr)
+	}
+}
+
+func TestVerifyEvent_MultipleSelectorsIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, ids := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath, "--public-key", pubKeyPath,
+		"--id", ids[0], "--chain-head",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "mutually exclusive") {
+		t.Errorf("stderr = %q, expected a mutual-exclusion diagnostic", stderr)
+	}
+}
+
+func TestVerifyEvent_UnknownIDIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath, _ := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath, "--public-key", pubKeyPath,
+		"--id", "urn:receipt:does-not-exist",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "no receipt with id") {
+		t.Errorf("stderr = %q, expected a not-found diagnostic", stderr)
+	}
+}
+
+func TestVerifyEvent_MalformedPublicKeyIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _, ids := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
+	badKey := filepath.Join(dir, "garbage.pub")
+	if err := os.WriteFile(badKey, []byte("not a pem block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath, "--public-key", badKey, "--id", ids[0],
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d (malformed key is a usage error, not a verdict)", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "invalid public key") {
+		t.Errorf("stderr = %q, expected an 'invalid public key' diagnostic", stderr)
+	}
+}
+
+func TestVerifyEvent_AmbiguousChainIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	// Two chains in one store; --chain-head with no --chain-id is ambiguous.
+	dbPath, pubKeyPath, _ := buildStore(t, dir, "chain-1", []recSpec{{peer: linuxPeer("/usr/bin/mcp-proxy")}})
+	// Append a second chain to the same DB.
+	appendChain(t, dbPath, pubKeyPath, dir, "chain-2")
+
+	code, _, stderr := runOnce(t, []string{
+		"--db", dbPath, "--public-key", pubKeyPath, "--chain-head",
+	})
+	if code != ExitUsageError {
+		t.Fatalf("exit = %d, want %d", code, ExitUsageError)
+	}
+	if !strings.Contains(stderr, "pass --chain-id") {
+		t.Errorf("stderr = %q, expected a chain-disambiguation diagnostic", stderr)
+	}
+}
+
+// appendChain adds a second single-receipt chain to an existing DB, signed by
+// the key already written at pubKeyPath's sibling (regenerated here — the
+// verify only needs the chain to exist for the ambiguity check).
+func appendChain(t *testing.T, dbPath, pubKeyPath, dir, chainID string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	unsigned := receipt.Create(receipt.CreateInput{
+		Issuer:    receipt.Issuer{ID: "did:test"},
+		Principal: receipt.Principal{ID: "did:user:test"},
+		Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow},
+		Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain:     receipt.Chain{Sequence: 1, ChainID: chainID},
+	})
+	signed, err := receipt.Sign(unsigned, privPEM, "did:test#k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := receipt.HashReceipt(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Insert(signed, h); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyEvent_HelpExitsCleanly(t *testing.T) {
+	code, _, stderr := runOnce(t, []string{"-h"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (help is not an error)", code, ExitOK)
+	}
+	if !strings.Contains(stderr, "verify-event") {
+		t.Errorf("stderr = %q, expected usage text", stderr)
+	}
+}


### PR DESCRIPTION
Closes #540.

## What & why

`agent-receipts verify` answers "is this chain internally consistent?". It does
not answer the narrower question that turns out to matter most for trust: **was
this *specific* historical receipt produced by the documented
`emitter → daemon → chain` pipeline, or written to the store by some other
path?**

`verify-event` is the verifier-side counterpart to the daemon-captured
`peer_credential` (ADR-0010 § Permissions and trust, #511): the agent's
self-asserted identity is untrusted; peer attestation is what makes the audit
meaningful, and this is the command that actually consumes that field. It
composes the existing chain checks (#479 sequence contiguity, signature, hash
linkage) with peer-credential evidence to draw a distinction operators
previously could not: a receipt that *verifies cryptographically but carries no
pipeline-provenance evidence* (the Max-incident state) versus one whose
provenance is confirmed.

## How it works

Resolves the receipt(s) to inspect by exactly one selector:
- `--id <receipt-id>`
- `--chain-head` (most recent receipt; `--chain-id` auto-detected when the store holds one chain)
- `--since <dur>` (every receipt in the trailing window, e.g. `10m`, `24h`)

Then runs six structured checks per receipt (each reported pass / fail / warn / n/a):

1. **Signature** — Ed25519 verifies under the supplied public key.
2. **Hash linkage** — chains back to the daemon's startup baseline *and* is reachable from the chain head (a break anywhere taints it).
3. **Peer credential present** — daemon-captured `peer_credential` present and well-formed. Absent is flagged **n/a, not failed** ("predates peer-credential evidence"); present-but-malformed **is** a failure.
4. **Emitter identity** — captured `exe_path` matches the operator `--emitter-allowlist`. Operator policy, not protocol: a mismatch **warns, never fails**; with no allowlist configured the observed path is surfaced informationally.
5. **Schema version** — receipt's schema version is one this verifier understands (compatible by major version).
6. **Chain context** — sequence position is contiguous with its neighbours (#479).

## Output & exit codes

Human-readable by default, `--json` for tooling. Store opened **read-only**, so
it is safe against a live daemon database or a forensic snapshot; it never
emits (unlike `doctor`'s synthetic round-trip).

| Code | Meaning |
|---|---|
| `0` | Verified **and** pipeline-provenance confirmed |
| `1` | A check failed — the receipt is suspect, investigate |
| `2` | Usage error (bad flags, no/ambiguous selector, unreadable DB or key) |
| `3` | Verifies cryptographically but lacks peer-credential evidence |

The split between `0` and `3` is the point of the command: a CI gate can require
provenance (gate on `0`) or accept crypto-only validity (accept `0` and `3`).
For a multi-receipt `--since` batch the process exit code is the worst case
(`1` > `3` > `0`).

## Scope boundaries (deliberate)

Does **not** check whether the audited action happened in the world (no protocol
can), nor whether the emitter binary is trustworthy beyond `exe_path` matching
the allowlist (binary attestation is a separate, ADR-grade decision).

## Files

- `daemon/internal/verifyeventcli/verify_event.go` — the subcommand (logic lives here, away from `main.go`, so tests drive it with captured I/O). Chain verification and the first-linkage-break scan are cached once per chain so a `--since` batch stays linear.
- `daemon/internal/verifyeventcli/verify_event_test.go` — covers the four acceptance scenarios (full peer-cred → confirmed; no peer-cred → no-provenance; mismatched `exe_path` → warn, not fail; broken linkage → fail) plus downstream-break, unknown schema version, every selector, JSON output, and the usage-error paths.
- `daemon/cmd/agent-receipts/main.go` — registered the subcommand.
- `daemon/README.md` — documented checks, verdicts, use cases (forensic snapshot review, post-incident triage, CI gate), and exit-code conventions.

No new dependencies. No spec, CI, or cryptographic-parameter changes.

## Test plan

- [x] `go build ./...`, `go vet ./internal/verifyeventcli/` clean
- [x] `go test ./internal/verifyeventcli/ -race` passes
- [x] full daemon `internal/...` + `cmd/...` suites pass
- [ ] manual: `agent-receipts verify-event --since 24h --json` against a live daemon store

## Notes / follow-ups

- #539 (`doctor`) is not yet implemented, so there was no shared peer-credential validation code to extract; that refactor can happen when `doctor` lands.
- Reviewers: the **hash-linkage** check intentionally fails the target when a break exists *anywhere* in the chain (including downstream of the target), since a tampered head means the receipt is no longer "reachable from a known chain head" per the issue. Flagging in case a narrower (prefix-only) interpretation is preferred.