### PR TITLE
docs: add package doc.go for pkg.go.dev

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/doc.go
+++ b/mcp-proxy/cmd/mcp-proxy/doc.go
@@ -1,0 +1,17 @@
+// Command mcp-proxy sits between an MCP client and an MCP server, transparently
+// intercepting every tool call to classify it, evaluate YAML policy rules
+// (pass/flag/pause/block), run optional approval workflows, and forward
+// completed events to the agent-receipts daemon for signing and persistence.
+//
+// Usage:
+//
+//	mcp-proxy [flags] <command> [args...]
+//	mcp-proxy serve   [flags] <command> [args...]
+//	mcp-proxy doctor  [-rules <file>] [-approver <url>] [-json]
+//	mcp-proxy init    [-name <name>] [-http-port <port>] [-no-approval]
+//
+// The default subcommand is serve, which wraps the given MCP server command
+// and proxies its stdin/stdout, applying policy and emitting receipts.
+//
+// See https://agentreceipts.ai/mcp-proxy/ for full documentation.
+package main


### PR DESCRIPTION
## Summary

- Audited all Go packages in `sdk/go/` (receipt, store, taxonomy, chain, emitter, emitters, aws) and `mcp-proxy/` (configs, internal/*): every public package already had a package-level doc comment in an existing `.go` file.
- The sole missing doc was `mcp-proxy/cmd/mcp-proxy` (the binary's `package main`), which had no comment, causing pkg.go.dev to show "There is no documentation for this package."
- Added `mcp-proxy/cmd/mcp-proxy/doc.go` with an idiomatic `// Command mcp-proxy …` comment describing the binary's purpose, subcommands (`serve`, `doctor`, `init`), their flags, and a link to the documentation site.

## Test / vet results

```
sdk/go:    go build ./... ✔  go vet ./... ✔  go test ./... ✔ (all 6 packages)
mcp-proxy: go build ./... ✔  go vet ./... ✔  go test ./... ✔ (all 6 packages)
```

Pre-push hook confirmed clean before push.

Closes #73