### PR TITLE
feat(mcp-proxy): warn on world/group-accessible ~/.agent-receipts

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/dirperms.go
+++ b/mcp-proxy/cmd/mcp-proxy/dirperms.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+)
+
+// dataDirGroupOtherMask matches any group or world permission bit (read, write,
+// or execute). The agent-receipts data home holds the daemon's SQLite store and
+// signing keys; any bit here means another local user can reach those files.
+const dataDirGroupOtherMask fs.FileMode = 0o077
+
+// dataDirPermWarning returns a one-line warning when dir's permission bits grant
+// any access to group or other, and "" otherwise. The check is pure (it takes
+// the mode rather than touching the filesystem) so it is unit-testable on every
+// platform.
+//
+// The directory is created 0o700, but os.MkdirAll is a no-op on a pre-existing
+// directory: if ~/.agent-receipts/ already existed with broader perms, the
+// proxy keeps using it. We only warn — a broad mode may be a deliberate choice
+// (e.g. shared group access), so silently tightening it could surprise the
+// operator. The returned line is grep-able and states both the current mode and
+// the chmod that fixes it.
+func dataDirPermWarning(dir string, mode fs.FileMode) string {
+	perm := mode.Perm()
+	if perm&dataDirGroupOtherMask == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"mcp-proxy: [WARNING] data directory %s has mode %04o (group/other-accessible); "+
+			"the daemon's receipt store and keys may be readable by other local users — run `chmod 0700 %s` to restrict it",
+		dir, perm, dir)
+}

--- a/mcp-proxy/cmd/mcp-proxy/dirperms_other.go
+++ b/mcp-proxy/cmd/mcp-proxy/dirperms_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package main
+
+import "io"
+
+// warnDataDirPerms is a no-op on non-unix platforms. os.MkdirAll does not honour
+// Unix permission bits on Windows, so a group/other-access warning would be
+// meaningless there. The unix implementation lives in dirperms_unix.go.
+func warnDataDirPerms(io.Writer) {}

--- a/mcp-proxy/cmd/mcp-proxy/dirperms_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/dirperms_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestDataDirPermWarning is the unit test for the pure perm-check helper. It is
+// OS-independent (it takes an fs.FileMode, not a real directory) so it runs and
+// is meaningful on every platform, including Windows CI.
+//
+// The mask is 0o077: any group or world bit (read, write, or execute) means the
+// agent-receipts data home — which holds the daemon's SQLite store and signing
+// keys — is reachable by other local users and should warn.
+func TestDataDirPermWarning(t *testing.T) {
+	const dir = "/home/alice/.local/share/agent-receipts"
+
+	tests := []struct {
+		name     string
+		mode     fs.FileMode
+		wantWarn bool
+	}{
+		{"owner-only 0700", 0o700, false},
+		{"owner-only 0600 (no exec)", 0o600, false},
+		{"owner-only 0500", 0o500, false},
+		{"world rx 0755", 0o755, true},
+		{"group rx 0750", 0o750, true},
+		{"world rwx 0707", 0o707, true},
+		{"world exec only 0701", 0o701, true},
+		{"group read only 0740", 0o740, true},
+		{"world read only 0704", 0o704, true},
+		{"group write only 0720", 0o720, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dataDirPermWarning(dir, tc.mode)
+			if tc.wantWarn && got == "" {
+				t.Fatalf("dataDirPermWarning(%q, %#o) = %q, want a warning", dir, tc.mode, got)
+			}
+			if !tc.wantWarn {
+				if got != "" {
+					t.Fatalf("dataDirPermWarning(%q, %#o) = %q, want no warning", dir, tc.mode, got)
+				}
+				return
+			}
+			// A warning was produced: it must be a single grep-able line that
+			// states the current mode and the chmod fix-hint.
+			if strings.ContainsRune(got, '\n') {
+				t.Errorf("warning must be a single line (no embedded newlines), got: %q", got)
+			}
+			if !strings.Contains(got, "WARNING") {
+				t.Errorf("warning must contain WARNING, got: %q", got)
+			}
+			if !strings.Contains(got, dir) {
+				t.Errorf("warning must name the directory %q, got: %q", dir, got)
+			}
+			// Mode is rendered as 4-digit octal (matching the daemon doctor's
+			// "%04o" style).
+			wantMode := fmt.Sprintf("%04o", tc.mode.Perm())
+			if !strings.Contains(got, wantMode) {
+				t.Errorf("warning must state the current mode %s, got: %q", wantMode, got)
+			}
+			if !strings.Contains(got, "chmod 0700") {
+				t.Errorf("warning must include the chmod fix-hint, got: %q", got)
+			}
+		})
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/dirperms_unix.go
+++ b/mcp-proxy/cmd/mcp-proxy/dirperms_unix.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// warnDataDirPerms stats the agent-receipts data directory and, when it grants
+// any group/other access, writes a single grep-able WARNING line to w. It is
+// expected to fire on every startup until the operator tightens the mode. The
+// proxy never tightens the directory itself (see dataDirPermWarning).
+//
+// Errors resolving or stat-ing the directory are silent: a missing directory is
+// the normal pre-init state, and a stat failure here must not block startup.
+// This wrapper is Unix-only — os.MkdirAll does not honour Unix perm bits on
+// Windows, so a perm warning there would be meaningless (dirperms_other.go
+// provides a no-op).
+func warnDataDirPerms(w io.Writer) {
+	dh := xdgDataHome()
+	if dh == "" {
+		return
+	}
+	dir := filepath.Join(dh, "agent-receipts")
+	info, err := os.Stat(dir)
+	if err != nil {
+		return
+	}
+	if warning := dataDirPermWarning(dir, info.Mode()); warning != "" {
+		fmt.Fprintln(w, warning)
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/dirperms_unix_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/dirperms_unix_test.go
@@ -1,0 +1,83 @@
+//go:build unix
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWarnDataDirPermsUnix exercises the real wrapper against on-disk
+// directories. It is Unix-only: it relies on os.Chmod honouring Unix perm bits,
+// which Windows does not. dataDirPermWarning's pure logic is covered for all
+// platforms in dirperms_test.go.
+func TestWarnDataDirPermsUnix(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     os.FileMode
+		wantWarn bool
+	}{
+		{"owner-only 0700", 0o700, false},
+		{"world rx 0755", 0o755, true},
+		{"group rx 0750", 0o750, true},
+		{"world exec only 0701", 0o701, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			withHomeDirResolver(t, func() (string, error) { return home, nil })
+			withXDGDataHome(t, "") // resolve via HOME
+
+			dir := filepath.Join(home, ".local", "share", "agent-receipts")
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.Chmod(dir, tc.mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			// Confirm the FS actually applied the mode; some environments (e.g.
+			// restrictive mounts) may mask bits, which would make the test
+			// vacuous.
+			info, err := os.Stat(dir)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			if info.Mode().Perm() != tc.mode.Perm() {
+				t.Skipf("filesystem did not honour mode %#o (got %#o); skipping", tc.mode, info.Mode().Perm())
+			}
+
+			var buf bytes.Buffer
+			warnDataDirPerms(&buf)
+			out := buf.String()
+
+			if tc.wantWarn {
+				if !strings.Contains(out, "WARNING") || !strings.Contains(out, dir) {
+					t.Errorf("expected perm WARNING naming %q, got: %q", dir, out)
+				}
+				if strings.Count(out, "\n") > 1 {
+					t.Errorf("expected a single warning line, got: %q", out)
+				}
+			} else if out != "" {
+				t.Errorf("expected no warning for mode %#o, got: %q", tc.mode, out)
+			}
+		})
+	}
+}
+
+// TestWarnDataDirPermsAbsentDir verifies the wrapper stays silent when the data
+// directory does not exist (nothing created yet — common before first init).
+func TestWarnDataDirPermsAbsentDir(t *testing.T) {
+	home := t.TempDir()
+	withHomeDirResolver(t, func() (string, error) { return home, nil })
+	withXDGDataHome(t, "")
+
+	var buf bytes.Buffer
+	warnDataDirPerms(&buf)
+	if out := buf.String(); out != "" {
+		t.Errorf("expected no output when data dir is absent, got: %q", out)
+	}
+}

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -144,6 +144,13 @@ func serve() {
 	// the daemon's store at the same directory is authoritative now.
 	noteLegacyAuditDB()
 
+	// Warn (every startup) if the agent-receipts data directory pre-exists with
+	// group/other-accessible perms. The directory is created 0o700, but
+	// os.MkdirAll won't tighten an existing one — so a dir left at e.g. 0o755
+	// would silently expose the daemon's store and keys to other local users.
+	// No-op on Windows (Unix perm bits don't apply there).
+	warnDataDirPerms(os.Stderr)
+
 	// Wire the daemon emitter (ADR-0010). The daemon is the sole receipt writer;
 	// the proxy is a thin emitter. Emit surfaces transport failure by default
 	// (ADR-0025), so an unreachable daemon propagates to the handler as a log


### PR DESCRIPTION
## Summary

`os.MkdirAll(dir, 0o700)` is a no-op when the agent-receipts data directory already exists. If `~/.agent-receipts/` (resolved via `$XDG_DATA_HOME/agent-receipts`, default `~/.local/share/agent-receipts`) pre-exists with broader perms (e.g. `0o755`), the proxy keeps using it and the daemon's SQLite store and signing keys inside are readable by other local users.

This adds a startup check in `serve()` that stats the data directory and emits a single grep-able stderr WARNING when its mode grants any group/other access. It only **warns** — a broad mode may be a deliberate choice (shared group access), so it never silently `Chmod`s.

## Mapping to issue #213

- **After the dir is touched, Stat it and warn if `perm & 0o077 != 0`** — `dataDirPermWarning` uses mask `0o077`; the unix wrapper `warnDataDirPerms` does the `Stat`.
- **Do NOT silently Chmod** — the change only warns; the directory is still created `0o700` elsewhere. No existing permission is weakened.
- **One grep-able line stating the current mode + how to fix it, fires every startup** — wired unconditionally into `serve()` alongside `noteLegacyAuditDB()`.
- **Skip entirely on Windows** — `warnDataDirPerms` is `//go:build unix`; a `//go:build !unix` no-op keeps the package building on Windows (verified via `GOOS=windows go build/vet`).
- **DB-file perm check ("consider")** — left out to keep scope tight to the directory warning; noted as a possible follow-up.

## Warning text

```
mcp-proxy: [WARNING] data directory /home/alice/.local/share/agent-receipts has mode 0755 (group/other-accessible); the daemon's receipt store and keys may be readable by other local users — run `chmod 0700 /home/alice/.local/share/agent-receipts` to restrict it
```

The fix-hint uses the resolved absolute path rather than the literal `~/.agent-receipts/`, since the real location is XDG-based and the resolved path is directly copy-pasteable.

## Design

- `dirperms.go` — pure, OS-independent helper `dataDirPermWarning(dir, mode)` returning the warning line or `""`. Unit-testable on every platform.
- `dirperms_unix.go` (`//go:build unix`) — resolves the path (same logic as `noteLegacyAuditDB`), stats, and writes to an `io.Writer`.
- `dirperms_other.go` (`//go:build !unix`) — no-op on Windows.

This mirrors the existing `*_unix.go` / `*_other.go` convention used by the daemon (`umask_unix.go`) and `internal/host` (`detect_linux.go`).

## Tests

- `dirperms_test.go` — table test of the pure helper: `0o755`, `0o750`, `0o707`, `0o701`, `0o740`, `0o704`, `0o720` warn; `0o700`, `0o600`, `0o500` do not. Asserts the warning is a single line stating the mode and `chmod 0700` hint.
- `dirperms_unix_test.go` (`//go:build unix`) — real-directory test via `t.TempDir()` + `os.Chmod`, plus an absent-dir case (stays silent).

Gate (in `mcp-proxy`): `go build ./...`, `go vet ./...`, `go test ./...` all pass; `gofmt -l` clean on touched files. `GOOS=windows` build + vet pass (no-op path compiles).

Closes #213