### PR TITLE
feat(mcp-proxy/host): env-marker secondary detection for host identity (#462)

### DIFF
--- a/mcp-proxy/internal/host/detect_linux.go
+++ b/mcp-proxy/internal/host/detect_linux.go
@@ -5,6 +5,7 @@ package host
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -18,25 +19,64 @@ var readComm = func(pid int) (string, error) {
 	return strings.ToLower(strings.TrimRight(string(b), "\n")), nil
 }
 
-// Detect inspects the parent process name via /proc/<ppid>/comm and returns
-// the best-guess Identity. Source is "auto:<key>" on a registry hit, or
-// "unknown" when the parent process is not in the built-in registry.
-//
-// TODO(#462): env-marker secondary checks for cases where /proc gives no
-// useful result (e.g. process name aliased by a wrapper shell):
-//   - CLAUDECODE (Claude Code SDK)
-//   - CURSOR_TRACE_ID (Cursor)
-//   - WINDSURF_* (Windsurf)
-//   - CODEX_* (OpenAI Codex)
+// environ lists the process environment as "KEY=VALUE" strings.
+// Swapped in tests to avoid depending on the real environment.
+var environ = os.Environ
+
+// envMarkers map a host's environment-variable signal to its registry key, used
+// as a secondary signal when /proc gives no useful result. A marker matches by
+// exact variable name, or by name prefix for variable families (WINDSURF_*,
+// CODEX_*). Markers are checked in declared order, so earlier hosts win when a
+// process sets signals for more than one.
+var envMarkers = []struct {
+	name   string // exact variable name, or prefix when prefix is true
+	prefix bool   // match name as a prefix (variable families)
+	key    string // registry key; must exist in registry (asserted by tests)
+}{
+	{name: "CLAUDECODE", key: "claude"},
+	{name: "CURSOR_TRACE_ID", key: "cursor"},
+	{name: "WINDSURF_", prefix: true, key: "windsurf"},
+	{name: "CODEX_", prefix: true, key: "codex"},
+}
+
+// Detect inspects the parent process name via /proc/<ppid>/comm and returns the
+// best-guess Identity. A registry hit yields Source "auto:<comm>". When /proc
+// gives no useful result — the parent comm is unknown (e.g. aliased by a
+// wrapper shell) or unreadable — detection falls through to an environment
+// marker scan, yielding Source "env:<var>". Source is "unknown" when neither
+// signal matches.
 func Detect() Identity {
-	comm, err := readComm(os.Getppid())
-	if err != nil {
-		return Identity{Source: "unknown"}
+	if comm, err := readComm(os.Getppid()); err == nil {
+		if id, ok := registry[comm]; ok {
+			id.Source = "auto:" + comm
+			return id
+		}
 	}
-	id, ok := registry[comm]
-	if !ok {
-		return Identity{Source: "unknown"}
+	if id, ok := detectEnv(); ok {
+		return id
 	}
-	id.Source = "auto:" + comm
-	return id
+	return Identity{Source: "unknown"}
+}
+
+// detectEnv scans the environment for known host markers, returning the
+// matching Identity (Source "env:<var>") and true on the first hit, or a zero
+// Identity and false when none match. The environment is sorted first so a
+// family marker that matches several variables reports a stable Source.
+func detectEnv() (Identity, bool) {
+	env := environ()
+	slices.Sort(env)
+	for _, m := range envMarkers {
+		id, ok := registry[m.key]
+		if !ok {
+			continue // misconfigured marker: no registry entry to stamp
+		}
+		for _, kv := range env {
+			name, _, _ := strings.Cut(kv, "=")
+			if name == m.name || (m.prefix && strings.HasPrefix(name, m.name)) {
+				id.Source = "env:" + name
+				return id, true
+			}
+		}
+	}
+	return Identity{}, false
 }

--- a/mcp-proxy/internal/host/detect_linux_test.go
+++ b/mcp-proxy/internal/host/detect_linux_test.go
@@ -46,10 +46,20 @@ func TestDetect_KnownHosts(t *testing.T) {
 	}
 }
 
+// noEnv stubs environ to an empty environment so env-marker detection is a
+// no-op for tests that exercise only /proc behaviour.
+func noEnv(t *testing.T) {
+	t.Helper()
+	orig := environ
+	environ = func() []string { return nil }
+	t.Cleanup(func() { environ = orig })
+}
+
 func TestDetect_UnknownHost(t *testing.T) {
 	orig := readComm
 	readComm = func(_ int) (string, error) { return "vscode", nil }
 	t.Cleanup(func() { readComm = orig })
+	noEnv(t)
 
 	id := Detect()
 	if id.Source != "unknown" {
@@ -64,6 +74,7 @@ func TestDetect_ReadCommError(t *testing.T) {
 	orig := readComm
 	readComm = func(_ int) (string, error) { return "", os.ErrNotExist }
 	t.Cleanup(func() { readComm = orig })
+	noEnv(t)
 
 	id := Detect()
 	if id.Source != "unknown" {
@@ -80,5 +91,151 @@ func TestDetect_ReadCommError(t *testing.T) {
 	}
 	if id.OperatorName != "" {
 		t.Errorf("OperatorName = %q, want empty on read error", id.OperatorName)
+	}
+}
+
+// unknownComm stubs /proc detection to a non-registry comm so detection falls
+// through to the env-marker scan.
+func unknownComm(t *testing.T) {
+	t.Helper()
+	orig := readComm
+	readComm = func(_ int) (string, error) { return "bash", nil }
+	t.Cleanup(func() { readComm = orig })
+}
+
+func TestDetect_EnvMarker(t *testing.T) {
+	cases := []struct {
+		name         string
+		env          []string
+		wantName     string
+		wantOperator string
+		wantOperID   string
+		wantSource   string
+	}{
+		{"claude", []string{"CLAUDECODE=1"}, "Claude Code", "Anthropic", "did:web:anthropic.com", "env:CLAUDECODE"},
+		{"cursor", []string{"CURSOR_TRACE_ID=abc123"}, "Cursor", "Cursor", "did:web:cursor.com", "env:CURSOR_TRACE_ID"},
+		{"windsurf", []string{"WINDSURF_SESSION_ID=xyz"}, "Windsurf", "Codeium", "did:web:codeium.com", "env:WINDSURF_SESSION_ID"},
+		{"codex", []string{"CODEX_SANDBOX=seatbelt"}, "Codex", "OpenAI", "did:web:openai.com", "env:CODEX_SANDBOX"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			unknownComm(t)
+			origEnv := environ
+			environ = func() []string { return tc.env }
+			t.Cleanup(func() { environ = origEnv })
+
+			id := Detect()
+			if id.IssuerName != tc.wantName {
+				t.Errorf("IssuerName = %q, want %q", id.IssuerName, tc.wantName)
+			}
+			if id.OperatorName != tc.wantOperator {
+				t.Errorf("OperatorName = %q, want %q", id.OperatorName, tc.wantOperator)
+			}
+			if id.OperatorID != tc.wantOperID {
+				t.Errorf("OperatorID = %q, want %q", id.OperatorID, tc.wantOperID)
+			}
+			if id.Source != tc.wantSource {
+				t.Errorf("Source = %q, want %q", id.Source, tc.wantSource)
+			}
+		})
+	}
+}
+
+// A /proc registry hit must win outright — the env scan is skipped even when a
+// different host's marker is also present.
+func TestDetect_ProcWinsOverEnv(t *testing.T) {
+	orig := readComm
+	readComm = func(_ int) (string, error) { return "cursor", nil }
+	t.Cleanup(func() { readComm = orig })
+	origEnv := environ
+	environ = func() []string { return []string{"CLAUDECODE=1"} }
+	t.Cleanup(func() { environ = origEnv })
+
+	id := Detect()
+	if id.Source != "auto:cursor" {
+		t.Errorf("Source = %q, want \"auto:cursor\"", id.Source)
+	}
+	if id.IssuerName != "Cursor" {
+		t.Errorf("IssuerName = %q, want \"Cursor\"", id.IssuerName)
+	}
+}
+
+// When /proc is unreadable, detection still falls through to the env scan.
+func TestDetect_ReadCommErrorFallsThroughToEnv(t *testing.T) {
+	orig := readComm
+	readComm = func(_ int) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() { readComm = orig })
+	origEnv := environ
+	environ = func() []string { return []string{"CODEX_SANDBOX=seatbelt"} }
+	t.Cleanup(func() { environ = origEnv })
+
+	id := Detect()
+	if id.Source != "env:CODEX_SANDBOX" {
+		t.Errorf("Source = %q, want \"env:CODEX_SANDBOX\"", id.Source)
+	}
+	if id.IssuerName != "Codex" {
+		t.Errorf("IssuerName = %q, want \"Codex\"", id.IssuerName)
+	}
+}
+
+// Markers are checked in declared order, so an earlier host wins when signals
+// for several hosts are present at once.
+func TestDetect_EnvMarkerPriority(t *testing.T) {
+	unknownComm(t)
+	origEnv := environ
+	environ = func() []string { return []string{"CODEX_SANDBOX=1", "CLAUDECODE=1"} }
+	t.Cleanup(func() { environ = origEnv })
+
+	id := Detect()
+	if id.Source != "env:CLAUDECODE" {
+		t.Errorf("Source = %q, want \"env:CLAUDECODE\"", id.Source)
+	}
+	if id.IssuerName != "Claude Code" {
+		t.Errorf("IssuerName = %q, want \"Claude Code\"", id.IssuerName)
+	}
+}
+
+// A family marker matching several variables reports a stable Source regardless
+// of environment order, because detectEnv sorts before scanning.
+func TestDetect_EnvMarkerStableSource(t *testing.T) {
+	unknownComm(t)
+	origEnv := environ
+	// Deliberately unsorted; CODEX_HOME sorts before CODEX_SANDBOX.
+	environ = func() []string { return []string{"CODEX_SANDBOX=1", "CODEX_HOME=/x"} }
+	t.Cleanup(func() { environ = origEnv })
+
+	id := Detect()
+	if id.Source != "env:CODEX_HOME" {
+		t.Errorf("Source = %q, want \"env:CODEX_HOME\"", id.Source)
+	}
+	if id.IssuerName != "Codex" {
+		t.Errorf("IssuerName = %q, want \"Codex\"", id.IssuerName)
+	}
+}
+
+// An exact-name marker must not match a longer variable that merely shares its
+// prefix — CLAUDECODE_DEBUG is not the CLAUDECODE signal.
+func TestDetect_EnvMarkerExactNoPrefixMatch(t *testing.T) {
+	unknownComm(t)
+	origEnv := environ
+	environ = func() []string { return []string{"CLAUDECODE_DEBUG=1", "CURSOR_TRACE_ID_PARENT=x"} }
+	t.Cleanup(func() { environ = origEnv })
+
+	id := Detect()
+	if id.Source != "unknown" {
+		t.Errorf("Source = %q, want \"unknown\"", id.Source)
+	}
+	if id.IssuerName != "" {
+		t.Errorf("IssuerName = %q, want empty", id.IssuerName)
+	}
+}
+
+// Every env marker must reference a key present in the registry; a typo would
+// otherwise stamp a blank issuer/operator onto receipts.
+func TestEnvMarkers_RegistryKeys(t *testing.T) {
+	for _, m := range envMarkers {
+		if _, ok := registry[m.key]; !ok {
+			t.Errorf("envMarker %q references unknown registry key %q", m.name, m.key)
+		}
 	}
 }

--- a/mcp-proxy/internal/host/host.go
+++ b/mcp-proxy/internal/host/host.go
@@ -9,7 +9,7 @@ type Identity struct {
 	IssuerModel  string // optional, e.g. ""
 	OperatorID   string // e.g. "did:web:anthropic.com"
 	OperatorName string // e.g. "Anthropic"
-	Source       string // "auto:<key>" | "flags" | "unknown" — for logging only
+	Source       string // "auto:<comm>" | "env:<var>" | "flags" | "unknown" — for logging only
 }
 
 // registry maps parent process comm names to their known Identity.


### PR DESCRIPTION
When /proc/<ppid>/comm detection yields no registry hit — the parent
process name is aliased by a wrapper shell, or comm is unreadable —
fall through to a secondary scan of environment-variable markers set by
known hosts:

  - CLAUDECODE       (exact)  → Claude Code
  - CURSOR_TRACE_ID  (exact)  → Cursor
  - WINDSURF_*       (prefix) → Windsurf
  - CODEX_*          (prefix) → Codex

A /proc registry hit still wins outright (no env scan). On an env hit,
Identity.Source is "env:<var>" (mirroring "auto:<comm>"); flag overrides
in main.go continue to take precedence. Markers are checked in declared
order, and the environment is sorted before scanning, so detection and
the reported Source stay deterministic even when several markers — or
several variables within one family — are set.

Env lookup is injectable (var environ) for tests, alongside the existing
readComm seam. A guard test asserts every marker maps to a real registry
key so a typo can't stamp a blank issuer/operator. Kept Linux-only for
now; cross-platform env detection is noted as a follow-up in the issue.