### PR TITLE
feat(mcp-proxy): fail fast when the approval server dies mid-session

### DIFF
--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -421,20 +421,25 @@ func serve() int {
 
 	p := proxy.New(command, commandArgs, handler)
 	log.Printf("mcp-proxy: session %s, server %s", sessionID, *serverName)
-	runErr := p.Run(ctx)
+
+	// Run the proxy in a goroutine so we can watch the approval server's health
+	// concurrently. If the approval HTTP listener dies mid-session (a
+	// non-ErrServerClosed Serve failure while the run loop is still blocked),
+	// awaitSessionEnd cancels the session so Run unblocks promptly and the proxy
+	// stops advertising an approval URL it can no longer honour — instead of
+	// leaving callers to time out in WaitForApproval (#691).
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- p.Run(ctx) }()
+	outcome := awaitSessionEnd(runErrCh, httpSrv, stop, httpCancel)
 	log.Printf("mcp-proxy: session %s ended", sessionID)
 
-	// Wind down the approval server on EVERY path, before the deferred emitter
-	// Close() runs. The signal path already cancelled ctx (and thus httpCtx);
-	// the clean stdin-EOF path did not, so httpCancel() here is what drives the
-	// graceful Shutdown(grace) in that case. httpCancel is idempotent, so
-	// calling it on both paths is safe. waitForHTTPShutdown then blocks until
-	// Serve returns (bounded by the grace window) — a no-op when no approval
-	// server runs. The ordering is: Run unblocks → approval server
-	// Shutdown(grace) → emitter Close() (deferred).
-	httpCancel()
-	httpErr := waitForHTTPShutdown(httpSrv)
-
+	// A mid-session approval-server death is fatal: surface the wrapped error and
+	// exit non-zero. Checked before the signal branch because the fail-fast path
+	// cancels the session ctx itself, which would otherwise look like a signal.
+	if outcome.serverDied {
+		log.Printf("mcp-proxy: approval server: %v", outcome.httpErr)
+		return 1
+	}
 	// When a signal cancelled ctx, Run returned because we killed the upstream;
 	// the resulting Wait error is expected, not a failure. Log a single clear
 	// shutdown line and return so the deferred emitter Close() runs last.
@@ -447,15 +452,69 @@ func serve() int {
 	// non-ErrServerClosed Serve failure — propagated out of the goroutine via
 	// waitForHTTPShutdown rather than crashing it — is reported the same way as
 	// a Run failure.
-	if runErr != nil {
-		log.Printf("mcp-proxy: %v", runErr)
+	if outcome.runErr != nil {
+		log.Printf("mcp-proxy: %v", outcome.runErr)
 		return 1
 	}
-	if httpErr != nil {
-		log.Printf("mcp-proxy: approval server: %v", httpErr)
+	if outcome.httpErr != nil {
+		log.Printf("mcp-proxy: approval server: %v", outcome.httpErr)
 		return 1
 	}
 	return 0
+}
+
+// shutdownOutcome reports how a proxy session ended so serve() can choose the
+// exit code and shutdown log line.
+type shutdownOutcome struct {
+	runErr     error // result of p.Run; nil on a clean stdin-EOF
+	httpErr    error // non-ErrServerClosed approval-server Serve failure, if any
+	serverDied bool  // the approval server failed while the session was still live
+}
+
+// awaitSessionEnd coordinates the end of a proxy session. It blocks until
+// either the run loop finishes (signal or stdin-EOF) or the approval HTTP
+// server dies mid-session, whichever happens first, then winds the other side
+// down and reports the outcome. runErrCh receives exactly one value — the
+// result of p.Run. stopSession cancels the session context; httpCancel and
+// httpSrv drive and await the approval server's graceful shutdown.
+//
+// The approval handle's errCh is buffered (size 1) and carries exactly one
+// value, so this function reads it AT MOST once: on the run-completed branch it
+// leaves errCh for waitForHTTPShutdown to read; on the server-died branch it
+// consumes that value directly and must NOT also call waitForHTTPShutdown,
+// which would block re-reading an already-drained channel.
+//
+// When httpSrv is nil (the -http-off STDIO-only flow) the server-done channel
+// is nil and never fires, so the only path is run-completed and the helper is a
+// thin pass-through.
+func awaitSessionEnd(runErrCh <-chan error, httpSrv *approvalServer, stopSession, httpCancel context.CancelFunc) shutdownOutcome {
+	var serverDone <-chan struct{}
+	if httpSrv != nil {
+		serverDone = httpSrv.done
+	}
+
+	select {
+	case runErr := <-runErrCh:
+		// Normal end (signal or stdin-EOF). Wind the approval server down and
+		// await it exactly as before: httpCancel drives the graceful
+		// Shutdown(grace); waitForHTTPShutdown reads the single errCh value (a
+		// no-op when no approval server runs).
+		httpCancel()
+		return shutdownOutcome{runErr: runErr, httpErr: waitForHTTPShutdown(httpSrv)}
+	case <-serverDone:
+		// The approval server's Serve returned while the session was still live.
+		// Its errCh already holds the single Serve result; read it once here.
+		// During a live session this is genuinely a mid-session failure: the
+		// clean ErrServerClosed (nil) path only fires after httpCancel, which the
+		// run-completed branch above is the sole caller of. Guard on a non-nil
+		// error anyway so a clean stop never gets misreported as a death.
+		httpErr := <-httpSrv.errCh
+		// Unblock Run so the session tears down promptly rather than waiting for
+		// an independent end (signal/EOF).
+		stopSession()
+		runErr := <-runErrCh
+		return shutdownOutcome{runErr: runErr, httpErr: httpErr, serverDied: httpErr != nil}
+	}
 }
 
 // waitForHTTPShutdown blocks until the approval HTTP server has finished

--- a/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/shutdown_test.go
@@ -94,6 +94,140 @@ func TestServeApprovalsCleanCancelShutsDown(t *testing.T) {
 	}
 }
 
+// TestAwaitSessionEndFailsFastOnServerDeath verifies the fail-fast behaviour
+// from #691: when the approval HTTP server dies mid-session — a
+// non-ErrServerClosed Serve error while the proxy run loop is still blocked —
+// awaitSessionEnd must NOT wait for an independent session end. It must cancel
+// the session (via stopSession) so Run unblocks promptly, then surface the
+// wrapped Serve error with serverDied set.
+//
+// We model the live session with a runErrCh that stays empty until the session
+// context is cancelled; a real serveApprovals server is then killed by closing
+// its listener WITHOUT cancelling the session. If awaitSessionEnd waited for an
+// unrelated end the test would hang; instead it returns promptly with the
+// propagated error.
+func TestAwaitSessionEndFailsFastOnServerDeath(t *testing.T) {
+	token := generateToken(16)
+	approvals := audit.NewApprovalManager()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// httpCtx is the approval server's own context; sessionCtx models p.Run's
+	// context. Neither is cancelled by the test — only awaitSessionEnd's
+	// stopSession (the death path) may cancel sessionCtx.
+	httpCtx, httpCancel := context.WithCancel(context.Background())
+	defer httpCancel()
+	sessionCtx, stopSession := context.WithCancel(context.Background())
+	defer stopSession()
+
+	srv := serveApprovals(httpCtx, ln, buildApprovalMux(approvals, token))
+	waitAccepting(t, ln.Addr().String())
+
+	// The proxy run loop only ends once the session context is cancelled; until
+	// then runErrCh is empty, mirroring a live session blocked in p.Run.
+	runErrCh := make(chan error, 1)
+	go func() {
+		<-sessionCtx.Done()
+		runErrCh <- sessionCtx.Err()
+	}()
+
+	// Kill the approval server out from under the session, without cancelling
+	// the session context. awaitSessionEnd must detect this and tear down.
+	_ = ln.Close()
+
+	outcomeCh := make(chan shutdownOutcome, 1)
+	go func() {
+		outcomeCh <- awaitSessionEnd(runErrCh, srv, stopSession, httpCancel)
+	}()
+
+	select {
+	case outcome := <-outcomeCh:
+		if !outcome.serverDied {
+			t.Fatalf("expected serverDied=true on a mid-session approval-server failure, got %+v", outcome)
+		}
+		if outcome.httpErr == nil {
+			t.Fatal("expected the wrapped Serve error to be surfaced, got nil")
+		}
+		if errors.Is(outcome.httpErr, http.ErrServerClosed) {
+			t.Fatalf("ErrServerClosed must not be treated as a mid-session death: %v", outcome.httpErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("awaitSessionEnd did not fail fast on approval-server death; it waited for an independent session end")
+	}
+}
+
+// TestAwaitSessionEndNormalCompletion verifies the non-error path is unchanged:
+// when the proxy run loop completes first (signal or stdin-EOF) and the
+// approval server stops cleanly, awaitSessionEnd reports no error and does not
+// flag serverDied. The run result is threaded back unchanged.
+func TestAwaitSessionEndNormalCompletion(t *testing.T) {
+	token := generateToken(16)
+	approvals := audit.NewApprovalManager()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	httpCtx, httpCancel := context.WithCancel(context.Background())
+	defer httpCancel()
+	_, stopSession := context.WithCancel(context.Background())
+	defer stopSession()
+
+	srv := serveApprovals(httpCtx, ln, buildApprovalMux(approvals, token))
+	waitAccepting(t, ln.Addr().String())
+
+	// Run completed normally (clean stdin-EOF: nil error) before any server
+	// failure. awaitSessionEnd should drive the approval server's graceful
+	// shutdown via httpCancel and surface a nil httpErr.
+	runErrCh := make(chan error, 1)
+	runErrCh <- nil
+
+	outcome := awaitSessionEnd(runErrCh, srv, stopSession, httpCancel)
+	if outcome.serverDied {
+		t.Fatalf("normal completion must not flag serverDied: %+v", outcome)
+	}
+	if outcome.runErr != nil {
+		t.Fatalf("expected runErr to be threaded through as nil, got %v", outcome.runErr)
+	}
+	if outcome.httpErr != nil {
+		t.Fatalf("clean graceful shutdown must surface nil httpErr, got %v", outcome.httpErr)
+	}
+
+	if _, err := ln.Accept(); err == nil {
+		t.Fatal("expected listener to be closed after graceful shutdown")
+	}
+}
+
+// TestAwaitSessionEndNoApprovalServer verifies the -http-off flow: with a nil
+// approval-server handle the run result is threaded straight through and the
+// nil server-done channel never fires, so the helper neither blocks nor flags a
+// death.
+func TestAwaitSessionEndNoApprovalServer(t *testing.T) {
+	_, stopSession := context.WithCancel(context.Background())
+	defer stopSession()
+	_, httpCancel := context.WithCancel(context.Background())
+	defer httpCancel()
+
+	sentinel := errors.New("run failure")
+	runErrCh := make(chan error, 1)
+	runErrCh <- sentinel
+
+	outcome := awaitSessionEnd(runErrCh, nil, stopSession, httpCancel)
+	if outcome.serverDied {
+		t.Fatalf("nil approval server must never flag serverDied: %+v", outcome)
+	}
+	if !errors.Is(outcome.runErr, sentinel) {
+		t.Fatalf("expected runErr to thread through unchanged, got %v", outcome.runErr)
+	}
+	if outcome.httpErr != nil {
+		t.Fatalf("nil approval server must surface nil httpErr, got %v", outcome.httpErr)
+	}
+}
+
 // TestServeApprovalsPropagatesServeError verifies that a non-ErrServerClosed
 // Serve error is PROPAGATED back to the caller (via the handle's error channel,
 // surfaced by waitForHTTPShutdown) rather than crashing the process with


### PR DESCRIPTION
## What

Monitor the approval HTTP server's health concurrently with `p.Run(ctx)` so that a mid-session listener death fails fast instead of stalling.

## Why

Today the approval-server error is only read *after* `p.Run(ctx)` returns: `serve()` does `runErr := p.Run(ctx)` (blocks until signal-cancel or stdin EOF), then `httpCancel()` + `waitForHTTPShutdown(httpSrv)`. If the approval HTTP listener dies **mid-session** (a non-`http.ErrServerClosed` `Serve` error while a proxy session is live), the error sits unread in the server's buffered `errCh`, `Run` keeps blocking, and the proxy keeps advertising an approval URL it can no longer honour. Any call needing approval then blocks until `WaitForApproval` times out instead of failing fast.

Closes #691.

## Approach — concurrent monitoring

`p.Run(ctx)` now runs in a goroutine feeding a `chan error`. A new `awaitSessionEnd` helper `select`s on:

- **run-completed** (signal or stdin-EOF) — winds the approval server down exactly as before: `httpCancel()` drives the graceful `Shutdown(grace)`, then `waitForHTTPShutdown` reads the single `errCh` value.
- **approval-server `done` closed** — the listener died mid-session. The helper reads the single `errCh` value directly, cancels the session context (`stop()`) so `Run` unblocks promptly, drains the run result, and reports `serverDied`.

`serve()` checks `serverDied` *before* the signal branch (the fail-fast path cancels the session ctx itself, which would otherwise look like a signal) and exits non-zero with the wrapped Serve error. The existing ordering is preserved: signal path still logs `shutting down (signal received)` and returns 0; the wind-down still runs `httpCancel()` → graceful `Shutdown(grace)` → deferred emitter `Close()` last; the clean stdin-EOF path still shuts the approval server down and awaits it (#690 behaviour); the forced-shutdown log line is unchanged.

### Avoiding double-consume of `errCh`

`errCh` is buffered (size 1) and carries exactly one value. `awaitSessionEnd` reads it **at most once**: the run-completed branch leaves it for `waitForHTTPShutdown`; the server-died branch consumes it directly and does **not** call `waitForHTTPShutdown` (which would block re-reading an already-drained, never-closed channel). `serverDied` is gated on a non-nil error so that even if the `select` happens to pick the server-`done` branch on the signal path (where `httpCtx` cancellation produces a clean `ErrServerClosed`/`nil`), a clean stop is never misreported as a death.

### `-http` off

When `httpSrv` is nil, the helper's server-`done` channel is a nil channel (never fires in `select`), so the only path is run-completed and `awaitSessionEnd` is a thin pass-through. All `httpSrv` access on the death branch is guarded by that nil channel, so there is no nil-deref.

## Tests

Added to `mcp-proxy/cmd/mcp-proxy/shutdown_test.go`, mirroring the existing style and reusing `serveApprovals`, `buildApprovalMux`, `waitAccepting`, `generateToken`:

- `TestAwaitSessionEndFailsFastOnServerDeath` — starts the real approval server, closes its listener out from under it **without** cancelling the session, with a `runErrCh` that only delivers once the session ctx is cancelled. Asserts the helper returns promptly (3s guard) with `serverDied` and the wrapped (non-`ErrServerClosed`) error — i.e. it does NOT wait for an independent session end.
- `TestAwaitSessionEndNormalCompletion` — run completes first; asserts no `serverDied`, run result threaded through, clean nil `httpErr`, listener torn down.
- `TestAwaitSessionEndNoApprovalServer` — nil handle (`-http` off); asserts pass-through with no death flagged.

## Gates (run in `mcp-proxy/`)

- `go test ./...` — pass
- `go test -race ./...` — pass (coordination tests also stressed `-count=20 -race`, stable)
- `go vet ./...` — clean
- `go build ./cmd/mcp-proxy` — pass
- `gofmt -l` — clean on touched files

No changes outside `mcp-proxy/`. No CI/workflow, spec, crypto, or SDK changes.