### PR TITLE
chore(sdk/ts): replace @hpke/core with hand-rolled HPKE from node:crypto

### DIFF
--- a/sdk/ts/AGENTS.md
+++ b/sdk/ts/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Runtime dependencies: `zod` (schema validation), `node:crypto`, `node:sqlite`; HPKE disclosure functions additionally require `@hpke/core` (tracked for removal in #473).
+TypeScript SDK for the Agent Receipts protocol — create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions. Runtime dependencies: `zod` (schema validation), `node:crypto`, `node:sqlite`. The HPKE disclosure envelope is hand-rolled on `node:crypto` (`src/receipt/hpke.ts`) — no third-party crypto dependency.
 
 ## Commands
 
@@ -38,7 +38,7 @@ src/
 
 - **ESM-only** (`"type": "module"`, imports use `.js` extensions)
 - **Strict TypeScript** — `strict: true`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`
-- **Runtime dependencies** — `zod` (schema validation), `node:crypto`, `node:sqlite`; `@hpke/core` for HPKE disclosure functions (tracked for removal in #473); `undici` (mTLS dispatcher path — Node 18+ already bundles undici, so the package.json entry exposes the public API surface to TypeScript rather than introducing new runtime code; required because Node's global `fetch` silently ignores `init.agent` and only honours undici's `dispatcher` field)
+- **Runtime dependencies** — `zod` (schema validation), `node:crypto`, `node:sqlite`; the HPKE disclosure envelope is hand-rolled on `node:crypto` (`src/receipt/hpke.ts`), so there is no third-party crypto dependency; `undici` (mTLS dispatcher path — Node 18+ already bundles undici, so the package.json entry exposes the public API surface to TypeScript rather than introducing new runtime code; required because Node's global `fetch` silently ignores `init.agent` and only honours undici's `dispatcher` field)
 - **Colocated tests** — `foo.ts` → `foo.test.ts` in the same directory
 - **Biome** for linting and formatting (tab indentation, double quotes)
 - **Explicit type imports** — use `import type` for type-only imports

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -15,6 +15,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 - **`DaemonEmitter.emit` surfaces transport failure by default** ([#599](https://github.com/agent-receipts/ar/issues/599), ADR-0025). When the daemon is unreachable or a write fails, `emit()` now resolves with the new `EmitTransportError` (a subclass of `Error`, exported from the package root) instead of `null`. Check `err instanceof EmitTransportError` to distinguish it from the plain `Error` returned for caller bugs. Pass `bestEffort: true` to the constructor to opt back into loss-tolerant emission (`emit()` resolves with `null` on transport failure).
 
+### Changed
+
+- **Dropped the `@hpke/core` runtime dependency** ([#473](https://github.com/agent-receipts/ar/issues/473)). The HPKE disclosure envelope (`encryptDisclosure` / `decryptDisclosure` / `generateForensicKeyPair`) now uses an in-tree RFC 9180 base-mode implementation built on `node:crypto` (`src/receipt/hpke.ts`), removing a third-party crypto dependency from a cryptographic protocol's supply chain. The public API and the on-the-wire envelope are unchanged — the deterministic cross-SDK test vectors still pass byte-for-byte.
+
 ## [0.10.0] - 2026-05-24
 
 Implements spec v0.4.0 (`action.idempotency_key`), the ADR-0020 emitter interface redesign (WAL, HTTP, composite, in-memory), and aligns `peer_credential` uid/gid types with the Go SDK. Two breaking changes.

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -13,7 +13,7 @@
 
 Create, sign, hash-chain, store, and verify cryptographically signed audit trails for AI agent actions.
 
-Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage; `@hpke/core` is installed as a dependency and dynamically loaded only when disclosure functions are invoked (tracked for removal in [#473](https://github.com/agent-receipts/ar/issues/473)).
+Minimal runtime dependencies — `zod` for schema validation, `node:crypto` and `node:sqlite` for cryptography and storage. The HPKE disclosure envelope (RFC 9180) is implemented directly on `node:crypto`, with no third-party crypto dependency.
 
 [Spec](https://github.com/agent-receipts/spec) &bull; [Reference Implementation](https://github.com/ojongerius/attest) &bull; [npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)
 
@@ -235,7 +235,7 @@ pnpm run build         # compile to dist/
 | **Language** | TypeScript ESM, strict mode |
 | **Linting** | Biome (tabs, double quotes) |
 | **Testing** | Vitest (colocated `*.test.ts` files) |
-| **Runtime deps** | `zod` (schema validation) + `node:crypto` / `node:sqlite`; `@hpke/core` lazy-loaded for disclosure only |
+| **Runtime deps** | `zod` (schema validation) + `node:crypto` / `node:sqlite`; HPKE disclosure is hand-rolled on `node:crypto` |
 
 ## Ecosystem
 

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -55,7 +55,6 @@
 	},
 	"packageManager": "pnpm@10.33.0",
 	"dependencies": {
-		"@hpke/core": "^1.9.0",
 		"undici": "^8.3.0",
 		"zod": "^4.4.2"
 	},

--- a/sdk/ts/pnpm-lock.yaml
+++ b/sdk/ts/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hpke/core':
-        specifier: ^1.9.0
-        version: 1.9.0
       undici:
         specifier: ^8.3.0
         version: 8.3.0
@@ -104,14 +101,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@hpke/common@1.10.1':
-    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
-    engines: {node: '>=16.0.0'}
-
-  '@hpke/core@1.9.0':
-    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
-    engines: {node: '>=16.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -654,12 +643,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@hpke/common@1.10.1': {}
-
-  '@hpke/core@1.9.0':
-    dependencies:
-      '@hpke/common': 1.10.1
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -3,28 +3,15 @@
  *
  * Ciphersuite: hpke-x25519-hkdf-sha256-aes-256-gcm
  * (RFC 9180, KEM=DHKEM(X25519,HKDF-SHA256) 0x0020, KDF=HKDF-SHA256 0x0001, AEAD=AES-256-GCM 0x0002)
+ *
+ * The HPKE primitives are implemented in ./hpke.ts on top of node:crypto, so
+ * disclosure has no third-party crypto dependency.
  */
 
-import type { CipherSuite } from "@hpke/core";
 import { canonicalize, isPlainObject } from "./hash.js";
+import { generateKeyPair, open, seal } from "./hpke.js";
 
 const V1_ALG = "hpke-x25519-hkdf-sha256-aes-256-gcm" as const;
-
-// Loaded on first use so importing this module does not force consumers to
-// resolve @hpke/core unless they actually invoke a disclosure function.
-let _suitePromise: Promise<CipherSuite> | undefined;
-
-async function getSuite(): Promise<CipherSuite> {
-	_suitePromise ??= import("@hpke/core").then(
-		({ Aes256Gcm, CipherSuite, DhkemX25519HkdfSha256, HkdfSha256 }) =>
-			new CipherSuite({
-				kem: new DhkemX25519HkdfSha256(),
-				kdf: new HkdfSha256(),
-				aead: new Aes256Gcm(),
-			}),
-	);
-	return _suitePromise;
-}
 
 /** One entry in the recipients array. Field names match RFC 9180 §4.1 ("enc", not "encap"). */
 export interface DisclosureRecipient {
@@ -79,14 +66,8 @@ function fromBase64Url(s: string): Uint8Array {
  * The public key is shared with emitters; the private key must be kept offline.
  */
 export async function generateForensicKeyPair(): Promise<ForensicKeyPair> {
-	const suite = await getSuite();
-	const kp = await suite.kem.generateKeyPair();
-	const pubBytes = await suite.kem.serializePublicKey(kp.publicKey);
-	const privBytes = await suite.kem.serializePrivateKey(kp.privateKey);
-	return {
-		publicKey: new Uint8Array(pubBytes),
-		privateKey: new Uint8Array(privBytes),
-	};
+	const { publicKey, privateKey } = generateKeyPair();
+	return { publicKey, privateKey };
 }
 
 /**
@@ -120,9 +101,9 @@ export async function encryptDisclosure(
 
 /**
  * Deterministic variant of encryptDisclosure for cross-SDK test vectors.
- * ikmE (32 bytes) is passed as the ephemeral key material; @hpke/core internally
- * applies DHKEM(X25519) DeriveKeyPair (RFC 9180 §4.1 HKDF derivation) to produce
- * the ephemeral scalar — it does NOT use ikmE directly as the scalar. This is
+ * ikmE (32 bytes) is the ephemeral key material; the HPKE layer applies
+ * DHKEM(X25519) DeriveKeyPair (RFC 9180 §7.1.3 HKDF derivation) to produce the
+ * ephemeral scalar — it does NOT use ikmE directly as the scalar. This is
  * confirmed by vector-1: ikmE = RFC 9180 §A.1.1 ikmE → enc = RFC 9180 §A.1.1 pkEm.
  *
  * @internal FOR TESTING ONLY. Reusing ikmE across real encryptions breaks confidentiality.
@@ -156,27 +137,20 @@ async function encryptWithOptions(
 	kid: string,
 	ikmE: Uint8Array | undefined,
 ): Promise<DisclosureEnvelope> {
-	const suite = await getSuite();
-	const pubKey = await suite.kem.deserializePublicKey(recipientPublicKey);
-
 	// RFC 8785 JCS before encryption — cross-SDK interop depends on this.
 	const canonical = canonicalize(params);
 
-	// info="" (omitted = library default EMPTY) and AAD="" per ADR-0012 amendment §8.
-	const sender = await suite.createSenderContext({
-		recipientPublicKey: pubKey,
-		...(ikmE !== undefined ? { ekm: ikmE } : {}),
-	});
-
-	const ct = await sender.seal(
+	// info="" and AAD="" per ADR-0012 amendment §8 — both baked into seal().
+	const { enc, ct } = seal(
+		recipientPublicKey,
 		new TextEncoder().encode(canonical),
-		new Uint8Array(0), // AAD = ""
+		ikmE,
 	);
 
 	return {
 		v: "1",
 		alg: V1_ALG,
-		recipients: [{ kid, enc: toBase64Url(sender.enc) }],
+		recipients: [{ kid, enc: toBase64Url(enc) }],
 		ct: toBase64Url(ct),
 	};
 }
@@ -224,9 +198,6 @@ export async function decryptDisclosure(
 		throw new Error("recipient kid must be a non-empty string");
 	}
 
-	const suite = await getSuite();
-	const privKey = await suite.kem.deserializePrivateKey(recipientPrivateKey);
-
 	const enc = fromBase64Url(recipient.enc);
 	if (enc.byteLength !== 32) {
 		throw new Error(
@@ -235,12 +206,7 @@ export async function decryptDisclosure(
 	}
 	const ct = fromBase64Url(env.ct);
 
-	const receiver = await suite.createRecipientContext({
-		recipientKey: privKey,
-		enc,
-	});
-
-	const plaintext = await receiver.open(ct, new Uint8Array(0)); // AAD = ""
+	const plaintext = open(recipientPrivateKey, enc, ct);
 
 	const result: unknown = JSON.parse(new TextDecoder().decode(plaintext));
 	if (!isPlainObject(result)) {

--- a/sdk/ts/src/receipt/hpke.test.ts
+++ b/sdk/ts/src/receipt/hpke.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPair, open, seal } from "./hpke.js";
+
+// RFC 7748 §6.1 well-known X25519 test keys. Published IETF vectors — not real secrets.
+const ALICE_PUB_HEX =
+	"8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"; // skipcq: SCM-001
+const ALICE_PRIV_HEX =
+	"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"; // skipcq: SCM-001
+
+// RFC 9180 §A.1.1 ephemeral seed (DHKEM(X25519) base-mode test vector). DeriveKeyPair(ikmE)
+// yields skEm whose public key is pkEm = 37fda3… — base64url N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE.
+const RFC9180_A11_IKME_HEX =
+	"7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234";
+const RFC9180_A11_PKEM_B64URL = "N_2jVnvb1ijohmjDyNfpfR0SU7bU6m1EwVD3QfG_RDE";
+
+function fromHex(hex: string): Uint8Array {
+	const bytes = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < hex.length; i += 2) {
+		bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+	}
+	return bytes;
+}
+
+describe("hpke kem", () => {
+	it("derives the RFC 9180 §A.1.1 encapsulated key from its ikmE", () => {
+		const ikmE = fromHex(RFC9180_A11_IKME_HEX);
+		const { enc } = seal(
+			fromHex(ALICE_PUB_HEX),
+			new TextEncoder().encode("{}"),
+			ikmE,
+		);
+		// enc depends only on ikmE via DeriveKeyPair, so it matches the RFC's pkEm
+		// regardless of recipient. This pins the X25519 §7.1.3 DeriveKeyPair path.
+		expect(Buffer.from(enc).toString("base64url")).toBe(
+			RFC9180_A11_PKEM_B64URL,
+		);
+		expect(enc).toHaveLength(32);
+	});
+});
+
+describe("hpke seal/open", () => {
+	it("round-trips with the RFC 7748 Alice key pair", () => {
+		const pt = new TextEncoder().encode("disclosure plaintext");
+		const { enc, ct } = seal(fromHex(ALICE_PUB_HEX), pt);
+		const got = open(fromHex(ALICE_PRIV_HEX), enc, ct);
+		expect(Buffer.from(got).toString("utf-8")).toBe("disclosure plaintext");
+	});
+
+	it("round-trips with a freshly generated key pair", () => {
+		const kp = generateKeyPair();
+		expect(kp.publicKey).toHaveLength(32);
+		expect(kp.privateKey).toHaveLength(32);
+		const { enc, ct } = seal(kp.publicKey, new TextEncoder().encode("{}"));
+		expect(new TextDecoder().decode(open(kp.privateKey, enc, ct))).toBe("{}");
+	});
+
+	it("produces a fresh ephemeral key (and ciphertext) per call without a seed", () => {
+		const pub = fromHex(ALICE_PUB_HEX);
+		const pt = new TextEncoder().encode("{}");
+		const a = seal(pub, pt);
+		const b = seal(pub, pt);
+		expect(Buffer.from(a.enc).toString("hex")).not.toBe(
+			Buffer.from(b.enc).toString("hex"),
+		);
+	});
+
+	it("is deterministic given a fixed ikmE seed", () => {
+		const pub = fromHex(ALICE_PUB_HEX);
+		const ikmE = fromHex(RFC9180_A11_IKME_HEX);
+		const pt = new TextEncoder().encode("{}");
+		const a = seal(pub, pt, ikmE);
+		const b = seal(pub, pt, ikmE);
+		expect(Buffer.from(a.enc).toString("hex")).toBe(
+			Buffer.from(b.enc).toString("hex"),
+		);
+		expect(Buffer.from(a.ct).toString("hex")).toBe(
+			Buffer.from(b.ct).toString("hex"),
+		);
+	});
+
+	it("fails to open with the wrong private key (GCM tag mismatch)", () => {
+		const wrong = generateKeyPair();
+		const { enc, ct } = seal(
+			fromHex(ALICE_PUB_HEX),
+			new TextEncoder().encode("{}"),
+		);
+		expect(() => open(wrong.privateKey, enc, ct)).toThrow();
+	});
+
+	it("fails to open tampered ciphertext", () => {
+		const { enc, ct } = seal(
+			fromHex(ALICE_PUB_HEX),
+			new TextEncoder().encode("{}"),
+		);
+		const tampered = Uint8Array.from(ct);
+		tampered[0] ^= 0x01;
+		expect(() => open(fromHex(ALICE_PRIV_HEX), enc, tampered)).toThrow();
+	});
+});
+
+describe("hpke input validation", () => {
+	it("rejects a recipient public key that is not 32 bytes", () => {
+		expect(() => seal(new Uint8Array(31), new Uint8Array(0))).toThrow(
+			"32 bytes",
+		);
+	});
+
+	it("rejects an ikmE seed that is not 32 bytes", () => {
+		expect(() =>
+			seal(fromHex(ALICE_PUB_HEX), new Uint8Array(0), new Uint8Array(16)),
+		).toThrow("32 bytes");
+	});
+
+	it("rejects a recipient private key that is not 32 bytes on open", () => {
+		const { enc, ct } = seal(
+			fromHex(ALICE_PUB_HEX),
+			new TextEncoder().encode("{}"),
+		);
+		expect(() => open(new Uint8Array(16), enc, ct)).toThrow("32 bytes");
+	});
+
+	it("rejects an enc that is not 32 bytes on open", () => {
+		const { ct } = seal(fromHex(ALICE_PUB_HEX), new TextEncoder().encode("{}"));
+		expect(() => open(fromHex(ALICE_PRIV_HEX), new Uint8Array(31), ct)).toThrow(
+			"32 bytes",
+		);
+	});
+});

--- a/sdk/ts/src/receipt/hpke.test.ts
+++ b/sdk/ts/src/receipt/hpke.test.ts
@@ -125,4 +125,38 @@ describe("hpke input validation", () => {
 			"32 bytes",
 		);
 	});
+
+	it("rejects a ciphertext too short to hold a GCM tag", () => {
+		// 32-byte enc passes the length check, so open() reaches aeadOpen, which
+		// guards the 16-byte tag minimum.
+		const { enc } = seal(
+			fromHex(ALICE_PUB_HEX),
+			new TextEncoder().encode("{}"),
+		);
+		expect(() =>
+			open(fromHex(ALICE_PRIV_HEX), enc, new Uint8Array(15)),
+		).toThrow("too short");
+	});
+});
+
+describe("hpke degenerate-key rejection", () => {
+	// The all-zero X25519 public key is a low-order point: the DH output is the
+	// all-zero shared secret RFC 7748 §6.1 warns about. We rely on OpenSSL's
+	// X25519 to reject it at derivation time rather than producing that secret;
+	// these tests pin that contract so a future DH-backend change can't silently
+	// regress it.
+	const LOW_ORDER = new Uint8Array(32); // 32 zero bytes
+
+	it("rejects a low-order recipient public key on seal", () => {
+		expect(() => seal(LOW_ORDER, new TextEncoder().encode("{}"))).toThrow(
+			"invalid recipient public key",
+		);
+	});
+
+	it("rejects a low-order enc on open", () => {
+		const { ct } = seal(fromHex(ALICE_PUB_HEX), new TextEncoder().encode("{}"));
+		expect(() => open(fromHex(ALICE_PRIV_HEX), LOW_ORDER, ct)).toThrow(
+			"invalid encapsulated key",
+		);
+	});
 });

--- a/sdk/ts/src/receipt/hpke.ts
+++ b/sdk/ts/src/receipt/hpke.ts
@@ -38,10 +38,12 @@ const HPKE_SUITE_ID = concatBytes(
 	i2osp2(0x0002),
 );
 
+const HASH_LEN = 32; // SHA-256 output (Nh)
 const NSECRET = 32; // DHKEM(X25519) shared secret length
 const NSK = 32; // X25519 private scalar length (Nsk)
 const NK = 32; // AES-256-GCM key length (Nk)
 const NN = 12; // AES-256-GCM nonce length (Nn)
+const NT = 16; // AES-256-GCM authentication tag length
 const MODE_BASE = 0x00;
 
 /** Raw 32-byte X25519 key pair. */
@@ -59,10 +61,14 @@ function hkdfExtract(salt: Uint8Array, ikm: Uint8Array): Buffer {
 	return createHmac("sha256", salt).update(ikm).digest();
 }
 
-// HKDF-Expand. `length` for this suite is always <= HASH_LEN (sk/shared_secret
-// =32, key=32, base_nonce=12), so a single HMAC block would suffice; the loop
-// is kept so the primitive stays correct for any length.
+// HKDF-Expand. Every call in this suite requests <= HASH_LEN bytes
+// (sk/shared_secret/key=32, base_nonce=12), so the loop runs once; it is kept
+// general so the primitive stays correct for any length up to RFC 5869's
+// 255*HashLen ceiling, beyond which the single-byte counter would wrap.
 function hkdfExpand(prk: Uint8Array, info: Uint8Array, length: number): Buffer {
+	if (length > 255 * HASH_LEN) {
+		throw new Error(`HKDF-Expand length ${length} exceeds 255*HashLen`);
+	}
 	const blocks: Buffer[] = [];
 	let prev = Buffer.alloc(0);
 	for (let counter = 1; blockLen(blocks) < length; counter++) {
@@ -152,10 +158,11 @@ function kemEncap(
 ): { enc: Uint8Array; sharedSecret: Uint8Array } {
 	const ephemeral =
 		ikmE !== undefined ? kemDeriveKeyPair(ikmE) : generateKeyPair();
-	const dh = diffieHellman({
-		privateKey: privFromRaw(ephemeral.privateKey),
-		publicKey: pubFromRaw(recipientPublicKey),
-	});
+	const dh = x25519(
+		privFromRaw(ephemeral.privateKey),
+		pubFromRaw(recipientPublicKey),
+		"recipient public key",
+	);
 	const kemContext = concatBytes(ephemeral.publicKey, recipientPublicKey);
 	return {
 		enc: ephemeral.publicKey,
@@ -169,13 +176,28 @@ function kemEncap(
  */
 function kemDecap(enc: Uint8Array, recipientPrivateKey: Uint8Array): Buffer {
 	const recipientPriv = privFromRaw(recipientPrivateKey);
-	const dh = diffieHellman({
-		privateKey: recipientPriv,
-		publicKey: pubFromRaw(enc),
-	});
+	const dh = x25519(recipientPriv, pubFromRaw(enc), "encapsulated key");
 	const recipientPub = rawPublicKey(createPublicKey(recipientPriv));
 	const kemContext = concatBytes(enc, recipientPub);
 	return extractAndExpand(dh, kemContext);
+}
+
+// X25519 key agreement that maps OpenSSL's opaque derivation failure to an
+// actionable error. A low-order public key (the all-zero shared secret RFC 7748
+// §6.1 warns about) is rejected here rather than producing that secret;
+// `keyName` identifies whose key was rejected for the caller.
+function x25519(
+	privateKey: KeyObject,
+	publicKey: KeyObject,
+	keyName: string,
+): Buffer {
+	try {
+		return diffieHellman({ privateKey, publicKey });
+	} catch (err) {
+		throw new Error(`invalid ${keyName}: X25519 key agreement failed`, {
+			cause: err,
+		});
+	}
 }
 
 // --- Key schedule (RFC 9180 §5.1) -------------------------------------------
@@ -227,11 +249,11 @@ function aeadOpen(
 	aad: Uint8Array,
 	ciphertext: Uint8Array,
 ): Buffer {
-	if (ciphertext.length < 16) {
-		throw new Error("ciphertext too short to contain a 16-byte GCM tag");
+	if (ciphertext.length < NT) {
+		throw new Error(`ciphertext too short to contain a ${NT}-byte GCM tag`);
 	}
-	const tag = ciphertext.subarray(ciphertext.length - 16);
-	const body = ciphertext.subarray(0, ciphertext.length - 16);
+	const tag = ciphertext.subarray(ciphertext.length - NT);
+	const body = ciphertext.subarray(0, ciphertext.length - NT);
 	const decipher = createDecipheriv("aes-256-gcm", key, nonce);
 	decipher.setAAD(aad);
 	decipher.setAuthTag(tag);

--- a/sdk/ts/src/receipt/hpke.ts
+++ b/sdk/ts/src/receipt/hpke.ts
@@ -1,0 +1,371 @@
+/**
+ * RFC 9180 HPKE base mode, hand-rolled from node:crypto built-ins.
+ *
+ * Pinned ciphersuite (ADR-0012): hpke-x25519-hkdf-sha256-aes-256-gcm
+ *   KEM  = DHKEM(X25519, HKDF-SHA256)  (0x0020)
+ *   KDF  = HKDF-SHA256                 (0x0001)
+ *   AEAD = AES-256-GCM                 (0x0002)
+ *
+ * Only the slice of RFC 9180 the disclosure envelope needs is implemented:
+ * base mode (no PSK, no sender auth), single-shot seal/open, `info` and `aad`
+ * both empty. Anything outside that profile is intentionally absent.
+ *
+ * This replaces the @hpke/core dependency — a small library is a real supply
+ * chain surface for a cryptographic protocol, and the X25519 path is short
+ * enough to own outright. The deterministic vectors in disclosure.test.ts pin
+ * the output byte-for-byte against the Go SDK reference and RFC 9180 §A.1.1.
+ */
+
+import {
+	createCipheriv,
+	createDecipheriv,
+	createHmac,
+	createPrivateKey,
+	createPublicKey,
+	diffieHellman,
+	generateKeyPairSync,
+	type KeyObject,
+} from "node:crypto";
+
+// suite_id values per RFC 9180 §4.1 / §5.1.
+//   KEM : "KEM"  || I2OSP(kem_id, 2)
+//   HPKE: "HPKE" || I2OSP(kem_id, 2) || I2OSP(kdf_id, 2) || I2OSP(aead_id, 2)
+const KEM_SUITE_ID = concatBytes(asBytes("KEM"), i2osp2(0x0020));
+const HPKE_SUITE_ID = concatBytes(
+	asBytes("HPKE"),
+	i2osp2(0x0020),
+	i2osp2(0x0001),
+	i2osp2(0x0002),
+);
+
+const NSECRET = 32; // DHKEM(X25519) shared secret length
+const NSK = 32; // X25519 private scalar length (Nsk)
+const NK = 32; // AES-256-GCM key length (Nk)
+const NN = 12; // AES-256-GCM nonce length (Nn)
+const MODE_BASE = 0x00;
+
+/** Raw 32-byte X25519 key pair. */
+export interface HpkeKeyPair {
+	publicKey: Uint8Array;
+	privateKey: Uint8Array;
+}
+
+// --- HKDF (RFC 5869) ---------------------------------------------------------
+
+// HKDF-Extract. An empty salt is HMAC with an empty key, which Node treats
+// identically to a HashLen-zero key — the behaviour RFC 5869 specifies and
+// the disclosure vectors confirm byte-for-byte.
+function hkdfExtract(salt: Uint8Array, ikm: Uint8Array): Buffer {
+	return createHmac("sha256", salt).update(ikm).digest();
+}
+
+// HKDF-Expand. `length` for this suite is always <= HASH_LEN (sk/shared_secret
+// =32, key=32, base_nonce=12), so a single HMAC block would suffice; the loop
+// is kept so the primitive stays correct for any length.
+function hkdfExpand(prk: Uint8Array, info: Uint8Array, length: number): Buffer {
+	const blocks: Buffer[] = [];
+	let prev = Buffer.alloc(0);
+	for (let counter = 1; blockLen(blocks) < length; counter++) {
+		prev = createHmac("sha256", prk)
+			.update(prev)
+			.update(info)
+			.update(Uint8Array.of(counter))
+			.digest();
+		blocks.push(prev);
+	}
+	return Buffer.concat(blocks).subarray(0, length);
+}
+
+// --- Labeled HKDF (RFC 9180 §4) ---------------------------------------------
+
+function labeledExtract(
+	suiteId: Uint8Array,
+	salt: Uint8Array,
+	label: string,
+	ikm: Uint8Array,
+): Buffer {
+	const labeledIkm = concatBytes(
+		asBytes("HPKE-v1"),
+		suiteId,
+		asBytes(label),
+		ikm,
+	);
+	return hkdfExtract(salt, labeledIkm);
+}
+
+function labeledExpand(
+	suiteId: Uint8Array,
+	prk: Uint8Array,
+	label: string,
+	info: Uint8Array,
+	length: number,
+): Buffer {
+	const labeledInfo = concatBytes(
+		i2osp2(length),
+		asBytes("HPKE-v1"),
+		suiteId,
+		asBytes(label),
+		info,
+	);
+	return hkdfExpand(prk, labeledInfo, length);
+}
+
+// --- DHKEM(X25519, HKDF-SHA256) (RFC 9180 §7.1) -----------------------------
+
+/**
+ * DeriveKeyPair for X25519 (RFC 9180 §7.1.3): HKDF over `ikm`, then the scalar
+ * is used directly. This is the simple path — unlike NIST curves, X25519 does
+ * NOT run the "candidate" rejection-sampling loop, and the LabeledExpand label
+ * is "sk" with empty info.
+ */
+function kemDeriveKeyPair(ikm: Uint8Array): HpkeKeyPair {
+	const dkpPrk = labeledExtract(KEM_SUITE_ID, EMPTY, "dkp_prk", ikm);
+	const sk = labeledExpand(KEM_SUITE_ID, dkpPrk, "sk", EMPTY, NSK);
+	const privateKeyObj = privFromRaw(sk);
+	return {
+		privateKey: sk,
+		publicKey: rawPublicKey(createPublicKey(privateKeyObj)),
+	};
+}
+
+// ExtractAndExpand (RFC 9180 §4.1) over the DH output and KEM context.
+function extractAndExpand(dh: Uint8Array, kemContext: Uint8Array): Buffer {
+	const eaePrk = labeledExtract(KEM_SUITE_ID, EMPTY, "eae_prk", dh);
+	return labeledExpand(
+		KEM_SUITE_ID,
+		eaePrk,
+		"shared_secret",
+		kemContext,
+		NSECRET,
+	);
+}
+
+/**
+ * Encap (RFC 9180 §7.1.1): generate (or, in the deterministic test path,
+ * derive from `ikmE`) an ephemeral key pair, DH against the recipient, and
+ * derive the shared secret. Returns the encapsulated public key and the
+ * shared secret.
+ */
+function kemEncap(
+	recipientPublicKey: Uint8Array,
+	ikmE?: Uint8Array,
+): { enc: Uint8Array; sharedSecret: Uint8Array } {
+	const ephemeral =
+		ikmE !== undefined ? kemDeriveKeyPair(ikmE) : generateKeyPair();
+	const dh = diffieHellman({
+		privateKey: privFromRaw(ephemeral.privateKey),
+		publicKey: pubFromRaw(recipientPublicKey),
+	});
+	const kemContext = concatBytes(ephemeral.publicKey, recipientPublicKey);
+	return {
+		enc: ephemeral.publicKey,
+		sharedSecret: extractAndExpand(dh, kemContext),
+	};
+}
+
+/**
+ * Decap (RFC 9180 §7.1.1): DH the recipient private key against the
+ * encapsulated public key and re-derive the shared secret.
+ */
+function kemDecap(enc: Uint8Array, recipientPrivateKey: Uint8Array): Buffer {
+	const recipientPriv = privFromRaw(recipientPrivateKey);
+	const dh = diffieHellman({
+		privateKey: recipientPriv,
+		publicKey: pubFromRaw(enc),
+	});
+	const recipientPub = rawPublicKey(createPublicKey(recipientPriv));
+	const kemContext = concatBytes(enc, recipientPub);
+	return extractAndExpand(dh, kemContext);
+}
+
+// --- Key schedule (RFC 9180 §5.1) -------------------------------------------
+
+// Base mode, info="", psk="", psk_id="". Derives the AEAD key and base nonce;
+// the exporter secret is not needed by the disclosure envelope, so it is not
+// computed.
+function keySchedule(sharedSecret: Uint8Array): {
+	key: Buffer;
+	baseNonce: Buffer;
+} {
+	const pskIdHash = labeledExtract(HPKE_SUITE_ID, EMPTY, "psk_id_hash", EMPTY);
+	const infoHash = labeledExtract(HPKE_SUITE_ID, EMPTY, "info_hash", EMPTY);
+	const ksContext = concatBytes(Uint8Array.of(MODE_BASE), pskIdHash, infoHash);
+
+	const secret = labeledExtract(HPKE_SUITE_ID, sharedSecret, "secret", EMPTY);
+	return {
+		key: labeledExpand(HPKE_SUITE_ID, secret, "key", ksContext, NK),
+		baseNonce: labeledExpand(
+			HPKE_SUITE_ID,
+			secret,
+			"base_nonce",
+			ksContext,
+			NN,
+		),
+	};
+}
+
+// --- AEAD (AES-256-GCM) ------------------------------------------------------
+
+// Single-shot seal: sequence number 0, so the nonce is the base nonce directly
+// (RFC 9180 §5.2 ComputeNonce with seq=0). GCM tag is appended to the
+// ciphertext, matching the @hpke/core and circl wire layout.
+function aeadSeal(
+	key: Uint8Array,
+	nonce: Uint8Array,
+	aad: Uint8Array,
+	plaintext: Uint8Array,
+): Buffer {
+	const cipher = createCipheriv("aes-256-gcm", key, nonce);
+	cipher.setAAD(aad);
+	const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+	return Buffer.concat([body, cipher.getAuthTag()]);
+}
+
+function aeadOpen(
+	key: Uint8Array,
+	nonce: Uint8Array,
+	aad: Uint8Array,
+	ciphertext: Uint8Array,
+): Buffer {
+	if (ciphertext.length < 16) {
+		throw new Error("ciphertext too short to contain a 16-byte GCM tag");
+	}
+	const tag = ciphertext.subarray(ciphertext.length - 16);
+	const body = ciphertext.subarray(0, ciphertext.length - 16);
+	const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+	decipher.setAAD(aad);
+	decipher.setAuthTag(tag);
+	// final() throws on tag mismatch — wrong key or tampered ciphertext.
+	return Buffer.concat([decipher.update(body), decipher.final()]);
+}
+
+// --- Public API (info="" and aad="" baked in per ADR-0012) ------------------
+
+/** Generates a fresh random X25519 key pair as raw 32-byte values. */
+export function generateKeyPair(): HpkeKeyPair {
+	const { privateKey, publicKey } = generateKeyPairSync("x25519");
+	return {
+		privateKey: rawPrivateKey(privateKey),
+		publicKey: rawPublicKey(publicKey),
+	};
+}
+
+/**
+ * HPKE single-shot seal in base mode against `recipientPublicKey`.
+ *
+ * @param ikmE - Deterministic ephemeral key material (RFC 9180 §7.1.3
+ *   DeriveKeyPair). FOR TESTING ONLY — production callers omit it so a fresh
+ *   random ephemeral key is generated per call.
+ */
+export function seal(
+	recipientPublicKey: Uint8Array,
+	plaintext: Uint8Array,
+	ikmE?: Uint8Array,
+): { enc: Uint8Array; ct: Uint8Array } {
+	if (recipientPublicKey.length !== 32) {
+		throw new Error(
+			`recipientPublicKey must be 32 bytes, got ${recipientPublicKey.length}`,
+		);
+	}
+	if (ikmE !== undefined && ikmE.length !== NSK) {
+		throw new Error(`ikmE must be ${NSK} bytes, got ${ikmE.length}`);
+	}
+	const { enc, sharedSecret } = kemEncap(recipientPublicKey, ikmE);
+	const { key, baseNonce } = keySchedule(sharedSecret);
+	return { enc, ct: aeadSeal(key, baseNonce, EMPTY, plaintext) };
+}
+
+/** HPKE single-shot open in base mode with `recipientPrivateKey`. */
+export function open(
+	recipientPrivateKey: Uint8Array,
+	enc: Uint8Array,
+	ciphertext: Uint8Array,
+): Uint8Array {
+	if (recipientPrivateKey.length !== 32) {
+		throw new Error(
+			`recipientPrivateKey must be 32 bytes, got ${recipientPrivateKey.length}`,
+		);
+	}
+	if (enc.length !== 32) {
+		throw new Error(
+			`enc must be 32 bytes (X25519 public key), got ${enc.length}`,
+		);
+	}
+	const sharedSecret = kemDecap(enc, recipientPrivateKey);
+	const { key, baseNonce } = keySchedule(sharedSecret);
+	return aeadOpen(key, baseNonce, EMPTY, ciphertext);
+}
+
+// --- X25519 raw <-> KeyObject helpers ---------------------------------------
+
+// Node has no direct "raw bytes" import for X25519, so wrap the 32-byte scalar
+// / public key in the fixed PKCS#8 / SPKI DER prefixes for the id-X25519 OID
+// (1.3.101.110). The prefixes are constant; only the trailing 32 bytes vary.
+const PKCS8_X25519_PREFIX = Buffer.from(
+	"302e020100300506032b656e04220420",
+	"hex",
+);
+const SPKI_X25519_PREFIX = Buffer.from("302a300506032b656e032100", "hex");
+
+function privFromRaw(scalar: Uint8Array): KeyObject {
+	if (scalar.length !== 32) {
+		throw new Error(
+			`X25519 private key must be 32 bytes, got ${scalar.length}`,
+		);
+	}
+	return createPrivateKey({
+		key: Buffer.concat([PKCS8_X25519_PREFIX, scalar]),
+		format: "der",
+		type: "pkcs8",
+	});
+}
+
+function pubFromRaw(pub: Uint8Array): KeyObject {
+	if (pub.length !== 32) {
+		throw new Error(`X25519 public key must be 32 bytes, got ${pub.length}`);
+	}
+	return createPublicKey({
+		key: Buffer.concat([SPKI_X25519_PREFIX, pub]),
+		format: "der",
+		type: "spki",
+	});
+}
+
+function rawPublicKey(key: KeyObject): Uint8Array {
+	const jwk = key.export({ format: "jwk" });
+	if (typeof jwk.x !== "string") {
+		throw new Error("X25519 public key JWK is missing the x coordinate");
+	}
+	return new Uint8Array(Buffer.from(jwk.x, "base64url"));
+}
+
+function rawPrivateKey(key: KeyObject): Uint8Array {
+	const jwk = key.export({ format: "jwk" });
+	if (typeof jwk.d !== "string") {
+		throw new Error("X25519 private key JWK is missing the d scalar");
+	}
+	return new Uint8Array(Buffer.from(jwk.d, "base64url"));
+}
+
+// --- byte helpers ------------------------------------------------------------
+
+const EMPTY = new Uint8Array(0);
+
+function asBytes(s: string): Uint8Array {
+	return new TextEncoder().encode(s);
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+	return Buffer.concat(parts);
+}
+
+// I2OSP(n, 2): big-endian 2-byte encoding. All HPKE lengths here fit in 16 bits.
+function i2osp2(n: number): Uint8Array {
+	return Uint8Array.of((n >>> 8) & 0xff, n & 0xff);
+}
+
+function blockLen(blocks: Buffer[]): number {
+	let total = 0;
+	for (const b of blocks) total += b.length;
+	return total;
+}


### PR DESCRIPTION
Implement RFC 9180 HPKE base mode for the pinned disclosure ciphersuite
(DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM) directly on
node:crypto, dropping the @hpke/core runtime dependency and the supply
chain surface it adds to a cryptographic protocol project.

New src/receipt/hpke.ts contains the primitives: labeled HKDF
extract/expand (§4), X25519 DeriveKeyPair (§7.1.3, the "sk"/empty-info
path, not the NIST candidate loop), KEM encap/decap, base-mode key
schedule, and single-shot AES-256-GCM seal/open. disclosure.ts now calls
seal()/open()/generateKeyPair() instead of the lazy-loaded suite.

The public API and on-the-wire envelope are unchanged: the deterministic
cross-SDK vectors in disclosure.test.ts still pass byte-for-byte against
the Go SDK reference and RFC 9180 §A.1.1. hpke.test.ts adds RFC-anchored
KEM and seal/open coverage for the primitives in isolation.