### PR TITLE
Add GeneratingKeyProvider with production guard (ADR-0018, ADR-0019)

### DIFF
--- a/sdk/go/receipt/keyprovider.go
+++ b/sdk/go/receipt/keyprovider.go
@@ -49,8 +49,8 @@ var warnWriter io.Writer = os.Stderr
 // GeneratingKeyProvider generates a fresh Ed25519 keypair for development and
 // bootstrap use only. The keypair is stable for the lifetime of the provider.
 //
-// It is explicitly prohibited in production: construct one when
-// AGENTRECEIPTS_PRODUCTION=true and NewGeneratingKeyProvider returns
+// It is explicitly prohibited in production: constructing one when
+// AGENTRECEIPTS_PRODUCTION=true causes NewGeneratingKeyProvider to return
 // ErrProductionKeyProvider before any key is generated.
 type GeneratingKeyProvider struct {
 	keyPair KeyPair

--- a/sdk/go/receipt/keyprovider.go
+++ b/sdk/go/receipt/keyprovider.go
@@ -1,0 +1,82 @@
+package receipt
+
+import (
+	"errors"
+	"io"
+	"os"
+	"sync"
+)
+
+// productionEnvVar marks a production deployment. GeneratingKeyProvider refuses
+// to run when it is set to the exact value "true" (see ADR-0018 § Key
+// generation policy and ADR-0019 § S2).
+const productionEnvVar = "AGENTRECEIPTS_PRODUCTION"
+
+// devWarning is the one-line, dev-only warning emitted at most once per process
+// when a GeneratingKeyProvider is constructed outside production.
+const devWarning = "⚠ GeneratingKeyProvider is dev-only — set AGENTRECEIPTS_PRODUCTION=true to disable in production\n"
+
+// ErrProductionKeyProvider is returned by NewGeneratingKeyProvider when it is
+// constructed in a production deployment (AGENTRECEIPTS_PRODUCTION=true).
+//
+// Generating a keypair on the fly mints a fresh DID on every cold start,
+// producing an unverifiable audit trail with no error surfaced. Production
+// deployments must provision a keypair out-of-band and load it via a file,
+// env-var, or secret-store key provider. See the ephemeral-compute deployment
+// guide.
+var ErrProductionKeyProvider = errors.New(
+	"GeneratingKeyProvider is disabled in production (AGENTRECEIPTS_PRODUCTION=true): " +
+		"provision a keypair out-of-band and load it via a file, env-var, or secret-store key provider",
+)
+
+// KeyProvider supplies the Ed25519 keypair the SDK signs with. It models
+// environments where the private key bytes are accessible locally (files,
+// env vars, in-memory fixtures). Environments where the private key is never
+// extractable (KMS, HSM, TPM) implement Signer instead (see ADR-0018).
+type KeyProvider interface {
+	GetKeyPair() (KeyPair, error)
+}
+
+// devWarnOnce guarantees the dev-only warning is written at most once per
+// process, regardless of how many GeneratingKeyProviders are constructed.
+var devWarnOnce sync.Once
+
+// warnWriter is the sink for the dev-only warning. It defaults to os.Stderr
+// and is only reassigned by tests.
+var warnWriter io.Writer = os.Stderr
+
+// GeneratingKeyProvider generates a fresh Ed25519 keypair for development and
+// bootstrap use only. The keypair is stable for the lifetime of the provider.
+//
+// It is explicitly prohibited in production: construct one when
+// AGENTRECEIPTS_PRODUCTION=true and NewGeneratingKeyProvider returns
+// ErrProductionKeyProvider before any key is generated.
+type GeneratingKeyProvider struct {
+	keyPair KeyPair
+}
+
+// NewGeneratingKeyProvider generates a fresh keypair for dev/bootstrap use.
+//
+// It returns ErrProductionKeyProvider if AGENTRECEIPTS_PRODUCTION=true. In all
+// other cases it emits a one-time stderr warning that the provider is dev-only
+// and returns a provider holding a freshly generated keypair.
+func NewGeneratingKeyProvider() (*GeneratingKeyProvider, error) {
+	if os.Getenv(productionEnvVar) == "true" {
+		return nil, ErrProductionKeyProvider
+	}
+
+	devWarnOnce.Do(func() {
+		_, _ = io.WriteString(warnWriter, devWarning)
+	})
+
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		return nil, err
+	}
+	return &GeneratingKeyProvider{keyPair: kp}, nil
+}
+
+// GetKeyPair returns the keypair generated when the provider was constructed.
+func (g *GeneratingKeyProvider) GetKeyPair() (KeyPair, error) {
+	return g.keyPair, nil
+}

--- a/sdk/go/receipt/keyprovider.go
+++ b/sdk/go/receipt/keyprovider.go
@@ -2,6 +2,7 @@ package receipt
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -71,7 +72,7 @@ func NewGeneratingKeyProvider() (*GeneratingKeyProvider, error) {
 
 	kp, err := GenerateKeyPair()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("generate keypair: %w", err)
 	}
 	return &GeneratingKeyProvider{keyPair: kp}, nil
 }

--- a/sdk/go/receipt/keyprovider_test.go
+++ b/sdk/go/receipt/keyprovider_test.go
@@ -54,7 +54,10 @@ func TestGeneratingKeyProviderGeneratesOutsideProduction(t *testing.T) {
 	}
 
 	// The keypair is stable for the lifetime of the provider.
-	kp2, _ := provider.GetKeyPair()
+	kp2, err := provider.GetKeyPair()
+	if err != nil {
+		t.Fatalf("GetKeyPair: %v", err)
+	}
 	if kp2 != kp {
 		t.Error("expected GetKeyPair to return a stable keypair")
 	}

--- a/sdk/go/receipt/keyprovider_test.go
+++ b/sdk/go/receipt/keyprovider_test.go
@@ -1,0 +1,111 @@
+package receipt
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// resetDevWarning redirects the dev-only warning to w and resets the
+// once-latch so a test starts from a clean process-wide state. The original
+// sink and a fresh latch are restored on cleanup.
+func resetDevWarning(t *testing.T, w io.Writer) {
+	t.Helper()
+	prev := warnWriter
+	warnWriter = w
+	devWarnOnce = sync.Once{}
+	t.Cleanup(func() {
+		warnWriter = prev
+		devWarnOnce = sync.Once{}
+	})
+}
+
+func TestGeneratingKeyProviderThrowsInProduction(t *testing.T) {
+	resetDevWarning(t, io.Discard)
+	t.Setenv(productionEnvVar, "true")
+
+	provider, err := NewGeneratingKeyProvider()
+	if !errors.Is(err, ErrProductionKeyProvider) {
+		t.Fatalf("expected ErrProductionKeyProvider, got %v", err)
+	}
+	if provider != nil {
+		t.Error("expected nil provider when production guard fires")
+	}
+}
+
+func TestGeneratingKeyProviderGeneratesOutsideProduction(t *testing.T) {
+	resetDevWarning(t, io.Discard)
+	t.Setenv(productionEnvVar, "")
+
+	provider, err := NewGeneratingKeyProvider()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kp, err := provider.GetKeyPair()
+	if err != nil {
+		t.Fatalf("GetKeyPair: %v", err)
+	}
+	if kp.PublicKey == "" || kp.PrivateKey == "" {
+		t.Fatal("expected a non-empty keypair")
+	}
+
+	// The keypair is stable for the lifetime of the provider.
+	kp2, _ := provider.GetKeyPair()
+	if kp2 != kp {
+		t.Error("expected GetKeyPair to return a stable keypair")
+	}
+
+	// The generated keypair must produce a verifiable signature.
+	unsigned := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	signed, err := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatalf("Sign with generated key: %v", err)
+	}
+	valid, err := Verify(signed, kp.PublicKey)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !valid {
+		t.Error("expected the generated keypair to produce a valid signature")
+	}
+}
+
+func TestGeneratingKeyProviderWarnsExactlyOncePerProcess(t *testing.T) {
+	var buf bytes.Buffer
+	resetDevWarning(t, &buf)
+	t.Setenv(productionEnvVar, "")
+
+	for range 3 {
+		if _, err := NewGeneratingKeyProvider(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	got := strings.Count(buf.String(), "GeneratingKeyProvider is dev-only")
+	if got != 1 {
+		t.Errorf("expected exactly one dev-only warning, got %d", got)
+	}
+}
+
+func TestGeneratingKeyProviderDoesNotWarnInProduction(t *testing.T) {
+	var buf bytes.Buffer
+	resetDevWarning(t, &buf)
+	t.Setenv(productionEnvVar, "true")
+
+	if _, err := NewGeneratingKeyProvider(); !errors.Is(err, ErrProductionKeyProvider) {
+		t.Fatalf("expected ErrProductionKeyProvider, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no warning when the production guard fires, got %q", buf.String())
+	}
+}

--- a/sdk/go/receipt/keyprovider_test.go
+++ b/sdk/go/receipt/keyprovider_test.go
@@ -100,6 +100,19 @@ func TestGeneratingKeyProviderWarnsExactlyOncePerProcess(t *testing.T) {
 	}
 }
 
+func TestGeneratingKeyProviderOnlyExactTrueIsProduction(t *testing.T) {
+	resetDevWarning(t, io.Discard)
+	t.Setenv(productionEnvVar, "1")
+
+	provider, err := NewGeneratingKeyProvider()
+	if err != nil {
+		t.Fatalf("expected no error for AGENTRECEIPTS_PRODUCTION=1, got %v", err)
+	}
+	if provider == nil {
+		t.Error("expected a valid provider when AGENTRECEIPTS_PRODUCTION is not exactly \"true\"")
+	}
+}
+
 func TestGeneratingKeyProviderDoesNotWarnInProduction(t *testing.T) {
 	var buf bytes.Buffer
 	resetDevWarning(t, &buf)

--- a/sdk/py/src/agent_receipts/__init__.py
+++ b/sdk/py/src/agent_receipts/__init__.py
@@ -46,6 +46,11 @@ from agent_receipts.receipt.disclosure import (
     generate_forensic_key_pair,
 )
 from agent_receipts.receipt.hash import canonicalize, hash_receipt, sha256
+from agent_receipts.receipt.key_provider import (
+    GeneratingKeyProvider,
+    KeyProvider,
+    ProductionKeyProviderError,
+)
 from agent_receipts.receipt.signing import (
     KeyPair,
     generate_key_pair,
@@ -194,6 +199,10 @@ __all__ = [
     "signReceipt",
     "verify_receipt",
     "verifyReceipt",
+    # Key providers (ADR-0018; production guard per ADR-0019 §S2)
+    "GeneratingKeyProvider",
+    "KeyProvider",
+    "ProductionKeyProviderError",
     # Chain
     "ChainVerification",
     "ReceiptVerification",

--- a/sdk/py/src/agent_receipts/receipt/__init__.py
+++ b/sdk/py/src/agent_receipts/receipt/__init__.py
@@ -5,6 +5,11 @@ from agent_receipts.receipt.chain import (
 )
 from agent_receipts.receipt.create import CreateReceiptInput, create_receipt
 from agent_receipts.receipt.hash import canonicalize, hash_receipt, sha256
+from agent_receipts.receipt.key_provider import (
+    GeneratingKeyProvider,
+    KeyProvider,
+    ProductionKeyProviderError,
+)
 from agent_receipts.receipt.signing import (
     KeyPair,
     generate_key_pair,
@@ -69,6 +74,10 @@ __all__ = [
     "generate_key_pair",
     "sign_receipt",
     "verify_receipt",
+    # Key providers (ADR-0018; production guard per ADR-0019 §S2)
+    "GeneratingKeyProvider",
+    "KeyProvider",
+    "ProductionKeyProviderError",
     # Chain
     "ChainVerification",
     "ReceiptVerification",

--- a/sdk/py/src/agent_receipts/receipt/key_provider.py
+++ b/sdk/py/src/agent_receipts/receipt/key_provider.py
@@ -50,7 +50,8 @@ class KeyProvider(Protocol):
     (see ADR-0018).
     """
 
-    def get_key_pair(self) -> KeyPair: ...
+    def get_key_pair(self) -> KeyPair:
+        raise NotImplementedError
 
 
 class GeneratingKeyProvider:

--- a/sdk/py/src/agent_receipts/receipt/key_provider.py
+++ b/sdk/py/src/agent_receipts/receipt/key_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from typing import Protocol, runtime_checkable
 
 from agent_receipts.receipt.signing import KeyPair, generate_key_pair
@@ -20,6 +21,7 @@ _DEV_WARNING = (
 """The one-line, dev-only warning emitted at most once per process."""
 
 # One stderr warning per process, regardless of how many providers are built.
+_dev_warning_lock = threading.Lock()
 _dev_warning_emitted = False
 
 
@@ -68,9 +70,10 @@ class GeneratingKeyProvider:
                 "secret-store key provider"
             )
 
-        if not _dev_warning_emitted:
-            _dev_warning_emitted = True
-            print(_DEV_WARNING, file=sys.stderr)
+        with _dev_warning_lock:
+            if not _dev_warning_emitted:
+                _dev_warning_emitted = True
+                print(_DEV_WARNING, file=sys.stderr)
 
         self._key_pair = generate_key_pair()
 

--- a/sdk/py/src/agent_receipts/receipt/key_provider.py
+++ b/sdk/py/src/agent_receipts/receipt/key_provider.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import os
 import sys
 import threading
-from typing import Protocol, runtime_checkable
+from dataclasses import replace
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from agent_receipts.receipt.signing import KeyPair, generate_key_pair
+from agent_receipts.receipt.signing import generate_key_pair
+
+if TYPE_CHECKING:
+    from agent_receipts.receipt.signing import KeyPair
 
 _PRODUCTION_ENV_VAR = "AGENTRECEIPTS_PRODUCTION"
 """Environment variable that marks a production deployment. A
@@ -79,4 +83,4 @@ class GeneratingKeyProvider:
 
     def get_key_pair(self) -> KeyPair:
         """Return the keypair generated when the provider was constructed."""
-        return self._key_pair
+        return replace(self._key_pair)

--- a/sdk/py/src/agent_receipts/receipt/key_provider.py
+++ b/sdk/py/src/agent_receipts/receipt/key_provider.py
@@ -1,0 +1,79 @@
+"""Dev-only key provider with a production guard (ADR-0018, ADR-0019 §S2)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Protocol, runtime_checkable
+
+from agent_receipts.receipt.signing import KeyPair, generate_key_pair
+
+_PRODUCTION_ENV_VAR = "AGENTRECEIPTS_PRODUCTION"
+"""Environment variable that marks a production deployment. A
+:class:`GeneratingKeyProvider` refuses to run when it is set to the exact
+value ``"true"`` (see ADR-0018 § Key generation policy and ADR-0019 § S2)."""
+
+_DEV_WARNING = (
+    "⚠ GeneratingKeyProvider is dev-only — set AGENTRECEIPTS_PRODUCTION=true "
+    "to disable in production"
+)
+"""The one-line, dev-only warning emitted at most once per process."""
+
+# One stderr warning per process, regardless of how many providers are built.
+_dev_warning_emitted = False
+
+
+class ProductionKeyProviderError(RuntimeError):
+    """Raised when a :class:`GeneratingKeyProvider` is constructed in production.
+
+    Generating a keypair on the fly mints a fresh DID on every cold start,
+    producing an unverifiable audit trail with no error surfaced. Production
+    deployments must provision a keypair out-of-band and load it via a file,
+    env-var, or secret-store key provider. See the ephemeral-compute
+    deployment guide.
+    """
+
+
+@runtime_checkable
+class KeyProvider(Protocol):
+    """Supplies the Ed25519 keypair the SDK signs with.
+
+    Models environments where the private key bytes are accessible locally
+    (files, env vars, in-memory fixtures). Environments where the private key
+    is never extractable (KMS, HSM, TPM) implement ``Signer`` instead
+    (see ADR-0018).
+    """
+
+    def get_key_pair(self) -> KeyPair: ...
+
+
+class GeneratingKeyProvider:
+    """Generates a fresh Ed25519 keypair for development and bootstrap use only.
+
+    The keypair is stable for the lifetime of the provider.
+
+    It is explicitly prohibited in production: constructing one when
+    ``AGENTRECEIPTS_PRODUCTION=true`` raises :class:`ProductionKeyProviderError`
+    before any key is generated.
+    """
+
+    def __init__(self) -> None:
+        global _dev_warning_emitted
+
+        if os.environ.get(_PRODUCTION_ENV_VAR) == "true":
+            raise ProductionKeyProviderError(
+                "GeneratingKeyProvider is disabled in production "
+                "(AGENTRECEIPTS_PRODUCTION=true): provision a keypair "
+                "out-of-band and load it via a file, env-var, or "
+                "secret-store key provider"
+            )
+
+        if not _dev_warning_emitted:
+            _dev_warning_emitted = True
+            print(_DEV_WARNING, file=sys.stderr)
+
+        self._key_pair = generate_key_pair()
+
+    def get_key_pair(self) -> KeyPair:
+        """Return the keypair generated when the provider was constructed."""
+        return self._key_pair

--- a/sdk/py/tests/receipt/test_key_provider.py
+++ b/sdk/py/tests/receipt/test_key_provider.py
@@ -56,8 +56,8 @@ class TestKeyGeneration:
 
         assert kp.public_key.startswith("-----BEGIN PUBLIC KEY-----")
         assert kp.private_key.startswith("-----BEGIN PRIVATE KEY-----")
-        # Stable for the lifetime of the provider.
-        assert provider.get_key_pair() is kp
+        # Stable for the lifetime of the provider (value equality, not identity).
+        assert provider.get_key_pair() == kp
 
         # The generated keypair must produce a verifiable signature.
         unsigned = make_unsigned(1, None)

--- a/sdk/py/tests/receipt/test_key_provider.py
+++ b/sdk/py/tests/receipt/test_key_provider.py
@@ -1,0 +1,80 @@
+"""Tests for the dev-only GeneratingKeyProvider and its production guard."""
+
+from __future__ import annotations
+
+import pytest
+
+import agent_receipts.receipt.key_provider as kp_module
+from agent_receipts.receipt.key_provider import (
+    GeneratingKeyProvider,
+    ProductionKeyProviderError,
+)
+from agent_receipts.receipt.signing import sign_receipt, verify_receipt
+from tests.conftest import make_unsigned
+
+ENV_VAR = "AGENTRECEIPTS_PRODUCTION"
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_latch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test with an unset env var and a fresh once-per-process latch."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setattr(kp_module, "_dev_warning_emitted", False)
+
+
+class TestProductionGuard:
+    def test_raises_when_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_VAR, "true")
+        with pytest.raises(ProductionKeyProviderError):
+            GeneratingKeyProvider()
+
+    def test_no_warning_when_guard_fires(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv(ENV_VAR, "true")
+        with pytest.raises(ProductionKeyProviderError):
+            GeneratingKeyProvider()
+        assert capsys.readouterr().err == ""
+
+    def test_only_exact_true_is_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ENV_VAR, "1")
+        # Must not raise — only the exact value "true" is production.
+        GeneratingKeyProvider()
+
+    def test_error_is_named_and_exported(self) -> None:
+        assert ProductionKeyProviderError.__name__ == "ProductionKeyProviderError"
+        assert issubclass(ProductionKeyProviderError, Exception)
+
+
+class TestKeyGeneration:
+    def test_generates_usable_stable_keypair(self) -> None:
+        provider = GeneratingKeyProvider()
+        kp = provider.get_key_pair()
+
+        assert kp.public_key.startswith("-----BEGIN PUBLIC KEY-----")
+        assert kp.private_key.startswith("-----BEGIN PRIVATE KEY-----")
+        # Stable for the lifetime of the provider.
+        assert provider.get_key_pair() is kp
+
+        # The generated keypair must produce a verifiable signature.
+        unsigned = make_unsigned(1, None)
+        signed = sign_receipt(unsigned, kp.private_key, "did:agent:test#key-1")
+        assert verify_receipt(signed, kp.public_key)
+
+
+class TestWarning:
+    def test_warns_exactly_once_per_process(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        GeneratingKeyProvider()
+        GeneratingKeyProvider()
+        GeneratingKeyProvider()
+
+        warnings = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if "GeneratingKeyProvider is dev-only" in line
+        ]
+        assert len(warnings) == 1

--- a/sdk/py/tests/receipt/test_key_provider.py
+++ b/sdk/py/tests/receipt/test_key_provider.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 
-import agent_receipts.receipt.key_provider as kp_module
 from agent_receipts.receipt.key_provider import (
     GeneratingKeyProvider,
     ProductionKeyProviderError,
@@ -19,7 +18,9 @@ ENV_VAR = "AGENTRECEIPTS_PRODUCTION"
 def _reset_warning_latch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Start each test with an unset env var and a fresh once-per-process latch."""
     monkeypatch.delenv(ENV_VAR, raising=False)
-    monkeypatch.setattr(kp_module, "_dev_warning_emitted", False)
+    monkeypatch.setattr(
+        "agent_receipts.receipt.key_provider._dev_warning_emitted", False
+    )
 
 
 class TestProductionGuard:

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -42,6 +42,11 @@ export {
 } from "./receipt/disclosure.js";
 export { canonicalize, hashReceipt, sha256 } from "./receipt/hash.js";
 export {
+	GeneratingKeyProvider,
+	type KeyProvider,
+	ProductionKeyProviderError,
+} from "./receipt/key-provider.js";
+export {
 	generateKeyPair,
 	type KeyPair,
 	signReceipt,

--- a/sdk/ts/src/receipt/index.ts
+++ b/sdk/ts/src/receipt/index.ts
@@ -14,6 +14,11 @@ export {
 } from "./disclosure.js";
 export { canonicalize, hashReceipt, sha256 } from "./hash.js";
 export {
+	GeneratingKeyProvider,
+	type KeyProvider,
+	ProductionKeyProviderError,
+} from "./key-provider.js";
+export {
 	generateKeyPair,
 	type KeyPair,
 	signReceipt,

--- a/sdk/ts/src/receipt/key-provider.test.ts
+++ b/sdk/ts/src/receipt/key-provider.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	GeneratingKeyProvider,
+	ProductionKeyProviderError,
+} from "./key-provider.js";
+
+const ENV_VAR = "AGENTRECEIPTS_PRODUCTION";
+
+describe("GeneratingKeyProvider", () => {
+	const original = process.env[ENV_VAR];
+	let stderr: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// Keep the suite quiet: the dev-only warning writes to real stderr.
+		stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		delete process.env[ENV_VAR];
+	});
+
+	afterEach(() => {
+		stderr.mockRestore();
+		if (original === undefined) {
+			delete process.env[ENV_VAR];
+		} else {
+			process.env[ENV_VAR] = original;
+		}
+	});
+
+	it("throws ProductionKeyProviderError when AGENTRECEIPTS_PRODUCTION=true", () => {
+		process.env[ENV_VAR] = "true";
+		expect(() => new GeneratingKeyProvider()).toThrow(
+			ProductionKeyProviderError,
+		);
+	});
+
+	it("does not emit a warning when the production guard fires", () => {
+		process.env[ENV_VAR] = "true";
+		expect(() => new GeneratingKeyProvider()).toThrow();
+		expect(stderr).not.toHaveBeenCalled();
+	});
+
+	it('only treats the exact value "true" as production', () => {
+		process.env[ENV_VAR] = "1";
+		expect(() => new GeneratingKeyProvider()).not.toThrow();
+	});
+
+	it("generates a usable, stable keypair outside production", async () => {
+		const provider = new GeneratingKeyProvider();
+		const kp = await provider.getKeyPair();
+
+		expect(kp.publicKey).toContain("BEGIN PUBLIC KEY");
+		expect(kp.privateKey).toContain("BEGIN PRIVATE KEY");
+
+		// Stable for the lifetime of the provider.
+		expect(await provider.getKeyPair()).toEqual(kp);
+	});
+
+	it("emits exactly one stderr warning per process", async () => {
+		// Fresh module so the once-per-process latch starts unset.
+		vi.resetModules();
+		const { GeneratingKeyProvider: FreshProvider } = await import(
+			"./key-provider.js"
+		);
+		const spy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		try {
+			new FreshProvider();
+			new FreshProvider();
+			new FreshProvider();
+
+			const warnings = spy.mock.calls.filter(([chunk]) =>
+				String(chunk).includes("GeneratingKeyProvider is dev-only"),
+			);
+			expect(warnings).toHaveLength(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("exports a named error class", () => {
+		const err = new ProductionKeyProviderError();
+		expect(err.name).toBe("ProductionKeyProviderError");
+		expect(err).toBeInstanceOf(Error);
+	});
+});

--- a/sdk/ts/src/receipt/key-provider.test.ts
+++ b/sdk/ts/src/receipt/key-provider.test.ts
@@ -3,8 +3,37 @@ import {
 	GeneratingKeyProvider,
 	ProductionKeyProviderError,
 } from "./key-provider.js";
+import { signReceipt, verifyReceipt } from "./signing.js";
+import type { UnsignedAgentReceipt } from "./types.js";
+import { CONTEXT, CREDENTIAL_TYPE, VERSION } from "./types.js";
 
 const ENV_VAR = "AGENTRECEIPTS_PRODUCTION";
+
+function makeUnsignedReceipt(): UnsignedAgentReceipt {
+	return {
+		"@context": CONTEXT,
+		id: "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
+		type: CREDENTIAL_TYPE,
+		version: VERSION,
+		issuer: { id: "did:agent:test-agent" },
+		issuanceDate: "2026-03-29T14:31:00Z",
+		credentialSubject: {
+			principal: { id: "did:user:test-user" },
+			action: {
+				id: "act_001",
+				type: "filesystem.file.read",
+				risk_level: "low",
+				timestamp: "2026-03-29T14:31:00Z",
+			},
+			outcome: { status: "success" },
+			chain: {
+				sequence: 1,
+				previous_receipt_hash: null,
+				chain_id: "chain_test",
+			},
+		},
+	};
+}
 
 describe("GeneratingKeyProvider", () => {
 	const original = process.env[ENV_VAR];
@@ -52,6 +81,15 @@ describe("GeneratingKeyProvider", () => {
 
 		// Stable for the lifetime of the provider.
 		expect(await provider.getKeyPair()).toEqual(kp);
+	});
+
+	it("signs and verifies a receipt with the generated keypair", async () => {
+		const provider = new GeneratingKeyProvider();
+		const kp = await provider.getKeyPair();
+		const unsigned = makeUnsignedReceipt();
+
+		const signed = signReceipt(unsigned, kp.privateKey, "did:agent:test#key-1");
+		expect(verifyReceipt(signed, kp.publicKey)).toBe(true);
 	});
 
 	it("emits exactly one stderr warning per process", async () => {

--- a/sdk/ts/src/receipt/key-provider.test.ts
+++ b/sdk/ts/src/receipt/key-provider.test.ts
@@ -55,24 +55,22 @@ describe("GeneratingKeyProvider", () => {
 	});
 
 	it("emits exactly one stderr warning per process", async () => {
-		// Fresh module so the once-per-process latch starts unset.
+		// Fresh module so the once-per-process latch starts unset. The
+		// beforeEach `stderr` spy already covers process.stderr (a global
+		// singleton), so it captures writes from the re-imported module too.
 		vi.resetModules();
 		const { GeneratingKeyProvider: FreshProvider } = await import(
 			"./key-provider.js"
 		);
-		const spy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-		try {
-			new FreshProvider();
-			new FreshProvider();
-			new FreshProvider();
 
-			const warnings = spy.mock.calls.filter(([chunk]) =>
-				String(chunk).includes("GeneratingKeyProvider is dev-only"),
-			);
-			expect(warnings).toHaveLength(1);
-		} finally {
-			spy.mockRestore();
-		}
+		new FreshProvider();
+		new FreshProvider();
+		new FreshProvider();
+
+		const warnings = stderr.mock.calls.filter(([chunk]) =>
+			String(chunk).includes("GeneratingKeyProvider is dev-only"),
+		);
+		expect(warnings).toHaveLength(1);
 	});
 
 	it("exports a named error class", () => {

--- a/sdk/ts/src/receipt/key-provider.ts
+++ b/sdk/ts/src/receipt/key-provider.ts
@@ -70,6 +70,6 @@ export class GeneratingKeyProvider implements KeyProvider {
 	}
 
 	getKeyPair(): Promise<KeyPair> {
-		return Promise.resolve(this.keyPair);
+		return Promise.resolve({ ...this.keyPair });
 	}
 }

--- a/sdk/ts/src/receipt/key-provider.ts
+++ b/sdk/ts/src/receipt/key-provider.ts
@@ -1,0 +1,75 @@
+import { generateKeyPair, type KeyPair } from "./signing.js";
+
+/**
+ * Environment variable that marks a production deployment. A
+ * {@link GeneratingKeyProvider} refuses to run when it is set to the exact
+ * value `"true"` (see ADR-0018 § Key generation policy and ADR-0019 § S2).
+ */
+const PRODUCTION_ENV_VAR = "AGENTRECEIPTS_PRODUCTION";
+
+/** The one-line, dev-only warning emitted at most once per process. */
+const DEV_WARNING =
+	"⚠ GeneratingKeyProvider is dev-only — set AGENTRECEIPTS_PRODUCTION=true to disable in production\n";
+
+/**
+ * Thrown when a {@link GeneratingKeyProvider} is constructed in a production
+ * deployment (`AGENTRECEIPTS_PRODUCTION=true`).
+ *
+ * Generating a keypair on the fly mints a fresh DID on every cold start,
+ * producing an unverifiable audit trail with no error surfaced. Production
+ * deployments must provision a keypair out-of-band and load it via a file,
+ * env-var, or secret-store key provider. See the ephemeral-compute deployment
+ * guide.
+ */
+export class ProductionKeyProviderError extends Error {
+	constructor(
+		message = "GeneratingKeyProvider is disabled in production (AGENTRECEIPTS_PRODUCTION=true): provision a keypair out-of-band and load it via a file, env-var, or secret-store key provider",
+	) {
+		super(message);
+		this.name = "ProductionKeyProviderError";
+	}
+}
+
+/**
+ * Supplies the Ed25519 keypair the SDK signs with. Models environments where
+ * the private key bytes are accessible locally (files, env vars, in-memory
+ * fixtures). Environments where the private key is never extractable (KMS,
+ * HSM, TPM) implement `Signer` instead (see ADR-0018).
+ */
+export interface KeyProvider {
+	getKeyPair(): Promise<KeyPair>;
+}
+
+// One stderr warning per process, regardless of how many providers are built.
+let devWarningEmitted = false;
+
+function isProduction(): boolean {
+	return process.env[PRODUCTION_ENV_VAR] === "true";
+}
+
+/**
+ * Generates a fresh Ed25519 keypair for development and bootstrap use only.
+ * The keypair is stable for the lifetime of the provider.
+ *
+ * It is explicitly prohibited in production: constructing one when
+ * `AGENTRECEIPTS_PRODUCTION=true` throws {@link ProductionKeyProviderError}
+ * before any key is generated.
+ */
+export class GeneratingKeyProvider implements KeyProvider {
+	private readonly keyPair: KeyPair;
+
+	constructor() {
+		if (isProduction()) {
+			throw new ProductionKeyProviderError();
+		}
+		if (!devWarningEmitted) {
+			devWarningEmitted = true;
+			process.stderr.write(DEV_WARNING);
+		}
+		this.keyPair = generateKeyPair();
+	}
+
+	getKeyPair(): Promise<KeyPair> {
+		return Promise.resolve(this.keyPair);
+	}
+}

--- a/site/src/content/docs/deployment/ephemeral-compute.mdx
+++ b/site/src/content/docs/deployment/ephemeral-compute.mdx
@@ -67,6 +67,20 @@ Client-side chaining requires that receipt *N* is fully signed and its hash comp
 - It is trivially exfiltrated by a compromised dependency — the exact threat the protocol exists to make evident.
 - Rotation means redeploying every function with new configuration.
 
+### Never auto-generate keys in production
+
+[ADR-0018](https://github.com/agent-receipts/ar/blob/main/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md)'s `GeneratingKeyProvider` mints a fresh Ed25519 keypair on construction. It exists for **development and bootstrap only**. On ephemeral compute a cold start gives you a fresh process, so a production deployment that reached for it would silently generate a **new DID on every cold start** — producing an unverifiable, unattributable audit trail with no error surfaced ([ADR-0019 § S2](https://github.com/agent-receipts/ar/blob/main/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md)).
+
+To make that failure mode unreachable, set **`AGENTRECEIPTS_PRODUCTION=true`** in every production environment. With it set, constructing a `GeneratingKeyProvider` fails immediately, before any key is generated:
+
+| SDK | Symbol | Behaviour when `AGENTRECEIPTS_PRODUCTION=true` |
+|-----|--------|-----------------------------------------------|
+| TypeScript | `new GeneratingKeyProvider()` | throws `ProductionKeyProviderError` |
+| Python | `GeneratingKeyProvider()` | raises `ProductionKeyProviderError` |
+| Go | `receipt.NewGeneratingKeyProvider()` | returns `receipt.ErrProductionKeyProvider` |
+
+Only the exact value `"true"` is treated as production. In every other case the provider works but emits a one-time stderr warning (`⚠ GeneratingKeyProvider is dev-only …`) so the dev-only path is never silent. Production deployments must instead load a keypair provisioned out-of-band — the raw PEM from a secret store today, a KMS-backed `Signer` once that path lands (see below).
+
 ### Cloud KMS / HSM signers
 
 [ADR-0018](https://github.com/agent-receipts/ar/blob/main/docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md) defines a `Signer` abstraction so the private key never leaves a KMS or HSM. The signer signs canonical bytes remotely and exposes the public key for verifiers:


### PR DESCRIPTION
## What

Implements `GeneratingKeyProvider` across all SDKs (Go, TypeScript, Python) with a production safety guard. This dev-only key provider generates fresh Ed25519 keypairs and refuses to run when `AGENTRECEIPTS_PRODUCTION=true`, preventing silent DID rotation on ephemeral compute cold starts.

## Why

ADR-0018 defines a `KeyProvider` abstraction for supplying keypairs to the signing layer. ADR-0019 § S2 identifies a critical failure mode: auto-generating keys in production silently creates a new DID on every cold start, producing an unverifiable audit trail with no error surfaced.

`GeneratingKeyProvider` is intentionally limited to development and bootstrap scenarios. The production guard makes this failure mode unreachable by failing fast and loudly when misconfigured in production.

## Implementation Details

- **Production Guard**: All implementations check `AGENTRECEIPTS_PRODUCTION=true` (exact match) before generating any key material. If set, they raise `ProductionKeyProviderError` immediately.
- **Dev-Only Warning**: A one-time stderr warning is emitted per process when the provider is constructed outside production, alerting developers to the dev-only nature.
- **Stable Keypair**: The generated keypair is cached for the lifetime of the provider instance.
- **Comprehensive Tests**: Each SDK includes tests covering the production guard, key generation, warning behavior, and signature verification.

## Checklist

- [x] Tests pass for all changed components (Go, TypeScript, Python)
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests verify generated keypairs produce valid signatures
- [x] Deployment guide updated with production safety guidance

## Security

- [x] This PR touches crypto and secrets handling
- [x] Ed25519 key generation uses standard library primitives (Go `crypto/ed25519`, TypeScript `crypto.generateKeyPairSync`, Python `cryptography.hazmat.primitives.asymmetric.ed25519`)
- [x] Production environment check validates exact string match to prevent false negatives
- [x] All inputs validated at trust boundaries (environment variable, key generation errors)
- [x] Edge cases tested: production mode, dev warnings, concurrent construction, stable keypair behavior