### PR TITLE
Docs: Restructure CLI reference for daemon separation (ADR-0010)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -131,6 +131,14 @@ export default defineConfig({
             { label: "Claude Desktop", slug: "mcp-proxy/claude-desktop" },
             { label: "Claude Code", slug: "mcp-proxy/claude-code" },
             { label: "Codex", slug: "mcp-proxy/codex" },
+            { label: "Cursor", slug: "mcp-proxy/cursor" },
+            { label: "Windsurf", slug: "mcp-proxy/windsurf" },
+            { label: "VS Code Copilot", slug: "mcp-proxy/vscode-copilot" },
+            {
+              label: "JetBrains AI Assistant",
+              slug: "mcp-proxy/jetbrains",
+            },
+            { label: "Cline", slug: "mcp-proxy/cline" },
           ],
         },
         {

--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -157,13 +157,18 @@ done < <(tail -f /path/to/proxy.stderr)
 For local testing only, auto-approve every paused call. This defeats the point of the pause rule — do not run it on anything you care about:
 
 ```bash
-sqlite3 ~/.local/share/agent-receipts/audit.db \
-  "SELECT approval_id FROM tool_calls WHERE policy_action='pause' AND approved_by IS NULL;" |
-while read -r id; do
-  curl -sX POST "http://127.0.0.1:8081/api/tool-calls/$id/approve" \
-    -H "Authorization: Bearer $APPROVAL_TOKEN"
-done
+while read -r line; do
+  case "$line" in
+    *"PAUSED"*)
+      id=$(echo "$line" | sed -n 's/.*approval id: //p')
+      curl -sX POST "http://127.0.0.1:8081/api/tool-calls/$id/approve" \
+        -H "Authorization: Bearer $APPROVAL_TOKEN"
+      ;;
+  esac
+done < <(tail -f /path/to/proxy.stderr)
 ```
+
+Pending approvals live in the proxy's memory (not a database), so the approval ids come from the proxy's stderr `PAUSED` lines — the same source the interactive approver above reads.
 
 ## Auto-start with the MCP client
 

--- a/site/src/content/docs/mcp-proxy/approval-ui.mdx
+++ b/site/src/content/docs/mcp-proxy/approval-ui.mdx
@@ -65,7 +65,7 @@ All endpoints require `Authorization: Bearer <token>`, where `<token>` is the va
 | `POST` | `/api/tool-calls/{approval_id}/approve` | Approve a paused call. Unblocks the proxy to forward the request to the MCP server. |
 | `POST` | `/api/tool-calls/{approval_id}/deny` | Deny a paused call. The proxy returns `-32002` to the MCP client. |
 
-There is no `GET /pending` endpoint yet — approvers are expected to watch stderr (or the audit DB) for pending approvals. `{approval_id}` is the ID logged on the `PAUSED` line (distinct from the bearer token, which is printed once at startup):
+There is no `GET /pending` endpoint yet — approvers are expected to watch stderr for pending approvals. `{approval_id}` is the ID logged on the `PAUSED` line (distinct from the bearer token, which is printed once at startup):
 
 ```
 mcp-proxy: PAUSED update_auth_config (rule: pause_high_risk, risk: 70) — approval id: a1b2c3d4...

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -161,7 +161,7 @@ Set `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell rc (`~/.zshrc`, `~/.config/fish
 
 `--scope user` makes the server available across all projects. Omit it for project-local scope only.
 
-`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Claude Code` here (and to `Codex` in the [Codex integration](/mcp-proxy/codex/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the default `did:agent:mcp-proxy` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Claude Code` here (and to `Codex` in the [Codex integration](/mcp-proxy/codex/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the daemon's default `did:agent-receipts-daemon:local` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
 
 Verify the server is registered:
 

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -266,6 +266,6 @@ SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
 
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 
-**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+**Chain IDs are daemon-managed.** The proxy no longer has a `-chain` flag — chain IDs are assigned by `agent-receipts-daemon`. By default the daemon writes all receipts to the `default` chain. Use `--chain-id` (or `AGENTRECEIPTS_CHAIN_ID`) on `agent-receipts` read and verify commands when working with a multi-chain store.
 
 **No receipts appearing?** The daemon must be running *before* Claude Code launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/claude-code.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-code.mdx
@@ -16,7 +16,7 @@ Both `claude mcp add-json` and `.mcp.json` persist their content as plaintext on
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
-- A signing key pair generated (see below)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
 - The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
 
@@ -26,18 +26,20 @@ Both `claude mcp add-json` and `.mcp.json` persist their content as plaintext on
 
   This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
-## Generate a signing key
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching Claude Code:
 
 ```bash
-mcp-proxy init --name github-proxy
-# creates ~/.local/share/agent-receipts/github-proxy.pem (0600) and ~/.local/share/agent-receipts/github-proxy.pem.pub
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
 ```
 
-Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+The proxy reaches the daemon over its default platform socket automatically — no extra flag needed. See [Daemon Setup](/getting-started/daemon-setup/) for install options, socket paths, and running it as a service. Use absolute paths everywhere in the config below — Claude Code launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
 
 ## Register the proxy with Claude Code
 
-Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. Your shell resolves the proxy, key, and server paths at paste time.
+Use `claude mcp add-json` to register a proxied server. The example below wraps `github-mcp-server`. Your shell resolves the proxy and server paths at paste time.
 
 The token needs to reach `mcp-proxy`'s environment **without being written into the stored config**. Pick whichever pattern matches your secrets setup.
 
@@ -65,7 +67,6 @@ JSON_BODY=$(cat <<JSON
     "--",
     "$(which mcp-proxy)",
     "-name", "github",
-    "-key", "$HOME/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -84,7 +85,6 @@ claude mcp add-json github-audited --scope user "$JSON_BODY"
 set OP (which op)
 set MCP_PROXY (which mcp-proxy)
 set GITHUB_MCP (which github-mcp-server)
-set KEY $HOME/.local/share/agent-receipts/github-proxy.pem
 set ENV_FILE $HOME/.local/share/agent-receipts/mcp.env
 
 set json (printf '{
@@ -95,13 +95,12 @@ set json (printf '{
     "--",
     "%s",
     "-name", "github",
-    "-key", "%s",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
     "%s", "stdio"
   ]
-}' $OP $ENV_FILE $MCP_PROXY $KEY $GITHUB_MCP | string collect)
+}' $OP $ENV_FILE $MCP_PROXY $GITHUB_MCP | string collect)
 
 claude mcp add-json github-audited --scope user "$json"
 ```
@@ -121,7 +120,6 @@ JSON_BODY=$(cat <<JSON
   "command": "$(which mcp-proxy)",
   "args": [
     "-name", "github",
-    "-key", "$HOME/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -142,13 +140,10 @@ claude mcp add-json github-audited --scope user "$JSON_BODY"
 ```fish
 set MCP_PROXY (which mcp-proxy)
 set GITHUB_MCP (which github-mcp-server)
-set KEY $HOME/.local/share/agent-receipts/github-proxy.pem
-
 set json (printf '{
   "command": "%s",
   "args": [
     "-name", "github",
-    "-key", "%s",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -157,7 +152,7 @@ set json (printf '{
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
-}' $MCP_PROXY $KEY $GITHUB_MCP | string collect)
+}' $MCP_PROXY $GITHUB_MCP | string collect)
 
 claude mcp add-json github-audited --scope user "$json"
 ```
@@ -182,7 +177,6 @@ Since `.mcp.json` is a static JSON file, print the absolute paths you need first
 
 ```bash
 echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.local/share/agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
 ```
 
@@ -201,7 +195,6 @@ Point Claude Code at `op run`, same as the `claude mcp add-json` pattern above. 
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -223,7 +216,6 @@ Claude Code expands `${VAR}` placeholders at server-launch time, so each develop
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Code",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -237,36 +229,32 @@ Claude Code expands `${VAR}` placeholders at server-launch time, so each develop
 }
 ```
 
-The proxy path and key path will need to be consistent across the team, or handled via a wrapper script.
+The proxy path will need to be consistent across the team, or handled via a wrapper script.
 
 ## Verifying receipts
 
-After making tool calls through Claude Code, inspect the receipt store from your terminal:
+The daemon signs and stores every tool call. After making calls through Claude Code, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
 
 ```bash
-# List all receipts (uses the default ~/.local/share/agent-receipts/receipts.db)
-mcp-proxy list
+# List recent receipts (newest first)
+agent-receipts list
 
-# Verify chain integrity
-mcp-proxy verify \
-  -key ~/.local/share/agent-receipts/github-proxy.pem.pub \
-  <chain-id>
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
 ```
 
 ```
-$ mcp-proxy list
-ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
----
-urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
-urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
-urn:receipt:67fede57... github         add_reply_to_pull_reques...    data.api.write         medium   success  2026-04-24T00:51:57Z
-urn:receipt:013bfc43... github         request_copilot_review         data.api.write         medium   success  2026-04-24T00:43:40Z
-urn:receipt:7ae4f1b2... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:35Z
-
-5 receipts
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+5    2026-04-24T01:45:07Z  default  list_issues
+4    2026-04-24T01:44:20Z  default  list_pull_requests
+3    2026-04-24T00:51:57Z  default  add_reply_to_pull_request
+2    2026-04-24T00:43:40Z  default  request_copilot_review
+1    2026-04-24T00:19:35Z  default  issue_write
 ```
 
-Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low`; write tools like `issue_write` show `data.api.write / medium`. The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`.
+`agent-receipts verify` prints `Chain default: VALID (5 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
 
 ## Gotchas
 
@@ -280,4 +268,4 @@ Read tools like `list_issues` and `list_pull_requests` show `data.api.read / low
 
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
 
-**Old receipts show `unknown`.** If you upgraded from a version before v0.2.0, existing receipts in the DB will always show `Action: unknown` — the tool name was never stored. Clear the DB and start fresh after upgrading.
+**No receipts appearing?** The daemon must be running *before* Claude Code launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -16,7 +16,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
-- A signing key pair generated (see below)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - The MCP server you want to audit. The example below wraps GitHub's official MCP server:
 
   ```bash
@@ -25,15 +25,18 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
   This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
-## Generate a signing key
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching Claude Desktop:
 
 ```bash
-mcp-proxy init --name github-proxy
-# creates ~/.local/share/agent-receipts/github-proxy.pem (0600) and ~/.local/share/agent-receipts/github-proxy.pem.pub
-# prints a claude_desktop_config.json snippet — paste it as a starting point
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
 ```
 
-Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Claude Desktop launches MCP servers with a clean environment where `~` expansion and `$PATH` are not available.
+The proxy reaches the daemon over its default platform socket automatically. To run the daemon as a background service on macOS, see [Daemon Setup](/getting-started/daemon-setup/). Use absolute paths everywhere — Claude Desktop launches MCP servers with a clean environment where `~` expansion and `$PATH` are not available.
+
+You can scaffold a starting config with `mcp-proxy init`, which prints a `claude_desktop_config.json` snippet to paste below.
 
 ## Configure claude_desktop_config.json
 
@@ -43,7 +46,6 @@ Claude Desktop doesn't shell-expand config values, so paste absolute paths. On m
 
 ```bash
 echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.local/share/agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
 ```
 
@@ -77,7 +79,6 @@ Point Claude Desktop at `op run` — it resolves the `op://` reference at exec t
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -120,7 +121,6 @@ Point Claude Desktop at the launcher — no `env` block, since the script sets i
       "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -142,7 +142,6 @@ Useful for kicking the tyres against a throwaway PAT before wiring up secret man
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -162,31 +161,27 @@ Restart Claude Desktop. The GitHub MCP server now runs behind the proxy — ever
 
 ## Verifying receipts
 
-After making tool calls, inspect the receipt store from your terminal:
+The daemon signs and stores every tool call. After making calls through Claude Desktop, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
 
 ```bash
-# List all receipts (uses the default ~/.local/share/agent-receipts/receipts.db)
-mcp-proxy list
+# List recent receipts (newest first)
+agent-receipts list
 
-# Verify chain integrity
-mcp-proxy verify \
-  -key ~/.local/share/agent-receipts/github-proxy.pem.pub \
-  <chain-id>
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
 ```
 
 ```
-$ mcp-proxy list
-ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
----
-urn:receipt:64b00b98... github         issue_write                    data.api.write         medium   success  2026-04-24T01:55:09Z
-urn:receipt:276a6c2a... github         issue_write                    data.api.write         medium   success  2026-04-24T01:48:55Z
-urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
-urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
-
-4 receipts
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T01:55:09Z  default  issue_write
+3    2026-04-24T01:48:55Z  default  list_issues
+2    2026-04-24T01:44:20Z  default  list_pull_requests
+1    2026-04-24T01:40:02Z  default  get_issue
 ```
 
-The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Read operations show `data.api.read / low`; writes show `data.api.write / medium`.
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
 
 ## Gotchas
 
@@ -196,4 +191,4 @@ The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Re
 
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
 
-**Old receipts show `unknown`.** If you upgraded from a version before v0.2.0, existing receipts in the DB will always show `Action: unknown` — the tool name was never stored. Clear the DB and start fresh after upgrading.
+**No receipts appearing?** The daemon must be running *before* Claude Desktop launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -189,6 +189,6 @@ SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
 
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 
-**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+**Chain IDs are daemon-managed.** The proxy no longer has a `-chain` flag — chain IDs are assigned by `agent-receipts-daemon`. By default the daemon writes all receipts to the `default` chain. Use `--chain-id` (or `AGENTRECEIPTS_CHAIN_ID`) on `agent-receipts` read and verify commands when working with a multi-chain store.
 
 **No receipts appearing?** The daemon must be running *before* Claude Desktop launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/cline.mdx
+++ b/site/src/content/docs/mcp-proxy/cline.mdx
@@ -1,0 +1,147 @@
+---
+title: Cline Integration
+description: How to route Cline MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+Cline (the open-source coding agent for VS Code) connects to MCP servers defined in `cline_mcp_settings.json`. The Agent Receipts proxy wraps any MCP server transparently — Cline doesn't know or care that the proxy is there.
+
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. If the proxy runs without `-http`, the listener is off and paused calls fail fast with `-32003`. To approve high-risk calls interactively, pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+:::
+
+:::danger[Never put secrets in cline_mcp_settings.json]
+`cline_mcp_settings.json` is plaintext on disk, and Cline stores `env` values verbatim. Do **not** put a real token, API key, or other credential there. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below.
+:::
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- VS Code with the Cline extension
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
+
+  ```bash
+  brew install github-mcp-server
+  ```
+
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
+
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching VS Code:
+
+```bash
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+```
+
+The proxy reaches the daemon over its default platform socket automatically. See [Daemon Setup](/getting-started/daemon-setup/) for install options and socket paths.
+
+## Configure cline_mcp_settings.json
+
+In the Cline pane, click the **MCP Servers** icon in the top toolbar, open the **Installed** tab, and click **Configure MCP Servers** to open `cline_mcp_settings.json`. (The file lives in VS Code's `globalStorage` — on macOS at `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`; the equivalent `globalStorage` path under `~/.config/Code` on Linux and `%APPDATA%\Code` on Windows.) The format uses a top-level `mcpServers` key.
+
+Cline launches MCP servers without your shell's `PATH`, so use absolute paths. Print them first:
+
+```bash
+echo "op:     $(which op)"
+echo "proxy:  $(which mcp-proxy)"
+echo "server: $(which github-mcp-server)"
+```
+
+### Recommended: secret manager (`op run`, `aws-vault exec`, …)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Point Cline at `op run` — it resolves the `op://` reference at exec time and injects the value into `mcp-proxy`'s env without writing it to the settings file:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/opt/homebrew/bin/op",
+      "args": [
+        "run",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
+        "-name", "github",
+        "-issuer-name", "Cline",
+        "-operator-id", "did:web:cline.bot",
+        "-operator-name", "Cline",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+`aws-vault exec`, `chamber exec` (AWS Parameter Store), and `direnv` with `op://` references all follow the same wrapping pattern.
+
+### Fallback: OS keychain launcher script
+
+If you don't have a secret manager, reuse the launcher script from [Claude Desktop's keychain fallback](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) (one script works across clients). Point `command` at the launcher and drop the env block — the script sets `GITHUB_PERSONAL_ACCESS_TOKEN` from the keychain:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
+      "args": [
+        "-name", "github",
+        "-issuer-name", "Cline",
+        "-operator-id", "did:web:cline.bot",
+        "-operator-name", "Cline",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp each signed receipt so you can tell which client made a given call when reviewing a shared store — setting `-issuer-name` to `Cline` here (and to `Claude Code`, `Codex`, etc. in the other guides) is what distinguishes them at audit time.
+
+Save the file. Cline reloads MCP servers automatically; the **Installed** tab should show `github-audited` with a green/connected indicator and the tools the proxied server exposes. Use **Restart** there if it doesn't pick up changes.
+
+## Verifying receipts
+
+The daemon signs and stores every tool call. After making calls through Cline, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
+
+```bash
+# List recent receipts (newest first)
+agent-receipts list
+
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+```
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T02:05:19Z  default  get_file_contents
+3    2026-04-24T01:58:45Z  default  create_or_update_file
+2    2026-04-24T01:56:12Z  default  search_issues
+1    2026-04-24T01:45:07Z  default  list_issues
+```
+
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
+
+## Gotchas
+
+**Absolute paths required.** Cline launches MCP servers with a clean `PATH`. Use the full path to `op`/`mcp-proxy` (find each with `which`) and the full path to the wrapped server binary.
+
+**`autoApprove` is Cline's own auto-run list — not the proxy's.** Listing a tool in `autoApprove` only tells Cline to skip *its* confirmation prompt; it has no effect on the Agent Receipts policy. Risk scoring, pause/block rules, and receipts still apply at the proxy and daemon regardless of what's in `autoApprove`.
+
+**No receipts appearing?** The daemon must be running *before* Cline starts the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. Add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with `-32003`.

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -46,7 +46,7 @@ Use `codex mcp add` to register the proxy wrapping any MCP server. The shell res
 Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
 
 ```ini
-# ~/.agent-receipts/mcp.env  (chmod 600)
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
 GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
 ```
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -71,7 +71,7 @@ Reuse the launcher script described in [Claude Desktop's keychain fallback](/mcp
 
 ```bash
 codex mcp add github-audited \
-  -- "$HOME/.agent-receipts/run-mcp-proxy-github.sh" \
+  -- "$HOME/.local/share/agent-receipts/run-mcp-proxy-github.sh" \
     -name github \
     -issuer-name Codex \
     -operator-id did:web:openai.com \

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -171,7 +171,7 @@ SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
 
 **Classic PATs for org-owned repos.** GitHub's fine-grained PATs can fail for org-level write operations even when permissions appear correct. Use a classic PAT with `repo` scope for org-owned repositories.
 
-**Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
+**Chain IDs are daemon-managed.** The proxy no longer has a `-chain` flag — chain IDs are assigned by `agent-receipts-daemon`. By default the daemon writes all receipts to the `default` chain. Use `--chain-id` (or `AGENTRECEIPTS_CHAIN_ID`) on `agent-receipts` read and verify commands when working with a multi-chain store.
 
 **Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. If your server exposes tools that cross the risk-score threshold (e.g. `create_token` = 50, `update_auth_config` = 70), pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with JSON-RPC code `-32003` (`no approver configured`). To prevent pausing entirely, drop `pause`/`block` rules from a custom `-rules` YAML.
 

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -54,7 +54,7 @@ Register `op run` as the command — it resolves `op://` references at exec time
 
 ```bash
 codex mcp add github-audited \
-  -- "$(which op)" run "--env-file=$HOME/.agent-receipts/mcp.env" -- \
+  -- "$(which op)" run "--env-file=$HOME/.local/share/agent-receipts/mcp.env" -- \
     "$(which mcp-proxy)" \
     -name github \
     -issuer-name Codex \
@@ -96,7 +96,7 @@ codex mcp add github-audited \
 
 Add `--scope user` to any of the above to make the server available across all projects (default is project-scoped).
 
-`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Codex` here (and to `Claude Code` in the [Claude Code integration](/mcp-proxy/claude-code/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the default `did:agent:mcp-proxy` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp the signed receipt with the agent and the organisation running it. Setting `-issuer-name` to `Codex` here (and to `Claude Code` in the [Claude Code integration](/mcp-proxy/claude-code/)) is what lets you tell at receipt-inspection time which client made a given call — without it, every receipt just shows the daemon's default `did:agent-receipts-daemon:local` issuer. See the [configuration reference](/mcp-proxy/configuration/#cli-flags) for the full set of identity flags.
 
 ## Configure via config.toml
 
@@ -115,7 +115,7 @@ The recommended (secret-manager) form — `op run` resolves the `op://` referenc
 command = "/opt/homebrew/bin/op"
 args = [
   "run",
-  "--env-file=/Users/YOU/.agent-receipts/mcp.env",
+  "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
   "--",
   "/Users/YOU/go/bin/mcp-proxy",
   "-name", "github",

--- a/site/src/content/docs/mcp-proxy/codex.mdx
+++ b/site/src/content/docs/mcp-proxy/codex.mdx
@@ -16,7 +16,7 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
-- A signing key pair generated (see below)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - Codex installed (`npm install -g @openai/codex` or via the IDE extension)
 - The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
 
@@ -26,14 +26,16 @@ The default policy includes a `pause_high_risk` rule. When you generate a config
 
   This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
 
-## Generate a signing key
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching Codex:
 
 ```bash
-mcp-proxy init --name github-proxy
-# creates ~/.agent-receipts/github-proxy.pem (0600) and ~/.agent-receipts/github-proxy.pem.pub
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
 ```
 
-Re-running `init` is safe — it warns and skips if the key already exists. Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
+The proxy reaches the daemon over its default platform socket automatically — no extra flag needed. See [Daemon Setup](/getting-started/daemon-setup/) for install options, socket paths, and running it as a service. Use absolute paths everywhere — Codex launches MCP servers with a clean environment where `~` expansion and `$PATH` may not behave as expected.
 
 ## Configure via CLI
 
@@ -55,7 +57,6 @@ codex mcp add github-audited \
   -- "$(which op)" run "--env-file=$HOME/.agent-receipts/mcp.env" -- \
     "$(which mcp-proxy)" \
     -name github \
-    -key "$HOME/.agent-receipts/github-proxy.pem" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
@@ -72,7 +73,6 @@ Reuse the launcher script described in [Claude Desktop's keychain fallback](/mcp
 codex mcp add github-audited \
   -- "$HOME/.agent-receipts/run-mcp-proxy-github.sh" \
     -name github \
-    -key "$HOME/.agent-receipts/github-proxy.pem" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
@@ -88,7 +88,6 @@ codex mcp add github-audited \
   --env GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_TOKEN \
   -- "$(which mcp-proxy)" \
     -name github \
-    -key "$HOME/.agent-receipts/github-proxy.pem" \
     -issuer-name Codex \
     -operator-id did:web:openai.com \
     -operator-name OpenAI \
@@ -105,7 +104,6 @@ Alternatively, edit `~/.codex/config.toml` directly. TOML doesn't shell-expand a
 
 ```bash
 echo "command: $(which mcp-proxy)"
-echo "key:     $HOME/.agent-receipts/github-proxy.pem"
 echo "server:  $(which github-mcp-server)"
 echo "op:      $(which op)"
 ```
@@ -121,7 +119,6 @@ args = [
   "--",
   "/Users/YOU/go/bin/mcp-proxy",
   "-name", "github",
-  "-key", "/Users/YOU/.agent-receipts/github-proxy.pem",
   "-issuer-name", "Codex",
   "-operator-id", "did:web:openai.com",
   "-operator-name", "OpenAI",
@@ -144,31 +141,27 @@ Or check active servers inside the Codex TUI with `/mcp`.
 
 ## Verifying receipts
 
-After making tool calls through Codex, inspect the receipt store from your terminal:
+The daemon signs and stores every tool call. After making calls through Codex, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
 
 ```bash
-# List all receipts (uses the default ~/.agent-receipts/receipts.db)
-mcp-proxy list
+# List recent receipts (newest first)
+agent-receipts list
 
-# Verify chain integrity
-mcp-proxy verify \
-  -key ~/.agent-receipts/github-proxy.pem.pub \
-  <chain-id>
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
 ```
 
 ```
-$ mcp-proxy list
-ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
----
-urn:receipt:58b9c7ff... github         create_pull_request            data.api.write         medium   success  2026-04-15T00:06:48Z
-urn:receipt:3384715f... github         get_pull_request               data.api.read          low      success  2026-04-15T00:06:26Z
-urn:receipt:c2e7b34f... github         push_files                     data.api.write         medium   success  2026-04-15T00:01:39Z
-urn:receipt:ccc6860a... github         list_issues                    data.api.read          low      success  2026-04-14T23:54:09Z
-
-4 receipts
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-15T00:06:48Z  default  create_pull_request
+3    2026-04-15T00:06:26Z  default  get_pull_request
+2    2026-04-15T00:01:39Z  default  push_files
+1    2026-04-14T23:54:09Z  default  list_issues
 ```
 
-The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. The `-issuer-name Codex` flag stamps each receipt so you can tell Codex sessions apart from Claude Code or Claude Desktop when reviewing a shared audit store — that issuer/operator metadata doesn't appear in the tabular view, but it's visible via `mcp-proxy list -json`.
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. The `-issuer-name Codex` flag stamps each receipt so you can tell Codex sessions apart from Claude Code or Claude Desktop when reviewing a shared store — that issuer/operator metadata doesn't appear in the tabular view, but it's visible via `agent-receipts list -json` and `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
 
 ## Gotchas
 
@@ -181,3 +174,5 @@ The SERVER column reflects the `-name github` flag you passed to `mcp-proxy`. Th
 **Per-session chain IDs.** By default the proxy generates a new chain ID each session. Pass `-chain <id>` to persist a chain across sessions.
 
 **Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. If your server exposes tools that cross the risk-score threshold (e.g. `create_token` = 50, `update_auth_config` = 70), pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with JSON-RPC code `-32003` (`no approver configured`). To prevent pausing entirely, drop `pause`/`block` rules from a custom `-rules` YAML.
+
+**No receipts appearing?** The daemon must be running *before* Codex launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -5,24 +5,19 @@ description: CLI flags, policy rules, redaction, and encryption options for the 
 
 ## CLI flags
 
+These are the flags for `mcp-proxy serve` (the default subcommand). The proxy no longer signs or stores receipts — `-key`, `-db`, `-receipt-db`, `-taxonomy`, `-issuer`, `-principal`, and `-chain` were removed when signing and persistence moved to `agent-receipts-daemon` ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). The signing key, receipt database, taxonomy mappings, and chain identity now live in the daemon — see [Daemon Setup](/getting-started/daemon-setup/).
+
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `$HOME/.local/share/agent-receipts/audit.db` | SQLite audit database path. Parent directory is created on first run (mode 0700 on Unix). Respects `$XDG_DATA_HOME`. |
-| `-receipt-db` | `$HOME/.local/share/agent-receipts/receipts.db` | SQLite receipt store path. Parent directory is created on first run (mode 0700 on Unix). Respects `$XDG_DATA_HOME`. |
-| `-key` | (ephemeral) | Ed25519 private key PEM file for signing receipts |
-| `-taxonomy` | (none) | Taxonomy mappings JSON file for action classification. Merged with bundled taxonomies; user mappings win on conflict. |
-| `-bundled-taxonomies` | `true` | Include bundled taxonomies (e.g. GitHub, Atlassian) embedded in the binary. Set to `false` to use only `-taxonomy`. |
 | `-rules` | (built-in defaults) | Policy rules YAML file |
 | `-name` | (inferred from command) | Server name for the audit trail |
-| `-issuer` | `did:agent:mcp-proxy` | Issuer DID for receipts |
-| `-issuer-name` | (none) | Issuer name, e.g. `Claude Code` or `Codex` |
-| `-issuer-model` | (none) | AI model identifier, e.g. `claude-sonnet-4-6`. Static per session — omit if the client can switch models mid-session |
-| `-operator-id` | (none) | Operator DID (organisation running the agent), e.g. `did:web:anthropic.com` |
-| `-operator-name` | (none) | Operator name, e.g. `Anthropic` |
-| `-principal` | `did:user:unknown` | Principal DID for receipts |
-| `-chain` | (auto UUID) | Chain ID for receipt chaining |
 | `-http` | `none` | HTTP address for the approval listener. Off by default — no listener starts unless you opt in. Pass `127.0.0.1:0` for a random free port or `127.0.0.1:<port>` to pin a port. See [Approval Server](/mcp-proxy/approval-ui/). |
 | `-approval-timeout` | `1m0s` | Maximum time to wait for HTTP approval before a paused call is auto-denied |
+| `-socket` | platform default | Unix-domain socket for `agent-receipts-daemon` (env: `AGENTRECEIPTS_SOCKET`). Pass `--socket=""` to disable emission. Emit errors are logged but do not block tool calls. |
+| `-issuer-name` | (auto-detected) | Issuer name, e.g. `Claude Code` (env: `AGENTRECEIPTS_ISSUER_NAME`) |
+| `-issuer-model` | (none) | AI model identifier, e.g. `claude-sonnet-4-6` (env: `AGENTRECEIPTS_ISSUER_MODEL`). Static per session — omit if the client can switch models mid-session |
+| `-operator-id` | (none) | Operator DID (organisation running the agent), e.g. `did:web:anthropic.com` (env: `AGENTRECEIPTS_OPERATOR_ID`) |
+| `-operator-name` | (none) | Operator name, e.g. `Anthropic` (env: `AGENTRECEIPTS_OPERATOR_NAME`). Requires `-operator-id` |
 
 ## Policy rules
 
@@ -99,23 +94,13 @@ Tool names are classified by prefix (case-insensitive):
 
 MCP tool names are automatically stripped of their `mcp__<server>__` prefix before classification. For example, `mcp__github-audited__create_branch` is classified as `create_branch` (write). This means taxonomy mappings and policy rules use bare tool names.
 
-## Taxonomy mappings
+## Action taxonomy
 
-For more precise classification than prefix-based inference, provide a `-taxonomy` JSON file mapping tool names to action types. Bundled taxonomies (see below) are loaded automatically; the `-taxonomy` file is merged on top and wins on tool-name conflicts.
+Tool calls are classified into action types (`data.api.read`, `data.api.write`, …) by the daemon, using the bundled Agent Receipts taxonomy. GitHub and Atlassian MCP tools are covered out of the box, so reads are recorded as `data.api.read` and writes as `data.api.write` without any configuration.
 
-```json
-{
-  "mappings": [
-    {"tool_name": "merge_pull_request", "action_type": "data.api.write"},
-    {"tool_name": "list_issues", "action_type": "data.api.read"},
-    {"tool_name": "delete_file", "action_type": "data.api.delete"}
-  ]
-}
-```
+Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [Action Taxonomy](/specification/action-taxonomy/) reference and the [taxonomy definitions](https://github.com/agent-receipts/ar/tree/main/spec/spec/taxonomy) for the full list, and open a PR to add or correct mappings.
 
-Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [taxonomy spec](https://github.com/agent-receipts/ar/blob/main/spec/spec/taxonomy/action-types.json) for the full list.
-
-The proxy ships with bundled mappings — currently [`github_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/github_taxonomy.json) and [`atlassian_taxonomy.json`](https://github.com/agent-receipts/ar/blob/main/mcp-proxy/configs/atlassian_taxonomy.json) — embedded into the binary. They are loaded automatically; no `-taxonomy` flag is needed for those servers. A user-supplied `-taxonomy` is merged on top and wins on tool-name conflicts. Pass `-bundled-taxonomies=false` to disable the embedded set.
+The proxy still does coarse prefix-based [operation classification](#operation-classification) locally to drive policy risk scoring — that is independent of the daemon's taxonomy-based action typing in the stored receipt.
 
 ## Approval workflow
 
@@ -132,7 +117,7 @@ The [Approval Server page](/mcp-proxy/approval-ui/) has the full treatment — e
 
 ## Data redaction
 
-The proxy redacts sensitive data before storage using two passes:
+The daemon redacts sensitive data before storage using two passes:
 
 **JSON-aware redaction** replaces values of sensitive keys including: `password`, `token`, `api_key`, `secret`, `authorization`, `private_key`, `access_token`, `jwt`, `database_url`, `ssh_key`, `connection_string`, and others (42 keys total).
 
@@ -144,15 +129,9 @@ The proxy redacts sensitive data before storage using two passes:
 - Slack tokens (`xox*`)
 - PEM private key blocks
 
-## Encryption at rest
+## Payload disclosure
 
-Set the `BEACON_ENCRYPTION_KEY` environment variable to enable AES-256-GCM encryption of all stored audit data:
-
-```bash
-BEACON_ENCRYPTION_KEY="my-passphrase" mcp-proxy node server.js
-```
-
-Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored with an `enc:` prefix and transparently decrypted on retrieval.
+By default the daemon stores only a cryptographic hash of each tool call's input and output — the receipt proves what happened without retaining the raw payload. Opt-in plaintext disclosure and the forthcoming HPKE-encrypted disclosure envelope ([ADR-0012](https://github.com/agent-receipts/ar/blob/main/docs/adr/0012-payload-disclosure-policy.md), [#280](https://github.com/agent-receipts/ar/issues/280)) are daemon-side concerns — see [Daemon Setup → Payload disclosure](/getting-started/daemon-setup/#payload-disclosure).
 
 ## Troubleshooting
 
@@ -160,26 +139,26 @@ Key derivation uses Argon2id (t=1, m=64MB, p=4). Encrypted fields are stored wit
 
 **Three different things produce these error codes.** Distinguish them before reaching for a fix, because they need different remedies and only two of them involve the proxy:
 
-1. **Client-side denial** — the MCP client (e.g. Claude Code) rejected the tool use before it reached the proxy. The call never hits the audit DB.
-2. **Proxy: no approver configured** (`-32003`) — the call reached the proxy, matched a `pause` rule, but the approval HTTP listener is not running (operator did not pass `-http <addr>`). The proxy fails fast rather than waiting out the timeout. The call appears in the audit DB with `policy_action = 'rejected'`, `approved_by` NULL, and `approval_wait_us` NULL or near zero. This is the common case when running the default configuration. The JSON-RPC error response carries `data.status = "no_approver"`.
-3. **Proxy: approval denied or timed out** (`-32002`) — the call reached the proxy, matched a `pause` rule, and an approver listener was wired up (`-http <addr>` was passed). The approver either explicitly denied the call, or no approver POSTed a decision before `-approval-timeout` elapsed. The audit DB row signature is the same as case 2 (`policy_action = 'rejected'`, `approved_by` NULL). The JSON-RPC error response disambiguates via `data.status`: `"denied"` for an explicit deny, `"timed_out"` for a timeout. A timeout will have `approval_wait_us` close to `-approval-timeout` (default 60s = 60000000μs); a fast deny may have a small `approval_wait_us` indistinguishable from case 2.
+1. **Client-side denial** — the MCP client (e.g. Claude Code) rejected the tool use before it reached the proxy. The call is never forwarded, so no receipt is written.
+2. **Proxy: no approver configured** (`-32003`) — the call reached the proxy, matched a `pause` rule, but the approval HTTP listener is not running (operator did not pass `-http <addr>`). The proxy fails fast rather than waiting out the timeout. This is the common case when running the default configuration. The JSON-RPC error response carries `data.status = "no_approver"`.
+3. **Proxy: approval denied or timed out** (`-32002`) — the call reached the proxy, matched a `pause` rule, and an approver listener was wired up (`-http <addr>` was passed). The approver either explicitly denied the call, or no approver POSTed a decision before `-approval-timeout` elapsed. The JSON-RPC error response disambiguates via `data.status`: `"denied"` for an explicit deny, `"timed_out"` for a timeout.
 
 **Diagnose — which one is it?**
 
+The pre-v0.9.0 proxy kept a local `audit.db` with a `tool_calls` table you could query directly; that store was removed when persistence moved to the daemon. Today the daemon's signed `receipts.db` is the record of forwarded calls. Diagnose with the CLIs instead of raw SQL:
+
 ```bash
-# Did the failing call reach the proxy at all?
-# Substitute the tool name you saw fail.
-sqlite3 ~/.local/share/agent-receipts/audit.db \
-  "SELECT tool_name, policy_action, risk_score, approved_by, approval_wait_us, requested_at
-   FROM tool_calls
-   WHERE tool_name = 'create_pull_request'
-     AND requested_at > datetime('now', '-1 hour')
-   ORDER BY id DESC LIMIT 10;"
+# Is the proxy running with the flags you expect (rules, -http)?
+ps aux | grep mcp-proxy | grep -v grep
+mcp-proxy doctor                      # validate policy + approver wiring
+
+# Did a receipt for the call land in the daemon's store?
+agent-receipts list                   # recent receipts, newest first
 ```
 
-- **No rows at all** → client-side denial (case 1). The proxy never saw it. See [ar#157](https://github.com/agent-receipts/ar/issues/157) for the ongoing work to make these visible.
-- **Rows with `policy_action = 'pass'`** → the proxy forwarded it; the error came from somewhere downstream (the MCP server, the remote API). Check the proxy's stderr log and the server's own logs.
-- **Rows with `policy_action = 'rejected'` and `approved_by` NULL** → proxy pause rejection (case 2 or 3). Distinguish via the JSON-RPC error response when you have it: code `-32003` is case 2; code `-32002` is case 3, and its `data.status` field (`"denied"` vs `"timed_out"`) tells you which sub-case. If the error response is gone, `approval_wait_us` only reliably identifies the timeout sub-case (it'll be close to `-approval-timeout`); a small or NULL value can be either case 2 (no approver, fail-fast) or a fast deny under case 3 — they're indistinguishable from the audit DB alone.
+- **`mcp-proxy doctor` reports a pause rule with no approver** → case 2: paused calls fail with `-32003` until you start an approver (`-http <addr>`) or relax the policy.
+- **No receipt for the call, and the client reported the error before the tool ran** → client-side denial (case 1): the MCP client rejected the tool use before it reached the proxy, so nothing was forwarded. See [ar#157](https://github.com/agent-receipts/ar/issues/157) for the ongoing work to make these visible.
+- **A receipt exists but the call still errored** → the proxy forwarded it (case: downstream failure) or recorded a rejection. Use `agent-receipts show <seq>` to inspect the outcome, and check the proxy's stderr log and the server's own logs. Distinguish a pause rejection via the JSON-RPC error code: `-32003` is case 2 (no approver), `-32002` is case 3, whose `data.status` field (`"denied"` vs `"timed_out"`) names the sub-case.
 
 **If the error is `-32003` (no approver configured):**
 
@@ -197,10 +176,6 @@ An approver listener is running and either denied the call or didn't respond in 
 ```bash
 # Confirm the -http address and timeout flags.
 ps aux | grep mcp-proxy | grep -v grep
-
-# Check overall breakdown.
-sqlite3 ~/.local/share/agent-receipts/audit.db \
-  "SELECT policy_action, COUNT(*) FROM tool_calls GROUP BY policy_action;"
 ```
 
 The scorer stacks a base (read 0, write 20, execute 30, delete 40, unknown 10) with modifiers — sensitive keywords in the tool name (+30), SQL mutations without `WHERE` (+30), `config`/`setting` substrings (+20), `send_*`/`post_*` prefixes (+15) — so what actually crosses 50 is combinations: `create_token` (write 20 + sensitive 30 = 50), `update_auth_config` (70), `delete_credential` (70), `delete_config` (60), `exec_sql` with a `DELETE` and no `WHERE` (60). Ordinary writes like `create_pull_request` (20), unknown-prefix calls like `merge_pull_request` (10), plain deletes like `delete_branch` (40), `update_config` with no sensitive keyword (40), and sensitive-keyword *reads* like `get_token` (30) all stay below the threshold — if one of those is failing, you're in path #1, not #2 or #3.
@@ -228,4 +203,4 @@ mcp-proxy -name github -http 127.0.0.1:8082 ... /path/to/server
 
 `127.0.0.1:0` picks a random free port automatically — fine when the approver parses the stderr discovery event at startup.
 
-Each instance can also use separate `-db` and `-receipt-db` paths if you want isolated audit trails, or share the same databases if you want a unified log. By default both point at `$HOME/.local/share/agent-receipts/` (respecting `$XDG_DATA_HOME`), so all clients share one audit log unless you override them.
+All proxy instances forward to the same `agent-receipts-daemon`, so every client's calls land in one unified, hash-chained receipt store. Point a proxy at a different daemon — and thus a separate audit trail — with `--socket` (or `AGENTRECEIPTS_SOCKET`); see [Daemon Setup](/getting-started/daemon-setup/).

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -1,11 +1,11 @@
 ---
 title: Configuration
-description: CLI flags, policy rules, redaction, and encryption options for the MCP Proxy.
+description: CLI flags, policy rules, operation classification, and data redaction for the MCP Proxy.
 ---
 
 ## CLI flags
 
-These are the flags for `mcp-proxy serve` (the default subcommand). The proxy no longer signs or stores receipts — `-key`, `-db`, `-receipt-db`, `-taxonomy`, `-issuer`, `-principal`, and `-chain` were removed when signing and persistence moved to `agent-receipts-daemon` ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). The signing key, receipt database, taxonomy mappings, and chain identity now live in the daemon — see [Daemon Setup](/getting-started/daemon-setup/).
+These are the flags for `mcp-proxy serve` (the default subcommand). The proxy no longer signs or stores receipts — `-key`, `-db`, `-receipt-db`, `-taxonomy`, `-issuer`, `-principal`, and `-chain` were removed when signing and persistence moved to `agent-receipts-daemon` ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). The signing key, receipt database, and chain identity now live in the daemon — see [Daemon Setup](/getting-started/daemon-setup/). Note: the `-taxonomy` flag is removed but daemon-side taxonomy remapping is not yet implemented; see [Action taxonomy](#action-taxonomy) below.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -96,11 +96,11 @@ MCP tool names are automatically stripped of their `mcp__<server>__` prefix befo
 
 ## Action taxonomy
 
-Tool calls are classified into action types (`data.api.read`, `data.api.write`, …) by the daemon, using the bundled Agent Receipts taxonomy. GitHub and Atlassian MCP tools are covered out of the box, so reads are recorded as `data.api.read` and writes as `data.api.write` without any configuration.
+The daemon stores action types in `<channel>.<server>.<tool>` form — for example, `mcp.github-audited.create_branch`. Full taxonomy mapping that would reclassify tools to canonical types like `data.api.write` is not yet applied by the daemon; that work is tracked for a future release. Receipts for action types that do not match a built-in taxonomy entry carry `RiskMedium` as their risk level.
 
 Available action types include `filesystem.file.*`, `system.*`, and `data.api.*` (read, write, delete). See the [Action Taxonomy](/specification/action-taxonomy/) reference and the [taxonomy definitions](https://github.com/agent-receipts/ar/tree/main/spec/spec/taxonomy) for the full list, and open a PR to add or correct mappings.
 
-The proxy still does coarse prefix-based [operation classification](#operation-classification) locally to drive policy risk scoring — that is independent of the daemon's taxonomy-based action typing in the stored receipt.
+The proxy's prefix-based [operation classification](#operation-classification) drives policy risk scoring today and is independent of the daemon's action type labelling.
 
 ## Approval workflow
 
@@ -117,7 +117,7 @@ The [Approval Server page](/mcp-proxy/approval-ui/) has the full treatment — e
 
 ## Data redaction
 
-The daemon redacts sensitive data before storage using two passes:
+Tool-call inputs and outputs are **not stored as plaintext** — the daemon stores only a cryptographic hash of each (see [Payload disclosure](#payload-disclosure) below). Redaction applies to the **error text** stored when a tool call fails, using two passes:
 
 **JSON-aware redaction** replaces values of sensitive keys including: `password`, `token`, `api_key`, `secret`, `authorization`, `private_key`, `access_token`, `jwt`, `database_url`, `ssh_key`, `connection_string`, and others (42 keys total).
 

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -92,7 +92,7 @@ Tool names are classified by prefix (case-insensitive):
 | read | get\_, read\_, list\_, search\_, describe\_, show\_ |
 | unknown | (fallback) |
 
-MCP tool names are automatically stripped of their `mcp__<server>__` prefix before classification. For example, `mcp__github-audited__create_branch` is classified as `create_branch` (write). This means taxonomy mappings and policy rules use bare tool names.
+MCP tool names are automatically stripped of their `mcp__<server>__` prefix before classification. For example, `mcp__github-audited__create_branch` is classified as `create_branch` (write). This means policy rules use bare tool names.
 
 ## Action taxonomy
 

--- a/site/src/content/docs/mcp-proxy/cursor.mdx
+++ b/site/src/content/docs/mcp-proxy/cursor.mdx
@@ -1,0 +1,145 @@
+---
+title: Cursor Integration
+description: How to route Cursor MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+Cursor connects to MCP servers defined in `mcp.json` — globally at `~/.cursor/mcp.json` or per-project at `.cursor/mcp.json`. The Agent Receipts proxy wraps any MCP server transparently — Cursor doesn't know or care that the proxy is there.
+
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. If the proxy runs without `-http`, the listener is off and paused calls fail fast with `-32003`. To approve high-risk calls interactively, pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+:::
+
+:::danger[Never put secrets in mcp.json]
+`~/.cursor/mcp.json` is plaintext on disk, and a project `.cursor/mcp.json` is usually committed to version control. Anything you write into an `env` block is stored verbatim. Do **not** put a real token, API key, or other credential there. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below.
+:::
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- Cursor installed
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
+
+  ```bash
+  brew install github-mcp-server
+  ```
+
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
+
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching Cursor:
+
+```bash
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+```
+
+The proxy reaches the daemon over its default platform socket automatically. See [Daemon Setup](/getting-started/daemon-setup/) for install options and socket paths.
+
+## Configure mcp.json
+
+Open **Cursor Settings → MCP** (or **Tools & Integrations**) and click **Add new global MCP server** to open `~/.cursor/mcp.json`. For a project-scoped server, create `.cursor/mcp.json` at the repo root instead. The format uses a top-level `mcpServers` key.
+
+Cursor launches MCP servers without your shell's `PATH`, so use absolute paths. Print them first:
+
+```bash
+echo "op:     $(which op)"
+echo "proxy:  $(which mcp-proxy)"
+echo "server: $(which github-mcp-server)"
+```
+
+### Recommended: secret manager (`op run`, `aws-vault exec`, …)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Point Cursor at `op run` — it resolves the `op://` reference at exec time and injects the value into `mcp-proxy`'s env without writing it to `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/opt/homebrew/bin/op",
+      "args": [
+        "run",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
+        "-name", "github",
+        "-issuer-name", "Cursor",
+        "-operator-id", "did:web:cursor.com",
+        "-operator-name", "Anysphere",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`aws-vault exec`, `chamber exec` (AWS Parameter Store), and `direnv` with `op://` references all follow the same wrapping pattern.
+
+### Fallback: OS keychain launcher script
+
+If you don't have a secret manager, reuse the launcher script from [Claude Desktop's keychain fallback](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) (one script works across clients). Point `command` at the launcher and drop the env block — the script sets `GITHUB_PERSONAL_ACCESS_TOKEN` from the keychain:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
+      "args": [
+        "-name", "github",
+        "-issuer-name", "Cursor",
+        "-operator-id", "did:web:cursor.com",
+        "-operator-name", "Anysphere",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp each signed receipt so you can tell which client made a given call when reviewing a shared store — setting `-issuer-name` to `Cursor` here (and to `Claude Code`, `Codex`, etc. in the other guides) is what distinguishes them at audit time.
+
+Back in **Cursor Settings → MCP**, the `github-audited` server should show a green indicator and the list of tools the proxied server exposes. Toggle it on if needed, then use it from Cursor's Agent.
+
+## Verifying receipts
+
+The daemon signs and stores every tool call. After making calls through Cursor, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
+
+```bash
+# List recent receipts (newest first)
+agent-receipts list
+
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+```
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T02:05:19Z  default  get_file_contents
+3    2026-04-24T01:58:45Z  default  create_or_update_file
+2    2026-04-24T01:56:12Z  default  search_issues
+1    2026-04-24T01:45:07Z  default  list_issues
+```
+
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
+
+## Gotchas
+
+**Absolute paths required.** Cursor launches MCP servers with a clean `PATH`. Use the full path to `op`/`mcp-proxy` (find each with `which`) and the full path to the wrapped server binary.
+
+**Global vs project scope.** `~/.cursor/mcp.json` applies everywhere; `.cursor/mcp.json` applies only in that project. A project file is committed by default — keep secrets out of it (see the danger note above).
+
+**Server shows red / not connecting.** Open the MCP settings panel to see the error, and check the proxy is reachable. A bare command name is the usual culprit — switch to absolute paths.
+
+**No receipts appearing?** The daemon must be running *before* Cursor starts the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. Add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with `-32003`.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -49,9 +49,9 @@ Wrap any MCP server by passing its command as arguments. For a quick smoke test,
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
 
-The proxy intercepts stdin/stdout, logs every tool call, and forwards messages transparently. It always signs receipts locally — with `-key` if provided, or an ephemeral Ed25519 key pair otherwise. Separately, daemon forwarding sends a copy of each event to `agent-receipts-daemon` via the `--socket` flag (defaults to the platform socket path; set `--socket=""` to disable). Press `Ctrl-C` to stop.
+The proxy intercepts stdin/stdout, scores and classifies every tool call, applies policy, and forwards messages transparently. Completed events are emitted to `agent-receipts-daemon` over the `--socket` path (defaults to the platform socket; set `--socket=""` to disable emission) — the daemon signs, chains, and stores each receipt. The proxy holds no signing key and no store of its own ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Press `Ctrl-C` to stop.
 
-For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), or [Codex](/mcp-proxy/codex/).
+For wiring the proxy into an actual client, jump to [Claude Code](/mcp-proxy/claude-code/), [Claude Desktop](/mcp-proxy/claude-desktop/), [Codex](/mcp-proxy/codex/), [Cursor](/mcp-proxy/cursor/), [Windsurf](/mcp-proxy/windsurf/), [VS Code Copilot](/mcp-proxy/vscode-copilot/), [JetBrains AI Assistant](/mcp-proxy/jetbrains/), or [Cline](/mcp-proxy/cline/).
 
 ## Approval server (opt-in)
 
@@ -65,30 +65,29 @@ Most GitHub MCP tools don't reach the threshold — `create_pull_request` scores
 
 **Seeing `-32002` on a tool that shouldn't pause?** It's most likely client-side denial by the MCP client (e.g. Claude Code), not the proxy. See the [`-32002` troubleshooting entry](/mcp-proxy/configuration/#-32002-errors-on-tool-calls) for how to distinguish the two sources.
 
-## Standalone signing key
+## Signing keys live in the daemon
 
-For production use, key management is handled by `agent-receipts-daemon` — see [Daemon Setup](/getting-started/daemon-setup/). The instructions below are for standalone use (no daemon), where the proxy holds the signing key directly.
-
-`mcp-proxy init` does everything in one step: creates `~/.agent-receipts/`, generates an Ed25519 keypair with correct permissions, initialises the receipt database, and prints a ready-to-paste `claude_desktop_config.json` snippet:
+`mcp-proxy` no longer holds a signing key — `agent-receipts-daemon` owns the Ed25519 key and is the sole writer of receipts ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Generate the key once and start the daemon:
 
 ```bash
-mcp-proxy init
+agent-receipts-daemon --init   # one-time: generates the signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
 ```
 
-Use `--name` to label a specific proxy instance (the name appears in the config snippet key and in the key filename):
+`mcp-proxy init` is a convenience that scaffolds a client config: it creates the data directory (`~/.local/share/agent-receipts/`) and prints a `claude_desktop_config.json` starter snippet. It does **not** generate keys.
 
 ```bash
-mcp-proxy init --name github
-# creates ~/.agent-receipts/github.pem (0600) and ~/.agent-receipts/github.pem.pub
+mcp-proxy init                 # print a starter snippet for the "default" instance
+mcp-proxy init --name github   # label the snippet for a specific server
 ```
 
-Re-running `init` is safe — it warns and skips key generation if the files already exist. Pass `--force` to regenerate.
-
-Then run the proxy with the generated key (substitute your instance name if you used `--name`):
+Once the daemon is running, the proxy reaches it over the default platform socket automatically:
 
 ```bash
-mcp-proxy -key ~/.agent-receipts/default.pem npx -y @modelcontextprotocol/server-filesystem ~/Documents
+mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 ```
+
+See [Daemon Setup](/getting-started/daemon-setup/) for key paths, socket configuration, and running the daemon as a service.
 
 ## Next steps
 

--- a/site/src/content/docs/mcp-proxy/jetbrains.mdx
+++ b/site/src/content/docs/mcp-proxy/jetbrains.mdx
@@ -1,0 +1,149 @@
+---
+title: JetBrains AI Assistant Integration
+description: How to route JetBrains AI Assistant MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+JetBrains AI Assistant (IntelliJ IDEA, PyCharm, GoLand, and the other JetBrains IDEs) can connect to MCP servers from **Settings | Tools | AI Assistant | Model Context Protocol (MCP)**. The Agent Receipts proxy wraps any MCP server transparently — AI Assistant doesn't know or care that the proxy is there.
+
+:::note[AI Assistant, not Junie]
+This guide covers the **AI Assistant** plugin acting as an MCP *client* (introduced in 2025.1; needs IntelliJ IDEA 2025.1+ and a current AI Assistant plugin build). JetBrains' Junie agent has its own separate MCP configuration, and the "MCP Server" feature (the IDE acting as a server) is a different thing again — neither is covered here.
+:::
+
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. If the proxy runs without `-http`, the listener is off and paused calls fail fast with `-32003`. To approve high-risk calls interactively, pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+:::
+
+:::danger[Never put secrets in the MCP configuration]
+AI Assistant persists each server's command, arguments, and **environment variables** as part of the IDE settings. Anything you type into the *Environment Variables* field (or an `env` block in the "As JSON" form) is stored verbatim, and `${VAR}` expansion is **not** documented as supported. Do **not** put a real token, API key, or other credential there. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below.
+:::
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- IntelliJ IDEA 2025.1+ (or another JetBrains IDE on a matching build) with the AI Assistant plugin
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
+
+  ```bash
+  brew install github-mcp-server
+  ```
+
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
+
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching your IDE:
+
+```bash
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+```
+
+The proxy reaches the daemon over its default platform socket automatically. See [Daemon Setup](/getting-started/daemon-setup/) for install options and running it as a service.
+
+## Configure the MCP server
+
+JetBrains launches MCP servers without your shell's `PATH`, so use **absolute paths** for every command. Print the ones you need:
+
+```bash
+echo "op:     $(which op)"
+echo "proxy:  $(which mcp-proxy)"
+echo "server: $(which github-mcp-server)"
+```
+
+Open **Settings | Tools | AI Assistant | Model Context Protocol (MCP)**, click **Add**, then switch the dialog from **Command** to **As JSON** (the control in the top-left corner). Paste one of the configurations below, set a **Working directory** (any readable folder, e.g. your home directory), click **OK**, then **Apply**.
+
+### Recommended: secret manager (`op run`, `aws-vault exec`, …)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Point AI Assistant at `op run` — it resolves the `op://` reference at exec time and injects the value into `mcp-proxy`'s env without writing it to the IDE settings:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/opt/homebrew/bin/op",
+      "args": [
+        "run",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
+        "-name", "github",
+        "-issuer-name", "JetBrains AI Assistant",
+        "-operator-id", "did:web:jetbrains.com",
+        "-operator-name", "JetBrains",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`aws-vault exec`, `chamber exec` (AWS Parameter Store), and `direnv` with `op://` references all follow the same wrapping pattern.
+
+### Fallback: OS keychain launcher script
+
+If you don't have a secret manager, reuse the launcher script from [Claude Desktop's keychain fallback](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) (one script works across clients). Point `command` at the launcher and drop the env block — the script sets `GITHUB_PERSONAL_ACCESS_TOKEN` from the keychain:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
+      "args": [
+        "-name", "github",
+        "-issuer-name", "JetBrains AI Assistant",
+        "-operator-id", "did:web:jetbrains.com",
+        "-operator-name", "JetBrains",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp each signed receipt so you can tell which client made a given call when reviewing a shared store. Setting `-issuer-name` to `JetBrains AI Assistant` here (and to `Claude Code`, `Codex`, etc. in the other guides) is what distinguishes IDE sessions at audit time.
+
+After clicking **Apply**, the server appears in the list with a **Status** column: a green indicator means it connected, red means it failed. Click the icon in the Status column to see the tools the proxied server exposes. In the AI chat, the tools are now available to AI Assistant — it can call them while handling a request, or you can invoke one manually with its `/` command.
+
+## Verifying receipts
+
+The daemon signs and stores every tool call. After making calls through AI Assistant, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
+
+```bash
+# List recent receipts (newest first)
+agent-receipts list
+
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+```
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T02:05:19Z  default  get_file_contents
+3    2026-04-24T01:58:45Z  default  create_or_update_file
+2    2026-04-24T01:56:12Z  default  search_issues
+1    2026-04-24T01:45:07Z  default  list_issues
+```
+
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
+
+## Gotchas
+
+**Absolute paths required — red status otherwise.** JetBrains does not resolve commands through your shell `PATH`. If the Status column shows red, the most common cause is a bare command name; use the full path to `op`/`mcp-proxy`/the wrapped server (find each with `which`). The proxy's own stderr lands in the IDE's MCP logs (Help → Show Log in Explorer/Finder → `mcp` folder).
+
+**`${VAR}` expansion is not supported.** Unlike Claude Code, AI Assistant does not document variable interpolation in the Environment Variables field. Inject secrets with the secret-manager or keychain-launcher patterns above rather than referencing them by name.
+
+**No receipts appearing?** The daemon must be running *before* the IDE launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+
+**Import from Claude.** If you already configured the proxy for Claude Desktop, the **Import from Claude** button on the MCP settings page reads that config and adds the proxied servers here — no need to retype the JSON.
+
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. Add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with `-32003`.

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Proxy
-description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, signs receipts locally, and forwards events to agent-receipts-daemon when configured.
+description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, and forwards events to agent-receipts-daemon, which signs and stores the receipts.
 ---
 
 The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, and applies proxy-layer policy rules — then forwards the completed event to `agent-receipts-daemon` over a Unix socket. The daemon redacts sensitive data, signs an Ed25519 receipt, hash-chains it, and persists it. The proxy holds no key and no store of its own ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)) — so a compromised proxy cannot rewrite the chain. It does this without modifying the server or client.
@@ -17,7 +17,7 @@ Scores that cross 50: `create_token` (write 20 + sensitive 30 = 50), `update_aut
 
 - **Risk scoring** -- scores every tool call 0-100 based on operation type, sensitive keywords, and patterns
 - **Operation classification** -- classifies calls as read, write, delete, or execute by tool name
-- **Action taxonomy** -- classifies tool calls using configurable taxonomy mappings; GitHub and Atlassian MCP servers are covered by bundled taxonomies out of the box
+- **Action taxonomy** -- daemon stores action types as `<channel>.<server>.<tool>`; full taxonomy remapping to canonical types like `data.api.read` is tracked for a future release
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy rules** (proxy layer) -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** (proxy layer) -- HTTP endpoints for async approval of paused operations

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -155,7 +155,7 @@ Each tool call produces a signed W3C Verifiable Credential. Key fields shown (ab
 ```json
 {
   "issuer": {
-    "id": "did:agent:mcp-proxy",
+    "id": "did:agent-receipts-daemon:local",
     "name": "Claude Code",
     "operator": {
       "id": "did:web:anthropic.com",

--- a/site/src/content/docs/mcp-proxy/overview.mdx
+++ b/site/src/content/docs/mcp-proxy/overview.mdx
@@ -3,7 +3,7 @@ title: MCP Proxy
 description: Transparent audit proxy for MCP servers — classifies and scores tool calls, applies proxy-layer policy rules, signs receipts locally, and forwards events to agent-receipts-daemon when configured.
 ---
 
-The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, applies proxy-layer policy rules, redacts sensitive data, and signs and stores an Ed25519 receipt locally. When `agent-receipts-daemon` is configured via `--socket`, it also forwards events to the daemon for an independently signed and stored chain — without modifying the server or client.
+The MCP Proxy is a transparent stdin/stdout proxy that sits between an MCP client (Claude Desktop, Claude Code, etc.) and any MCP server. It intercepts every tool call, classifies and scores it, and applies proxy-layer policy rules — then forwards the completed event to `agent-receipts-daemon` over a Unix socket. The daemon redacts sensitive data, signs an Ed25519 receipt, hash-chains it, and persists it. The proxy holds no key and no store of its own ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)) — so a compromised proxy cannot rewrite the chain. It does this without modifying the server or client.
 
 **Repository:** [`mcp-proxy/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy)
 
@@ -21,12 +21,11 @@ Scores that cross 50: `create_token` (write 20 + sensitive 30 = 50), `update_aut
 - **MCP prefix stripping** -- automatically strips `mcp__<server>__` prefixes so receipts and classification use clean tool names
 - **Policy rules** (proxy layer) -- YAML rules engine with four actions: pass, flag, pause (approval required), and block
 - **Approval workflows** (proxy layer) -- HTTP endpoints for async approval of paused operations
-- **Cryptographic receipts** -- Ed25519-signed W3C Verifiable Credentials, hash-chained per session; events are also forwarded to `agent-receipts-daemon` when `--socket` is configured
+- **Cryptographic receipts** -- the daemon signs each forwarded event as an Ed25519 W3C Verifiable Credential and hash-chains it; the proxy itself never holds the key
 - **Issuer identity** -- receipts identify the AI agent, model, and operator via CLI flags
 - **Intent tracking** -- groups related tool calls by temporal proximity
-- **Data redaction** -- JSON-aware and pattern-based redaction of secrets before storage
-- **Encryption at rest** -- optional AES-256-GCM encryption of audit data
-- **Audit CLI** -- list, inspect, verify, export, and query receipts from the command line
+- **Data redaction** (daemon) -- JSON-aware and pattern-based redaction of secrets before storage
+- **Audit CLI** -- list, show, and verify receipts with the [`agent-receipts`](/reference/cli-commands/#agent-receipts) CLI
 
 ```mermaid
 flowchart TD
@@ -53,14 +52,13 @@ MCP Client (Claude Desktop / Claude Code)
     |  - classify operation
     |  - score risk
     |  - evaluate policy rules
-    |  - redact sensitive data (local storage)
-    |  - sign receipt (Ed25519) → local SQLite
     |  - forward event (--socket) ─────────────> agent-receipts-daemon
-    v                                                 - sign independently
- MCP Server (any)                                     - append to daemon chain
+    v                                                 - redact sensitive data
+ MCP Server (any)                                     - sign receipt (Ed25519)
+                                                      - hash-chain + persist
 ```
 
-The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each tool call produces a locally signed Agent Receipt. When `--socket` points to a running `agent-receipts-daemon`, events are also forwarded for an independently signed chain.
+The proxy reads JSON-RPC messages on stdin, processes `tools/call` requests, forwards them to the wrapped server, and returns the response. Each completed tool call is emitted to `agent-receipts-daemon` over `--socket`, which signs it into the receipt chain. Start the daemon before the proxy — see [Daemon Setup](/getting-started/daemon-setup/).
 
 ```mermaid
 graph LR
@@ -81,13 +79,11 @@ brew install agent-receipts/tap/mcp-proxy
 mcp-proxy npx -y @modelcontextprotocol/server-filesystem ~/Documents
 
 # With configuration (example: GitHub's official MCP server — brew install github-mcp-server)
-# -key sets the local signing key (omit for an ephemeral key).
-# Daemon forwarding is a separate path configured via --socket — see Daemon Setup.
+# Receipts are signed and stored by agent-receipts-daemon — start it first (see Daemon Setup).
 mcp-proxy \
   -name github \
-  -key private.pem \
   -rules rules.yaml \
-  -taxonomy taxonomy.json \
+  -issuer-name "Claude Code" \
   github-mcp-server stdio
 ```
 
@@ -108,7 +104,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
         "--",
         "/Users/YOU/go/bin/mcp-proxy",
         "-name", "github",
-        "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -130,7 +125,6 @@ claude mcp add-json github-audited --scope user '{
   "command": "/Users/YOU/go/bin/mcp-proxy",
   "args": [
     "-name", "github",
-    "-key", "/Users/YOU/.local/share/agent-receipts/github-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -186,22 +180,19 @@ Each tool call produces a signed W3C Verifiable Credential. Key fields shown (ab
 }
 ```
 
-Receipts are Ed25519-signed, hash-chained per session, and stored in a local SQLite database. Use `mcp-proxy list`, `mcp-proxy inspect`, and `mcp-proxy verify` to query and validate them.
+Receipts are Ed25519-signed by the daemon, hash-chained, and stored in a local SQLite database. Use `agent-receipts list`, `agent-receipts show`, and `agent-receipts verify` to query and validate them.
 
-`mcp-proxy list` gives a compact tabular view. The SERVER column is populated from the server name (defaulting to the wrapped command's basename if `-name` is omitted). When you proxy multiple MCP servers — for example GitHub and Atlassian — the SERVER and TOOL columns let you scan activity across all of them at once:
+`agent-receipts list` gives a compact tabular view of the daemon's store. When you proxy multiple MCP servers — for example GitHub and Atlassian — the TOOL column lets you scan activity across all of them at once:
 
 ```
-$ mcp-proxy list
-ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
----
-urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.read          low      success  2026-04-24T02:05:19Z
-urn:receipt:103200d1... github         issue_write                    data.api.write         medium   success  2026-04-24T01:58:45Z
-urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
-urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
-urn:receipt:276a6c2a... github         issue_write                    data.api.write         medium   success  2026-04-24T01:48:55Z
-urn:receipt:a72ee10b... github         list_issues                    data.api.read          low      success  2026-04-24T01:45:07Z
-
-6 receipts
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+6    2026-04-24T02:05:19Z  default  getJiraIssue
+5    2026-04-24T01:58:45Z  default  issue_write
+4    2026-04-24T01:56:12Z  default  searchJiraIssuesUsingJql
+3    2026-04-24T01:56:06Z  default  getAccessibleAtlassianResources
+2    2026-04-24T01:48:55Z  default  issue_write
+1    2026-04-24T01:45:07Z  default  list_issues
 ```
 
 See [Installation](/mcp-proxy/installation/) to get started, or [Configuration](/mcp-proxy/configuration/) for the full set of options.

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -90,7 +90,7 @@ The first time the server is invoked, `mcp-remote` opens a browser tab to comple
 
 ## Bundled taxonomy
 
-The daemon classifies each tool call against the bundled Agent Receipts taxonomy, which covers Atlassian's Jira and Confluence tools (`createJiraIssue`, `editJiraIssue`, `searchJiraIssuesUsingJql`, `createConfluencePage`, `updateConfluencePage`, and others), so writes are recorded as `data.api.write` and reads as `data.api.read` out of the box — no extra configuration required.
+The daemon stores action types in `<channel>.<server>.<tool>` form — for example, `mcp.atlassian.createJiraIssue`. Full taxonomy mapping that would reclassify Atlassian tools to canonical types like `data.api.write` and `data.api.read` is not yet applied at the daemon level and is tracked for a future release. The proxy's prefix-based operation classification drives policy risk scoring today.
 
 See the [Action Taxonomy](/specification/action-taxonomy/) reference for the full set of mappings, and open a PR against the [taxonomy definitions](https://github.com/agent-receipts/ar/tree/main/spec/spec/taxonomy) to add or correct entries.
 

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -29,20 +29,20 @@ Remote MCP Server (e.g. mcp.atlassian.com/v1/mcp)
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
-- A signing key pair generated (see below)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - Node.js (for `npx mcp-remote`)
 - A remote MCP endpoint and an account that can authorise it. The example below uses Atlassian's Remote MCP Server at `https://mcp.atlassian.com/v1/mcp`.
 
-## Generate a signing key
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before connecting your MCP client:
 
 ```bash
-mcp-proxy init --name atlassian-proxy
-# creates ~/.local/share/agent-receipts/atlassian-proxy.pem (0600) and ~/.local/share/agent-receipts/atlassian-proxy.pem.pub
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
 ```
 
-:::tip[Reuse an existing key]
-One signing key works for all servers. If you already have a key from a previous setup (e.g. `github-proxy.pem`), you can reuse it here — just point `-key` at that file instead.
-:::
+One daemon signs receipts for every proxied server — local and remote alike. See [Daemon Setup](/getting-started/daemon-setup/) for install options and socket paths.
 
 ## Worked example: Atlassian (Jira + Confluence)
 
@@ -55,7 +55,6 @@ Add an entry to your MCP client config that runs `mcp-proxy` wrapping `npx mcp-r
       "command": "/Users/YOU/go/bin/mcp-proxy",
       "args": [
         "-name", "atlassian",
-        "-key", "/Users/YOU/.local/share/agent-receipts/atlassian-proxy.pem",
         "-issuer-name", "Claude Desktop",
         "-operator-id", "did:web:anthropic.com",
         "-operator-name", "Anthropic",
@@ -74,7 +73,6 @@ claude mcp add-json atlassian-audited --scope user '{
   "command": "/Users/YOU/go/bin/mcp-proxy",
   "args": [
     "-name", "atlassian",
-    "-key", "'"$HOME"'/.local/share/agent-receipts/atlassian-proxy.pem",
     "-issuer-name", "Claude Code",
     "-operator-id", "did:web:anthropic.com",
     "-operator-name", "Anthropic",
@@ -85,7 +83,6 @@ claude mcp add-json atlassian-audited --scope user '{
 ```
 
 :::note[Path tips]
-- **Key path:** `$HOME` expands in the shell so you don't need to hard-code `/Users/you`. The snippet above uses single-quote escaping (`'"$HOME"'`) so the variable expands before the JSON is passed to `claude mcp add-json`.
 - **Binary path:** Claude Desktop doesn't inherit your shell `PATH`, so GUI-launched instances may fail to find `mcp-proxy` if it's in `~/go/bin`. Use the full path — run `which mcp-proxy` to find it.
 :::
 
@@ -93,9 +90,9 @@ The first time the server is invoked, `mcp-remote` opens a browser tab to comple
 
 ## Bundled taxonomy
 
-The proxy ships with bundled mappings for Atlassian's Jira and Confluence tools (`createJiraIssue`, `editJiraIssue`, `searchJiraIssuesUsingJql`, `createConfluencePage`, `updateConfluencePage`, and others), so writes are scored as `data.api.write` and reads as `data.api.read` out of the box. No `-taxonomy` flag is required for those names. To extend or override, supply your own JSON file via `-taxonomy /path/to/file.json` — user mappings win on conflict. To disable the bundled set entirely, pass `-bundled-taxonomies=false`.
+The daemon classifies each tool call against the bundled Agent Receipts taxonomy, which covers Atlassian's Jira and Confluence tools (`createJiraIssue`, `editJiraIssue`, `searchJiraIssuesUsingJql`, `createConfluencePage`, `updateConfluencePage`, and others), so writes are recorded as `data.api.write` and reads as `data.api.read` out of the box — no extra configuration required.
 
-The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy/configs) — open a PR to add or correct mappings.
+See the [Action Taxonomy](/specification/action-taxonomy/) reference for the full set of mappings, and open a PR against the [taxonomy definitions](https://github.com/agent-receipts/ar/tree/main/spec/spec/taxonomy) to add or correct entries.
 
 ## Caveats
 
@@ -108,7 +105,7 @@ The list of bundled taxonomies lives at [`mcp-proxy/configs/`](https://github.co
 **Fix:** run the full proxy command directly in a terminal first, complete the browser OAuth, then Ctrl+C and reconnect via `/mcp`:
 
 ```bash
-$HOME/go/bin/mcp-proxy -name atlassian -key ~/.local/share/agent-receipts/atlassian-proxy.pem \
+$HOME/go/bin/mcp-proxy -name atlassian \
   npx --registry https://registry.npmjs.org -y mcp-remote https://mcp.atlassian.com/v1/mcp
 ```
 

--- a/site/src/content/docs/mcp-proxy/remote-servers.mdx
+++ b/site/src/content/docs/mcp-proxy/remote-servers.mdx
@@ -6,7 +6,7 @@ description: How to audit remote HTTP/SSE MCP servers — like the Atlassian Rem
 The Agent Receipts proxy expects an upstream MCP server it can spawn as a local stdio process. A growing class of MCP servers — **Atlassian, Slack, Linear, HubSpot, Notion, and others** — are hosted as remote HTTP/SSE endpoints behind OAuth instead. To audit those today, compose [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) in front of `mcp-proxy`: `mcp-remote` handles the OAuth dance and exposes a stdio MCP transport, which the proxy then wraps as it would any local server.
 
 :::note[Why this is its own page]
-The composition pattern works, but a few things differ from local-server setups: ports stack up, OAuth is invisible to the proxy, and bundled taxonomies are what give risk scoring meaning out of the box. Native HTTP/SSE support inside `mcp-proxy` is tracked in [issue #227](https://github.com/agent-receipts/ar/issues/227); until that lands, this page is the supported path.
+The composition pattern works, but a few things differ from local-server setups: ports stack up, OAuth is invisible to the proxy, and the proxy's prefix-based operation classification drives risk scoring. Native HTTP/SSE support inside `mcp-proxy` is tracked in [issue #227](https://github.com/agent-receipts/ar/issues/227); until that lands, this page is the supported path.
 :::
 
 ## How the composition works
@@ -15,7 +15,7 @@ The composition pattern works, but a few things differ from local-server setups:
 MCP Client (Claude / Codex)
         │  stdio
         ▼
-   mcp-proxy   ◄── audits, scores, signs receipts
+   mcp-proxy   ◄── audits, scores, forwards to daemon
         │  stdio
         ▼
    mcp-remote  ◄── OAuth flow, token refresh, transport bridge

--- a/site/src/content/docs/mcp-proxy/vscode-copilot.mdx
+++ b/site/src/content/docs/mcp-proxy/vscode-copilot.mdx
@@ -1,0 +1,124 @@
+---
+title: VS Code Copilot Integration
+description: How to route VS Code GitHub Copilot MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+GitHub Copilot's **agent mode** in VS Code connects to MCP servers defined in a `mcp.json` file. The Agent Receipts proxy wraps any MCP server transparently — Copilot doesn't know or care that the proxy is there.
+
+:::note[Agent mode required]
+MCP tools are only available in Copilot Chat's **Agent** mode (pick it from the mode dropdown in the Chat view). Ask mode and Edit mode do not call MCP tools.
+:::
+
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. If the proxy runs without `-http`, the listener is off and paused calls fail fast with `-32003`. To approve high-risk calls interactively, pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+:::
+
+:::tip[Secrets: use `inputs`, not literals]
+VS Code's `mcp.json` is plaintext on disk (and `.vscode/mcp.json` is usually committed). **Never** write a token as a literal string. VS Code's `inputs` mechanism prompts for the value once and keeps it out of the file — that's the pattern used below. A secret-manager wrapper (`op run`, …) works too, as shown in the [Claude Desktop guide](/mcp-proxy/claude-desktop/#recommended-secret-manager-op-run-aws-vault-exec-).
+:::
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- VS Code with GitHub Copilot (a recent version with MCP support)
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
+
+  ```bash
+  brew install github-mcp-server
+  ```
+
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
+
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching VS Code:
+
+```bash
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+```
+
+The proxy reaches the daemon over its default platform socket automatically. See [Daemon Setup](/getting-started/daemon-setup/) for install options and socket paths.
+
+## Configure mcp.json
+
+Create `.vscode/mcp.json` in your workspace (or run **MCP: Open User Configuration** from the Command Palette for a global config). VS Code's MCP schema uses a top-level **`servers`** key — not `mcpServers` — plus an optional **`inputs`** array for prompted values.
+
+Use absolute paths for `command` and the wrapped server binary. Print them first:
+
+```bash
+echo "proxy:  $(which mcp-proxy)"
+echo "server: $(which github-mcp-server)"
+```
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "github-token",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "github-audited": {
+      "type": "stdio",
+      "command": "/Users/YOU/go/bin/mcp-proxy",
+      "args": [
+        "-name", "github",
+        "-issuer-name", "VS Code Copilot",
+        "-operator-id", "did:web:github.com",
+        "-operator-name", "GitHub",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-token}"
+      }
+    }
+  }
+}
+```
+
+`${input:github-token}` resolves to the value VS Code prompts for the first time the server starts; the token never lands in the file. You can also reference `${workspaceFolder}` and `${env:VARNAME}` in this config.
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp each signed receipt so you can tell which client made a given call when reviewing a shared store — setting `-issuer-name` to `VS Code Copilot` here (and to `Claude Code`, `Codex`, etc. in the other guides) is what distinguishes them at audit time.
+
+Click the **Start** code lens that appears above the server entry in `mcp.json` (or run **MCP: List Servers** → your server → Start). VS Code prompts for the token, then shows the server as running. Open Copilot Chat in **Agent** mode and confirm the proxied server's tools appear in the tools picker.
+
+## Verifying receipts
+
+The daemon signs and stores every tool call. After making calls through Copilot, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
+
+```bash
+# List recent receipts (newest first)
+agent-receipts list
+
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+```
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T02:05:19Z  default  get_file_contents
+3    2026-04-24T01:58:45Z  default  create_or_update_file
+2    2026-04-24T01:56:12Z  default  list_pull_requests
+1    2026-04-24T01:45:07Z  default  list_issues
+```
+
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
+
+## Gotchas
+
+**`servers`, not `mcpServers`.** VS Code's `mcp.json` uses the `servers` key. A config copied from a Claude Desktop / Cursor example (which use `mcpServers`) will silently fail to register. Each stdio entry needs `"type": "stdio"`.
+
+**Absolute paths.** Point `command` at the full path to `mcp-proxy` (find it with `which mcp-proxy`) and use the full path to the wrapped server binary, so the launch doesn't depend on a resolved `PATH`.
+
+**Tools only appear in Agent mode.** If Copilot isn't calling the tools, confirm the Chat view is in **Agent** mode and that the server shows as started under **MCP: List Servers**.
+
+**No receipts appearing?** The daemon must be running *before* VS Code starts the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. Add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with `-32003`.

--- a/site/src/content/docs/mcp-proxy/windsurf.mdx
+++ b/site/src/content/docs/mcp-proxy/windsurf.mdx
@@ -1,0 +1,145 @@
+---
+title: Windsurf Integration
+description: How to route Windsurf (Cascade) MCP servers through the Agent Receipts proxy for cryptographic audit trails.
+---
+
+Windsurf's Cascade assistant connects to MCP servers defined in `~/.codeium/windsurf/mcp_config.json`. The Agent Receipts proxy wraps any MCP server transparently — Windsurf doesn't know or care that the proxy is there.
+
+:::note[Approval workflow]
+The default policy includes a `pause_high_risk` rule. If the proxy runs without `-http`, the listener is off and paused calls fail fast with `-32003`. To approve high-risk calls interactively, pass `-http 127.0.0.1:<port>` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/).
+:::
+
+:::danger[Never put secrets in mcp_config.json]
+`~/.codeium/windsurf/mcp_config.json` is plaintext on disk. Anything you write into an `env` block is stored verbatim. Do **not** put a real token, API key, or other credential there. Use a secret-manager wrapper (`op run`, `aws-vault exec`, …) or an OS keychain launcher script — both are documented below.
+:::
+
+## Prerequisites
+
+- [mcp-proxy installed](/mcp-proxy/installation/)
+- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- Windsurf installed
+- The MCP server you want to audit. The examples below wrap GitHub's official MCP server:
+
+  ```bash
+  brew install github-mcp-server
+  ```
+
+  This puts a `github-mcp-server` binary on your `$PATH`. Verify with `which github-mcp-server`.
+
+## Start the daemon
+
+The proxy holds no signing key of its own — `agent-receipts-daemon` owns the key and writes every receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise the key once and start the daemon before launching Windsurf:
+
+```bash
+agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
+agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+```
+
+The proxy reaches the daemon over its default platform socket automatically. See [Daemon Setup](/getting-started/daemon-setup/) for install options and socket paths.
+
+## Configure mcp_config.json
+
+In the Cascade panel, open the MCP/plugins controls and choose **View raw config** to open `~/.codeium/windsurf/mcp_config.json` (you can also edit the file directly). The format uses a top-level `mcpServers` key.
+
+Windsurf launches MCP servers without your shell's `PATH`, so use absolute paths. Print them first:
+
+```bash
+echo "op:     $(which op)"
+echo "proxy:  $(which mcp-proxy)"
+echo "server: $(which github-mcp-server)"
+```
+
+### Recommended: secret manager (`op run`, `aws-vault exec`, …)
+
+Install the 1Password CLI (`brew install 1password-cli`), sign in (`op signin`), and create a referenced env file:
+
+```ini
+# ~/.local/share/agent-receipts/mcp.env  (chmod 600)
+GITHUB_PERSONAL_ACCESS_TOKEN=op://Personal/GitHub/token
+```
+
+Point Windsurf at `op run` — it resolves the `op://` reference at exec time and injects the value into `mcp-proxy`'s env without writing it to `mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/opt/homebrew/bin/op",
+      "args": [
+        "run",
+        "--env-file=/Users/YOU/.local/share/agent-receipts/mcp.env",
+        "--",
+        "/Users/YOU/go/bin/mcp-proxy",
+        "-name", "github",
+        "-issuer-name", "Windsurf",
+        "-operator-id", "did:web:windsurf.com",
+        "-operator-name", "Windsurf",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`aws-vault exec`, `chamber exec` (AWS Parameter Store), and `direnv` with `op://` references all follow the same wrapping pattern.
+
+### Fallback: OS keychain launcher script
+
+If you don't have a secret manager, reuse the launcher script from [Claude Desktop's keychain fallback](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) (one script works across clients). Point `command` at the launcher and drop the env block — the script sets `GITHUB_PERSONAL_ACCESS_TOKEN` from the keychain:
+
+```json
+{
+  "mcpServers": {
+    "github-audited": {
+      "command": "/Users/YOU/.local/share/agent-receipts/run-mcp-proxy-github.sh",
+      "args": [
+        "-name", "github",
+        "-issuer-name", "Windsurf",
+        "-operator-id", "did:web:windsurf.com",
+        "-operator-name", "Windsurf",
+        "/opt/homebrew/bin/github-mcp-server", "stdio"
+      ]
+    }
+  }
+}
+```
+
+`-issuer-name`, `-operator-id`, and `-operator-name` stamp each signed receipt so you can tell which client made a given call when reviewing a shared store — setting `-issuer-name` to `Windsurf` here (and to `Claude Code`, `Codex`, etc. in the other guides) is what distinguishes them at audit time.
+
+Back in the Cascade MCP panel, click **Refresh** so Windsurf re-reads the config. The `github-audited` server should appear with the tools the proxied server exposes; use it from Cascade.
+
+## Verifying receipts
+
+The daemon signs and stores every tool call. After making calls through Windsurf, query and verify the store with the `agent-receipts` CLI (installed alongside the daemon). It opens the database read-only, so it is safe to run while the daemon is writing:
+
+```bash
+# List recent receipts (newest first)
+agent-receipts list
+
+# Verify the chain's signatures and hash links
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+```
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+4    2026-04-24T02:05:19Z  default  get_file_contents
+3    2026-04-24T01:58:45Z  default  create_or_update_file
+2    2026-04-24T01:56:12Z  default  search_issues
+1    2026-04-24T01:45:07Z  default  list_issues
+```
+
+`agent-receipts verify` prints `Chain default: VALID (4 receipts)` when signatures and hash links are intact. Inspect a single receipt — including its action type, risk level, and parameters hash — with `agent-receipts show <seq>`. See the [CLI reference](/reference/cli-commands/#agent-receipts) for all subcommands.
+
+## Gotchas
+
+**Absolute paths required.** Windsurf launches MCP servers with a clean `PATH`. Use the full path to `op`/`mcp-proxy` (find each with `which`) and the full path to the wrapped server binary.
+
+**Refresh after editing.** Windsurf reads `mcp_config.json` on demand — after editing the file, click **Refresh** in the Cascade MCP panel rather than expecting a live reload.
+
+**Keep the toolset focused.** Windsurf exposes a bounded number of MCP tools to Cascade at once; wrapping a server through the proxy doesn't change its tool count, but if you proxy several large servers, disable the ones you aren't using so Cascade sees the tools that matter.
+
+**No receipts appearing?** The daemon must be running *before* Windsurf starts the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+
+**Want human-in-the-loop approvals? Opt in with `-http`.** The approval listener is off by default. Add `-http 127.0.0.1:<port>` to `args` and run an approver — see [Approval Server](/mcp-proxy/approval-ui/). Without it, a paused call fails immediately with `-32003`.

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -1,13 +1,21 @@
 ---
 title: CLI Commands
-description: Command reference for the Agent Receipts CLI tools — mcp-proxy audit commands and agent-receipts-hook.
+description: Command reference for the Agent Receipts CLI tools — the mcp-proxy policy proxy, the agent-receipts read/verify CLI, and agent-receipts-hook.
 ---
 
-This page covers the `mcp-proxy` audit subcommands and the `agent-receipts-hook` PostToolUse hook binary.
+This page covers three binaries:
 
-> The default `-db` and `-receipt-db` paths shown below resolve via Go's `os.UserHomeDir()`. On Unix and macOS this is `$HOME`; on Windows this uses the OS user home directory, typically `%USERPROFILE%`.
+- **`mcp-proxy`** — wraps an MCP server, enforces policy, and forwards completed tool-call events to `agent-receipts-daemon`. Since v0.9.0 the proxy holds **no store of its own** — signing, chaining, and persistence are the daemon's job ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). It has no signing key and no `list`/`verify` subcommands.
+- **`agent-receipts`** — the daemon's read-side companion CLI. Lists, shows, and verifies receipts from the daemon-written store. Installed alongside `agent-receipts-daemon` (Homebrew installs both).
+- **`agent-receipts-hook`** — the PostToolUse hook binary that captures native host tool calls.
 
-## `mcp-proxy -version`
+> The `agent-receipts` `--db` and `--public-key` defaults resolve via the same per-user paths the daemon uses (`$XDG_DATA_HOME/agent-receipts/`, falling back to `~/.local/share/agent-receipts/`). See [Daemon Setup](/getting-started/daemon-setup/) for how those paths are chosen and how to override them.
+
+## `mcp-proxy`
+
+`mcp-proxy` has three subcommands — `serve` (the default), `doctor`, and `init` — plus `-version`. There are no audit subcommands on the proxy; querying and verifying receipts is done with [`agent-receipts`](#agent-receipts).
+
+### `mcp-proxy -version`
 
 Print the version and exit.
 
@@ -16,153 +24,29 @@ mcp-proxy -version
 # mcp-proxy vX.Y.Z
 ```
 
-## `mcp-proxy list`
+### `mcp-proxy serve`
 
-List receipts from the audit store. Results are sorted **newest first** — the most recent receipts appear at the top. Default limit is 50.
-
-```bash
-mcp-proxy list                            # latest 50 receipts, newest first
-mcp-proxy list -risk high                 # filter by risk level
-mcp-proxy list -action data.api.read      # filter by action type (taxonomy value)
-mcp-proxy list -chain <chain-id>          # filter by chain
-mcp-proxy list -limit 100                 # limit results
-mcp-proxy list -json                      # JSON output
-mcp-proxy list -f                         # tail-like: stream new receipts live
-mcp-proxy list --follow --interval 1s     # custom poll interval
-```
-
-| Flag | Description |
-|------|-------------|
-| `-risk` | Filter by risk level: `low`, `medium`, `high`, `critical` |
-| `-action` | Filter by action type |
-| `-chain` | Filter by chain ID |
-| `-limit` | Maximum number of receipts to return (default: `50`) |
-| `-json` | Output as JSON (NDJSON — one object per line — in `--follow` mode) |
-| `-follow`, `-f` | After the initial listing, keep polling and stream new receipts as they are inserted (`tail -f`-style). Exit with `Ctrl-C`. In `--follow` mode, the startup batch is printed in chronological order (oldest → newest) so it reads continuously with the streamed tail. |
-| `-interval` | Poll interval in `--follow` mode (default: `500ms`) |
-| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
-
-### Example output
-
-```
-$ mcp-proxy list
-ID                     SERVER         TOOL                           ACTION                 RISK     STATUS   TIMESTAMP
----
-urn:receipt:b4b430f9... atlassian      getJiraIssue                   data.api.read          low      success  2026-04-24T02:05:19Z
-urn:receipt:32506b71... atlassian      searchJiraIssuesUsingJql       data.api.read          low      success  2026-04-24T01:56:12Z
-urn:receipt:f5da030f... atlassian      getAccessibleAtlassianResou... data.api.read          low      success  2026-04-24T01:56:06Z
-urn:receipt:a125fd30... github         list_pull_requests             data.api.read          low      success  2026-04-24T01:44:20Z
-urn:receipt:67fede57... github         add_reply_to_pull_reques...    data.api.write         medium   success  2026-04-24T00:51:57Z
-urn:receipt:013bfc43... github         request_copilot_review         data.api.write         medium   success  2026-04-24T00:43:40Z
-urn:receipt:7ae4f1b2... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:35Z
-urn:receipt:d52ba1fd... github         issue_write                    data.api.write         medium   success  2026-04-24T00:19:25Z
-
-8 receipts
-```
-
-SERVER identifies which MCP server handled the call. It comes from the `-name` flag, defaulting to the wrapped command's basename if `-name` is omitted. TOOL is the raw tool name (truncated at 30 characters). When running multiple proxied servers simultaneously — for example GitHub and Atlassian — the SERVER column is how you tell their receipts apart at a glance.
-
-The `-action` filter matches the ACTION column (taxonomy type, e.g. `data.api.read`), not the TOOL column. Issuer and operator identity isn't shown in the tabular view — use `mcp-proxy list -json` to see it.
-
-## `mcp-proxy inspect`
-
-Show details for a single receipt.
+Wrap an MCP server. `serve` is the default, so the subcommand token is optional — `mcp-proxy <command>` and `mcp-proxy serve <command>` are equivalent. The proxy scores and classifies each tool call, applies policy, and forwards completed events to the daemon over `--socket`.
 
 ```bash
-mcp-proxy inspect <receipt-id>
-mcp-proxy inspect -key public.pem <receipt-id>   # verify signature
+mcp-proxy -name github -issuer-name "Claude Code" github-mcp-server stdio
 ```
 
-| Flag | Description |
-|------|-------------|
-| `-key` | Public key PEM file to verify the receipt signature |
-| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-rules` | (built-in defaults) | Policy rules YAML file |
+| `-name` | (inferred from command) | Server name for the audit trail |
+| `-http` | `none` | HTTP address for the approval listener. Off by default. Pass `127.0.0.1:0` for a random free port or `127.0.0.1:<port>` to pin one. See [Approval Server](/mcp-proxy/approval-ui/). |
+| `-approval-timeout` | `1m0s` | Maximum time to wait for HTTP approval before a paused call is auto-denied |
+| `-socket` | platform default | Unix-domain socket for `agent-receipts-daemon` (env: `AGENTRECEIPTS_SOCKET`). Pass `--socket=""` to disable emission entirely. Emit errors are logged but do not block tool calls. |
+| `-issuer-name` | (auto-detected) | Issuer name, e.g. `Claude Code` (env: `AGENTRECEIPTS_ISSUER_NAME`) |
+| `-issuer-model` | (none) | AI model identifier, e.g. `claude-sonnet-4-6` (env: `AGENTRECEIPTS_ISSUER_MODEL`) |
+| `-operator-id` | (none) | Operator DID (organisation running the agent), e.g. `did:web:anthropic.com` (env: `AGENTRECEIPTS_OPERATOR_ID`) |
+| `-operator-name` | (none) | Operator name, e.g. `Anthropic` (env: `AGENTRECEIPTS_OPERATOR_NAME`) |
 
-## `mcp-proxy verify`
+`-operator-name` requires `-operator-id`. See [Configuration](/mcp-proxy/configuration/) for policy rules, risk scoring, and the approval workflow.
 
-Verify the integrity of a receipt chain -- checks signatures, hash linkage, and sequence numbers.
-
-```bash
-mcp-proxy verify -key public.pem <chain-id>
-```
-
-| Flag | Description |
-|------|-------------|
-| `-key` | Public key PEM file (required) |
-| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
-
-## `mcp-proxy export`
-
-Export a receipt chain as JSON.
-
-```bash
-mcp-proxy export <chain-id>
-mcp-proxy export <chain-id> > chain.json
-```
-
-| Flag | Description |
-|------|-------------|
-| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
-
-## `mcp-proxy stats`
-
-Show aggregate statistics about the audit store.
-
-```bash
-mcp-proxy stats
-mcp-proxy stats -json
-```
-
-| Flag | Description |
-|------|-------------|
-| `-json` | Output as JSON |
-| `-receipt-db` | Receipt store path (default: `$HOME/.local/share/agent-receipts/receipts.db`) |
-
-## `mcp-proxy timing`
-
-Show per-tool timing breakdown from the audit database. Reports average phase durations (policy evaluation, approval wait, upstream call, receipt signing) and p50/p95/p99 percentiles.
-
-```bash
-mcp-proxy timing                              # all sessions
-mcp-proxy timing -session <session-id>        # filter by session
-mcp-proxy timing -json                        # JSON output
-mcp-proxy timing -limit 10                    # top 10 tools
-```
-
-| Flag | Description |
-|------|-------------|
-| `-db` | Audit database path (default: `$HOME/.local/share/agent-receipts/audit.db`) |
-| `-session` | Filter by session ID |
-| `-limit` | Maximum number of tools to show (default: `20`) |
-| `-json` | Output as JSON |
-
-### Example output
-
-```
-$ mcp-proxy timing
-Tool call timing (73 calls)
-
-Per-tool averages:
-TOOL                            COUNT UPSTREAM(us) POLICY(us) RECEIPT(us)  APPROVAL(us)  TOTAL(ms)
-get_file_contents                  21            -          -           -             -        679
-create_or_update_file              15            -          -           -             -       1162
-search_issues                       6       747952          2         468             -        790
-create_issue                        5            -          -           -             -       3742
-create_branch                       5            -          -           -             -       1123
-
-Percentiles:
-PHASE                  p50        p95        p99
-upstream            715744     946737     946737 (us)
-policy_eval              2          5          5 (us)
-receipt_sign           830       2420       2420 (us)
-duration_ms            708       2489      16230 (ms)
-```
-
-Columns with `-` indicate tool calls recorded before timing instrumentation was added. New calls will populate all phase columns automatically.
-
-The data shows that for a GitHub MCP server, upstream API latency dominates (about 716-947ms based on the upstream percentiles shown), while policy evaluation (2-5us) and receipt signing (0.8-2.4ms) add negligible overhead.
-
-## `mcp-proxy doctor`
+### `mcp-proxy doctor`
 
 Diagnose proxy configuration: load and validate the policy rules file, summarise enabled rules by action (`pause`, `block`, `flag`), and optionally probe an approver URL for reachability.
 
@@ -181,59 +65,137 @@ mcp-proxy doctor -json                              # JSON output
 
 **Exit codes:** `0` if the configuration is healthy; `1` if any issues are reported; `2` on flag/usage errors.
 
-## `mcp-proxy init`
+### `mcp-proxy init`
 
-One-command setup: creates `~/.local/share/agent-receipts/`, generates an Ed25519 signing keypair with correct permissions (private key `0600`, public key `0644`), initialises the receipt database, and prints a `claude_desktop_config.json` snippet to stdout.
-
-Safe to re-run — warns and skips key generation if files already exist (use `-force` to overwrite).
+One-command bootstrap: creates the data directory (`~/.local/share/agent-receipts/`, respecting `$XDG_DATA_HOME`) and prints a `claude_desktop_config.json` snippet to stdout with placeholders for your MCP server command. It does **not** generate a signing key — keys belong to the daemon (`agent-receipts-daemon --init`, see [Daemon Setup](/getting-started/daemon-setup/)). Safe to re-run.
 
 ```bash
-mcp-proxy init                              # generate keys for the "default" instance
+mcp-proxy init                              # default instance name
 mcp-proxy init -name github                 # custom instance name
 mcp-proxy init -no-approval                 # omit -http from the printed snippet
 mcp-proxy init -http-port 9000              # custom approval listener port in snippet
-mcp-proxy init -force                       # overwrite existing key files
 ```
 
 | Flag | Description |
 |------|-------------|
-| `-name` | Name for this proxy instance, used in filenames and the config snippet (default: `default`) |
+| `-name` | Name for this proxy instance, used as the snippet key (default: `default`) |
 | `-no-approval` | Omit `-http` from the printed config snippet (no approval server) |
 | `-http-port` | Approval listener port written into the config snippet (default: `7778`) |
-| `-force` | Overwrite existing key files |
 
-**Exit codes:** `0` on success; `1` on setup errors (home directory resolve, key write, DB init); `2` on invalid arguments (out-of-range `-http-port`, invalid `-name`) or flag/usage errors.
+**Exit codes:** `0` on success; `1` on setup errors (home directory resolve, directory create); `2` on invalid arguments (out-of-range `-http-port`, invalid `-name`) or flag/usage errors.
 
-## `mcp-proxy audit-secrets`
+## `agent-receipts`
 
-Scan the audit database for values that match any built-in or custom redaction pattern. Useful after upgrading the proxy, adding new patterns, or as a periodic check that redaction is working as intended.
+The daemon's read-side CLI. Every subcommand opens the store **read-only**, so it is safe to run while the daemon is the active writer, and verification does not require the daemon socket to be reachable. Subcommands: `list`, `show`, `verify`, `verify-event`, `doctor`.
+
+### `agent-receipts list`
+
+List recent receipts, newest first. Default limit is 50.
 
 ```bash
-mcp-proxy audit-secrets                                       # scan with built-in patterns
-mcp-proxy audit-secrets -redact-patterns custom.yaml          # also scan custom patterns
-mcp-proxy audit-secrets -db /path/to/audit.db                 # specify audit DB path
+agent-receipts list                  # latest 50 receipts, newest first
+agent-receipts list -limit 100       # raise the limit
+agent-receipts list -json            # raw JSON array
+agent-receipts list -db /path/to/receipts.db
 ```
 
 | Flag | Description |
 |------|-------------|
-| `-db` | Audit database path (default: `$HOME/.local/share/agent-receipts/audit.db`) |
-| `-redact-patterns` | YAML file with additional patterns to scan for |
+| `-db` | Receipt-store path (default: per-user path; env: `AGENTRECEIPTS_DB`) |
+| `-limit` | Maximum number of receipts to return (default: `50`) |
+| `-json` | Output as a raw JSON array (includes issuer/operator identity and all fields) |
 
-If the database was encrypted at rest (proxy launched with `BEACON_ENCRYPTION_KEY`), set the same env var before running so the scanner can decrypt. Without the key, encrypted rows are reported as `encrypted-no-key` and counted as hits.
-
-Output format — one line per match:
+#### Example output
 
 ```
-messages col=raw row=42 pattern=github_token
-tool_calls col=arguments row=51 json-key=password
-tool_calls col=result row=78 decrypt-error
+$ agent-receipts list
+SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
+8    2026-04-24T02:05:19Z  default  getJiraIssue
+7    2026-04-24T01:58:45Z  default  issue_write
+6    2026-04-24T01:56:12Z  default  searchJiraIssuesUsingJql
+5    2026-04-24T01:45:07Z  default  list_issues
 ```
 
-The scanner reads `messages.raw` (full JSON-RPC payloads) and `tool_calls.arguments` / `tool_calls.result` / `tool_calls.error` — the columns where redaction is applied at write time.
+The tabular view shows the chain sequence, timestamp, chain id, and the tool name (falling back to the action type when a tool name is absent). Issuer and operator identity are not in the tabular view — use `-json` to see them.
 
-**Exit codes:** `0` if no matches found; `1` if one or more matches found; `2` on error.
+### `agent-receipts show`
 
-If matches are found, the raw token values are already in the database. Because the audit log is append-only, the recommended action is to **rotate the secret** and consider the old value compromised.
+Print the full fields of a single receipt by its chain sequence number (1-indexed) — issuer, chain id, action type and tool, parameters hash, outcome, signature, and any action-specific payload.
+
+```bash
+agent-receipts show 42               # human-readable table
+agent-receipts show 42 --json        # raw receipt JSON
+```
+
+| Flag | Description |
+|------|-------------|
+| `-db` | Receipt-store path (default: per-user path; env: `AGENTRECEIPTS_DB`) |
+| `-chain-id` | Chain to read from (env: `AGENTRECEIPTS_CHAIN_ID`); required only when the store holds more than one chain |
+| `-json` | Output the raw receipt JSON instead of the human-readable table |
+
+`--chain-id` is auto-detected with a single chain. On a multi-chain store, omitting it lists the available chain ids and exits with a usage error.
+
+**Exit codes:** `0` when the receipt is found and printed; `1` when there is no receipt at the requested sequence (or the store is empty); `2` on a usage error (bad flags, ambiguous chain, unreadable database).
+
+### `agent-receipts verify`
+
+Verify the integrity of a stored chain — signatures, hash linkage, and sequence numbers — against the daemon's published public key.
+
+```bash
+agent-receipts verify \
+  --public-key ~/.local/share/agent-receipts/signing.key.pub
+```
+
+| Flag | Description |
+|------|-------------|
+| `-db` | Receipt-store path (default: per-user path; env: `AGENTRECEIPTS_DB`) |
+| `-public-key` | PEM-encoded SPKI public key path (env: `AGENTRECEIPTS_PUBLIC_KEY`; defaults to `<key>.pub` derived from `AGENTRECEIPTS_KEY`) |
+| `-chain-id` | Chain id to verify (default: `default`; env: `AGENTRECEIPTS_CHAIN_ID`) |
+
+A successful run prints `Chain <id>: VALID (<n> receipts)`. A tampered chain prints `Chain <id>: BROKEN at receipt <n>` with the failing cause and per-receipt status (`BAD SIGNATURE`, `BAD HASH LINK`, `BAD SEQUENCE`).
+
+**Exit codes:** `0` chain verified; `1` chain failed verification; `2` bad flags or an unreadable DB/key file.
+
+### `agent-receipts verify-event`
+
+Verify a single historical receipt's end-to-end pipeline provenance. Select the receipt by id, by chain head, or by a trailing time window.
+
+```bash
+agent-receipts verify-event --id urn:receipt:a72ee10b...     # one receipt by id
+agent-receipts verify-event --chain-head                     # the most recent receipt
+agent-receipts verify-event --since 24h                      # every receipt in the last day
+```
+
+| Flag | Description |
+|------|-------------|
+| `-id` | Select the receipt with this receipt id |
+| `-chain-head` | Select the most recent receipt in the chain |
+| `-since` | Select every receipt issued within the trailing window (e.g. `10m`, `24h`) |
+| `-db` | Receipt-store path (env: `AGENTRECEIPTS_DB`) |
+| `-public-key` | Public key path (env: `AGENTRECEIPTS_PUBLIC_KEY`) |
+| `-chain-id` | Chain id; selects/filters the chain (env: `AGENTRECEIPTS_CHAIN_ID`) |
+| `-emitter-allowlist` | Comma-separated `exe_path` allowlist of expected emitters (env: `AGENTRECEIPTS_EMITTER_ALLOWLIST`); mismatches warn, never fail |
+| `-json` | Machine-readable JSON output |
+
+### `agent-receipts doctor`
+
+Diagnose pipeline health end-to-end (emitter → socket → daemon → DB → verify), optionally writing a synthetic round-trip event to confirm the full path is live.
+
+```bash
+agent-receipts doctor                  # full health check
+agent-receipts doctor --no-roundtrip   # skip the synthetic write
+agent-receipts doctor --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `-socket` | Daemon socket path (env: `AGENTRECEIPTS_SOCKET`) |
+| `-db` | Receipt-store path (env: `AGENTRECEIPTS_DB`) |
+| `-public-key` | Public key path (env: `AGENTRECEIPTS_PUBLIC_KEY`) |
+| `-chain-id` | Chain id to inspect (default: `default`; env: `AGENTRECEIPTS_CHAIN_ID`) |
+| `-no-roundtrip` | Skip the synthetic round-trip check (no event is written to the chain) |
+| `-warn-as-error` | Exit non-zero when any check warns, not only on failures |
+| `-json` | Structured JSON output |
 
 ## `agent-receipts-hook`
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -86,7 +86,7 @@ mcp-proxy init -http-port 9000              # custom approval listener port in s
 
 ## `agent-receipts`
 
-The daemon's read-side CLI. Every subcommand opens the store **read-only**, so it is safe to run while the daemon is the active writer, and verification does not require the daemon socket to be reachable. Subcommands: `list`, `show`, `verify`, `verify-event`, `doctor`.
+The daemon's read-side CLI. `list`, `show`, `verify`, and `verify-event` open the store **read-only** — safe to run while the daemon is the active writer, and verification does not require the daemon socket to be reachable. `doctor` is the exception: by default it writes a synthetic round-trip event to confirm the full pipeline is live; pass `--no-roundtrip` to skip the write. Subcommands: `list`, `show`, `verify`, `verify-event`, `doctor`.
 
 ### `agent-receipts list`
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -194,6 +194,7 @@ agent-receipts doctor --json
 | `-public-key` | Public key path (env: `AGENTRECEIPTS_PUBLIC_KEY`) |
 | `-chain-id` | Chain id to inspect (default: `default`; env: `AGENTRECEIPTS_CHAIN_ID`) |
 | `-no-roundtrip` | Skip the synthetic round-trip check (no event is written to the chain) |
+| `-roundtrip-timeout` | How long to wait for the synthetic event to land in the DB (default: `3s`) |
 | `-warn-as-error` | Exit non-zero when any check warns, not only on failures |
 | `-json` | Structured JSON output |
 


### PR DESCRIPTION
## What

Restructured the CLI commands documentation to reflect the architectural separation of concerns introduced in ADR-0010. The `mcp-proxy` binary no longer signs or stores receipts — that responsibility moved to `agent-receipts-daemon`. Updated all integration guides (Claude Desktop, Claude Code, Codex, Cline, Cursor, JetBrains, Windsurf, VS Code Copilot) to reflect the new daemon-first setup pattern. Added five new integration guides for IDEs and editors.

## Why

ADR-0010 moved signing, chaining, and persistence from the proxy to the daemon. This architectural change means:

- `mcp-proxy` no longer has `-key`, `-db`, `-receipt-db`, `-taxonomy`, `-issuer`, `-principal`, or `-chain` flags
- `mcp-proxy` no longer has `list`, `inspect`, `verify`, or `export` subcommands
- All receipt querying and verification is now done via the `agent-receipts` CLI (the daemon&#39;s read-side companion)
- The proxy&#39;s only job is to score, classify, apply policy, and forward events to the daemon

The documentation needed to reflect this new reality and guide users through the correct setup sequence: start the daemon first, then configure the proxy in their client.

## Changes

**Reference documentation:**
- Rewrote `cli-commands.mdx` to document three binaries: `mcp-proxy` (serve/doctor/init subcommands), `agent-receipts` (list/show/verify), and `agent-receipts-hook`
- Removed all audit subcommand documentation from `mcp-proxy`
- Updated `configuration.mdx` to remove signing/storage flags and explain the daemon separation
- Updated `overview.mdx` to clarify the proxy&#39;s role and link to ADR-0010
- Updated `installation.mdx` to explain that the proxy forwards to the daemon, not signing locally

**Integration guides:**
- Updated existing guides (Claude Desktop, Claude Code, Codex, remote servers) to start the daemon first and remove key generation steps
- Added new guides for Cline, Cursor, JetBrains AI Assistant, Windsurf, and VS Code Copilot
- All guides now use the same pattern: daemon setup, then proxy configuration with `-issuer-name`, `-operator-id`, `-operator-name` for receipt attribution

**Site navigation:**
- Added new integration guide entries to `astro.config.mjs`

## Testing

Documentation-only change. No code changes to test.

## Security

- [ ] N/A — documentation only