### PR TITLE
feat(readme-snippets): execute documented snippets (gate #1)

### DIFF
--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -1,9 +1,15 @@
 name: "CI: README snippets"
 
-# Compile / type-check the SDK code snippets embedded in the user-facing
-# READMEs against the in-tree SDK, so a snippet and the API it documents are
-# verified against the same commit. The release-blocking variant (against the
-# *published* artifact) lives in the publish-* workflows.
+# Verify the SDK code snippets embedded in the user-facing READMEs against the
+# in-tree SDK, so a snippet and the API it documents are verified against the
+# same commit. Two complementary gates run here:
+#   * typecheck — compile (Go) / type-check (TS, Py) every SDK snippet.
+#   * run       — execute every runnable snippet in an isolated tmpdir and
+#                 assert exit 0 (verification-gate #1 / ADR-0024). Snippets that
+#                 can't run hermetically carry a `<!-- snippet-check: no-run -->`
+#                 directive and stay covered by the typecheck gate.
+# The release-blocking variant (against the *published* artifact) lives in the
+# publish-* workflows.
 #
 # See scripts/readme_snippets/ for the extractor and orchestrator.
 
@@ -30,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: python3 scripts/readme_snippets/test_extract.py
+      - run: python3 scripts/readme_snippets/test_check.py
 
   go:
     runs-on: ubuntu-latest
@@ -40,6 +47,8 @@ jobs:
           go-version: "1.26"
       - name: Check Go snippets (in-tree)
         run: python3 scripts/readme_snippets/check.py --lang go --source local README.md sdk/go/README.md
+      - name: Run Go snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang go --source local --mode run README.md sdk/go/README.md
 
   typescript:
     runs-on: ubuntu-latest
@@ -58,6 +67,8 @@ jobs:
         run: pnpm install --frozen-lockfile && pnpm run build
       - name: Check TypeScript snippets (in-tree)
         run: python3 scripts/readme_snippets/check.py --lang ts --source local README.md sdk/ts/README.md
+      - name: Run TypeScript snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang ts --source local --mode run README.md sdk/ts/README.md
 
   python:
     runs-on: ubuntu-latest
@@ -65,3 +76,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check Python snippets (in-tree)
         run: python3 scripts/readme_snippets/check.py --lang py --source local README.md sdk/py/README.md
+      - name: Run Python snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang py --source local --mode run README.md sdk/py/README.md

--- a/scripts/readme_snippets/AGENTS.md
+++ b/scripts/readme_snippets/AGENTS.md
@@ -1,32 +1,46 @@
 # readme_snippets
 
-Release-blocking check that the SDK code snippets in the user-facing READMEs
-actually compile / type-check against the SDK. Catches the recurring papercut
-(#593, #594) where a quick-start snippet calls a non-existent API, imports a
-wrong module path, or drifts behind a published rename.
+Gate that the SDK code snippets in the user-facing READMEs hold up against the
+SDK. Two complementary modes (see `--mode` below):
+
+- **typecheck** — compile (Go) / type-check (TS, Py) every SDK snippet. Catches
+  the recurring papercut (#593, #594) where a quick-start snippet calls a
+  non-existent API, imports a wrong module path, or drifts behind a rename.
+- **run** — *execute* every runnable snippet in an isolated tmpdir and assert it
+  exits 0 (verification-gate #1 / ADR-0024). Catches snippets that type-check
+  but don't actually work.
 
 ## Layout
 
 | File | Role |
 |------|------|
 | `extract.py` | Pure fence extraction + per-language assembly. Unit tested. |
-| `check.py` | IO + subprocess driver: scaffolds a throwaway project and runs the compiler/type-checker. |
+| `check.py` | IO + subprocess driver: scaffolds a throwaway project and runs the compiler/type-checker, or executes the snippet. |
 | `test_extract.py` | Unit tests for `extract.py`. |
+| `test_check.py` | Unit tests for `check.py`'s run-mode pass/fail + no-run filtering logic. |
 
 ## Run locally
 
 ```sh
 python3 scripts/readme_snippets/test_extract.py          # unit tests
+python3 scripts/readme_snippets/test_check.py            # unit tests
 # TypeScript local mode needs the in-tree dist built first:
 ( cd sdk/ts && pnpm install && pnpm run build )
+# typecheck mode (default):
 python3 scripts/readme_snippets/check.py --lang go --source local README.md sdk/go/README.md
 python3 scripts/readme_snippets/check.py --lang ts --source local README.md sdk/ts/README.md
 python3 scripts/readme_snippets/check.py --lang py --source local README.md sdk/py/README.md
+# run mode (execute the snippets):
+python3 scripts/readme_snippets/check.py --lang go --source local --mode run README.md sdk/go/README.md
+python3 scripts/readme_snippets/check.py --lang ts --source local --mode run README.md sdk/ts/README.md
+python3 scripts/readme_snippets/check.py --lang py --source local --mode run README.md sdk/py/README.md
 ```
 
 `--source local` builds against the in-tree SDK (used on PRs). `--source
 published [--version X.Y.Z]` builds against the released artifact (used by the
-publish-* workflows at release time).
+publish-* workflows at release time). `--mode run` executes snippets instead of
+only type-checking them; `--mode typecheck` (the default) is the compile-only
+gate.
 
 ## Per-language tooling
 
@@ -41,15 +55,23 @@ publish-* workflows at release time).
 
 Every fenced `go` / `typescript` / `python` block that imports the SDK is
 checked **by default** — that default is what catches drift on a newly added
-snippet without anyone remembering to annotate it. Two invisible HTML-comment
+snippet without anyone remembering to annotate it. Invisible HTML-comment
 directives override this when a block isn't standalone:
 
 ```md
 <!-- snippet-check: continues -->   <!-- concatenate onto the previous checked block -->
-<!-- snippet-check: skip -->        <!-- exclude (intentionally partial pseudo-code) -->
+<!-- snippet-check: skip -->        <!-- exclude entirely (intentionally partial pseudo-code) -->
+<!-- snippet-check: no-run -->      <!-- type-check only; don't execute (run mode) -->
 ```
 
 Place the directive on its own line immediately above the opening fence.
+
+`no-run` is the opt-out for snippets that can't run in a hermetic clean tmpdir —
+they need a daemon, the network, AWS, or a writable system path (e.g. the
+daemon-emitter, collector-delivery, WAL, and KMS examples). Such a block is
+still extracted and compiled / type-checked; only execution is skipped. Prefer
+making a snippet self-contained over `no-run`; reach for `no-run` only when the
+snippet documents a path that inherently needs external state.
 
 ## Adding a README to the gate
 

--- a/scripts/readme_snippets/check.py
+++ b/scripts/readme_snippets/check.py
@@ -6,8 +6,9 @@ Three failure classes this guards against, all of which have shipped before
 module path, or drifts behind a published rename.
 
 Usage:
-    check.py --lang {go,ts,py} --source {local,published} [--version X.Y.Z]
-             [--repo-root .] [--workdir DIR] README.md [more/README.md ...]
+    check.py --lang {go,ts,py} --source {local,published} [--mode {typecheck,run}]
+             [--version X.Y.Z] [--repo-root .] [--workdir DIR]
+             README.md [more/README.md ...]
 
 Source modes:
     local      Build snippets against the in-tree SDK. Used on PRs so a snippet
@@ -17,6 +18,15 @@ Source modes:
                from the manifest). Used at release time to catch a README that
                has drifted from what users will actually `pip install` /
                `npm install` / `go get`.
+
+Check modes:
+    typecheck  (default) Compile (Go) / type-check (TS `tsc --noEmit`, Py mypy)
+               every SDK snippet without executing it. Catches API drift.
+    run        Execute every runnable SDK snippet in an isolated tmpdir and
+               assert it exits 0 (verification-gate #1 / ADR-0024). Snippets
+               that can't run hermetically (daemon, network, AWS, a writable
+               system path) carry a `<!-- snippet-check: no-run -->` directive
+               and are skipped here while remaining covered by typecheck mode.
 
 Only the extraction/assembly logic is unit tested (see test_extract.py); this
 module is the IO + subprocess driver and is exercised end-to-end by CI.
@@ -56,15 +66,55 @@ def _run(cmd: list[str], cwd: str, env: dict[str, str] | None = None, retries: i
     return proc.returncode
 
 
-def _collect_units(readmes: list[str], lang: str) -> list[extract.Unit]:
+def _collect_units(readmes: list[str], lang: str, mode: str = "typecheck") -> list[extract.Unit]:
     units: list[extract.Unit] = []
     for path in readmes:
         with open(path, encoding="utf-8") as fh:
             text = fh.read()
-        found = extract.build_units(path, text, lang)
+        found = extract.build_units(path, text, lang, mode=mode)
         units.extend(found)
         print(f"  {path}: {len(found)} {lang} unit(s)")
     return units
+
+
+# Written into every run dir so snippets that read a taxonomy config from the
+# working directory (`load_taxonomy_config` / `loadTaxonomyConfig`) resolve it.
+# The mapping matches what the READMEs claim classify returns for "read_file".
+_TAXONOMY_FIXTURE = json.dumps(
+    {"mappings": [{"tool_name": "read_file", "action_type": "filesystem.file.read"}]},
+    indent=2,
+)
+
+
+def _runnable(units: list[extract.Unit], lang: str) -> list[extract.Unit]:
+    """Filter to executable units, reporting any skipped via the no-run opt-out."""
+    runnable = [u for u in units if u.run]
+    skipped = [u for u in units if not u.run]
+    for u in skipped:
+        print(f"  skipping (no-run): {', '.join(u.sources)}")
+    if not runnable:
+        print(f"  no runnable {lang} units")
+    return runnable
+
+
+def _prepare_run_dir(workdir: str, n: int, filename: str, unit: extract.Unit) -> str:
+    """Create an isolated per-snippet run dir holding the snippet + fixtures."""
+    run_dir = os.path.join(workdir, f"run_{n:03d}")
+    os.makedirs(run_dir, exist_ok=True)
+    _write_unit(run_dir, filename, unit)
+    with open(os.path.join(run_dir, "taxonomy.json"), "w", encoding="utf-8") as fh:
+        fh.write(_TAXONOMY_FIXTURE)
+    return run_dir
+
+
+def _summarize_run(failures: list[extract.Unit], runnable: list[extract.Unit], label: str) -> int:
+    if failures:
+        print(f"\n{len(failures)} of {len(runnable)} {label} snippet(s) failed to run:")
+        for u in failures:
+            print(f"  - {', '.join(u.sources)}")
+        return 1
+    print(f"\nAll {len(runnable)} {label} snippet(s) ran and exited 0.")
+    return 0
 
 
 # --------------------------------------------------------------------------- #
@@ -97,25 +147,24 @@ def _resolve_version(lang: str, repo_root: str, override: str | None) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def check_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
-    if not units:
-        print("  no Go units to check")
-        return 0
+_GO_ENV = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
 
-    noncanonical = False
+
+def _go_noncanonical_guard(units: list[extract.Unit]) -> bool:
+    """Print and flag any non-canonical SDK import path. Returns True if found."""
+    found = False
     for unit in units:
-        bad = extract.go_noncanonical_imports(unit.code)
-        if bad:
-            noncanonical = True
-            for path in bad:
-                print(
-                    f"  non-canonical SDK import {path!r} ({', '.join(unit.sources)}); "
-                    f"use {GO_MODULE}"
-                )
-    if noncanonical:
-        return 1
+        for path in extract.go_noncanonical_imports(unit.code):
+            found = True
+            print(
+                f"  non-canonical SDK import {path!r} ({', '.join(unit.sources)}); "
+                f"use {GO_MODULE}"
+            )
+    return found
 
-    network_retries = 4 if source == "published" else 0
+
+def _write_go_mod(source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    """Write a throwaway go.mod for the snippet module; return the retry budget."""
     go_mod = ["module example.com/readme-snippets\n", "go 1.26.1\n"]
     if source == "local":
         sdk_path = os.path.join(repo_root, "sdk", "go")
@@ -125,19 +174,54 @@ def check_go(units: list[extract.Unit], source: str, version: str | None, repo_r
         go_mod.append(f"replace {GO_MODULE} => {sdk_path}\n")
     else:
         go_mod.append(f"require {GO_MODULE} v{version}\n")
-
     with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
         fh.writelines(go_mod)
+    return 4 if source == "published" else 0
+
+
+def check_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    if not units:
+        print("  no Go units to check")
+        return 0
+
+    if _go_noncanonical_guard(units):
+        return 1
+
+    network_retries = _write_go_mod(source, version, repo_root, workdir)
 
     for n, unit in enumerate(units, start=1):
         pkg_dir = os.path.join(workdir, f"snippet_{n:03d}")
         os.makedirs(pkg_dir, exist_ok=True)
         _write_unit(pkg_dir, "main.go", unit)
 
-    env = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
-    if _run(["go", "mod", "tidy"], cwd=workdir, env=env, retries=network_retries) != 0:
+    if _run(["go", "mod", "tidy"], cwd=workdir, env=_GO_ENV, retries=network_retries) != 0:
         return 1
-    return _run(["go", "build", "./..."], cwd=workdir, env=env)
+    return _run(["go", "build", "./..."], cwd=workdir, env=_GO_ENV)
+
+
+def run_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    runnable = _runnable(units, "Go")
+    if not runnable:
+        return 0
+
+    if _go_noncanonical_guard(runnable):
+        return 1
+
+    network_retries = _write_go_mod(source, version, repo_root, workdir)
+
+    # build_units(mode="run") rendered each unit as an executable `package main`.
+    run_dirs = [
+        _prepare_run_dir(workdir, n, "main.go", unit) for n, unit in enumerate(runnable, start=1)
+    ]
+
+    if _run(["go", "mod", "tidy"], cwd=workdir, env=_GO_ENV, retries=network_retries) != 0:
+        return 1
+
+    failures: list[extract.Unit] = []
+    for unit, run_dir in zip(runnable, run_dirs):
+        if _run(["go", "run", "."], cwd=run_dir, env=_GO_ENV) != 0:
+            failures.append(unit)
+    return _summarize_run(failures, runnable, "Go")
 
 
 # --------------------------------------------------------------------------- #
@@ -159,15 +243,19 @@ def _read_ts_dev_deps(repo_root: str) -> dict[str, str]:
         return {}
 
 
+def _ts_dep_spec(source: str, version: str | None, repo_root: str) -> str:
+    """The `@agnt-rcpt/sdk-ts` dependency spec: in-tree file: install or version."""
+    if source == "local":
+        return f"file:{os.path.join(repo_root, 'sdk', 'ts')}"
+    return version or ""
+
+
 def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
     if not units:
         print("  no TypeScript units to check")
         return 0
 
-    if source == "local":
-        dep = f"file:{os.path.join(repo_root, 'sdk', 'ts')}"
-    else:
-        dep = version
+    dep = _ts_dep_spec(source, version, repo_root)
 
     # Type-check with the same typescript / @types/node the SDK is built with,
     # so the gate matches the published .d.ts (newer TS type features included)
@@ -214,9 +302,59 @@ def check_ts(units: list[extract.Unit], source: str, version: str | None, repo_r
     return _run(["npx", "--no-install", "tsc", "--noEmit"], cwd=workdir)
 
 
+# Node executes the .ts directly via type stripping (Node 22.18+) rather than a
+# separate compile step; `node:sqlite` (used by the store snippets) is still
+# behind --experimental-sqlite on Node 22.
+_NODE_RUN_FLAGS = ["--experimental-strip-types", "--experimental-sqlite"]
+
+
+def run_ts(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    runnable = _runnable(units, "TypeScript")
+    if not runnable:
+        return 0
+
+    package_json = {
+        "name": "readme-snippets-run",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: _ts_dep_spec(source, version, repo_root)},
+    }
+    with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+
+    retries = 4 if source == "published" else 0
+    if _run(["npm", "install", "--no-audit", "--no-fund"], cwd=workdir, retries=retries) != 0:
+        return 1
+
+    failures: list[extract.Unit] = []
+    for n, unit in enumerate(runnable, start=1):
+        run_dir = _prepare_run_dir(workdir, n, "snippet.ts", unit)
+        if _run(["node", *_NODE_RUN_FLAGS, "snippet.ts"], cwd=run_dir, env={"NODE_NO_WARNINGS": "1"}) != 0:
+            failures.append(unit)
+    return _summarize_run(failures, runnable, "TypeScript")
+
+
 # --------------------------------------------------------------------------- #
 # Python
 # --------------------------------------------------------------------------- #
+
+
+def _make_venv(workdir: str) -> str | None:
+    """Create a venv under workdir; return the interpreter path or None on error."""
+    venv = os.path.join(workdir, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=workdir) != 0:
+        return None
+    return os.path.join(venv, "bin", "python")
+
+
+def _pip_install_sdk(py: str, source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    if source == "local":
+        target = os.path.join(repo_root, "sdk", "py")
+        retries = 0
+    else:
+        target = f"{PY_PACKAGE}=={version}"
+        retries = 4
+    return _run([py, "-m", "pip", "install", "--quiet", target], cwd=workdir, retries=retries)
 
 
 def check_py(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
@@ -231,28 +369,39 @@ def check_py(units: list[extract.Unit], source: str, version: str | None, repo_r
         path = _write_unit(snip_dir, f"snippet_{n:03d}.py", unit)
         files.append(path)
 
-    venv = os.path.join(workdir, "venv")
-    if _run([sys.executable, "-m", "venv", venv], cwd=workdir) != 0:
+    py = _make_venv(workdir)
+    if py is None:
         return 1
-    py = os.path.join(venv, "bin", "python")
     # Pin mypy so the gate is deterministic — a behaviour change in a future
     # release shouldn't silently start failing (or passing) snippet checks.
     if _run([py, "-m", "pip", "install", "--quiet", MYPY_VERSION], cwd=workdir) != 0:
         return 1
-
-    if source == "local":
-        target = os.path.join(repo_root, "sdk", "py")
-        retries = 0
-    else:
-        target = f"{PY_PACKAGE}=={version}"
-        retries = 4
-    if _run([py, "-m", "pip", "install", "--quiet", target], cwd=workdir, retries=retries) != 0:
+    if _pip_install_sdk(py, source, version, repo_root, workdir) != 0:
         return 1
 
     # mypy's default errors on a missing/renamed import and on a non-existent
     # attribute of a typed object (agent-receipts ships py.typed), catching all
     # three drift classes without executing the snippet.
     return _run([py, "-m", "mypy", *files], cwd=workdir)
+
+
+def run_py(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
+    runnable = _runnable(units, "Python")
+    if not runnable:
+        return 0
+
+    py = _make_venv(workdir)
+    if py is None:
+        return 1
+    if _pip_install_sdk(py, source, version, repo_root, workdir) != 0:
+        return 1
+
+    failures: list[extract.Unit] = []
+    for n, unit in enumerate(runnable, start=1):
+        run_dir = _prepare_run_dir(workdir, n, "snippet.py", unit)
+        if _run([py, "snippet.py"], cwd=run_dir) != 0:
+            failures.append(unit)
+    return _summarize_run(failures, runnable, "Python")
 
 
 # --------------------------------------------------------------------------- #
@@ -269,13 +418,17 @@ def _write_unit(dirpath: str, filename: str, unit: extract.Unit) -> str:
     return path
 
 
-_CHECKERS = {"go": check_go, "ts": check_ts, "py": check_py}
+_CHECKERS = {
+    "typecheck": {"go": check_go, "ts": check_ts, "py": check_py},
+    "run": {"go": run_go, "ts": run_ts, "py": run_py},
+}
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lang", required=True, choices=["go", "ts", "py"])
     parser.add_argument("--source", required=True, choices=["local", "published"])
+    parser.add_argument("--mode", default="typecheck", choices=["typecheck", "run"])
     parser.add_argument("--version", default=None)
     parser.add_argument("--repo-root", default=os.getcwd())
     parser.add_argument("--workdir", default=None)
@@ -293,8 +446,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  {r}")
         return 2
 
-    print(f"Checking {args.lang} snippets ({args.source}) in:")
-    units = _collect_units(readmes, args.lang)
+    print(f"Checking {args.lang} snippets ({args.source}, mode={args.mode}) in:")
+    units = _collect_units(readmes, args.lang, args.mode)
     if not units:
         print("No SDK snippets found — nothing to check.")
         return 0
@@ -313,15 +466,16 @@ def main(argv: list[str] | None = None) -> int:
         cleanup = True
 
     try:
-        rc = _CHECKERS[args.lang](units, args.source, version, repo_root, workdir)
+        rc = _CHECKERS[args.mode][args.lang](units, args.source, version, repo_root, workdir)
     finally:
         if cleanup:
             shutil.rmtree(workdir, ignore_errors=True)
 
-    if rc == 0:
+    if rc == 0 and args.mode == "typecheck":
+        # run mode prints its own per-unit summary via _summarize_run.
         print(f"\nAll {len(units)} {args.lang} snippet unit(s) compiled cleanly.")
-    else:
-        print(f"\nSnippet check FAILED for {args.lang} (see errors above).")
+    elif rc != 0:
+        print(f"\nSnippet {args.mode} FAILED for {args.lang} (see errors above).")
     return rc
 
 

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -17,6 +17,11 @@ Selection rules:
     state (store/verify follow-ons) resolve their references.
     ``<!-- snippet-check: skip -->`` opts a block out entirely (intentionally
     partial pseudo-code).
+    ``<!-- snippet-check: no-run -->`` keeps the block under the type-check gate
+    but opts it out of the execute gate — for snippets that can't run in a
+    hermetic clean tmpdir (they need a daemon, the network, AWS, a writable
+    system path, …). The block is still extracted and compiled / type-checked;
+    only execution is skipped (``Unit.run`` is ``False``).
   Directives are invisible in rendered markdown. Unmarked blocks are checked by
   default, so a newly added quick-start snippet is covered without anyone
   remembering to annotate it — which is the drift this gate exists to catch.
@@ -51,7 +56,7 @@ _SDK_IMPORT_PATTERN = {
 _DIRECTIVE_RE = re.compile(r"<!--\s*snippet-check:\s*(?P<directive>[\w-]+)\s*-->")
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<ticks>`{3,})(?P<info>.*)$")
 
-_VALID_DIRECTIVES = {"continues", "skip"}
+_VALID_DIRECTIVES = {"continues", "skip", "no-run"}
 
 
 @dataclass
@@ -72,6 +77,11 @@ class Unit:
     name: str
     code: str
     sources: list[str] = field(default_factory=list)
+    # False when any block in the unit carries the ``no-run`` directive: the
+    # snippet still type-checks but can't be executed hermetically (it needs a
+    # daemon, the network, a writable system path, …). The execute gate skips
+    # these; the type-check gate still covers them.
+    run: bool = True
 
 
 def parse_blocks(text: str) -> list[Block]:
@@ -142,11 +152,14 @@ def _imports_sdk(lang: str, code: str) -> bool:
     return bool(pattern and pattern.search(code))
 
 
-def build_units(readme_label: str, text: str, lang: str) -> list[Unit]:
+def build_units(readme_label: str, text: str, lang: str, mode: str = "typecheck") -> list[Unit]:
     """Assemble compilation units for a single README and target language.
 
     ``readme_label`` is a human-readable source reference (e.g. the README path),
-    used both for diagnostics and to derive stable unit names.
+    used both for diagnostics and to derive stable unit names. ``mode`` selects
+    how units are rendered: ``"typecheck"`` (the default) renders Go as a library
+    package so a block without ``func main`` still compiles; ``"run"`` renders Go
+    as an executable ``package main`` so the snippet can be run end-to-end.
     """
 
     blocks = [b for b in parse_blocks(text) if b.lang == lang]
@@ -159,9 +172,16 @@ def build_units(readme_label: str, text: str, lang: str) -> list[Unit]:
             return
         idx = len(units) + 1
         sources = [f"{readme_label}:{b.line}" for b in chain]
-        code = _render(lang, chain)
+        code = _render(lang, chain, mode)
+        run = not any(b.directive == "no-run" for b in chain)
         units.append(
-            Unit(lang=lang, name=f"{_safe_label(readme_label)}-{lang}-{idx}", code=code, sources=sources)
+            Unit(
+                lang=lang,
+                name=f"{_safe_label(readme_label)}-{lang}-{idx}",
+                code=code,
+                sources=sources,
+                run=run,
+            )
         )
         chain.clear()
 
@@ -191,7 +211,7 @@ def _safe_label(label: str) -> str:
     return re.sub(r"[^\w]+", "_", label).strip("_") or "readme"
 
 
-def _render(lang: str, chain: list[Block]) -> str:
+def _render(lang: str, chain: list[Block], mode: str = "typecheck") -> str:
     if lang == "go":
         # Go blocks are standalone (a full program or a bare statement snippet);
         # concatenating two would not compile. Fail loudly rather than silently
@@ -201,7 +221,7 @@ def _render(lang: str, chain: list[Block]) -> str:
             raise ValueError(
                 f"Go snippets cannot use 'continues' ({srcs}); each must be standalone"
             )
-        return _render_go(chain[0].code)
+        return _render_go(chain[0].code, mode)
     return "\n\n".join(b.code for b in chain)
 
 
@@ -218,14 +238,19 @@ _GO_IMPORT_BLOCK_OPEN_RE = re.compile(r"^import\s*\(\s*$")
 GO_SNIPPET_PACKAGE = "snippet"
 
 
-def _render_go(code: str) -> str:
-    """Render a Go snippet as a buildable, non-main library package.
+def _render_go(code: str, mode: str = "typecheck") -> str:
+    """Render a Go snippet as a buildable unit.
 
-    Every unit is compiled as ``package snippet`` rather than ``package main``:
-    that way a snippet that defines helper funcs but no ``main`` (e.g. the
-    collector-delivery example) still builds, and an unused ``func main`` is not
-    an error. Unused *imports* and unused *locals* remain errors, so genuine
-    drift is still caught.
+    In ``typecheck`` mode every unit is compiled as ``package snippet`` rather
+    than ``package main``: that way a snippet that defines helper funcs but no
+    ``main`` (e.g. the collector-delivery example) still builds, and an unused
+    ``func main`` is not an error. Unused *imports* and unused *locals* remain
+    errors, so genuine drift is still caught.
+
+    In ``run`` mode the unit is rendered as an executable ``package main`` with a
+    ``func main`` entry point, so ``go run`` actually executes the snippet. (Only
+    runnable snippets reach this mode — library-style blocks with no entry point
+    carry the ``no-run`` directive and are filtered out before execution.)
 
     Blocks that already declare a package have that line rewritten. Bare
     statement snippets (root README quick-start) have their ``import`` lines
@@ -234,9 +259,12 @@ def _render_go(code: str) -> str:
     trip Go's unused-variable error.
     """
 
+    package = "main" if mode == "run" else GO_SNIPPET_PACKAGE
+    entry_func = "main" if mode == "run" else "run"
+
     if re.search(r"^package\s+\w+", code, re.MULTILINE):
         rewritten = re.sub(
-            r"^package\s+\w+", f"package {GO_SNIPPET_PACKAGE}", code.strip(), count=1, flags=re.MULTILINE
+            r"^package\s+\w+", f"package {package}", code.strip(), count=1, flags=re.MULTILINE
         )
         return rewritten + "\n"
 
@@ -279,14 +307,14 @@ def _render_go(code: str) -> str:
         if var:
             declared.append(var.group("name"))
 
-    out: list[str] = [f"package {GO_SNIPPET_PACKAGE}", ""]
+    out: list[str] = [f"package {package}", ""]
     if imports:
         out.append("import (")
         for spec in imports:
             out.append(f"\t{spec}")
         out.append(")")
         out.append("")
-    out.append("func run() {")
+    out.append(f"func {entry_func}() {{")
     for line in _trim_blank_edges(body):
         out.append("\t" + line if line.strip() else "")
     for name in declared:

--- a/scripts/readme_snippets/test_check.py
+++ b/scripts/readme_snippets/test_check.py
@@ -1,0 +1,76 @@
+"""Unit tests for the run-mode decision logic in check.py.
+
+These cover the pass/fail and no-run filtering logic without spinning up a
+toolchain (the end-to-end execution itself is exercised by CI). Run with:
+python3 scripts/readme_snippets/test_check.py
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+import extract  # noqa: E402
+
+
+def _unit(name: str, run: bool = True) -> extract.Unit:
+    return extract.Unit(lang="py", name=name, code="x = 1\n", sources=[f"R.md:{name}"], run=run)
+
+
+def test_runnable_excludes_no_run() -> None:
+    units = [_unit("a", run=True), _unit("b", run=False), _unit("c", run=True)]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        runnable = check._runnable(units, "Python")
+    assert [u.name for u in runnable] == ["a", "c"]
+    # The skipped unit is reported, not silently dropped.
+    assert "skipping (no-run)" in buf.getvalue()
+
+
+def test_runnable_reports_when_nothing_runnable() -> None:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        runnable = check._runnable([_unit("a", run=False)], "Go")
+    assert runnable == []
+    assert "no runnable Go units" in buf.getvalue()
+
+
+def test_summarize_run_fails_when_any_snippet_fails() -> None:
+    runnable = [_unit("a"), _unit("b")]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = check._summarize_run([runnable[1]], runnable, "Python")
+    assert rc == 1
+    assert "failed to run" in buf.getvalue()
+    assert "R.md:b" in buf.getvalue()
+
+
+def test_summarize_run_passes_when_no_failures() -> None:
+    runnable = [_unit("a")]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = check._summarize_run([], runnable, "Python")
+    assert rc == 0
+    assert "ran and exited 0" in buf.getvalue()
+
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -238,6 +238,124 @@ st.Open("x")
     assert 'st "github.com/agent-receipts/ar/sdk/go/store"' in unit.code
 
 
+def test_default_unit_is_runnable() -> None:
+    text = "```python\nfrom agent_receipts import create_receipt\ncreate_receipt()\n```\n"
+    (unit,) = extract.build_units("R.md", text, "py")
+    assert unit.run is True
+
+
+def test_no_run_directive_marks_unit_not_runnable() -> None:
+    # `no-run` keeps the block (still type-checked) but flags it as not
+    # executable — the opt-out for snippets that can't run hermetically.
+    text = """
+<!-- snippet-check: no-run -->
+```python
+from agent_receipts.aws import KMSSigner
+
+signer = KMSSigner("arn:aws:kms:...")
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "py")
+    assert unit.run is False
+    assert "KMSSigner" in unit.code  # still present for the type-check gate
+
+
+def test_no_run_block_is_not_excluded_like_skip() -> None:
+    # A `skip` block disappears; a `no-run` block survives (just isn't run).
+    text = """
+```python
+from agent_receipts import create_receipt
+receipt = create_receipt()
+```
+
+<!-- snippet-check: no-run -->
+```python
+from agent_receipts import KMSSigner
+KMSSigner("x")
+```
+"""
+    units = extract.build_units("R.md", text, "py")
+    assert len(units) == 2
+    assert [u.run for u in units] == [True, False]
+
+
+def test_no_run_in_chain_taints_whole_unit() -> None:
+    text = """
+```python
+from agent_receipts import create_receipt
+receipt = create_receipt()
+```
+
+<!-- snippet-check: no-run -->
+```python
+from agent_receipts import verify_receipt
+verify_receipt(receipt)
+```
+"""
+    # The `no-run` block here is a standalone unit (it doesn't say `continues`),
+    # so we get two units; only the second is non-runnable.
+    units = extract.build_units("R.md", text, "py")
+    assert [u.run for u in units] == [True, False]
+
+
+def test_continues_chain_inherits_no_run() -> None:
+    text = """
+<!-- snippet-check: no-run -->
+```python
+from agent_receipts import HttpEmitter
+http = HttpEmitter()
+```
+
+<!-- snippet-check: continues -->
+```python
+http.emit(receipt)
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "py")
+    assert unit.run is False
+
+
+def test_go_run_mode_wraps_bare_snippet_as_main() -> None:
+    text = """
+```go
+import "github.com/agent-receipts/ar/sdk/go/receipt"
+
+keys, _ := receipt.GenerateKeyPair()
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "go", mode="run")
+    assert unit.code.startswith("package main")
+    assert "func main() {" in unit.code
+    assert "_ = keys" in unit.code
+
+
+def test_go_run_mode_keeps_full_program_as_main() -> None:
+    code = (
+        "package main\n\n"
+        'import "github.com/agent-receipts/ar/sdk/go/receipt"\n\n'
+        "func main() { _, _ = receipt.GenerateKeyPair() }"
+    )
+    text = f"```go\n{code}\n```\n"
+    (unit,) = extract.build_units("R.md", text, "go", mode="run")
+    assert unit.code.startswith("package main")
+    assert "func main()" in unit.code
+    assert "package snippet" not in unit.code
+
+
+def test_go_typecheck_mode_still_library_package() -> None:
+    # Default mode is unchanged: a bare snippet becomes a library package.
+    text = """
+```go
+import "github.com/agent-receipts/ar/sdk/go/receipt"
+
+keys, _ := receipt.GenerateKeyPair()
+```
+"""
+    (unit,) = extract.build_units("R.md", text, "go")
+    assert unit.code.startswith("package snippet")
+    assert "func run() {" in unit.code
+
+
 def test_go_continues_is_rejected_loudly() -> None:
     text = """
 ```go

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -42,6 +42,7 @@ your app cannot reach the key or forge receipts.
 
 Start the daemon, then emit events from your app:
 
+<!-- snippet-check: no-run -->
 ```go
 package main
 
@@ -161,6 +162,7 @@ daemon-side signing), `emitters` deliver *already-signed* `receipt.AgentReceipt`
 values — sign client-side (or accept pre-signed receipts), then POST them to a
 deployed `agent-receipts-collector`.
 
+<!-- snippet-check: no-run -->
 ```go
 package main
 

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -84,6 +84,7 @@ agent-receipts-daemon          # start the daemon (leave it running)
 signs, and chains the receipt. It is fire-and-forget — start the daemon before
 your app, since an unreachable daemon drops the event (logged at `DEBUG`).
 
+<!-- snippet-check: no-run -->
 ```python
 from agent_receipts import DaemonEmitter
 
@@ -157,6 +158,7 @@ you sign with `sign_receipt`, shown in the [in-process appendix](#appendix-in-pr
 - **`CompositeEmitter`** (fan-out), **`BufferingEmitter`** (batching), and
   **`InMemoryEmitter`** (testing) round out the set.
 
+<!-- snippet-check: no-run -->
 ```python
 from agent_receipts import (
     AgentReceipt,
@@ -190,6 +192,7 @@ never leaves AWS KMS:
 pip install "agent-receipts[aws]"
 ```
 
+<!-- snippet-check: no-run -->
 ```python
 from agent_receipts.aws import KMSSigner
 


### PR DESCRIPTION
## Verification-gate #1 (ADR-0024)

ADR-0024 D4 catalogues gate #1 as: *every code block in the README/docs runs against the artifact in a clean tmpdir and exits 0*. The existing snippet harness only **type-checks** (Go `go build`, TS `tsc --noEmit`, Py `mypy`) — it never executes. This PR adds the **execute** half: a `--mode run` that actually runs each documented snippet in an isolated tmpdir and asserts exit 0, wired as a CI gate for all three SDKs.

Per the issue&#39;s own note (*&#34;running against the published vs in-tree artifact … is the additional concern of Gate #2&#34;*), this gate runs against the **in-tree** SDK on PRs, like the existing `--source local` type-check. Moving execution to the published artifact + version round-trip is left to gate #2 (#651).

## What changed

- **`extract.py`** — new `` directive and `Unit.run` flag. In `run` mode Go renders as an executable `package main`/`func main`; type-check mode keeps the library `package snippet`/`func run`. Backward compatible (default mode unchanged).
- **`check.py`** — `--mode {typecheck,run}`; `run_go`/`run_ts`/`run_py` execute snippets (Go `go run`, TS via Node type-stripping + `node:sqlite`, Py in a venv). Shared install logic factored into helpers. A `taxonomy.json` fixture is dropped into each run dir so the classify snippets resolve their config from the working directory.
- **READMEs** — the four non-hermetic snippets are marked `no-run` (Python `DaemonEmitter`, WAL/`HttpEmitter`, `KMSSigner`; Go daemon emitter and collector delivery). They need a daemon, the network, AWS, or a writable system path, so they can&#39;t run in a clean tmpdir — but they stay fully covered by the type-check gate. The root README&#39;s three quick-start snippets needed no annotation (they run as-is).
- **CI** (`readme-snippets.yml`) — adds a `Run … snippets (in-tree)` step per SDK and runs the new `test_check.py` unit tests.
- **Tests** — `test_extract.py` covers the `no-run`/run-flag and Go run-mode rendering; new `test_check.py` covers the run/skip/fail-aggregation logic without a toolchain.

## Execution model

Run-by-default with an explicit, reason-documented `no-run` opt-out (matching the harness&#39;s existing &#34;covered by default&#34; philosophy). A newly added runnable quick-start snippet is executed without anyone remembering to annotate it.

## How verified (locally, in-tree)

| Mode | Python | TypeScript | Go |
|------|--------|------------|-----|
| run | 9 ran, 3 skipped (no-run) ✅ | 9 ran ✅ | 2 ran, 2 skipped (no-run) ✅ |
| typecheck | 12 units ✅ | 9 units ✅ | 4 units ✅ |

Type-check still covers every unit (incl. the `no-run` ones) — no regression. **Negative control:** a deliberately broken snippet (`from agent_receipts import this_function_does_not_exist`) makes `--mode run` exit 1 and name the failing source — confirming the gate fails on broken input (relevant to the future meta-gate, #657).

## Test plan

- [ ] CI `CI: README snippets` job green (extractor + check unit tests, and the new run steps for Go/TS/Py).

Closes #650. Refs ADR-0024 (docs/adr/0024-project-verification-contract.md).