### PR TITLE
feat(sdk): AWS KMS Signer for TypeScript and Python (#534)

### DIFF
--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -179,6 +179,37 @@ def deliver(receipt: AgentReceipt) -> None:
 Confirm receipts landed with `agent-receipts verify` (above) against the
 collector's store.
 
+### Signing with AWS KMS (production key custody)
+
+Client-side signing needs a private key. Loading raw PEM bytes from an env var
+or secrets manager keeps an extractable key in process memory — it will not pass
+most security reviews. The optional `aws` extra provides a `Signer` whose key
+never leaves AWS KMS:
+
+```sh
+pip install "agent-receipts[aws]"
+```
+
+```python
+from agent_receipts.aws import KMSSigner
+
+# keyId: a key ID, key ARN, alias name, or alias ARN. The key must be an
+# ECC_NIST_EDWARDS25519 (Ed25519) key with SIGN_VERIFY usage. Credentials come
+# from the ambient AWS provider chain (instance role, IRSA, env, profile).
+signer = KMSSigner("arn:aws:kms:us-east-1:111122223333:key/abc…", timeout=5.0)
+
+public_key = signer.get_public_key()  # raw 32 bytes (RFC 8032 §5.1.5)
+signature = signer.sign(canonical_receipt_bytes)
+```
+
+`sign` delegates to `kms:Sign` with `SigningAlgorithm=ED25519_SHA_512` and
+`MessageType=RAW` (pure Ed25519); the public key is fetched once via
+`kms:GetPublicKey` and cached. The key is not extractable, not present in process
+memory, and revocable via IAM — the production answer to the *"Not for
+production"* caveat below. (Wiring the `Signer` into `sign_receipt` so it signs
+canonical receipts end-to-end is tracked separately; this ships the key-custody
+half.)
+
 ## Appendix: in-process signing (tutorial and testing only)
 
 The SDK can also create and sign a receipt entirely in your process, with no

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -199,6 +199,9 @@ from agent_receipts.aws import KMSSigner
 signer = KMSSigner("arn:aws:kms:us-east-1:111122223333:key/abc…", timeout=5.0)
 
 public_key = signer.get_public_key()  # raw 32 bytes (RFC 8032 §5.1.5)
+
+# `sign` operates on the canonical (RFC 8785) bytes of a receipt.
+canonical_receipt_bytes = b"...canonicalised AgentReceipt..."
 signature = signer.sign(canonical_receipt_bytes)
 ```
 

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -33,6 +33,9 @@ Issues = "https://github.com/agent-receipts/ar/issues"
 Spec = "https://github.com/agent-receipts/spec"
 
 [project.optional-dependencies]
+aws = [
+    "boto3>=1.40",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.9",

--- a/sdk/py/src/agent_receipts/aws/__init__.py
+++ b/sdk/py/src/agent_receipts/aws/__init__.py
@@ -1,0 +1,10 @@
+"""AWS adapters for the Agent Receipts SDK.
+
+Requires the optional ``aws`` extra: ``pip install agent-receipts[aws]``.
+"""
+
+from __future__ import annotations
+
+from agent_receipts.aws.kms import KMSClient, KMSSigner, KMSSignerError, Signer
+
+__all__ = ["KMSClient", "KMSSigner", "KMSSignerError", "Signer"]

--- a/sdk/py/src/agent_receipts/aws/__init__.py
+++ b/sdk/py/src/agent_receipts/aws/__init__.py
@@ -1,6 +1,7 @@
 """AWS adapters for the Agent Receipts SDK.
 
-Requires the optional ``aws`` extra: ``pip install agent-receipts[aws]``.
+Install the optional ``aws`` extra (``pip install agent-receipts[aws]``) to use
+the default boto3-backed client; injecting your own ``client`` needs no AWS SDK.
 """
 
 from __future__ import annotations

--- a/sdk/py/src/agent_receipts/aws/kms.py
+++ b/sdk/py/src/agent_receipts/aws/kms.py
@@ -1,0 +1,205 @@
+"""AWS KMS-backed :class:`Signer` for Agent Receipts.
+
+``KMSSigner`` is an Ed25519 signer whose private key never leaves AWS KMS.
+Signature operations are delegated to ``kms:Sign`` and the public key is fetched
+once via ``kms:GetPublicKey`` and cached for the signer's lifetime. It mirrors
+the Go SDK's ``aws`` module.
+
+Requires the optional ``aws`` extra (``pip install agent-receipts[aws]``) only
+when building the default client; an injected client needs no AWS SDK.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+    load_der_public_key,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+SIGNING_ALGORITHM = "ED25519_SHA_512"
+"""Pure Ed25519 (RFC 8032): KMS performs the SHA-512 hash internally, so the
+signature verifies with a standard Ed25519 verifier. Do not switch to
+``ED25519_PH_SHA_512`` (pre-hashed)."""
+
+MESSAGE_TYPE = "RAW"
+
+
+@runtime_checkable
+class Signer(Protocol):
+    """The Agent Receipts signing abstraction from ADR-0018.
+
+    Implementations sign canonical receipt bytes without exposing the private
+    key. ``get_public_key`` returns the raw 32-byte Ed25519 public key (RFC 8032
+    §5.1.5) used by verifiers. The core package does not yet define this
+    protocol; it is declared here so adapters satisfy a single contract.
+    """
+
+    def sign(self, message: bytes) -> bytes: ...
+
+    def get_public_key(self) -> bytes: ...
+
+
+class KMSClient(Protocol):
+    """The subset of the boto3 KMS client that :class:`KMSSigner` depends on.
+
+    A boto3 ``kms`` client satisfies it; tests inject a mock. Deliberately narrow
+    so the dependency surface — and the mock — stay small.
+    """
+
+    def sign(
+        self,
+        *,
+        KeyId: str,
+        Message: bytes,
+        SigningAlgorithm: str,
+        MessageType: str,
+    ) -> Mapping[str, Any]: ...
+
+    def get_public_key(self, *, KeyId: str) -> Mapping[str, Any]: ...
+
+
+class KMSSignerError(Exception):
+    """Adapter-level error (malformed KMS response, non-Ed25519 key).
+
+    Errors raised by the AWS SDK (``botocore`` ``ClientError`` and friends) are
+    surfaced verbatim and are NOT wrapped in this type, so callers can still
+    distinguish throttling, access-denied, and key-not-found.
+    """
+
+
+def _default_client(region: str | None, timeout: float | None) -> KMSClient:
+    try:
+        import boto3  # pyright: ignore[reportMissingTypeStubs]
+        from botocore.config import (  # pyright: ignore[reportMissingTypeStubs]
+            Config,
+        )
+    except ImportError as exc:  # pragma: no cover - exercised without the extra
+        msg = (
+            "kms signer: boto3 is required to build the default KMS client; "
+            "install it with 'pip install agent-receipts[aws]'"
+        )
+        raise ImportError(msg) from exc
+
+    kwargs: dict[str, object] = {}
+    if region is not None:
+        kwargs["region_name"] = region
+    if timeout is not None:
+        kwargs["config"] = Config(connect_timeout=timeout, read_timeout=timeout)
+    return cast(
+        "KMSClient",
+        boto3.client("kms", **kwargs),  # pyright: ignore[reportUnknownMemberType]
+    )
+
+
+def _raw_ed25519_from_spki(der: bytes) -> bytes:
+    """Decode the DER-encoded SPKI KMS returns into the raw 32-byte Ed25519 key.
+
+    Rejects keys that are not Ed25519 — i.e. a KMS key that is not
+    ``ECC_NIST_EDWARDS25519``.
+    """
+    try:
+        key = load_der_public_key(der)
+    except Exception as exc:  # noqa: BLE001 - any decode failure is a bad key
+        msg = "kms signer: failed to parse SPKI public key"
+        raise KMSSignerError(msg) from exc
+    if not isinstance(key, Ed25519PublicKey):
+        msg = (
+            f"kms signer: key is not Ed25519 (got {type(key).__name__}); "
+            "use an ECC_NIST_EDWARDS25519 KMS key"
+        )
+        raise KMSSignerError(msg)
+    return key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+class KMSSigner:
+    """Signs Agent Receipts with an Ed25519 KMS key.
+
+    The private key never leaves KMS; this holds only the key identifier, a KMS
+    client, and a cached copy of the public key. Safe for concurrent use.
+    """
+
+    def __init__(
+        self,
+        key_id: str,
+        *,
+        client: KMSClient | None = None,
+        region: str | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        """Construct a signer for ``key_id``.
+
+        ``key_id`` is a key ID, key ARN, alias name, or alias ARN — passed to AWS
+        unchanged. The key must be an ``ECC_NIST_EDWARDS25519`` (Ed25519) key with
+        ``SIGN_VERIFY`` usage. Credentials come from the AWS SDK's default
+        provider chain (instance role, IRSA, environment, shared profile).
+
+        ``region`` and ``timeout`` configure the default client and are rejected
+        alongside an injected ``client`` (apply them to that client yourself).
+        ``timeout`` (seconds) sets the boto3 connect/read timeout; the AWS SDK
+        already retries, so no extra retry layer is added.
+        """
+        if not key_id:
+            msg = "kms signer: key_id must not be empty"
+            raise ValueError(msg)
+        if timeout is not None and timeout < 0:
+            msg = f"kms signer: timeout must not be negative, got {timeout}"
+            raise ValueError(msg)
+        if client is not None and (region is not None or timeout is not None):
+            msg = (
+                "kms signer: region/timeout configure the default client; omit "
+                "them when injecting a client"
+            )
+            raise ValueError(msg)
+
+        self._key_id = key_id
+        self._client = (
+            client if client is not None else _default_client(region, timeout)
+        )
+        self._lock = threading.Lock()
+        self._pub_key: bytes | None = None
+
+    def sign(self, message: bytes) -> bytes:
+        """Return the raw Ed25519 signature over ``message``, computed in KMS.
+
+        Calls ``kms:Sign`` with ``SigningAlgorithm=ED25519_SHA_512`` and
+        ``MessageType=RAW``. AWS SDK errors propagate unchanged.
+        """
+        resp = self._client.sign(
+            KeyId=self._key_id,
+            Message=message,
+            SigningAlgorithm=SIGNING_ALGORITHM,
+            MessageType=MESSAGE_TYPE,
+        )
+        sig = resp.get("Signature")
+        if not isinstance(sig, (bytes, bytearray)):
+            msg = "kms signer: KMS Sign returned no signature"
+            raise KMSSignerError(msg)
+        return bytes(sig)
+
+    def get_public_key(self) -> bytes:
+        """Return the raw 32-byte Ed25519 public key (RFC 8032 §5.1.5).
+
+        The first call fetches via ``kms:GetPublicKey`` and caches the result;
+        later calls return it without contacting AWS. A failed fetch is not
+        cached, so a later call retries. AWS SDK errors propagate unchanged. The
+        returned ``bytes`` are immutable, so callers cannot corrupt the cache.
+        """
+        with self._lock:
+            if self._pub_key is not None:
+                return self._pub_key
+            resp = self._client.get_public_key(KeyId=self._key_id)
+            der = resp.get("PublicKey")
+            if not isinstance(der, (bytes, bytearray)):
+                msg = "kms signer: KMS GetPublicKey returned no public key"
+                raise KMSSignerError(msg)
+            self._pub_key = _raw_ed25519_from_spki(bytes(der))
+            return self._pub_key

--- a/sdk/py/src/agent_receipts/aws/kms.py
+++ b/sdk/py/src/agent_receipts/aws/kms.py
@@ -43,9 +43,13 @@ class Signer(Protocol):
     protocol; it is declared here so adapters satisfy a single contract.
     """
 
-    def sign(self, message: bytes) -> bytes: ...
+    def sign(self, message: bytes) -> bytes:
+        """Return the raw Ed25519 signature over ``message``."""
+        raise NotImplementedError
 
-    def get_public_key(self) -> bytes: ...
+    def get_public_key(self) -> bytes:
+        """Return the raw 32-byte Ed25519 public key (RFC 8032 §5.1.5)."""
+        raise NotImplementedError
 
 
 class KMSClient(Protocol):
@@ -62,9 +66,11 @@ class KMSClient(Protocol):
         Message: bytes,
         SigningAlgorithm: str,
         MessageType: str,
-    ) -> Mapping[str, Any]: ...
+    ) -> Mapping[str, Any]:
+        raise NotImplementedError
 
-    def get_public_key(self, *, KeyId: str) -> Mapping[str, Any]: ...
+    def get_public_key(self, *, KeyId: str) -> Mapping[str, Any]:
+        raise NotImplementedError
 
 
 class KMSSignerError(Exception):

--- a/sdk/py/tests/aws/conftest.py
+++ b/sdk/py/tests/aws/conftest.py
@@ -1,0 +1,63 @@
+"""Test helpers for the AWS KMS signer.
+
+``MockKMSClient`` is a hand-written stand-in for a boto3 ``kms`` client, backed
+by an in-test Ed25519 key so a signature produced by ``sign`` verifies against
+the key returned by ``get_public_key`` — mirroring the Go SDK's ``mockKMS``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+class MockKMSClient:
+    def __init__(self) -> None:
+        self._priv = Ed25519PrivateKey.generate()
+        self.pub = self._priv.public_key()
+        self.sign_calls: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self.get_pub_calls = 0
+        self.sign_hook: Callable[[dict[str, Any]], Mapping[str, Any]] | None = None
+        self.get_pub_hook: Callable[[str], Mapping[str, Any]] | None = None
+
+    def raw_public_key(self) -> bytes:
+        return self.pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+    def spki_der(self) -> bytes:
+        return self.pub.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+
+    def sign(
+        self,
+        *,
+        KeyId: str,
+        Message: bytes,
+        SigningAlgorithm: str,
+        MessageType: str,
+    ) -> Mapping[str, Any]:
+        call = {
+            "KeyId": KeyId,
+            "Message": Message,
+            "SigningAlgorithm": SigningAlgorithm,
+            "MessageType": MessageType,
+        }
+        self.sign_calls.append(call)
+        if self.sign_hook is not None:
+            return self.sign_hook(call)
+        return {
+            "Signature": self._priv.sign(Message),
+            "SigningAlgorithm": SigningAlgorithm,
+        }
+
+    def get_public_key(self, *, KeyId: str) -> Mapping[str, Any]:
+        with self._lock:
+            self.get_pub_calls += 1
+        if self.get_pub_hook is not None:
+            return self.get_pub_hook(KeyId)
+        return {"PublicKey": self.spki_der(), "KeySpec": "ECC_NIST_EDWARDS25519"}

--- a/sdk/py/tests/aws/test_integration.py
+++ b/sdk/py/tests/aws/test_integration.py
@@ -1,0 +1,38 @@
+"""Real-KMS integration test.
+
+Skipped unless AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN is set, so CI stays
+offline by default. Run it locally against a real ECC_NIST_EDWARDS25519 KMS key
+with ambient credentials able to call kms:Sign and kms:GetPublicKey:
+
+    AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN=arn:aws:kms:...:key/... \\
+        uv run pytest tests/aws/test_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from agent_receipts.aws import KMSSigner
+
+_KEY_ARN = os.environ.get("AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN")
+
+
+@pytest.mark.skipif(
+    not _KEY_ARN,
+    reason="set AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN to run",
+)
+def test_sign_and_verify() -> None:
+    assert _KEY_ARN is not None
+    signer = KMSSigner(_KEY_ARN, timeout=15.0)
+
+    raw = signer.get_public_key()
+    assert len(raw) == 32
+
+    pub = Ed25519PublicKey.from_public_bytes(raw)
+    message = b"agent-receipts kms integration test message"
+    sig = signer.sign(message)
+
+    pub.verify(sig, message)  # raises InvalidSignature on failure

--- a/sdk/py/tests/aws/test_kms.py
+++ b/sdk/py/tests/aws/test_kms.py
@@ -1,0 +1,184 @@
+"""Unit tests for the AWS KMS signer, against a mocked KMS client."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+)
+
+from agent_receipts.aws import KMSSigner, KMSSignerError
+from agent_receipts.aws.kms import MESSAGE_TYPE, SIGNING_ALGORITHM
+from tests.aws.conftest import MockKMSClient
+
+TEST_KEY_ID = "arn:aws:kms:us-east-1:111122223333:key/test-ed25519"
+
+
+def _new_signer(mock: MockKMSClient) -> KMSSigner:
+    return KMSSigner(TEST_KEY_ID, client=mock)
+
+
+class TestConstruction:
+    def test_rejects_empty_key_id(self) -> None:
+        with pytest.raises(ValueError, match="key_id must not be empty"):
+            KMSSigner("", client=MockKMSClient())
+
+    def test_rejects_negative_timeout(self) -> None:
+        with pytest.raises(ValueError, match="timeout must not be negative"):
+            KMSSigner(TEST_KEY_ID, region="us-east-1", timeout=-1.0)
+
+    def test_rejects_client_with_region_or_timeout(self) -> None:
+        with pytest.raises(ValueError, match="omit them when injecting a client"):
+            KMSSigner(TEST_KEY_ID, client=MockKMSClient(), region="us-east-1")
+
+
+class TestSign:
+    def test_signature_verifies_against_public_key(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+
+        message = b"canonical receipt bytes"
+        sig = signer.sign(message)
+
+        mock.pub.verify(sig, message)  # raises InvalidSignature on mismatch
+
+    def test_passes_ed25519_algorithm_raw_message_type_and_key_id(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+
+        signer.sign(b"msg")
+
+        assert len(mock.sign_calls) == 1
+        call = mock.sign_calls[0]
+        assert call["SigningAlgorithm"] == SIGNING_ALGORITHM == "ED25519_SHA_512"
+        assert call["MessageType"] == MESSAGE_TYPE == "RAW"
+        assert call["KeyId"] == TEST_KEY_ID
+
+    def test_propagates_kms_errors_unchanged(self) -> None:
+        sentinel = RuntimeError("AccessDeniedException: not authorized")
+        mock = MockKMSClient()
+
+        def boom(_call: dict[str, object]) -> dict[str, object]:
+            raise sentinel
+
+        mock.sign_hook = boom
+        signer = _new_signer(mock)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            signer.sign(b"msg")
+        assert exc_info.value is sentinel
+
+    def test_missing_signature_raises_adapter_error(self) -> None:
+        mock = MockKMSClient()
+        mock.sign_hook = lambda _call: {}
+        signer = _new_signer(mock)
+
+        with pytest.raises(KMSSignerError, match="returned no signature"):
+            signer.sign(b"msg")
+
+
+class TestGetPublicKey:
+    def test_returns_raw_32_byte_public_key(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+
+        got = signer.get_public_key()
+
+        assert len(got) == 32
+        assert got == mock.raw_public_key()
+
+    def test_caches_after_first_call(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+
+        first = signer.get_public_key()
+        second = signer.get_public_key()
+
+        assert mock.get_pub_calls == 1
+        assert first == second
+
+    def test_propagates_kms_errors_unchanged(self) -> None:
+        sentinel = RuntimeError("NotFoundException: key does not exist")
+        mock = MockKMSClient()
+
+        def boom(_key_id: str) -> dict[str, object]:
+            raise sentinel
+
+        mock.get_pub_hook = boom
+        signer = _new_signer(mock)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            signer.get_public_key()
+        assert exc_info.value is sentinel
+
+    def test_does_not_cache_a_failed_fetch(self) -> None:
+        mock = MockKMSClient()
+        calls = {"n": 0}
+        good = {"PublicKey": mock.spki_der()}
+
+        def hook(_key_id: str) -> dict[str, object]:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("ThrottlingException")
+            return good
+
+        mock.get_pub_hook = hook
+        signer = _new_signer(mock)
+
+        with pytest.raises(RuntimeError, match="ThrottlingException"):
+            signer.get_public_key()
+        assert signer.get_public_key() == mock.raw_public_key()
+
+    def test_rejects_non_ed25519_key(self) -> None:
+        rsa_der = (
+            generate_private_key(public_exponent=65537, key_size=2048)
+            .public_key()
+            .public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+        )
+        mock = MockKMSClient()
+        mock.get_pub_hook = lambda _key_id: {"PublicKey": rsa_der}
+        signer = _new_signer(mock)
+
+        with pytest.raises(KMSSignerError, match="not Ed25519"):
+            signer.get_public_key()
+
+    def test_fetches_public_key_once_under_concurrency(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+        results: list[bytes] = []
+        results_lock = threading.Lock()
+
+        def worker() -> None:
+            signer.sign(b"msg")
+            key = signer.get_public_key()
+            with results_lock:
+                results.append(key)
+
+        threads = [threading.Thread(target=worker) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert mock.get_pub_calls == 1
+        expected = mock.raw_public_key()
+        assert all(r == expected for r in results)
+
+    def test_returned_key_round_trips_a_signature(self) -> None:
+        mock = MockKMSClient()
+        signer = _new_signer(mock)
+
+        raw = signer.get_public_key()
+        pub = Ed25519PublicKey.from_public_bytes(raw)
+        message = b"verify me"
+        sig = signer.sign(message)
+
+        pub.verify(sig, message)
+        with pytest.raises(InvalidSignature):
+            pub.verify(sig, b"tampered")

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -12,6 +12,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+aws = [
+    { name = "boto3" },
+]
 dev = [
     { name = "jsonschema", extra = ["format-nongpl"] },
     { name = "pyright" },
@@ -21,6 +24,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.40" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "jsonschema", extras = ["format-nongpl"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -28,7 +32,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["aws", "dev"]
 
 [[package]]
 name = "annotated-types"
@@ -59,6 +63,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/4f/f13d80d377b54dd2973e243e4eb7ce748706cd53876361cc72506006fd8b/boto3-1.43.16.tar.gz", hash = "sha256:6c337bbe608aacc7d335c79e671f0c893870293b74d652f7a7af22ccd0dfef16", size = 113152, upload-time = "2026-05-27T19:31:39.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/c0/7d687e40f4b7046ede66026ecd1b0a93d47afe26d9170f5926a1605c8641/boto3-1.43.16-py3-none-any.whl", hash = "sha256:dffc8a3cd3edbc0ad95b9c6b983e873b76ede46d3aa0709f94db253f2ff2388f", size = 140537, upload-time = "2026-05-27T19:31:36.453Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/74/140451a1fe027cb5e387cc7b1ec56224616ca742c330f1492f71c5cba3fb/botocore-1.43.16.tar.gz", hash = "sha256:813dae233d8b365c19aaf7865b32070e34d7e793654881bf86ecbbef3f4ad5c6", size = 15388648, upload-time = "2026-05-27T19:31:25.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/8f/25933240485c0662bb3fa430ed0c6b8b8124ab3bc136154c07ce12644cb0/botocore-1.43.16-py3-none-any.whl", hash = "sha256:8ab05b1346d26a3c6d69c7338051f07bd4739a090f414d2cff43c0dbc1e18ca7", size = 15067437, upload-time = "2026-05-27T19:31:19.212Z" },
 ]
 
 [[package]]
@@ -236,6 +268,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -680,6 +721,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -725,6 +778,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/sdk/ts-aws/.gitignore
+++ b/sdk/ts-aws/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/sdk/ts-aws/AGENTS.md
+++ b/sdk/ts-aws/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+AWS adapter for the TypeScript SDK. Implements the ADR-0018 `Signer`
+abstraction backed by AWS KMS (`KMSSigner`), so an Ed25519 private key can sign
+receipts without ever leaving KMS. Separate npm package
+(`@agnt-rcpt/sdk-ts-aws`): the core `@agnt-rcpt/sdk-ts` package stays free of
+AWS dependencies.
+
+## Getting started
+
+```sh
+pnpm install
+pnpm run build       # tsc
+pnpm run typecheck   # tsc --noEmit
+pnpm run lint        # biome check
+pnpm test            # vitest — mocked KMS client, no network or credentials
+```
+
+## Project structure
+
+```
+src/signer.ts            # KMSSigner: sign, getPublicKey, the narrow KMSClient seam
+src/signer.test.ts       # unit tests against a mocked KMSClient
+src/integration.test.ts  # real-KMS test, skipped unless AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN is set
+src/index.ts             # public exports
+```
+
+## Conventions
+
+- All changes go through pull requests — never push directly to main.
+- This package must not depend on `@agnt-rcpt/sdk-ts`; the `Signer` interface is
+  declared locally (mirrors the Go SDK's `aws` module).
+- Use AWS SDK v3 (`@aws-sdk/client-kms`).
+- KMS signing uses `SigningAlgorithm=ED25519_SHA_512` + `MessageType=RAW`
+  (pure Ed25519, RFC 8032). Do not switch to `ED25519_PH_SHA_512`.
+- Surface AWS SDK errors verbatim — callers distinguish throttling, access
+  denied, and key-not-found.
+- Do not add a retry layer; the AWS SDK already retries.
+- Tests must not require live AWS — gate integration tests behind the env var.
+- ESM only; `import type` for type-only imports (`verbatimModuleSyntax`).
+
+## Reference files
+
+- `src/signer.ts` — the `KMSClient` interface is the seam for mocking; keep it
+  minimal.
+- `src/signer.test.ts` — `MockKMS` is backed by an in-test Ed25519 key so
+  signatures produced by `sign` verify against `getPublicKey`.

--- a/sdk/ts-aws/README.md
+++ b/sdk/ts-aws/README.md
@@ -1,0 +1,69 @@
+# @agnt-rcpt/sdk-ts-aws
+
+AWS KMS `Signer` for the [Agent Receipts](https://github.com/agent-receipts/ar)
+TypeScript SDK.
+
+`KMSSigner` is an Ed25519 [`Signer`](./src/signer.ts) (ADR-0018) whose private
+key never leaves AWS KMS. Signature operations are delegated to `kms:Sign`; the
+public key is fetched once via `kms:GetPublicKey` and cached for the signer's
+lifetime. This is the production key story for client-side signing on AWS
+(Lambda, Fargate, ECS) where the receipt is signed before it is emitted to a
+collector — the private key is not extractable, not present in process memory,
+and revocable via IAM.
+
+The core `@agnt-rcpt/sdk-ts` package has zero cloud dependencies; install this
+package only when you sign with KMS.
+
+## Install
+
+```sh
+npm install @agnt-rcpt/sdk-ts-aws
+# peer: AWS credentials from the ambient provider chain (instance role, IRSA,
+# environment, shared profile) — the signer takes no static credentials.
+```
+
+## Usage
+
+```ts
+import { KMSSigner } from "@agnt-rcpt/sdk-ts-aws";
+
+// keyId: a key ID, key ARN, alias name, or alias ARN. The key must be an
+// ECC_NIST_EDWARDS25519 (Ed25519) key with SIGN_VERIFY usage.
+const signer = new KMSSigner("arn:aws:kms:us-east-1:111122223333:key/abc…", {
+	region: "us-east-1",
+	timeoutMs: 5_000,
+});
+
+const publicKey = await signer.getPublicKey(); // raw 32 bytes (RFC 8032)
+const signature = await signer.sign(canonicalReceiptBytes);
+```
+
+`sign` calls `kms:Sign` with `SigningAlgorithm=ED25519_SHA_512` and
+`MessageType=RAW` — standard (pure) Ed25519, so the signature verifies against
+the public key from `getPublicKey`. AWS SDK errors propagate unchanged.
+
+## Configuration
+
+| Option      | Default                    | Notes                                                                 |
+| ----------- | -------------------------- | --------------------------------------------------------------------- |
+| `client`    | built from the AWS SDK     | Inject a custom/mocked `KMSClient`; primarily for tests.              |
+| `region`    | AWS SDK default resolution | Region for the default client. Ignored when `client` is provided.     |
+| `timeoutMs` | `0` (SDK defaults)         | Per-request deadline via `AbortSignal`. The AWS SDK already retries.   |
+
+## Testing & development
+
+```sh
+pnpm install
+pnpm test        # mocked KMS client, no network or credentials
+pnpm run check   # typecheck + lint
+```
+
+The integration test in `src/integration.test.ts` is skipped unless
+`AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN` is set to a real
+`ECC_NIST_EDWARDS25519` KMS key ARN.
+
+## References
+
+- [ADR-0018](../../docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md)
+  — the `Signer` abstraction
+- [Go `aws` module](../go/aws) — reference implementation

--- a/sdk/ts-aws/biome.json
+++ b/sdk/ts-aws/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/sdk/ts-aws/package.json
+++ b/sdk/ts-aws/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "@agnt-rcpt/sdk-ts-aws",
+	"version": "0.1.0",
+	"description": "AWS KMS Signer for the Agent Receipts TypeScript SDK",
+	"license": "Apache-2.0",
+	"author": "Otto Jongerius",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/agent-receipts/ar.git",
+		"directory": "sdk/ts-aws"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"engines": {
+		"node": ">=22.11.0"
+	},
+	"scripts": {
+		"build": "tsc",
+		"typecheck": "tsc --noEmit",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"check": "pnpm run typecheck && pnpm run lint",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"packageManager": "pnpm@10.33.0",
+	"dependencies": {
+		"@aws-sdk/client-kms": "^3.1055.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.9",
+		"@types/node": "^25.5.0",
+		"typescript": "~6.0.2",
+		"vite": "^8.0.8",
+		"vitest": "^4.1.2"
+	}
+}

--- a/sdk/ts-aws/pnpm-lock.yaml
+++ b/sdk/ts-aws/pnpm-lock.yaml
@@ -1,0 +1,1283 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@aws-sdk/client-kms':
+        specifier: ^3.1055.0
+        version: 3.1055.0
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.9
+        version: 2.4.16
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.9.1
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.14(@types/node@25.9.1)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1))
+
+packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-kms@3.1055.0':
+    resolution: {integrity: sha512-ZyEImijPuTylhHtYVg732ShL2znQE4R7mGBslzAG7nX8sADjIUHa9oboIRvfmnLZl9ocmXYg/tzekoTmvZUJlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.5':
+    resolution: {integrity: sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.5':
+    resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.5':
+    resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-kms@3.1055.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.5
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.12':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@biomejs/biome@2.4.16':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    optional: true
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@nodable/entities@2.1.0': {}
+
+  '@oxc-project/types@0.132.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.9.1)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  bowser@2.14.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
+
+  path-expression-matcher@1.5.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  strnum@2.3.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1: {}
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}
+
+  vite@8.0.14(@types/node@25.9.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+
+  vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.9.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-naming@0.1.0: {}

--- a/sdk/ts-aws/src/index.ts
+++ b/sdk/ts-aws/src/index.ts
@@ -1,0 +1,11 @@
+export type {
+	KMSClient,
+	KMSGetPublicKeyInput,
+	KMSGetPublicKeyOutput,
+	KMSRequestOptions,
+	KMSSignerOptions,
+	KMSSignInput,
+	KMSSignOutput,
+	Signer,
+} from "./signer.js";
+export { KMSSigner } from "./signer.js";

--- a/sdk/ts-aws/src/integration.test.ts
+++ b/sdk/ts-aws/src/integration.test.ts
@@ -1,0 +1,37 @@
+import { createPublicKey, verify as nodeVerify } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { KMSSigner } from "./signer.js";
+
+/**
+ * Real-KMS test. Skipped unless AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN is
+ * set, so CI stays offline by default. Run it locally against a real
+ * ECC_NIST_EDWARDS25519 KMS key with ambient credentials able to call
+ * kms:Sign and kms:GetPublicKey:
+ *
+ *   AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN=arn:aws:kms:...:key/... \
+ *       pnpm test
+ */
+const keyArn = process.env.AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN;
+
+describe.skipIf(!keyArn)("KMSSigner integration", () => {
+	it("signs a message that verifies against the KMS public key", async () => {
+		const signer = new KMSSigner(keyArn as string, { timeoutMs: 15_000 });
+
+		const raw = await signer.getPublicKey();
+		expect(raw).toHaveLength(32);
+
+		const publicKey = createPublicKey({
+			key: {
+				kty: "OKP",
+				crv: "Ed25519",
+				x: Buffer.from(raw).toString("base64url"),
+			},
+			format: "jwk",
+		});
+
+		const message = Buffer.from("agent-receipts kms integration test message");
+		const sig = await signer.sign(message);
+
+		expect(nodeVerify(null, message, publicKey, sig)).toBe(true);
+	});
+});

--- a/sdk/ts-aws/src/signer.test.ts
+++ b/sdk/ts-aws/src/signer.test.ts
@@ -1,0 +1,213 @@
+import {
+	generateKeyPairSync,
+	type KeyObject,
+	sign as nodeSign,
+	verify as nodeVerify,
+} from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type {
+	KMSClient,
+	KMSGetPublicKeyInput,
+	KMSGetPublicKeyOutput,
+	KMSSignInput,
+	KMSSignOutput,
+} from "./signer.js";
+import { KMSSigner } from "./signer.js";
+
+const TEST_KEY_ID = "arn:aws:kms:us-east-1:111122223333:key/test-ed25519";
+
+/**
+ * A hand-written {@link KMSClient}. Unset hooks fall back to a default backed
+ * by an in-test Ed25519 key, so a signature produced by `sign` verifies against
+ * the key returned by `getPublicKey` — mirroring the Go SDK's `mockKMS`.
+ */
+class MockKMS implements KMSClient {
+	readonly publicKey: KeyObject;
+	readonly #privateKey: KeyObject;
+	readonly #spkiDer: Uint8Array;
+
+	signInputs: KMSSignInput[] = [];
+	getPubCalls = 0;
+	signHook: ((input: KMSSignInput) => Promise<KMSSignOutput>) | undefined;
+	getPubHook:
+		| ((input: KMSGetPublicKeyInput) => Promise<KMSGetPublicKeyOutput>)
+		| undefined;
+
+	constructor() {
+		const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+		this.publicKey = publicKey;
+		this.#privateKey = privateKey;
+		this.#spkiDer = new Uint8Array(
+			publicKey.export({ type: "spki", format: "der" }),
+		);
+	}
+
+	/** Raw 32-byte public key, for assertions. */
+	rawPublicKey(): Uint8Array {
+		const jwk = this.publicKey.export({ format: "jwk" }) as { x: string };
+		return new Uint8Array(Buffer.from(jwk.x, "base64url"));
+	}
+
+	async sign(input: KMSSignInput): Promise<KMSSignOutput> {
+		this.signInputs.push(input);
+		if (this.signHook) {
+			return this.signHook(input);
+		}
+		return {
+			Signature: new Uint8Array(
+				nodeSign(null, input.Message, this.#privateKey),
+			),
+		};
+	}
+
+	async getPublicKey(
+		input: KMSGetPublicKeyInput,
+	): Promise<KMSGetPublicKeyOutput> {
+		this.getPubCalls++;
+		if (this.getPubHook) {
+			return this.getPubHook(input);
+		}
+		return { PublicKey: this.#spkiDer };
+	}
+}
+
+function newSigner(mock: KMSClient): KMSSigner {
+	return new KMSSigner(TEST_KEY_ID, { client: mock });
+}
+
+describe("KMSSigner construction", () => {
+	it("rejects an empty keyId", () => {
+		expect(() => new KMSSigner("", { client: new MockKMS() })).toThrow(
+			/keyId must not be empty/,
+		);
+	});
+
+	it("rejects a negative timeout", () => {
+		expect(
+			() =>
+				new KMSSigner(TEST_KEY_ID, { client: new MockKMS(), timeoutMs: -1 }),
+		).toThrow(/timeoutMs must not be negative/);
+	});
+});
+
+describe("KMSSigner.sign", () => {
+	it("returns a signature that verifies against the KMS public key", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		const message = Buffer.from("canonical receipt bytes");
+		const sig = await signer.sign(message);
+
+		expect(nodeVerify(null, message, mock.publicKey, sig)).toBe(true);
+	});
+
+	it("calls kms:Sign with ED25519_SHA_512, RAW, and the keyId", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		await signer.sign(Buffer.from("msg"));
+
+		expect(mock.signInputs).toHaveLength(1);
+		const input = mock.signInputs[0];
+		expect(input?.SigningAlgorithm).toBe("ED25519_SHA_512");
+		expect(input?.MessageType).toBe("RAW");
+		expect(input?.KeyId).toBe(TEST_KEY_ID);
+	});
+
+	it("propagates KMS errors unchanged", async () => {
+		const sentinel = new Error("AccessDeniedException: not authorized");
+		const mock = new MockKMS();
+		mock.signHook = () => Promise.reject(sentinel);
+		const signer = newSigner(mock);
+
+		await expect(signer.sign(Buffer.from("msg"))).rejects.toBe(sentinel);
+	});
+});
+
+describe("KMSSigner.getPublicKey", () => {
+	it("returns the raw 32-byte Ed25519 public key", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		const got = await signer.getPublicKey();
+
+		expect(got).toHaveLength(32);
+		expect(Buffer.from(got)).toEqual(Buffer.from(mock.rawPublicKey()));
+	});
+
+	it("caches after the first call", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		const first = await signer.getPublicKey();
+		const second = await signer.getPublicKey();
+
+		expect(mock.getPubCalls).toBe(1);
+		expect(Buffer.from(first)).toEqual(Buffer.from(second));
+	});
+
+	it("returns a fresh copy so callers cannot corrupt the cache", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		const first = await signer.getPublicKey();
+		first.fill(0xff);
+
+		const second = await signer.getPublicKey();
+		expect(Buffer.from(second)).toEqual(Buffer.from(mock.rawPublicKey()));
+	});
+
+	it("propagates KMS errors unchanged", async () => {
+		const sentinel = new Error("NotFoundException: key does not exist");
+		const mock = new MockKMS();
+		mock.getPubHook = () => Promise.reject(sentinel);
+		const signer = newSigner(mock);
+
+		await expect(signer.getPublicKey()).rejects.toBe(sentinel);
+	});
+
+	it("does not cache a failed fetch — a later call retries", async () => {
+		const mock = new MockKMS();
+		let calls = 0;
+		const goodDer = mock.publicKey.export({ type: "spki", format: "der" });
+		mock.getPubHook = () => {
+			calls++;
+			if (calls === 1) {
+				return Promise.reject(new Error("ThrottlingException"));
+			}
+			return Promise.resolve({ PublicKey: new Uint8Array(goodDer) });
+		};
+		const signer = newSigner(mock);
+
+		await expect(signer.getPublicKey()).rejects.toThrow(/ThrottlingException/);
+		const got = await signer.getPublicKey();
+		expect(Buffer.from(got)).toEqual(Buffer.from(mock.rawPublicKey()));
+	});
+
+	it("rejects a non-Ed25519 key", async () => {
+		const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+		const rsaDer = new Uint8Array(
+			publicKey.export({ type: "spki", format: "der" }),
+		);
+		const mock = new MockKMS();
+		mock.getPubHook = () => Promise.resolve({ PublicKey: rsaDer });
+		const signer = newSigner(mock);
+
+		await expect(signer.getPublicKey()).rejects.toThrow(/not Ed25519/);
+	});
+
+	it("fetches the public key exactly once under concurrent calls", async () => {
+		const mock = new MockKMS();
+		const signer = newSigner(mock);
+
+		const results = await Promise.all(
+			Array.from({ length: 50 }, () => signer.getPublicKey()),
+		);
+
+		expect(mock.getPubCalls).toBe(1);
+		const expected = Buffer.from(mock.rawPublicKey());
+		for (const r of results) {
+			expect(Buffer.from(r)).toEqual(expected);
+		}
+	});
+});

--- a/sdk/ts-aws/src/signer.ts
+++ b/sdk/ts-aws/src/signer.ts
@@ -1,0 +1,234 @@
+import { createPublicKey } from "node:crypto";
+import {
+	KMSClient as AwsKMSClient,
+	GetPublicKeyCommand,
+	SignCommand,
+} from "@aws-sdk/client-kms";
+
+/**
+ * The Agent Receipts signing abstraction from ADR-0018, expressed in
+ * TypeScript. Implementations sign canonical receipt bytes without ever
+ * exposing the private key. `getPublicKey` returns the raw 32-byte Ed25519
+ * public key (RFC 8032 §5.1.5) used by verifiers.
+ *
+ * The core `@agnt-rcpt/sdk-ts` package does not yet define this interface; it
+ * is declared here so adapters in this package satisfy a single, documented
+ * contract (mirrors the Go SDK's `aws` module).
+ */
+export interface Signer {
+	sign(message: Uint8Array): Promise<Uint8Array>;
+	getPublicKey(): Promise<Uint8Array>;
+}
+
+/** Per-request options threaded through to the underlying KMS call. */
+export interface KMSRequestOptions {
+	abortSignal?: AbortSignal;
+}
+
+export interface KMSSignInput {
+	KeyId: string;
+	Message: Uint8Array;
+	SigningAlgorithm: "ED25519_SHA_512";
+	MessageType: "RAW";
+}
+
+export interface KMSSignOutput {
+	Signature?: Uint8Array;
+}
+
+export interface KMSGetPublicKeyInput {
+	KeyId: string;
+}
+
+export interface KMSGetPublicKeyOutput {
+	PublicKey?: Uint8Array;
+}
+
+/**
+ * The subset of the AWS KMS API that {@link KMSSigner} depends on. The concrete
+ * `@aws-sdk/client-kms` client satisfies it via a thin adapter; tests inject a
+ * mock. It is deliberately narrow so the dependency surface — and the mock —
+ * stay small.
+ */
+export interface KMSClient {
+	sign(
+		input: KMSSignInput,
+		options?: KMSRequestOptions,
+	): Promise<KMSSignOutput>;
+	getPublicKey(
+		input: KMSGetPublicKeyInput,
+		options?: KMSRequestOptions,
+	): Promise<KMSGetPublicKeyOutput>;
+}
+
+export interface KMSSignerOptions {
+	/**
+	 * Inject a custom KMS client. The primary use is testing with a mock;
+	 * production code omits it and lets {@link KMSSigner} build a client from the
+	 * ambient AWS credential chain.
+	 */
+	client?: KMSClient;
+	/** AWS region for the default client. Ignored when `client` is provided. */
+	region?: string;
+	/**
+	 * Per-request deadline (milliseconds) applied to each `kms:Sign` and
+	 * `kms:GetPublicKey` call via an `AbortSignal`. Zero/omitted relies on the
+	 * AWS SDK's built-in timeouts and retries; do not add a second retry layer.
+	 */
+	timeoutMs?: number;
+}
+
+function defaultClient(region?: string): KMSClient {
+	const aws = new AwsKMSClient(region ? { region } : {});
+	return {
+		sign: (input, options) =>
+			aws.send(new SignCommand(input), { abortSignal: options?.abortSignal }),
+		getPublicKey: (input, options) =>
+			aws.send(new GetPublicKeyCommand(input), {
+				abortSignal: options?.abortSignal,
+			}),
+	};
+}
+
+/**
+ * Decode the DER-encoded SPKI that `kms:GetPublicKey` returns into the raw
+ * 32-byte Ed25519 public key (RFC 8032 §5.1.5). Rejects keys that are not
+ * Ed25519 — i.e. a KMS key that is not `ECC_NIST_EDWARDS25519`.
+ */
+function rawEd25519FromSpki(der: Uint8Array): Uint8Array {
+	let key: ReturnType<typeof createPublicKey>;
+	try {
+		key = createPublicKey({
+			key: Buffer.from(der),
+			format: "der",
+			type: "spki",
+		});
+	} catch (cause) {
+		throw new Error("kms signer: parse SPKI public key", { cause });
+	}
+	if (key.asymmetricKeyType !== "ed25519") {
+		throw new Error(
+			`kms signer: key is not Ed25519 (got ${key.asymmetricKeyType}); use an ECC_NIST_EDWARDS25519 KMS key`,
+		);
+	}
+	const jwk = key.export({ format: "jwk" }) as { x?: string };
+	if (!jwk.x) {
+		throw new Error(
+			"kms signer: KMS public key JWK is missing the x coordinate",
+		);
+	}
+	const raw = Buffer.from(jwk.x, "base64url");
+	if (raw.length !== 32) {
+		throw new Error(`kms signer: public key is ${raw.length} bytes, want 32`);
+	}
+	return new Uint8Array(raw);
+}
+
+/**
+ * Signs Agent Receipts with an Ed25519 KMS key. The private key never leaves
+ * KMS; this holds only the key identifier, a KMS client, and a cached copy of
+ * the public key. Safe for concurrent use — concurrent first-time
+ * {@link getPublicKey} calls share a single in-flight fetch.
+ */
+export class KMSSigner implements Signer {
+	readonly #keyId: string;
+	readonly #client: KMSClient;
+	readonly #timeoutMs: number;
+
+	/** Raw 32-byte Ed25519 public key; undefined until the first fetch. */
+	#pubKey: Uint8Array | undefined;
+	/** Dedupes concurrent first-time fetches; cleared on settle. */
+	#inflight: Promise<Uint8Array> | undefined;
+
+	/**
+	 * @param keyId A key ID, key ARN, alias name, or alias ARN — passed to AWS
+	 * unchanged. The key must be an `ECC_NIST_EDWARDS25519` (Ed25519) key with
+	 * `SIGN_VERIFY` usage. Credentials come from the AWS SDK default credential
+	 * provider chain (instance role, IRSA, environment, shared profile).
+	 */
+	constructor(keyId: string, options: KMSSignerOptions = {}) {
+		if (!keyId) {
+			throw new Error("kms signer: keyId must not be empty");
+		}
+		const timeoutMs = options.timeoutMs ?? 0;
+		if (timeoutMs < 0) {
+			throw new Error(
+				`kms signer: timeoutMs must not be negative, got ${timeoutMs}`,
+			);
+		}
+		this.#keyId = keyId;
+		this.#timeoutMs = timeoutMs;
+		this.#client = options.client ?? defaultClient(options.region);
+	}
+
+	/**
+	 * Returns the raw Ed25519 signature over `message`, computed inside KMS.
+	 *
+	 * Calls `kms:Sign` with `SigningAlgorithm=ED25519_SHA_512` and
+	 * `MessageType=RAW`, which is standard (pure) Ed25519 per RFC 8032: KMS
+	 * performs the SHA-512 hash internally, so the signature verifies against the
+	 * public key from {@link getPublicKey}. AWS SDK errors propagate unchanged so
+	 * callers can distinguish throttling, access-denied, and key-not-found.
+	 */
+	async sign(message: Uint8Array): Promise<Uint8Array> {
+		const out = await this.#client.sign(
+			{
+				KeyId: this.#keyId,
+				Message: message,
+				SigningAlgorithm: "ED25519_SHA_512",
+				MessageType: "RAW",
+			},
+			this.#requestOptions(),
+		);
+		if (!out.Signature) {
+			throw new Error("kms signer: sign: KMS returned no signature");
+		}
+		return out.Signature;
+	}
+
+	/**
+	 * Returns the raw 32-byte Ed25519 public key (RFC 8032 §5.1.5).
+	 *
+	 * The first call fetches via `kms:GetPublicKey`, decodes the DER-encoded SPKI
+	 * KMS returns, and caches the raw bytes. Subsequent calls return a fresh copy
+	 * of the cached value without contacting AWS. A failed fetch is not cached, so
+	 * a later call retries. AWS SDK errors propagate unchanged.
+	 */
+	async getPublicKey(): Promise<Uint8Array> {
+		if (this.#pubKey) {
+			return this.#pubKey.slice();
+		}
+		if (!this.#inflight) {
+			this.#inflight = this.#fetchPublicKey().then(
+				(key) => {
+					this.#pubKey = key;
+					this.#inflight = undefined;
+					return key;
+				},
+				(err: unknown) => {
+					this.#inflight = undefined;
+					throw err;
+				},
+			);
+		}
+		const key = await this.#inflight;
+		return key.slice();
+	}
+
+	async #fetchPublicKey(): Promise<Uint8Array> {
+		const out = await this.#client.getPublicKey(
+			{ KeyId: this.#keyId },
+			this.#requestOptions(),
+		);
+		if (!out.PublicKey) {
+			throw new Error("kms signer: get public key: KMS returned no public key");
+		}
+		return rawEd25519FromSpki(out.PublicKey);
+	}
+
+	#requestOptions(): KMSRequestOptions | undefined {
+		return this.#timeoutMs > 0
+			? { abortSignal: AbortSignal.timeout(this.#timeoutMs) }
+			: undefined;
+	}
+}

--- a/sdk/ts-aws/tsconfig.json
+++ b/sdk/ts-aws/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist",
+
+		"module": "nodenext",
+		"target": "esnext",
+		"lib": ["esnext"],
+		"types": ["node"],
+
+		"sourceMap": true,
+		"declaration": true,
+		"declarationMap": true,
+
+		"noUncheckedIndexedAccess": true,
+		"strict": true,
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"noUncheckedSideEffectImports": true,
+		"moduleDetection": "force",
+		"skipLibCheck": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Implements the AWS slice of #534 — Ed25519 KMS `Signer` adapters for the two SDKs that were missing one. Go (`sdk/go/aws`) already shipped; these mirror it exactly. This is the production key story for **client-side signing** (sign in the workload, POST the signed receipt to a collector) on AWS ephemeral/long-lived compute: the private key never leaves KMS, is not in process memory, and is revocable via IAM.

See the [#534 re-scope](https://github.com/agent-receipts/ar/issues/534#issuecomment-4559890892) for why this narrowed from 9 adapters to the AWS slice.

**TypeScript — new standalone package `sdk/ts-aws/` (`@agnt-rcpt/sdk-ts-aws`)**
- `src/signer.ts` — `KMSSigner` + a locally-declared ADR-0018 `Signer` interface + a narrow injectable `KMSClient`.
- Depends only on `@aws-sdk/client-kms`; the core `@agnt-rcpt/sdk-ts` stays cloud-free.

**Python — new `agent_receipts.aws` module behind an optional `[aws]` extra**
- `src/agent_receipts/aws/kms.py` — `KMSSigner`, `Signer`/`KMSClient` protocols, `KMSSignerError`.
- `boto3` is imported lazily, so an injected client needs no AWS SDK and the core package stays cloud-free.

Both call `kms:Sign` with `SigningAlgorithm=ED25519_SHA_512` + `MessageType=RAW` (pure Ed25519, RFC 8032), fetch+cache the public key once via `kms:GetPublicKey` (decoded from SPKI), surface AWS SDK errors verbatim, and add no retry layer on top of the cloud SDK's own. Verified the `ED25519_SHA_512` / `ECC_NIST_EDWARDS25519` enums exist in both `@aws-sdk/client-kms` and `botocore`.

## Scope / follow-ups

- **Not yet wired into receipt creation.** Ships the key-custody half (a `Signer`), matching the Go module's current status; threading it through `sign_receipt`/client is separate.
- **Release CI deferred to human review** — no `release-sdk-ts-aws.yml` and no PyPI trusted-publisher entry for the `[aws]` extra (per the "don't touch CI without review" rule).
- **GCP/Azure** out of scope; the **daemon KMS keysource** (ECS sidecar path) remains the optional follow-up.

## Dependencies added

- TS package: `@aws-sdk/client-kms` (canonical AWS SDK v3 KMS client) — only in the new package.
- Python `[aws]` extra: `boto3>=1.40` (canonical AWS SDK) — optional, not pulled into the core install.

## Test plan

- [x] TS: `pnpm run typecheck`, `pnpm run lint`, `pnpm test` — 12 unit tests pass (+1 credential-gated integration test skipped)
- [x] Python: `ruff check`, `ruff format --check`, `pyright src` (strict), `pytest` — 14 AWS unit tests pass (+1 integration skipped); full suite 425 passed
- [x] Unit tests run against a mocked KMS client (no network, no credentials): signature verifies against the returned public key, correct algorithm/keyid, cache-once incl. under concurrency, no-cache-on-error retry, non-Ed25519 rejection, error pass-through
- [x] Pre-push hook green across all modules (`go-test`, `ts-typecheck`, `ts-test`, `mcp-proxy-test`, `py-test`)
- [ ] Integration test against a real `ECC_NIST_EDWARDS25519` KMS key (run locally with `AGENTRECEIPTS_AWS_KMS_INTEGRATION_KEY_ARN`)