### PR TITLE
feat(mdx-snippets): execute documented site snippets (gate #5)

### DIFF
--- a/.github/workflows/mdx-snippets.yml
+++ b/.github/workflows/mdx-snippets.yml
@@ -1,0 +1,65 @@
+name: "CI: MDX snippets"
+
+# Execute the SDK code snippets embedded in the site .mdx docs against the
+# in-tree SDK (verification-gate #5 / ADR-0024). The site is a primary assertion
+# surface — its docs make the same "this works" claim as the SDK READMEs — so
+# every runnable snippet must run in an isolated tmpdir and exit 0.
+#
+# This mirrors readme-snippets.yml but targets site/src/content and runs in
+# `--mode run` only. Illustrative or non-runnable blocks (API-reference import
+# listings, the "not a runnable template" deployment walk-throughs) carry a
+# `{/* snippet-check: skip */}` directive; daemon-dependent blocks run
+# hermetically (fire-and-forget drop with no daemon). See scripts/readme_snippets/.
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - "site/src/content/**/*.mdx"
+      - "scripts/readme_snippets/**"
+      - ".github/workflows/mdx-snippets.yml"
+      - "sdk/go/**"
+      - "sdk/ts/**"
+      - "sdk/py/**"
+  pull_request:
+    branches: [main]
+    paths: *paths
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - name: Run Go .mdx snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang go --source local --mode run $(find site/src/content -name '*.mdx' | sort)
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: sdk/ts/pnpm-lock.yaml
+      # The snippets resolve `@agnt-rcpt/sdk-ts` from a file: install of the
+      # in-tree package, so its dist/ must be built first.
+      - name: Build in-tree TypeScript SDK
+        working-directory: sdk/ts
+        run: pnpm install --frozen-lockfile && pnpm run build
+      - name: Run TypeScript .mdx snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang ts --source local --mode run $(find site/src/content -name '*.mdx' | sort)
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run Python .mdx snippets (in-tree)
+        run: python3 scripts/readme_snippets/check.py --lang py --source local --mode run $(find site/src/content -name '*.mdx' | sort)

--- a/scripts/readme_snippets/AGENTS.md
+++ b/scripts/readme_snippets/AGENTS.md
@@ -64,7 +64,9 @@ directives override this when a block isn't standalone:
 <!-- snippet-check: no-run -->      <!-- type-check only; don't execute (run mode) -->
 ```
 
-Place the directive on its own line immediately above the opening fence.
+Place the directive on its own line immediately above the opening fence. In
+`.mdx` site sources, use the JSX comment form instead (HTML comments are invalid
+MDX): `{/* snippet-check: skip */}`.
 
 `no-run` is the opt-out for snippets that can't run in a hermetic clean tmpdir —
 they need a daemon, the network, AWS, or a writable system path (e.g. the

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -25,6 +25,10 @@ Selection rules:
   Directives are invisible in rendered markdown. Unmarked blocks are checked by
   default, so a newly added quick-start snippet is covered without anyone
   remembering to annotate it — which is the drift this gate exists to catch.
+
+Directive syntax is the HTML comment ``<!-- snippet-check: ... -->`` in ``.md``
+and the JSX comment ``{/* snippet-check: ... */}`` in ``.mdx`` (HTML comments
+aren't valid MDX). Both forms are recognised identically.
 """
 
 from __future__ import annotations
@@ -53,7 +57,9 @@ _SDK_IMPORT_PATTERN = {
     "py": re.compile(r"\b(?:from|import)\s+agent_receipts\b"),
 }
 
-_DIRECTIVE_RE = re.compile(r"<!--\s*snippet-check:\s*(?P<directive>[\w-]+)\s*-->")
+_DIRECTIVE_RE = re.compile(
+    r"(?:<!--|\{/\*)\s*snippet-check:\s*(?P<directive>[\w-]+)\s*(?:-->|\*/\})"
+)
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<ticks>`{3,})(?P<info>.*)$")
 
 _VALID_DIRECTIVES = {"continues", "skip", "no-run"}

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -238,6 +238,29 @@ st.Open("x")
     assert 'st "github.com/agent-receipts/ar/sdk/go/store"' in unit.code
 
 
+def test_mdx_jsx_comment_directive() -> None:
+    # MDX can't use HTML comments; the JSX comment form must be recognised.
+    text = """
+{/* snippet-check: skip */}
+```python
+from agent_receipts import x
+```
+"""
+    (block,) = extract.parse_blocks(text)
+    assert block.directive == "skip"
+
+
+def test_mdx_jsx_comment_no_run() -> None:
+    text = """
+{/* snippet-check: no-run */}
+```typescript
+import { KMSSigner } from "@agnt-rcpt/sdk-ts";
+```
+"""
+    (unit,) = extract.build_units("page.mdx", text, "ts")
+    assert unit.run is False
+
+
 def test_default_unit_is_runnable() -> None:
     text = "```python\nfrom agent_receipts import create_receipt\ncreate_receipt()\n```\n"
     (unit,) = extract.build_units("R.md", text, "py")

--- a/site/src/content/docs/deployment/ephemeral-compute.mdx
+++ b/site/src/content/docs/deployment/ephemeral-compute.mdx
@@ -158,6 +158,7 @@ A documentation walk-through — not a runnable template (runnable starter proje
 
 ### Go
 
+{/* snippet-check: skip */}
 ```go
 package main
 
@@ -229,6 +230,7 @@ func main() {
 
 ### TypeScript
 
+{/* snippet-check: skip */}
 ```typescript
 import {
   HttpEmitter,
@@ -273,6 +275,7 @@ process.on("SIGTERM", async () => {
 
 ### Python
 
+{/* snippet-check: skip */}
 ```python
 import os
 import signal

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -62,6 +62,7 @@ agent-receipts-daemon          # start the daemon (leave it running)
 `DaemonEmitter` forwards the tool-call event to the daemon, which constructs, signs,
 and chains the receipt. It is fire-and-forget — start the daemon before your app.
 
+{/* snippet-check: no-run */}
 ```python
 from agent_receipts import DaemonEmitter
 
@@ -116,6 +117,7 @@ agent-receipts-daemon          # start the daemon (leave it running)
 `DaemonEmitter` forwards the tool-call event to the daemon, which constructs, signs,
 and chains the receipt. It is fire-and-forget — start the daemon before your app.
 
+{/* snippet-check: no-run */}
 ```typescript
 import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
 
@@ -184,6 +186,7 @@ agent-receipts-daemon          # start the daemon (leave it running)
 constructs, signs, and chains the receipt. It is fire-and-forget — start the daemon
 before your app.
 
+{/* snippet-check: no-run */}
 ```go
 package main
 

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -5,6 +5,7 @@ description: Go SDK API reference.
 
 ## Package `receipt`
 
+{/* snippet-check: skip */}
 ```go
 import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
 ```
@@ -238,6 +239,7 @@ const (
 
 ## Package `taxonomy`
 
+{/* snippet-check: skip */}
 ```go
 import "github.com/agent-receipts/ar/sdk/go/taxonomy"
 ```
@@ -320,6 +322,7 @@ type ClassificationResult struct {
 
 ## Package `store`
 
+{/* snippet-check: skip */}
 ```go
 import "github.com/agent-receipts/ar/sdk/go/store"
 ```

--- a/site/src/content/docs/sdk-go/installation.mdx
+++ b/site/src/content/docs/sdk-go/installation.mdx
@@ -11,6 +11,7 @@ go get github.com/agent-receipts/ar/sdk/go
 
 Import the packages you need:
 
+{/* snippet-check: skip */}
 ```go
 import (
 	receipt "github.com/agent-receipts/ar/sdk/go/receipt"


### PR DESCRIPTION
## Verification-gate #5 (ADR-0024)

The site `.mdx` docs are a primary assertion surface — they make the same "this works" claim as the SDK READMEs. This gate executes every runnable SDK snippet in the site docs against the in-tree SDK in an isolated tmpdir and asserts exit 0.

> **Stacked on #666 (gate #1).** This PR reuses gate #1's run-mode harness, so it targets the gate #1 branch and its diff shows only the gate #5 delta. Retarget to `main` once #666 merges.

## What changed

- **`extract.py`** — recognise the MDX JSX comment form `{/* snippet-check: … */}` in addition to the HTML-comment form (HTML comments are invalid MDX and would break the Astro build). Both map to the same `skip`/`continues`/`no-run` directives. +2 extractor tests.
- **Site docs** — `skip` the genuinely non-runnable blocks:
  - Go api-reference / installation **import-listings** (`import (...)` only — unused imports, can't compile standalone; illustrative).
  - `deployment/ephemeral-compute.mdx` Go/TS/Py blocks — the doc itself says *"not a runnable template"* (env vars + `/* … */` placeholders + module-scope `log.Fatal`/SIGTERM).
- **CI** — new `mdx-snippets.yml` runs the execute gate for all three SDKs over `site/src/content/**/*.mdx` (kept separate from `readme-snippets.yml`).

## Scope: run gate only

Gate #5 is the **execution** gate (per issue #652). I did **not** add an `.mdx` type-check gate, because a type-check pass surfaces ~12 pre-existing doc type-strictness issues (Python `dict` literals that pydantic coerces at runtime; a TS quick-start that omits `chain`) — those snippets *run* fine but don't statically type-check. Fixing them is doc-quality work beyond "make snippets execute"; flagging as a follow-up rather than expanding this PR's scope.

Daemon-emitter snippets run hermetically (fire-and-forget drop with no daemon) and stay under the gate, so they're verified rather than skipped.

## How verified (locally, in-tree)

| | Python | TypeScript | Go |
|---|---|---|---|
| run | 9 ran ✅ | 8 ran ✅ | 4 ran ✅ |

Skipped blocks excluded; before annotation the discovery pass failed exactly on the listed import-listings + ephemeral blocks. All three edited `.mdx` files compile cleanly through `@mdx-js/mdx` (the directives are valid MDX; the local site build only fails on a Playwright-browser download blocked by the network allowlist, on an unrelated mermaid page).

## Test plan

- [ ] CI `CI: MDX snippets` job green (go/typescript/python run steps).

Closes #652. Refs ADR-0024.