### PR TITLE
feat(mcp-proxy): add signal handling and graceful shutdown

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -13,10 +13,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
@@ -26,6 +28,10 @@ import (
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 	"github.com/google/uuid"
 )
+
+// httpShutdownGrace bounds how long the approval HTTP server gets to finish
+// in-flight requests after a shutdown signal before it is forced closed.
+const httpShutdownGrace = 5 * time.Second
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z".
 // Falls back to the module version from Go's build info (set automatically
@@ -103,6 +109,13 @@ func serve() {
 
 	command := args[0]
 	commandArgs := args[1:]
+
+	// Drive shutdown off a signal-cancelled context. SIGINT/SIGTERM cancel ctx,
+	// which unblocks the proxy pumps, any in-flight approval wait, and triggers
+	// graceful shutdown of the approval HTTP server. The normal STDIO path
+	// (client closes stdin → EOF) is unaffected and still ends Run cleanly.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	// Server name defaults to command basename.
 	if *serverName == "" {
@@ -212,7 +225,10 @@ func serve() {
 
 	// Start HTTP server for approvals only when the operator explicitly opts in
 	// via -http <addr>. "none" is the default — no listener, no port, no
-	// collision between concurrent sessions.
+	// collision between concurrent sessions. httpDone is closed once the
+	// approval server has fully shut down; it stays nil when no listener runs so
+	// the shutdown wait below is a no-op in the default STDIO-only flow.
+	var httpDone <-chan struct{}
 	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none")
 	if !approverDisabled && *httpAddr != "" {
 		ln, err := net.Listen("tcp", *httpAddr)
@@ -234,7 +250,8 @@ func serve() {
 			endpointJSON = []byte(`{"event":"approval_endpoint"}`)
 		}
 		fmt.Fprintln(os.Stderr, string(endpointJSON))
-		go startHTTPServer(ln, approvals, approvalToken)
+
+		httpDone = serveApprovals(ctx, ln, buildApprovalMux(approvals, approvalToken))
 	}
 
 	// Boot-time summary: one line covers the bulk of "why did my call fail?"
@@ -307,7 +324,7 @@ func serve() {
 						// No approver wired up — fail fast instead of timing out.
 						approvalStatus = audit.ApprovalNoApprover
 					} else {
-						approvalStatus = approvals.WaitForApproval(approvalID, *approvalWait)
+						approvalStatus = approvals.WaitForApproval(ctx, approvalID, *approvalWait)
 					}
 					approvalWaitUs := time.Since(waitStart).Microseconds()
 					if approvalStatus != audit.ApprovalApproved {
@@ -390,11 +407,38 @@ func serve() {
 
 	p := proxy.New(command, commandArgs, handler)
 	log.Printf("mcp-proxy: session %s, server %s", sessionID, *serverName)
-	runErr := p.Run()
+	runErr := p.Run(ctx)
 	log.Printf("mcp-proxy: session %s ended", sessionID)
+
+	// When a signal cancelled ctx, Run returned because we killed the upstream;
+	// the resulting Wait error is expected, not a failure. Log a single clear
+	// shutdown line, wait for the approval server to finish its grace window,
+	// then return so the deferred emitter Close() runs last. The ordering is:
+	// signal → Run unblocks → approval server Shutdown(grace) → emitter Close().
+	if ctx.Err() != nil {
+		log.Printf("mcp-proxy: shutting down (signal received)")
+		waitForHTTPShutdown(httpDone)
+		return
+	}
 	if runErr != nil {
 		log.Printf("mcp-proxy: %v", runErr)
 		os.Exit(1)
+	}
+}
+
+// waitForHTTPShutdown blocks until the approval HTTP server has finished
+// shutting down, bounded by the grace window plus a small margin so a wedged
+// listener can never hang process exit. done is nil when no approval server
+// was started (the default STDIO-only flow), in which case this returns
+// immediately.
+func waitForHTTPShutdown(done <-chan struct{}) {
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(httpShutdownGrace + time.Second):
+		log.Printf("mcp-proxy: approval server did not stop within grace window")
 	}
 }
 
@@ -680,8 +724,35 @@ func buildApprovalMux(approvals *audit.ApprovalManager, token string) http.Handl
 	return mux
 }
 
-func startHTTPServer(ln net.Listener, approvals *audit.ApprovalManager, token string) {
-	if err := http.Serve(ln, buildApprovalMux(approvals, token)); err != nil {
-		log.Fatalf("mcp-proxy: http server: %v", err)
-	}
+// serveApprovals runs the approval HTTP server on ln and wires graceful
+// shutdown to ctx. The returned channel is closed once the server has fully
+// stopped (Serve has returned), so the caller can wait for the grace window to
+// elapse before tearing down the rest of the process.
+//
+// On ctx cancel the server stops accepting and drains in-flight requests for up
+// to httpShutdownGrace; if that window expires it is forced closed. Serve's
+// ErrServerClosed is the clean-exit signal and is not treated as a failure; any
+// other Serve error means the listener died unexpectedly and is fatal.
+func serveApprovals(ctx context.Context, ln net.Listener, handler http.Handler) <-chan struct{} {
+	srv := &http.Server{Handler: handler}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("mcp-proxy: http server: %v", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), httpShutdownGrace)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("mcp-proxy: forced approval-server shutdown after %s: %v", httpShutdownGrace, err)
+			_ = srv.Close()
+		}
+	}()
+
+	return done
 }

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -66,10 +66,15 @@ func main() {
 		}
 	}
 
-	serve()
+	os.Exit(serve())
 }
 
-func serve() {
+// serve runs the proxy session and returns the process exit code. It returns
+// (rather than calling os.Exit) for any failure that occurs after the daemon
+// emitter is wired up, so the deferred emitter Close() and approval-server
+// teardown run before the process exits. main() performs the os.Exit at the
+// top-level boundary once serve has returned and its deferreds have run.
+func serve() int {
 	var (
 		rulesPath    = flag.String("rules", "", "Policy rules (YAML file)")
 		serverName   = flag.String("name", "", "Server name for audit trail")
@@ -197,7 +202,8 @@ func serve() {
 		var err error
 		rules, err = policy.LoadRules(*rulesPath)
 		if err != nil {
-			log.Fatalf("mcp-proxy: load rules: %v", err)
+			log.Printf("mcp-proxy: load rules: %v", err)
+			return 1
 		}
 	} else {
 		rules = policy.DefaultRules()
@@ -225,16 +231,24 @@ func serve() {
 
 	// Start HTTP server for approvals only when the operator explicitly opts in
 	// via -http <addr>. "none" is the default — no listener, no port, no
-	// collision between concurrent sessions. httpDone is closed once the
-	// approval server has fully shut down; it stays nil when no listener runs so
-	// the shutdown wait below is a no-op in the default STDIO-only flow.
-	var httpDone <-chan struct{}
+	// collision between concurrent sessions. httpSrv is the handle serve() uses
+	// to cancel and await the approval server during wind-down; it stays nil
+	// when no listener runs so the shutdown wait below is a no-op in the default
+	// STDIO-only flow.
+	//
+	// The approval server shuts down on a dedicated context derived from the
+	// signal ctx. Cancelling httpCancel — which serve() always does once Run
+	// returns, on the clean stdin-EOF path as well as the signal path — drives
+	// the graceful Shutdown(grace) without requiring an OS signal.
+	var httpSrv *approvalServer
+	httpCtx, httpCancel := context.WithCancel(ctx)
+	defer httpCancel()
 	approverDisabled := strings.EqualFold(strings.TrimSpace(*httpAddr), "none")
 	if !approverDisabled && *httpAddr != "" {
 		ln, err := net.Listen("tcp", *httpAddr)
 		if err != nil {
 			fmt.Fprint(os.Stderr, formatBindFailure(*httpAddr, err))
-			os.Exit(1)
+			return 1
 		}
 		approvalURL = "http://" + ln.Addr().String()
 		// Human-readable line (one copy-pasteable string, no log timestamp prefix).
@@ -251,7 +265,7 @@ func serve() {
 		}
 		fmt.Fprintln(os.Stderr, string(endpointJSON))
 
-		httpDone = serveApprovals(ctx, ln, buildApprovalMux(approvals, approvalToken))
+		httpSrv = serveApprovals(httpCtx, ln, buildApprovalMux(approvals, approvalToken))
 	}
 
 	// Boot-time summary: one line covers the bulk of "why did my call fail?"
@@ -410,35 +424,58 @@ func serve() {
 	runErr := p.Run(ctx)
 	log.Printf("mcp-proxy: session %s ended", sessionID)
 
+	// Wind down the approval server on EVERY path, before the deferred emitter
+	// Close() runs. The signal path already cancelled ctx (and thus httpCtx);
+	// the clean stdin-EOF path did not, so httpCancel() here is what drives the
+	// graceful Shutdown(grace) in that case. httpCancel is idempotent, so
+	// calling it on both paths is safe. waitForHTTPShutdown then blocks until
+	// Serve returns (bounded by the grace window) — a no-op when no approval
+	// server runs. The ordering is: Run unblocks → approval server
+	// Shutdown(grace) → emitter Close() (deferred).
+	httpCancel()
+	httpErr := waitForHTTPShutdown(httpSrv)
+
 	// When a signal cancelled ctx, Run returned because we killed the upstream;
 	// the resulting Wait error is expected, not a failure. Log a single clear
-	// shutdown line, wait for the approval server to finish its grace window,
-	// then return so the deferred emitter Close() runs last. The ordering is:
-	// signal → Run unblocks → approval server Shutdown(grace) → emitter Close().
+	// shutdown line and return so the deferred emitter Close() runs last.
 	if ctx.Err() != nil {
 		log.Printf("mcp-proxy: shutting down (signal received)")
-		waitForHTTPShutdown(httpDone)
-		return
+		return 0
 	}
+	// Surface a fatal error by returning a non-zero exit code so deferred
+	// cleanup (emitter Close) runs first; main() performs the os.Exit. A
+	// non-ErrServerClosed Serve failure — propagated out of the goroutine via
+	// waitForHTTPShutdown rather than crashing it — is reported the same way as
+	// a Run failure.
 	if runErr != nil {
 		log.Printf("mcp-proxy: %v", runErr)
-		os.Exit(1)
+		return 1
 	}
+	if httpErr != nil {
+		log.Printf("mcp-proxy: approval server: %v", httpErr)
+		return 1
+	}
+	return 0
 }
 
 // waitForHTTPShutdown blocks until the approval HTTP server has finished
 // shutting down, bounded by the grace window plus a small margin so a wedged
-// listener can never hang process exit. done is nil when no approval server
-// was started (the default STDIO-only flow), in which case this returns
-// immediately.
-func waitForHTTPShutdown(done <-chan struct{}) {
-	if done == nil {
-		return
+// listener can never hang process exit. srv is nil when no approval server was
+// started (the default STDIO-only flow), in which case this returns nil
+// immediately. On a clean stop it returns the Serve result: nil for the
+// ErrServerClosed path, or the underlying error when the listener died
+// unexpectedly. A grace-window timeout returns nil — the wedged listener is
+// logged but must not block process exit.
+func waitForHTTPShutdown(srv *approvalServer) error {
+	if srv == nil {
+		return nil
 	}
 	select {
-	case <-done:
+	case <-srv.done:
+		return <-srv.errCh
 	case <-time.After(httpShutdownGrace + time.Second):
 		log.Printf("mcp-proxy: approval server did not stop within grace window")
+		return nil
 	}
 }
 
@@ -724,24 +761,40 @@ func buildApprovalMux(approvals *audit.ApprovalManager, token string) http.Handl
 	return mux
 }
 
+// approvalServer is the handle serve() holds onto the running approval HTTP
+// server. done closes once Serve has returned (the server is fully stopped);
+// errCh (buffered, size 1) then carries the Serve result: nil on the clean
+// ErrServerClosed exit, or the underlying error when the listener died
+// unexpectedly. Surfacing the error this way — rather than log.Fatalf inside
+// the goroutine — lets serve()'s deferred cleanup (e.g. the daemon emitter
+// Close) run before the process exits, mirroring how collector.Run propagates
+// its ListenAndServe error back to its caller.
+type approvalServer struct {
+	done  <-chan struct{}
+	errCh <-chan error
+}
+
 // serveApprovals runs the approval HTTP server on ln and wires graceful
-// shutdown to ctx. The returned channel is closed once the server has fully
-// stopped (Serve has returned), so the caller can wait for the grace window to
-// elapse before tearing down the rest of the process.
+// shutdown to ctx. The caller awaits and tears down the server via
+// waitForHTTPShutdown.
 //
 // On ctx cancel the server stops accepting and drains in-flight requests for up
 // to httpShutdownGrace; if that window expires it is forced closed. Serve's
 // ErrServerClosed is the clean-exit signal and is not treated as a failure; any
-// other Serve error means the listener died unexpectedly and is fatal.
-func serveApprovals(ctx context.Context, ln net.Listener, handler http.Handler) <-chan struct{} {
+// other Serve error is propagated to the caller via the returned handle's errCh
+// instead of crashing the process, so deferred cleanup still runs.
+func serveApprovals(ctx context.Context, ln net.Listener, handler http.Handler) *approvalServer {
 	srv := &http.Server{Handler: handler}
 	done := make(chan struct{})
+	errCh := make(chan error, 1)
 
 	go func() {
 		defer close(done)
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("mcp-proxy: http server: %v", err)
+			errCh <- err
+			return
 		}
+		errCh <- nil
 	}()
 
 	go func() {
@@ -754,5 +807,5 @@ func serveApprovals(ctx context.Context, ln net.Listener, handler http.Handler) 
 		}
 	}()
 
-	return done
+	return &approvalServer{done: done, errCh: errCh}
 }

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -791,7 +791,7 @@ func serveApprovals(ctx context.Context, ln net.Listener, handler http.Handler) 
 	go func() {
 		defer close(done)
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
+			errCh <- fmt.Errorf("serve on %s: %w", ln.Addr(), err)
 			return
 		}
 		errCh <- nil

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log"
@@ -545,7 +546,7 @@ func TestApprovalHandlerApproveAfterConsumed(t *testing.T) {
 
 	result := make(chan audit.ApprovalStatus, 1)
 	go func() {
-		result <- approvals.WaitForApproval(approvalID, 3*time.Second)
+		result <- approvals.WaitForApproval(context.Background(), approvalID, 3*time.Second)
 	}()
 
 	// Spin until WaitForApproval has registered, consuming it via direct Approve.
@@ -590,7 +591,7 @@ func TestApprovalHandlerApproveFlowHTTP(t *testing.T) {
 	// We embed WaitForApproval inline: register via direct map access is internal,
 	// so instead start the goroutine and poll until it has registered.
 	go func() {
-		ch <- approvals.WaitForApproval(approvalID, 5*time.Second)
+		ch <- approvals.WaitForApproval(context.Background(), approvalID, 5*time.Second)
 	}()
 
 	// Poll via HTTP until the waiter registers; 10ms between attempts to avoid CPU churn.
@@ -628,7 +629,7 @@ func TestApprovalHandlerDenyFlow(t *testing.T) {
 
 	result := make(chan audit.ApprovalStatus, 1)
 	go func() {
-		result <- approvals.WaitForApproval(approvalID, 5*time.Second)
+		result <- approvals.WaitForApproval(context.Background(), approvalID, 5*time.Second)
 	}()
 
 	// Spin until the waiter goroutine has registered its channel, then send deny via HTTP.

--- a/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
@@ -2,12 +2,33 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
 )
+
+// waitAccepting blocks until the approval server on addr accepts a TCP
+// connection, or fails the test after 2s. Confirms the listener is live before
+// a test drives shutdown.
+func waitAccepting(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if dialErr == nil {
+			_ = conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not accept connections within 2s: %v", dialErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
 
 // TestServeApprovalsGracefulShutdown drives the real serveApprovals helper: it
 // starts the approval server on an ephemeral port, confirms it accepts, cancels
@@ -23,33 +44,86 @@ func TestServeApprovalsGracefulShutdown(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	done := serveApprovals(ctx, ln, buildApprovalMux(approvals, token))
+	srv := serveApprovals(ctx, ln, buildApprovalMux(approvals, token))
 
 	// Confirm the server is actually accepting before shutting it down.
-	addr := ln.Addr().String()
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		conn, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-		if dialErr == nil {
-			_ = conn.Close()
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("server did not accept connections within 2s: %v", dialErr)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitAccepting(t, ln.Addr().String())
 
 	// Cancelling the context drives Shutdown; done closes once Serve returns.
 	cancel()
-	select {
-	case <-done:
-	case <-time.After(httpShutdownGrace + 2*time.Second):
-		t.Fatal("serveApprovals did not signal done after context cancel")
+	if err := waitForHTTPShutdown(srv); err != nil {
+		t.Fatalf("clean ErrServerClosed shutdown must surface nil, got %v", err)
 	}
 
 	// The listener must be closed: a fresh Accept on it fails immediately.
 	if _, err := ln.Accept(); err == nil {
 		t.Fatal("expected listener to be closed after shutdown")
+	}
+}
+
+// TestServeApprovalsCleanCancelShutsDown covers Finding B: on the clean
+// stdin-EOF path the proxy cancels a dedicated approval-server context (derived
+// from the signal ctx) WITHOUT any OS signal. Cancelling that context alone
+// must drive graceful shutdown — the done channel closes and the listener is
+// torn down — so serve() never falls through while the HTTP goroutine is still
+// accepting and racing the deferred emitter Close().
+func TestServeApprovalsCleanCancelShutsDown(t *testing.T) {
+	token := generateToken(16)
+	approvals := audit.NewApprovalManager()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// httpCtx models serve()'s dedicated approval-server context. The parent is
+	// a plain Background context (no signal wiring), so the only thing that can
+	// trigger shutdown here is httpCancel — exactly the clean-EOF path.
+	httpCtx, httpCancel := context.WithCancel(context.Background())
+	srv := serveApprovals(httpCtx, ln, buildApprovalMux(approvals, token))
+	waitAccepting(t, ln.Addr().String())
+
+	// The clean-path trigger: cancel the dedicated context, then await teardown.
+	httpCancel()
+	if err := waitForHTTPShutdown(srv); err != nil {
+		t.Fatalf("clean-path shutdown must surface nil, got %v", err)
+	}
+
+	if _, err := ln.Accept(); err == nil {
+		t.Fatal("expected listener to be closed after clean-path shutdown")
+	}
+}
+
+// TestServeApprovalsPropagatesServeError covers Finding A: a non-ErrServerClosed
+// Serve error must be PROPAGATED back to the caller (via the handle's error
+// channel, surfaced by waitForHTTPShutdown) rather than crashing the process
+// with log.Fatalf, which would skip serve()'s deferred cleanup. We force Serve
+// to fail by closing the listener out from under it before any shutdown is
+// requested, then assert the error reaches the caller.
+func TestServeApprovalsPropagatesServeError(t *testing.T) {
+	token := generateToken(16)
+	approvals := audit.NewApprovalManager()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// Never cancel the context: this isolates the Serve-error path from the
+	// graceful ErrServerClosed path. Closing the listener makes srv.Serve return
+	// a non-ErrServerClosed accept error, which the goroutine must forward.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := serveApprovals(ctx, ln, buildApprovalMux(approvals, token))
+	waitAccepting(t, ln.Addr().String())
+
+	_ = ln.Close()
+
+	serveErr := waitForHTTPShutdown(srv)
+	if serveErr == nil {
+		t.Fatal("expected serveApprovals to propagate the non-ErrServerClosed Serve error")
+	}
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		t.Fatalf("ErrServerClosed must be treated as clean, not propagated: %v", serveErr)
 	}
 }

--- a/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
@@ -61,12 +61,12 @@ func TestServeApprovalsGracefulShutdown(t *testing.T) {
 	}
 }
 
-// TestServeApprovalsCleanCancelShutsDown covers Finding B: on the clean
-// stdin-EOF path the proxy cancels a dedicated approval-server context (derived
-// from the signal ctx) WITHOUT any OS signal. Cancelling that context alone
-// must drive graceful shutdown — the done channel closes and the listener is
-// torn down — so serve() never falls through while the HTTP goroutine is still
-// accepting and racing the deferred emitter Close().
+// TestServeApprovalsCleanCancelShutsDown verifies that on the clean stdin-EOF
+// path the proxy cancels a dedicated approval-server context (derived from the
+// signal ctx) WITHOUT any OS signal. Cancelling that context alone must drive
+// graceful shutdown — the done channel closes and the listener is torn down —
+// so serve() never falls through while the HTTP goroutine is still accepting
+// and racing the deferred emitter Close().
 func TestServeApprovalsCleanCancelShutsDown(t *testing.T) {
 	token := generateToken(16)
 	approvals := audit.NewApprovalManager()
@@ -94,11 +94,11 @@ func TestServeApprovalsCleanCancelShutsDown(t *testing.T) {
 	}
 }
 
-// TestServeApprovalsPropagatesServeError covers Finding A: a non-ErrServerClosed
-// Serve error must be PROPAGATED back to the caller (via the handle's error
-// channel, surfaced by waitForHTTPShutdown) rather than crashing the process
-// with log.Fatalf, which would skip serve()'s deferred cleanup. We force Serve
-// to fail by closing the listener out from under it before any shutdown is
+// TestServeApprovalsPropagatesServeError verifies that a non-ErrServerClosed
+// Serve error is PROPAGATED back to the caller (via the handle's error channel,
+// surfaced by waitForHTTPShutdown) rather than crashing the process with
+// log.Fatalf, which would skip serve()'s deferred cleanup. We force Serve to
+// fail by closing the listener out from under it before any shutdown is
 // requested, then assert the error reaches the caller.
 func TestServeApprovalsPropagatesServeError(t *testing.T) {
 	token := generateToken(16)

--- a/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+)
+
+// TestServeApprovalsGracefulShutdown drives the real serveApprovals helper: it
+// starts the approval server on an ephemeral port, confirms it accepts, cancels
+// the context, and asserts the done channel closes (Serve returned via the
+// ErrServerClosed clean-exit path) and the listener is closed afterwards.
+func TestServeApprovalsGracefulShutdown(t *testing.T) {
+	token := generateToken(16)
+	approvals := audit.NewApprovalManager()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := serveApprovals(ctx, ln, buildApprovalMux(approvals, token))
+
+	// Confirm the server is actually accepting before shutting it down.
+	addr := ln.Addr().String()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if dialErr == nil {
+			_ = conn.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not accept connections within 2s: %v", dialErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Cancelling the context drives Shutdown; done closes once Serve returns.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(httpShutdownGrace + 2*time.Second):
+		t.Fatal("serveApprovals did not signal done after context cancel")
+	}
+
+	// The listener must be closed: a fresh Accept on it fails immediately.
+	if _, err := ln.Accept(); err == nil {
+		t.Fatal("expected listener to be closed after shutdown")
+	}
+}

--- a/mcp-proxy/internal/audit/approval.go
+++ b/mcp-proxy/internal/audit/approval.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -29,9 +30,11 @@ func NewApprovalManager() *ApprovalManager {
 	}
 }
 
-// WaitForApproval blocks until the given approval ID is approved, denied, or
-// the timeout elapses.
-func (a *ApprovalManager) WaitForApproval(id string, timeout time.Duration) ApprovalStatus {
+// WaitForApproval blocks until the given approval ID is approved, denied, the
+// timeout elapses, or ctx is cancelled. A cancelled context (e.g. shutdown)
+// returns ApprovalTimedOut so the caller fails the paused call safely rather
+// than letting it proceed unapproved.
+func (a *ApprovalManager) WaitForApproval(ctx context.Context, id string, timeout time.Duration) ApprovalStatus {
 	ch := make(chan bool, 1)
 	a.mu.Lock()
 	a.pending[id] = ch
@@ -43,13 +46,18 @@ func (a *ApprovalManager) WaitForApproval(id string, timeout time.Duration) Appr
 		a.mu.Unlock()
 	}()
 
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case approved := <-ch:
 		if approved {
 			return ApprovalApproved
 		}
 		return ApprovalDenied
-	case <-time.After(timeout):
+	case <-timer.C:
+		return ApprovalTimedOut
+	case <-ctx.Done():
 		return ApprovalTimedOut
 	}
 }

--- a/mcp-proxy/internal/audit/approval_test.go
+++ b/mcp-proxy/internal/audit/approval_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -10,7 +11,7 @@ func TestApproveBeforeTimeout(t *testing.T) {
 
 	done := make(chan ApprovalStatus, 1)
 	go func() {
-		done <- am.WaitForApproval("req-1", 5*time.Second)
+		done <- am.WaitForApproval(context.Background(), "req-1", 5*time.Second)
 	}()
 
 	// Give WaitForApproval time to register.
@@ -31,7 +32,7 @@ func TestDenyBeforeTimeout(t *testing.T) {
 
 	done := make(chan ApprovalStatus, 1)
 	go func() {
-		done <- am.WaitForApproval("req-2", 5*time.Second)
+		done <- am.WaitForApproval(context.Background(), "req-2", 5*time.Second)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -49,9 +50,34 @@ func TestDenyBeforeTimeout(t *testing.T) {
 func TestApprovalTimeout(t *testing.T) {
 	am := NewApprovalManager()
 
-	result := am.WaitForApproval("req-3", 50*time.Millisecond)
+	result := am.WaitForApproval(context.Background(), "req-3", 50*time.Millisecond)
 	if result != ApprovalTimedOut {
 		t.Errorf("expected WaitForApproval to return %q on timeout, got %q", ApprovalTimedOut, result)
+	}
+}
+
+func TestApprovalContextCancel(t *testing.T) {
+	am := NewApprovalManager()
+
+	// A cancelled context unblocks the wait before the (long) timeout elapses
+	// and reports ApprovalTimedOut so the caller fails the paused call safely.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan ApprovalStatus, 1)
+	go func() {
+		done <- am.WaitForApproval(ctx, "req-cancel", time.Hour)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case result := <-done:
+		if result != ApprovalTimedOut {
+			t.Errorf("expected %q on context cancel, got %q", ApprovalTimedOut, result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForApproval did not return after context cancel")
 	}
 }
 
@@ -59,7 +85,7 @@ func TestApproveAfterTimeout(t *testing.T) {
 	am := NewApprovalManager()
 
 	// Let the wait expire.
-	am.WaitForApproval("req-4", 50*time.Millisecond)
+	am.WaitForApproval(context.Background(), "req-4", 50*time.Millisecond)
 
 	// Now try to approve — channel already consumed.
 	if am.Approve("req-4") {

--- a/mcp-proxy/internal/proxy/proxy.go
+++ b/mcp-proxy/internal/proxy/proxy.go
@@ -3,6 +3,7 @@ package proxy
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,6 +35,7 @@ type Proxy struct {
 	handler Handler
 
 	cmd          *exec.Cmd
+	clientReader io.Reader // os.Stdin — reads from MCP client
 	clientWriter io.Writer // os.Stdout — writes to MCP client
 	startOnce    sync.Once
 	writerMu     sync.Mutex
@@ -49,8 +51,10 @@ func New(command string, args []string, handler Handler) *Proxy {
 }
 
 // Run starts the child MCP server and proxies stdin/stdout bidirectionally.
-// It blocks until the child process exits.
-func (p *Proxy) Run() error {
+// It blocks until the child process exits, either of the STDIO pumps closes
+// (stdin EOF ends a normal STDIO session), or ctx is cancelled. Cancellation
+// kills the upstream child so both pumps unblock and Run returns promptly.
+func (p *Proxy) Run(ctx context.Context) error {
 	var firstCall bool
 	p.startOnce.Do(func() {
 		firstCall = true
@@ -59,6 +63,12 @@ func (p *Proxy) Run() error {
 		return fmt.Errorf("proxy already started")
 	}
 
+	// Capture stdin/stdout once, synchronously, before launching the pump
+	// goroutines so the standard streams are read under Run's own goroutine
+	// (tests may inject clientReader to avoid touching the os.Stdin global).
+	if p.clientReader == nil {
+		p.clientReader = os.Stdin
+	}
 	p.clientWriter = os.Stdout
 
 	p.cmd = exec.Command(p.command, p.args...)
@@ -84,7 +94,7 @@ func (p *Proxy) Run() error {
 	// Client → Server
 	go func() {
 		defer serverIn.Close()
-		p.pipe(os.Stdin, serverIn, "client_to_server")
+		p.pipe(p.clientReader, serverIn, "client_to_server")
 		exits <- "client_to_server"
 	}()
 
@@ -94,21 +104,35 @@ func (p *Proxy) Run() error {
 		exits <- "server_to_client"
 	}()
 
-	// Wait for the first pipe to finish, then kill the upstream so the
-	// surviving pipe unblocks instead of blocking forever.
-	first := <-exits
-	log.Printf("mcp-proxy: pipe %s exited, shutting down", first)
+	// Wait for the first pipe to finish or for ctx to be cancelled, then kill
+	// the upstream so the surviving pipe (and any blocked reads) unblock
+	// instead of blocking forever. remaining tracks how many pump exits we
+	// still expect to drain: a pipe exit consumes one, a ctx cancel consumes
+	// none.
+	remaining := 2
+	select {
+	case first := <-exits:
+		log.Printf("mcp-proxy: pipe %s exited, shutting down", first)
+		remaining = 1
+	case <-ctx.Done():
+		log.Printf("mcp-proxy: context cancelled, shutting down")
+	}
 	if p.cmd.Process != nil {
 		_ = p.cmd.Process.Kill()
 	}
 
-	// Drain the second exit with a short timeout so we capture the reason
-	// but do not block forever.
-	select {
-	case second := <-exits:
-		log.Printf("mcp-proxy: pipe %s exited", second)
-	case <-time.After(2 * time.Second):
-		log.Printf("mcp-proxy: second pipe did not exit within timeout")
+	// Drain the remaining pipe exits with a short timeout so we capture the
+	// reason but do not block forever. Killing the child closes server stdout
+	// (server→client unblocks); the client→server pump may still be blocked on
+	// a read of os.Stdin with no pending data, so the timeout bounds the wait.
+	for ; remaining > 0; remaining-- {
+		select {
+		case dir := <-exits:
+			log.Printf("mcp-proxy: pipe %s exited", dir)
+		case <-time.After(2 * time.Second):
+			log.Printf("mcp-proxy: remaining pipe did not exit within timeout")
+			remaining = 1 // loop decrement ends the drain
+		}
 	}
 
 	return p.cmd.Wait()

--- a/mcp-proxy/internal/proxy/proxy_shutdown_test.go
+++ b/mcp-proxy/internal/proxy/proxy_shutdown_test.go
@@ -1,0 +1,88 @@
+package proxy
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestRun_ContextCancelUnblocks asserts that cancelling ctx returns Run
+// promptly even when neither STDIO pump has reached EOF: the upstream child
+// stays alive (sleep) and the client→server reader never closes. Cancellation
+// must kill the child and unblock Run.
+func TestRun_ContextCancelUnblocks(t *testing.T) {
+	// Inject the read end of a pipe as the client reader, holding the write end
+	// open, so the client→server pump blocks on a read that never sees EOF.
+	// Injecting via the field avoids mutating the os.Stdin global from a test
+	// whose pump goroutine reads it concurrently.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		// Closing the write end gives the lingering client→server pump EOF so it
+		// exits. We do not close the read end: the pump may still be mid-read on
+		// it after Run returned (Run bounds its wait with a drain timeout rather
+		// than joining a wedged read), and closing it concurrently with that
+		// read would race. The read FD is reaped at process exit.
+		_ = w.Close()
+	})
+
+	// `sleep 30` neither reads stdin nor writes stdout, so the server→client
+	// pump blocks on the child's stdout (no EOF) and the child stays alive —
+	// only ctx cancel can end Run.
+	p := New("sleep", []string{"30"}, nil)
+	p.clientReader = r
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Run(ctx)
+	}()
+
+	// Let the pumps reach their blocking reads before cancelling.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Run returned promptly after cancel — success. The error is the
+		// expected "signal: killed" from killing the upstream child.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after context cancel")
+	}
+}
+
+// TestRun_StdinEOFEndsRun asserts the normal STDIO path is preserved: when the
+// client closes its end (EOF) the client→server pump exits and Run returns
+// without any signal, exactly as before context threading was added.
+func TestRun_StdinEOFEndsRun(t *testing.T) {
+	// A reader at EOF models a client that closed its end of the pipe to end the
+	// session. Inject it as the client reader; ctx is never cancelled, so Run
+	// must return on EOF alone.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	_ = w.Close() // immediate EOF on the read end
+
+	// `cat` keeps its stdout open until its stdin closes; the proxy closes the
+	// child's stdin when the client→server pump hits EOF, so cat then exits.
+	p := New("cat", nil, nil)
+	p.clientReader = r
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Run(context.Background())
+	}()
+
+	select {
+	case <-done:
+		// Run returned on EOF without any cancellation — normal flow intact.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s on stdin EOF")
+	}
+	_ = r.Close()
+}

--- a/mcp-proxy/internal/proxy/proxy_unit_test.go
+++ b/mcp-proxy/internal/proxy/proxy_unit_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -352,7 +353,7 @@ func TestRun_SecondCallReturnsError(t *testing.T) {
 	p := New("true", nil, nil)
 	// Mark as started.
 	p.startOnce.Do(func() {})
-	err := p.Run()
+	err := p.Run(context.Background())
 	if err == nil {
 		t.Fatal("expected error on second Run call")
 	}


### PR DESCRIPTION
## What

Adds signal handling and graceful shutdown to `mcp-proxy`. Closes #172.

Before this change the proxy had no `signal.Notify` wiring at all:

- The approval HTTP server ran a bare `http.Serve` with no `Shutdown` path, so the goroutine leaked on interrupt and in-flight approval requests got no grace.
- The two STDIO pump goroutines and any in-flight approval wait had no cancellation path.

## Why / how

- **Signal-driven context in `serve()`** (`cmd/mcp-proxy/main.go`): `signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)` drives shutdown; `stop()` is deferred. The normal STDIO path (client closes stdin to end the session) is unchanged.
- **`proxy.Run(ctx, ...)`** (`internal/proxy/proxy.go`): a context is threaded into the core. On cancel, the upstream child is killed so both STDIO pumps unblock and `Run` returns promptly. The first-pipe-exit (stdin EOF) path is preserved exactly. `clientReader` is now an injectable field so tests exercise cancellation without mutating the `os.Stdin` global.
- **Graceful approval-server shutdown:** the approval server (only started when `-http` is set) is now an `http.Server{}` value. On signal it `Shutdown(ctx)`s with a bounded 5s grace window; `http.ErrServerClosed` is treated as a clean exit, any other `Serve` error is fatal. If the grace window expires the listener is forced closed. When `-http` is unset, no server is started or awaited.
- **Shutdown ordering:** `signal -> Run unblocks -> approval-server Shutdown(grace) -> emitter Close()`. `serve()` waits for the approval server's grace window to elapse before returning, so the deferred emitter `Close()` runs last.
- **Approval wait cancellation:** `ApprovalManager.WaitForApproval(ctx, id, timeout)` unblocks on cancel and returns `ApprovalTimedOut`, so a paused call fails safely rather than proceeding unapproved.
- **Logging:** one structured line distinguishes graceful (`shutting down (signal received)`) from forced (`forced approval-server shutdown after Ns`), matching the proxy's existing `log.Printf` style.

## Reduced scope (important)

#172's original acceptance criterion — *"leave the local audit DB / receipt store consistent on shutdown"* — is **dropped**. #454 (thin-emitter migration, ADR-0010) removed the proxy's local SQLite store; the proxy now only forwards to the daemon over a socket and persists nothing locally. The only `Close()` honored on shutdown is the daemon emitter's, which already runs via `defer` once `serve()` returns. No proxy-side DB shutdown logic is implemented.

## Tests added

- `TestRun_ContextCancelUnblocks` (`internal/proxy`): with an alive upstream (`sleep`) and a never-closing client reader, cancelling `ctx` returns `Run` within the deadline (pumps unblock) without stdin EOF.
- `TestRun_StdinEOFEndsRun` (`internal/proxy`): the normal stdin-EOF path still ends `Run` cleanly with an uncancelled context (no regression).
- `TestServeApprovalsGracefulShutdown` (`cmd/mcp-proxy`): drives the real `serveApprovals` helper on an ephemeral port, confirms it accepts, cancels the context, asserts the done channel closes (Serve returned via the `ErrServerClosed` clean-exit path) and the listener is closed.
- `TestApprovalContextCancel` (`internal/audit`): a cancelled context unblocks `WaitForApproval` before the (long) timeout and reports `ApprovalTimedOut`.
- Existing call sites of `proxy.Run` and `WaitForApproval` updated for the new signatures.

## Verification

`go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./cmd/mcp-proxy` all pass in `mcp-proxy/`. `gofmt -l` is clean on all touched files.

## Not unit-tested

Real OS signal delivery (SIGINT/SIGTERM) is not exercised in a unit test; the code is structured so the context-driven core (`Run(ctx)`, `serveApprovals(ctx, ...)`, `WaitForApproval(ctx, ...)`) is fully testable, and `signal.NotifyContext` is the thin, well-trusted stdlib glue between the OS signal and that context.