### PR TITLE
Add collector module to release script

### DIFF
--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -57,8 +57,12 @@ _SDK_IMPORT_PATTERN = {
     "py": re.compile(r"\b(?:from|import)\s+agent_receipts\b"),
 }
 
+# The opener fixes the closer: an HTML comment (``<!--``) must close with
+# ``-->`` and a JSX comment (``{/*``) with ``*/}``. The conditional ``(?(html)…)``
+# enforces the matching pair so a mismatched directive (``<!-- … */}``) isn't
+# silently accepted, which would quietly skip or no-run a snippet on invalid syntax.
 _DIRECTIVE_RE = re.compile(
-    r"(?:<!--|\{/\*)\s*snippet-check:\s*(?P<directive>[\w-]+)\s*(?:-->|\*/\})"
+    r"(?:(?P<html><!--)|\{/\*)\s*snippet-check:\s*(?P<directive>[\w-]+)\s*(?(html)-->|\*/\})"
 )
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<ticks>`{3,})(?P<info>.*)$")
 

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -261,6 +261,22 @@ import { KMSSigner } from "@agnt-rcpt/sdk-ts";
     assert unit.run is False
 
 
+def test_mismatched_comment_delimiters_are_not_directives() -> None:
+    # The opener fixes the closer: a mismatched pair is invalid directive syntax
+    # and must not silently skip/no-run the snippet. An unrecognised "directive"
+    # leaves the block at its default (checked, runnable).
+    for opener, closer in (("<!--", "*/}"), ("{/*", "-->")):
+        text = f"""
+{opener} snippet-check: skip {closer}
+```python
+from agent_receipts import create_receipt
+create_receipt()
+```
+"""
+        (unit,) = extract.build_units("page.mdx", text, "py")
+        assert unit.run is True, f"{opener} … {closer} should not be a directive"
+
+
 def test_default_unit_is_runnable() -> None:
     text = "```python\nfrom agent_receipts import create_receipt\ncreate_receipt()\n```\n"
     (unit,) = extract.build_units("R.md", text, "py")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ Validate and push the git tag for a module in this monorepo.
 The script tags only. Each module has a dedicated per-module release
 workflow in .github/workflows/release-<module>.yml that triggers on the
 tag, runs CI tests in a clean environment, and creates the GitHub Release.
-For modules with binaries (hook, mcp-proxy, daemon) it also builds
-artifacts via GoReleaser and publishes a Homebrew formula.
+For modules with binaries (hook, mcp-proxy, daemon, collector) it also
+builds artifacts via GoReleaser and publishes a Homebrew formula.
 
 Modules:
   sdk-go       Go SDK                 (tag: sdk/go/vVERSION)
@@ -20,6 +20,7 @@ Modules:
   hook         agent-receipts-hook    (tag: hook/vVERSION)
   mcp-proxy    MCP proxy              (tag: mcp-proxy/vVERSION)
   daemon       agent-receipts daemon  (tag: daemon/vVERSION)
+  collector    reference collector    (tag: collector/vVERSION)
 
 Flags:
   --dry-run    Validate everything and print the actions, but do not push
@@ -34,6 +35,7 @@ Examples:
   $(basename "$0") sdk-go 0.2.0
   $(basename "$0") --dry-run mcp-proxy 0.8.0-alpha.1
   $(basename "$0") daemon 0.8.0-alpha.1
+  $(basename "$0") collector 0.13.0
 EOF
   exit 1
 }
@@ -72,7 +74,7 @@ case "$MODULE" in
     [[ "$VERSION" =~ $SEMVER_RE ]] || [[ "$VERSION" =~ $PEP440_PRE_RE ]] || \
       fail "invalid version '$VERSION' for sdk-py — expected SemVer (e.g. 0.5.0, 1.0.0-beta.1) or PEP 440 pre-release (e.g. 0.8.0a1)"
     ;;
-  sdk-go|sdk-ts|hook|mcp-proxy|daemon)
+  sdk-go|sdk-ts|hook|mcp-proxy|daemon|collector)
     [[ "$VERSION" =~ $SEMVER_RE ]] || \
       fail "invalid version '$VERSION' for $MODULE — expected SemVer (e.g. 0.2.0, 1.0.0-beta.1). PEP 440 form (e.g. 0.8.0a1) is accepted only for sdk-py."
     ;;
@@ -94,7 +96,7 @@ REMOTE=$(git rev-parse origin/main)
 
 # Go modules don't support build metadata in tags
 case "$MODULE" in
-  sdk-go|hook|mcp-proxy|daemon)
+  sdk-go|hook|mcp-proxy|daemon|collector)
     [[ "$VERSION" != *+* ]] || fail "Go module versions cannot contain build metadata (+...)"
     ;;
 esac
@@ -123,6 +125,10 @@ case "$MODULE" in
   daemon)
     TAG="daemon/v${VERSION}"
     DIR="daemon"
+    ;;
+  collector)
+    TAG="collector/v${VERSION}"
+    DIR="collector"
     ;;
   *)
     fail "unknown module '$MODULE' — run with no args for usage"
@@ -174,6 +180,21 @@ case "$MODULE" in
     # -tags=integration is intentionally omitted: integration tests spawn node
     # and uv subprocess emitters that require the full TS/Python SDK setup,
     # which is not guaranteed on a release operator's machine. CI covers those.
+    (cd "$DIR" && GOWORK=off go vet ./... && GOWORK=off go test -race ./...)
+    ;;
+  collector)
+    command -v go >/dev/null 2>&1 || fail "go is not installed"
+    echo "--- Checking for replace directive in $DIR/go.mod"
+    if grep -Eq '^[[:space:]]*replace[[:space:]]' "$DIR/go.mod"; then
+      fail "$DIR/go.mod contains a replace directive — remove it and point to a published sdk/go version before releasing"
+    fi
+    echo "--- Running Go checks in $DIR"
+    # GOWORK=off ensures vet/test resolve from collector/go.mod (published
+    # sdk/go) rather than the in-tree ./sdk/go wired up by the repo-root
+    # go.work — the same isolation the released binary builds under, so a
+    # stale transitive sdk/go pin (ADR-0023 D3) is caught here before tagging.
+    # -race mirrors collector CI: the in-memory and SQLite stores carry
+    # concurrency invariants exercised by the *_ConcurrentInserts tests.
     (cd "$DIR" && GOWORK=off go vet ./... && GOWORK=off go test -race ./...)
     ;;
   sdk-ts)


### PR DESCRIPTION
## What

Add support for the `collector` module to the release script (`scripts/release.sh`). This includes:
- Adding `collector` to the list of modules with binaries that trigger GoReleaser and Homebrew formula publishing
- Adding validation for the collector module (SemVer versioning, no build metadata, no replace directives in go.mod)
- Adding pre-release checks (go vet and go test with race detector) for the collector module
- Updating documentation and examples to reference the collector module

Also fixes a latent bug in `scripts/readme_snippets/extract.py` flagged during review: the `_DIRECTIVE_RE` regex previously accepted mismatched HTML/JSX comment pairs (e.g. `<!-- snippet-check: skip */}`), which would silently skip or no-run a snippet on invalid directive syntax. The regex now uses a conditional group to enforce that an HTML opener (`<!--`) is closed with `-->` and a JSX opener (`{/*`) with `*/}`. A test for mismatched delimiters is added alongside.

## Why

The collector module is a new Go binary in the monorepo that needs to follow the same release process as other binary modules (hook, mcp-proxy, daemon). This change enables the release script to properly validate and tag collector releases, triggering the corresponding per-module release workflow.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [x] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)