### PR TITLE
Document agent-receipts show command and update Claude Code setup

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -227,6 +227,26 @@ The paths above use the default fallback location (`~/.local/share/agent-receipt
 
 A successful run prints the chain length and confirms hash linkage and signatures are intact. This is the command auditors and operators should use after any session.
 
+## Inspect a single receipt
+
+`agent-receipts show <seq>` prints the full fields of one receipt by its chain sequence number (1-indexed) — issuer, chain id, action type and tool, parameters hash, outcome, signature, and any action-specific payload (such as the drop count on an `events_dropped` receipt). Like `verify`, it opens the store read-only, so it is safe to run while the daemon is writing.
+
+```bash
+AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
+  agent-receipts show 42
+```
+
+Add `--json` for the raw receipt JSON instead of the human-readable table:
+
+```bash
+AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
+  agent-receipts show 42 --json
+```
+
+`--chain-id` is required only when the store holds more than one chain; with a single chain it is auto-detected. Without it on a multi-chain store, the command lists the available chain ids and exits with a usage error.
+
+Exit codes are stable for scripting: `0` when the receipt is found and printed, `1` when there is no receipt at the requested sequence (or the store is empty), and `2` for a usage error (bad flags, ambiguous chain, or an unreadable database).
+
 ## Migrating from pre-v0.8 in-process signing
 
 **Chains are abandoned at the cutover.** The daemon starts a fresh chain at seq=1. There is no migration path for pre-cutover chains — do not attempt to resume them under the daemon.

--- a/site/src/content/docs/hook/claude-code.mdx
+++ b/site/src/content/docs/hook/claude-code.mdx
@@ -42,7 +42,7 @@ Add to `~/.claude/settings.json` to capture tool calls across all projects. Use 
 After running any Claude Code tool (e.g. a `Bash` command), check the dashboard — receipts with `channel: claude-code` should appear alongside any MCP receipts from `mcp-proxy`.
 
 :::note
-`agent-receipts list` is not yet implemented ([#410](https://github.com/agent-receipts/ar/issues/410)). Use the dashboard to inspect receipts in the interim.
+You can also inspect receipts from the command line: `agent-receipts list` shows recent receipts, and `agent-receipts show <seq>` prints the full fields of a single receipt by sequence number.
 :::
 
 ## What Claude Code sends


### PR DESCRIPTION
## What

Added documentation for the `agent-receipts show <seq>` command, which prints the full fields of a single receipt by its chain sequence number. Updated the Claude Code setup guide to reference both `list` and `show` commands instead of noting that `list` is unimplemented.

## Why

The `show` command is now available and useful for operators and auditors who need to inspect individual receipts. The documentation should reflect this capability and guide users on how to use it, including the `--json` flag for machine-readable output and `--chain-id` for multi-chain stores. The Claude Code guide can now point users to actual command-line tools rather than deferring them to the dashboard.

## Checklist

- [x] No real keys or secrets in the diff
- [x] Documentation only — no code changes requiring tests or linting

## Notes

- The `show` command documentation includes usage examples, flag descriptions, and exit code semantics for scripting
- Removed outdated note about `list` being unimplemented and replaced with accurate command references