### PR TITLE
feat(ci): Gate #2 — release round-trip version identity verification

### DIFF
--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -62,3 +62,43 @@ jobs:
             --title "sdk-go ${SDK_GO_VERSION}" \
             --generate-notes \
             "${PRERELEASE_ARG[@]}"
+
+  # Gate #1: the just-published module must satisfy the code snippets in the
+  # READMEs. Runs after release so the tag is live on the Go proxy; a drifted
+  # snippet turns the release red.
+  readme-snippets:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - name: Verify published README snippets build
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/readme_snippets/check.py \
+            --lang go --source published --version "$VERSION" \
+            README.md sdk/go/README.md
+
+  # Gate #2: verify the Go proxy resolved exactly the tagged version.
+  # Asserts version identity: the module the proxy serves is the one we tagged,
+  # not a redirect or stale cache entry.
+  release-verify:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - name: Verify published version identity (Gate #2)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/release_verify/check.py --lang go --version "$VERSION"
+      - name: Run unit tests for release-verify gate
+        run: python3 scripts/release_verify/test_check.py

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           packages-dir: sdk/py/dist/
 
-  # Release-blocking gate: the just-published package must satisfy the code
-  # snippets in the READMEs. Runs after publish so the version is live on PyPI;
-  # a drifted snippet turns the release red.
+  # Gate #1: the just-published package must satisfy the code snippets in the
+  # READMEs. Runs after publish so the version is live on PyPI; a drifted
+  # snippet turns the release red.
   readme-snippets:
     needs: release
     runs-on: ubuntu-latest
@@ -92,3 +92,23 @@ jobs:
           python-version: "3.13"
       - name: Verify published README snippets type-check
         run: python3 scripts/readme_snippets/check.py --lang py --source published README.md sdk/py/README.md
+
+  # Gate #2: verify PyPI resolved exactly the tagged version.
+  # Asserts version identity: `pip install agent-receipts==X.Y.Z` returns
+  # exactly X.Y.Z, not a yank-substitute or nearest match.
+  release-verify:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - name: Verify published version identity (Gate #2)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-py-v}"
+          python3 scripts/release_verify/check.py --lang py --version "$VERSION"
+      - name: Run unit tests for release-verify gate
+        run: python3 scripts/release_verify/test_check.py

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -90,9 +90,9 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}
 
-  # Release-blocking gate: the just-published npm package must satisfy the code
-  # snippets in the READMEs. Runs after publish so the version is live on npm;
-  # a drifted snippet turns the release red.
+  # Gate #1: the just-published npm package must satisfy the code snippets in
+  # the READMEs. Runs after publish so the version is live on npm; a drifted
+  # snippet turns the release red.
   readme-snippets:
     needs: release
     runs-on: ubuntu-latest
@@ -108,3 +108,23 @@ jobs:
           node-version: "24"
       - name: Verify published README snippets type-check
         run: python3 scripts/readme_snippets/check.py --lang ts --source published README.md sdk/ts/README.md
+
+  # Gate #2: verify npm resolved exactly the tagged version.
+  # Asserts version identity: `npm install @agnt-rcpt/sdk-ts@X.Y.Z` returns
+  # exactly X.Y.Z, not a redirect or dist-tag mismatch.
+  release-verify:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - name: Verify published version identity (Gate #2)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
+          python3 scripts/release_verify/check.py --lang ts --version "$VERSION"
+      - name: Run unit tests for release-verify gate
+        run: python3 scripts/release_verify/test_check.py

--- a/scripts/release_verify/AGENTS.md
+++ b/scripts/release_verify/AGENTS.md
@@ -1,0 +1,42 @@
+# release_verify
+
+Gate #2 from ADR-0024: release round-trip verification.
+
+After a release is published to PyPI / npm / the Go proxy, this gate
+verifies that the public registry resolves **exactly** the tagged version
+and that the installation succeeds in a clean environment.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Installs the released version from the registry and asserts the resolved version matches the release tag. |
+| `test_check.py` | Unit tests for the version-parsing and comparison logic (no registry calls). |
+
+## Run locally
+
+```sh
+python3 scripts/release_verify/test_check.py          # unit tests (no network)
+python3 scripts/release_verify/check.py --lang py --version 0.10.0
+python3 scripts/release_verify/check.py --lang ts --version 0.10.0
+python3 scripts/release_verify/check.py --lang go --version 0.12.0
+```
+
+## What this gate checks
+
+1. **Version identity** — the registry returns exactly the version we tagged,
+   not a yank-substitute, nearest match, or stale cache entry.
+2. **Installability** — the artifact is fetchable in a clean environment.
+
+Snippet consistency (documented code compiles against the fetched artifact)
+is covered by Gate #1 (`scripts/readme_snippets/check.py --source published`)
+which runs alongside this gate in each `release-sdk-*.yml` workflow.
+
+## Relationship to Gate #1
+
+Gate #1 (`readme-snippets`) runs first and checks that the snippets compile
+against the published artifact. Gate #2 runs in the same workflow and adds
+the version-identity assertion: "the thing that just got installed is
+actually version X, not some other version the registry decided to give us."
+
+Both gates must pass for a release to be considered green.

--- a/scripts/release_verify/AGENTS.md
+++ b/scripts/release_verify/AGENTS.md
@@ -34,9 +34,10 @@ which runs alongside this gate in each `release-sdk-*.yml` workflow.
 
 ## Relationship to Gate #1
 
-Gate #1 (`readme-snippets`) runs first and checks that the snippets compile
-against the published artifact. Gate #2 runs in the same workflow and adds
-the version-identity assertion: "the thing that just got installed is
-actually version X, not some other version the registry decided to give us."
+Gate #1 (`readme-snippets`) checks that the snippets compile against the
+published artifact. Gate #2 adds the version-identity assertion: "the thing
+that just got installed is actually version X, not some other version the
+registry decided to give us." Both jobs depend only on `release`, so CI runs
+them in parallel — there is no ordering between them.
 
 Both gates must pass for a release to be considered green.

--- a/scripts/release_verify/check.py
+++ b/scripts/release_verify/check.py
@@ -215,7 +215,16 @@ def verify_go(version: str, workdir: str) -> int:
     with open(os.path.join(workdir, "main.go"), "w", encoding="utf-8") as fh:
         fh.write("package main\n\nfunc main() {}\n")
 
-    env = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
+    # Pin GOPROXY to the public proxy with no `direct` fallback. The default
+    # (`https://proxy.golang.org,direct`) lets `go mod download` fetch straight
+    # from VCS when the proxy hasn't indexed the tag yet — which would let this
+    # gate pass without actually proving the public proxy resolves the release.
+    # Gate #2 asserts registry resolution, so the proxy must be the only source.
+    env = {
+        "GOFLAGS": "-mod=mod",
+        "GOWORK": "off",
+        "GOPROXY": "https://proxy.golang.org",
+    }
     print(f"\n--- Fetching {GO_MODULE}@v{version} from the Go proxy")
     if (
         _run(

--- a/scripts/release_verify/check.py
+++ b/scripts/release_verify/check.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Gate #2: Release round-trip verification.
+
+After a release is published, verify that the public registry resolves the
+exact version that was tagged and that the documented snippets run against
+the fetched artifact. This closes the gap between "we tagged it" and
+"consumers can actually install exactly that version".
+
+Three properties this gate asserts (ADR-0024 D1/D2):
+
+  1. Version identity — `pip install agent-receipts==X.Y.Z`, `npm install
+     @agnt-rcpt/sdk-ts@X.Y.Z`, or `go get ...@vX.Y.Z` resolves to exactly
+     the tagged version, not a redirect, yank-substitute, or nearest match.
+
+  2. Installability — the artifact is fetchable in a clean environment.
+
+  3. Snippet consistency — the documented snippets type-check against the
+     fetched artifact (shared with Gate #1; delegated to check.py).
+
+The gate intentionally does NOT execute snippets at runtime — static
+analysis (mypy / tsc / go build) is sufficient to detect API drift and
+avoids needing live credentials or network side-effects in CI.
+
+Usage:
+    check.py --lang {go,ts,py} --version X.Y.Z
+
+Exit codes:
+    0  all assertions passed
+    1  version mismatch or install/build failure
+    2  usage error (missing args, unknown lang)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+TS_PACKAGE = "@agnt-rcpt/sdk-ts"
+PY_PACKAGE = "agent-receipts"
+
+# How many times to retry a registry fetch before failing. The public
+# registries have occasional propagation lag after a new version is pushed;
+# retries cover the window between "tag pushed" and "version visible".
+REGISTRY_RETRIES = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    cmd: list[str],
+    cwd: str,
+    env: dict[str, str] | None = None,
+    retries: int = 0,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    full_env = {**os.environ, **(env or {})}
+    for attempt in range(retries + 1):
+        print(f"  $ {' '.join(cmd)}  (cwd={cwd})", flush=True)
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=full_env,
+            text=True,
+            capture_output=capture_output,
+        )
+        if proc.returncode == 0 or attempt == retries:
+            return proc
+        wait = 2 ** (attempt + 1)
+        print(f"  command failed (rc={proc.returncode}); retrying in {wait}s", flush=True)
+        time.sleep(wait)
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+_PY_VERSION_RE = re.compile(r"^Version:\s*(.+)$", re.MULTILINE)
+
+
+def _parse_pip_show_version(output: str) -> str | None:
+    """Extract the version string from `pip show` output.
+
+    Returns None if the Version: line is absent (package not installed).
+    """
+    m = _PY_VERSION_RE.search(output)
+    return m.group(1).strip() if m else None
+
+
+def verify_py(version: str, workdir: str) -> int:
+    """Install agent-receipts==version from PyPI and confirm the resolved version."""
+    venv = os.path.join(workdir, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=workdir).returncode != 0:
+        return 1
+    py = os.path.join(venv, "bin", "python")
+    pip = [py, "-m", "pip"]
+
+    spec = f"{PY_PACKAGE}=={version}"
+    print(f"\n--- Installing {spec} from PyPI")
+    if _run([*pip, "install", "--quiet", spec], cwd=workdir, retries=REGISTRY_RETRIES).returncode != 0:
+        print(f"ERROR: failed to install {spec} from PyPI")
+        return 1
+
+    result = _run([*pip, "show", PY_PACKAGE], cwd=workdir, capture_output=True)
+    if result.returncode != 0:
+        print(f"ERROR: pip show {PY_PACKAGE} failed")
+        return 1
+
+    resolved = _parse_pip_show_version(result.stdout)
+    return _assert_version(PY_PACKAGE, version, resolved)
+
+
+# ---------------------------------------------------------------------------
+# TypeScript
+# ---------------------------------------------------------------------------
+
+_TS_VERSION_RE = re.compile(
+    r'"' + re.escape(TS_PACKAGE.replace("/", r"\/")) + r'":\s*\{[^}]*"version":\s*"([^"]+)"',
+    re.DOTALL,
+)
+
+
+def _parse_npm_list_version(output: str, package: str) -> str | None:
+    """Extract the installed version for *package* from `npm list --json` output.
+
+    Returns None if the package is not present in the output.
+    """
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    deps = data.get("dependencies", {})
+    entry = deps.get(package, {})
+    version = entry.get("version")
+    return str(version).strip() if version else None
+
+
+def verify_ts(version: str, workdir: str) -> int:
+    """Install @agnt-rcpt/sdk-ts@version from npm and confirm the resolved version."""
+    package_json = {
+        "name": "release-verify",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: version},
+    }
+    with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+
+    print(f"\n--- Installing {TS_PACKAGE}@{version} from npm")
+    if (
+        _run(
+            ["npm", "install", "--no-audit", "--no-fund"],
+            cwd=workdir,
+            retries=REGISTRY_RETRIES,
+        ).returncode
+        != 0
+    ):
+        print(f"ERROR: npm install {TS_PACKAGE}@{version} failed")
+        return 1
+
+    result = _run(
+        ["npm", "list", "--json", TS_PACKAGE],
+        cwd=workdir,
+        capture_output=True,
+    )
+    # npm list exits 1 for extraneous packages but still outputs valid JSON;
+    # accept any output as long as we can parse the version.
+    resolved = _parse_npm_list_version(result.stdout, TS_PACKAGE)
+    return _assert_version(TS_PACKAGE, version, resolved)
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+_GO_MOD_VERSION_RE = re.compile(
+    r"^" + re.escape(GO_MODULE) + r"\s+v(\S+)",
+    re.MULTILINE,
+)
+
+
+def _parse_go_list_version(output: str) -> str | None:
+    """Extract the version (without the leading 'v') from `go list -m` output.
+
+    `go list -m` prints lines like:
+        github.com/agent-receipts/ar/sdk/go v0.12.0
+
+    Returns the bare semver string (e.g. "0.12.0"), or None if not found.
+    """
+    m = _GO_MOD_VERSION_RE.search(output)
+    return m.group(1) if m else None
+
+
+def verify_go(version: str, workdir: str) -> int:
+    """Fetch github.com/agent-receipts/ar/sdk/go@vVERSION from the Go proxy
+    and confirm the resolved version."""
+    go_mod = [
+        "module example.com/release-verify\n",
+        "go 1.26.1\n",
+        f"require {GO_MODULE} v{version}\n",
+    ]
+    with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
+        fh.writelines(go_mod)
+
+    # Minimal main.go so `go mod download` has something to compile against;
+    # we only need the module graph to resolve, not to build an actual program.
+    with open(os.path.join(workdir, "main.go"), "w", encoding="utf-8") as fh:
+        fh.write("package main\n\nfunc main() {}\n")
+
+    env = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
+    print(f"\n--- Fetching {GO_MODULE}@v{version} from the Go proxy")
+    if (
+        _run(
+            ["go", "mod", "download"],
+            cwd=workdir,
+            env=env,
+            retries=REGISTRY_RETRIES,
+        ).returncode
+        != 0
+    ):
+        print(f"ERROR: go mod download for {GO_MODULE}@v{version} failed")
+        return 1
+
+    result = _run(
+        ["go", "list", "-m", GO_MODULE],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: go list -m {GO_MODULE} failed")
+        return 1
+
+    raw = _parse_go_list_version(result.stdout)
+    # Strip the leading 'v' that go list emits (e.g. "v0.12.0" → "0.12.0")
+    resolved = raw.lstrip("v") if raw else None
+    return _assert_version(GO_MODULE, version, resolved)
+
+
+# ---------------------------------------------------------------------------
+# Version assertion (shared, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def assert_version(package: str, expected: str, resolved: str | None) -> int:
+    """Return 0 if resolved == expected, 1 otherwise.
+
+    This function is the core of the gate and is exercised by the unit tests
+    with controlled inputs (no registry calls). All output goes to stdout so
+    CI captures it in the job log.
+    """
+    if resolved is None:
+        print(
+            f"ERROR: could not determine installed version of {package}; "
+            "registry output was unexpected"
+        )
+        return 1
+    if resolved != expected:
+        print(
+            f"ERROR: version mismatch for {package}\n"
+            f"  expected : {expected}\n"
+            f"  resolved : {resolved}\n"
+            "The registry may have returned a different version than the one just published. "
+            "Check for yanked releases, index propagation delays, or a version bump mismatch."
+        )
+        return 1
+    print(f"OK: {package} resolved to {resolved} (matches release tag)")
+    return 0
+
+
+# Module-private alias so internal callers use the public name; tests import
+# the public name directly.
+_assert_version = assert_version
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_VERIFIERS = {"go": verify_go, "ts": verify_ts, "py": verify_py}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--lang", required=True, choices=["go", "ts", "py"])
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Released version string (no leading 'v'), e.g. 0.12.0 or 0.12.0-alpha.1",
+    )
+    parser.add_argument(
+        "--workdir",
+        default=None,
+        help="Working directory for the temporary project (default: auto-created tmpdir)",
+    )
+    args = parser.parse_args(argv)
+
+    # Validate version looks like a bare semver (no leading 'v'); callers
+    # pass the raw version, not the tag. We don't reject pre-release suffixes.
+    if args.version.startswith("v"):
+        parser.error(f"--version must not have a leading 'v' (got {args.version!r})")
+
+    cleanup = False
+    if args.workdir:
+        workdir = os.path.abspath(args.workdir)
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = tempfile.mkdtemp(prefix="release-verify-")
+        cleanup = True
+
+    print(f"Gate #2 — release round-trip verification")
+    print(f"  lang    : {args.lang}")
+    print(f"  version : {args.version}")
+    print(f"  workdir : {workdir}")
+
+    try:
+        rc = _VERIFIERS[args.lang](args.version, workdir)
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    if rc == 0:
+        print(f"\nGate #2 PASSED for {args.lang} {args.version}")
+    else:
+        print(f"\nGate #2 FAILED for {args.lang} {args.version} (see errors above)")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_verify/check.py
+++ b/scripts/release_verify/check.py
@@ -2,11 +2,11 @@
 """Gate #2: Release round-trip verification.
 
 After a release is published, verify that the public registry resolves the
-exact version that was tagged and that the documented snippets run against
-the fetched artifact. This closes the gap between "we tagged it" and
-"consumers can actually install exactly that version".
+exact version that was tagged and that it installs in a clean environment.
+This closes the gap between "we tagged it" and "consumers can actually
+install exactly that version".
 
-Three properties this gate asserts (ADR-0024 D1/D2):
+Two properties this gate asserts (ADR-0024 D1/D2):
 
   1. Version identity — `pip install agent-receipts==X.Y.Z`, `npm install
      @agnt-rcpt/sdk-ts@X.Y.Z`, or `go get ...@vX.Y.Z` resolves to exactly
@@ -14,12 +14,10 @@ Three properties this gate asserts (ADR-0024 D1/D2):
 
   2. Installability — the artifact is fetchable in a clean environment.
 
-  3. Snippet consistency — the documented snippets type-check against the
-     fetched artifact (shared with Gate #1; delegated to check.py).
-
-The gate intentionally does NOT execute snippets at runtime — static
-analysis (mypy / tsc / go build) is sufficient to detect API drift and
-avoids needing live credentials or network side-effects in CI.
+Snippet consistency (documented code compiles against the published
+artifact) is a separate property, covered by Gate #1
+(`scripts/readme_snippets/check.py --source published`), which runs as its
+own job alongside this gate in each release-sdk-*.yml workflow.
 
 Usage:
     check.py --lang {go,ts,py} --version X.Y.Z
@@ -128,11 +126,6 @@ def verify_py(version: str, workdir: str) -> int:
 # ---------------------------------------------------------------------------
 # TypeScript
 # ---------------------------------------------------------------------------
-
-_TS_VERSION_RE = re.compile(
-    r'"' + re.escape(TS_PACKAGE.replace("/", r"\/")) + r'":\s*\{[^}]*"version":\s*"([^"]+)"',
-    re.DOTALL,
-)
 
 
 def _parse_npm_list_version(output: str, package: str) -> str | None:
@@ -326,7 +319,7 @@ def main(argv: list[str] | None = None) -> int:
         workdir = tempfile.mkdtemp(prefix="release-verify-")
         cleanup = True
 
-    print(f"Gate #2 — release round-trip verification")
+    print("Gate #2 — release round-trip verification")
     print(f"  lang    : {args.lang}")
     print(f"  version : {args.version}")
     print(f"  workdir : {workdir}")

--- a/scripts/release_verify/test_check.py
+++ b/scripts/release_verify/test_check.py
@@ -1,0 +1,208 @@
+"""Unit tests for the Gate #2 release round-trip verifier.
+
+These tests exercise the version-parsing and comparison logic without
+making network calls. The core invariant under test: the gate must *fail*
+(return 1) when the registry resolves a version other than the one we
+expected, and *pass* (return 0) only when the two are identical.
+
+Run with:
+    python3 -m pytest scripts/release_verify/test_check.py
+    python3 scripts/release_verify/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# assert_version — the core gate logic
+# ---------------------------------------------------------------------------
+
+
+class TestAssertVersion:
+    """The version assertion is the heart of Gate #2.
+
+    Every test in this class that validates a *failure* case is a direct
+    implementation of ADR-0024 D6: the gate must be observed to fail on a
+    deliberately-broken input.
+    """
+
+    def test_matching_version_passes(self) -> None:
+        assert check.assert_version("pkg", "1.2.3", "1.2.3") == 0
+
+    def test_wrong_version_fails(self) -> None:
+        # Registry returns a different version than the one tagged.
+        assert check.assert_version("pkg", "1.2.3", "1.2.4") == 1
+
+    def test_older_version_fails(self) -> None:
+        # Registry returns an older version — e.g. index hasn't propagated yet.
+        assert check.assert_version("pkg", "1.2.3", "1.2.2") == 1
+
+    def test_none_resolved_fails(self) -> None:
+        # Registry output was unparseable; resolved is None.
+        assert check.assert_version("pkg", "1.2.3", None) == 1
+
+    def test_prerelease_exact_match_passes(self) -> None:
+        assert check.assert_version("pkg", "0.12.0-alpha.1", "0.12.0-alpha.1") == 0
+
+    def test_prerelease_stable_mismatch_fails(self) -> None:
+        # Released a pre-release but registry returned the stable version.
+        assert check.assert_version("pkg", "0.12.0-alpha.1", "0.12.0") == 1
+
+    def test_stable_prerelease_mismatch_fails(self) -> None:
+        # Released stable but registry returned a pre-release.
+        assert check.assert_version("pkg", "0.12.0", "0.12.0-alpha.1") == 1
+
+    def test_version_with_leading_v_in_resolved_fails(self) -> None:
+        # If a verifier forgets to strip the leading 'v' from go list output,
+        # the comparison must fail so the bug is visible rather than silently
+        # passing (e.g. resolved="v0.12.0" != expected="0.12.0").
+        assert check.assert_version(check.GO_MODULE, "0.12.0", "v0.12.0") == 1
+
+    def test_empty_string_resolved_fails(self) -> None:
+        assert check.assert_version("pkg", "1.0.0", "") == 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_pip_show_version
+# ---------------------------------------------------------------------------
+
+
+class TestParsePipShowVersion:
+    def test_parses_version_line(self) -> None:
+        output = (
+            "Name: agent-receipts\n"
+            "Version: 0.10.0\n"
+            "Summary: Agent Receipts SDK\n"
+        )
+        assert check._parse_pip_show_version(output) == "0.10.0"
+
+    def test_strips_whitespace(self) -> None:
+        assert check._parse_pip_show_version("Version:   1.2.3  \n") == "1.2.3"
+
+    def test_missing_version_returns_none(self) -> None:
+        assert check._parse_pip_show_version("Name: agent-receipts\nSummary: x\n") is None
+
+    def test_empty_output_returns_none(self) -> None:
+        assert check._parse_pip_show_version("") is None
+
+    def test_prerelease_version_parsed(self) -> None:
+        assert check._parse_pip_show_version("Version: 0.10.0a1\n") == "0.10.0a1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_npm_list_version
+# ---------------------------------------------------------------------------
+
+
+class TestParseNpmListVersion:
+    _PACKAGE = check.TS_PACKAGE
+
+    def test_parses_version_from_npm_list_json(self) -> None:
+        import json
+
+        data = {
+            "name": "release-verify",
+            "dependencies": {self._PACKAGE: {"version": "0.10.0", "resolved": "..."}},
+        }
+        assert check._parse_npm_list_version(json.dumps(data), self._PACKAGE) == "0.10.0"
+
+    def test_missing_package_returns_none(self) -> None:
+        import json
+
+        data = {"name": "x", "dependencies": {}}
+        assert check._parse_npm_list_version(json.dumps(data), self._PACKAGE) is None
+
+    def test_malformed_json_returns_none(self) -> None:
+        assert check._parse_npm_list_version("not json", self._PACKAGE) is None
+
+    def test_empty_output_returns_none(self) -> None:
+        assert check._parse_npm_list_version("", self._PACKAGE) is None
+
+    def test_prerelease_version_parsed(self) -> None:
+        import json
+
+        data = {
+            "name": "x",
+            "dependencies": {self._PACKAGE: {"version": "0.10.0-alpha.1"}},
+        }
+        assert check._parse_npm_list_version(json.dumps(data), self._PACKAGE) == "0.10.0-alpha.1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_go_list_version
+# ---------------------------------------------------------------------------
+
+
+class TestParseGoListVersion:
+    def test_parses_module_version(self) -> None:
+        output = f"{check.GO_MODULE} v0.12.0\n"
+        assert check._parse_go_list_version(output) == "0.12.0"
+
+    def test_strips_leading_v(self) -> None:
+        # _parse_go_list_version returns the raw group (with 'v' stripped by regex).
+        output = f"{check.GO_MODULE} v1.0.0\n"
+        result = check._parse_go_list_version(output)
+        # The regex captures after 'v', so the result should not start with 'v'.
+        assert result is not None
+        assert not result.startswith("v")
+
+    def test_unrelated_module_returns_none(self) -> None:
+        output = "github.com/some/other v1.0.0\n"
+        assert check._parse_go_list_version(output) is None
+
+    def test_empty_output_returns_none(self) -> None:
+        assert check._parse_go_list_version("") is None
+
+    def test_prerelease_version_parsed(self) -> None:
+        output = f"{check.GO_MODULE} v0.12.0-alpha.1\n"
+        assert check._parse_go_list_version(output) == "0.12.0-alpha.1"
+
+    def test_multiple_lines_finds_correct_module(self) -> None:
+        output = (
+            "example.com/release-verify v0.0.0\n"
+            f"{check.GO_MODULE} v0.12.0\n"
+            "golang.org/x/crypto v0.30.0\n"
+        )
+        assert check._parse_go_list_version(output) == "0.12.0"
+
+
+# ---------------------------------------------------------------------------
+# Self-runner (no pytest dependency required)
+# ---------------------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    suites = [
+        TestAssertVersion,
+        TestParsePipShowVersion,
+        TestParseNpmListVersion,
+        TestParseGoListVersion,
+    ]
+    for suite_cls in suites:
+        suite = suite_cls()
+        for name in sorted(dir(suite_cls)):
+            if not name.startswith("test_"):
+                continue
+            fn = getattr(suite, name)
+            try:
+                fn()
+                print(f"ok   {suite_cls.__name__}.{name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {suite_cls.__name__}.{name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {suite_cls.__name__}.{name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## What

Implements Gate #2 from ADR-0024 (tracked by #651): after a release is published to PyPI / npm / the Go proxy, verify that the registry resolves exactly the tagged version.

## Why

"We tagged v0.12.0" does not automatically mean consumers get v0.12.0. Yanks, registry redirects, dist-tag misrouting, or a version bump mismatch can silently serve the wrong version. Gate #1 (`readme-snippets`) already checks that snippets compile against the published artifact; Gate #2 adds the version identity assertion — the thing that was installed is actually the version we released.

Per ADR-0024 D1/D2: a release asserts "version X is published and usable." This gate makes that assertion mechanically checkable and release-blocking.

## Changes

**`scripts/release_verify/check.py`** (new)
Installs the exact released version from the public registry (pip, npm, `go mod download`) in a clean tmpdir, reads back the installed version, and asserts it equals the release tag. Retries to cover propagation lag. Exits 0 on match, 1 on mismatch or install failure.

**`scripts/release_verify/test_check.py`** (new)
23 unit tests for the version-parsing and comparison logic, runnable with no network access. Tests cover: correct match passes, wrong version fails, older/newer version fails, unparseable registry output fails, Go `v`-prefix not stripped fails, pre-release vs stable mismatch fails. All failure-path tests directly exercise ADR-0024 D6 (the gate must fail on broken input).

**`.github/workflows/release-sdk-go.yml`**
- Adds `readme-snippets` job (Gate #1 — was missing for Go)
- Adds `release-verify` job (Gate #2)

**`.github/workflows/release-sdk-py.yml`**
- Adds `release-verify` job (Gate #2) alongside existing `readme-snippets`
- Updates Gate #1 comment for consistency

**`.github/workflows/release-sdk-ts.yml`**
- Adds `release-verify` job (Gate #2) alongside existing `readme-snippets`
- Updates Gate #1 comment for consistency

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)