### PR TITLE
test(mcp-proxy): harden proxy shutdown tests

### DIFF
--- a/mcp-proxy/internal/proxy/proxy_shutdown_test.go
+++ b/mcp-proxy/internal/proxy/proxy_shutdown_test.go
@@ -141,6 +141,9 @@ func TestRun_StdinEOFEndsRun(t *testing.T) {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	t.Cleanup(func() { _ = r.Close() })
+	// Always close the write end too, even if the test fails before the happy
+	// path closes it below (closing an os.File twice is harmless here).
+	t.Cleanup(func() { _ = w.Close() })
 
 	// The copy helper keeps its stdout open until its stdin closes; the proxy
 	// closes the child's stdin when the client→server pump hits EOF, so the
@@ -169,10 +172,12 @@ func TestRun_StdinEOFEndsRun(t *testing.T) {
 	select {
 	case err := <-done:
 		// Run returned on EOF without any cancellation. After the first pump
-		// exits, Run kills the upstream child, so the child Wait reports
-		// "signal: killed" — not nil. The honest distinction from a false pass
+		// exits, Run kills the upstream child; depending on timing the child may
+		// already have exited cleanly on stdin close (Wait returns nil) or be
+		// killed first (Wait returns "signal: killed"), so either a nil or
+		// non-nil result is valid here. The honest distinction from a false pass
 		// is that this happened only after EOF (the guard above proved Run was
-		// live) and the error is the expected child-kill, not a startup error.
+		// live) and the result is not a startup error.
 		if err != nil && isStartupError(err) {
 			t.Fatalf("Run returned a startup error on the EOF path: %v", err)
 		}

--- a/mcp-proxy/internal/proxy/proxy_shutdown_test.go
+++ b/mcp-proxy/internal/proxy/proxy_shutdown_test.go
@@ -2,15 +2,71 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
 
+// helperFlag is the sentinel first argument that selects the upstream
+// helper-process behaviour. When os.Args[1] is this flag, TestMain runs the
+// helper (in the mode given by os.Args[2]) and exits instead of running the
+// test suite, so the shutdown tests can spawn this test binary (os.Args[0]) as
+// a portable upstream command rather than relying on external binaries like
+// sleep or cat.
+const helperFlag = "-mcp-proxy-test-helper"
+
+// TestMain runs the upstream helper process when invoked with helperFlag,
+// otherwise it runs the package test suite. There must be exactly one TestMain
+// per test binary; the shutdown tests reuse this entry point as their upstream
+// command, selecting a mode via the argument after helperFlag.
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == helperFlag {
+		runHelper(os.Args[2:])
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runHelper executes one upstream helper-process behaviour and exits. args is
+// the slice after helperFlag; args[0] is the mode.
+func runHelper(args []string) {
+	var mode string
+	if len(args) > 0 {
+		mode = args[0]
+	}
+	switch mode {
+	case "block":
+		// Block until the process is killed by reading stdin that never sees
+		// data or EOF (the proxy holds the child's stdin open). Never write
+		// stdout. Stands in for `sleep` — the server→client pump blocks on the
+		// child's stdout (no EOF) and the child stays alive, so only a kill can
+		// end Run. A blocking read keeps a goroutine parked in a syscall, unlike
+		// `select {}`, which the runtime would flag as a deadlock and abort.
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	case "copy":
+		// Copy stdin→stdout until EOF, then exit cleanly. Stands in for `cat`:
+		// the proxy closes the child's stdin when the client→server pump hits
+		// EOF, so the copy ends and the child exits 0.
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}
+
+// helperCommand returns the command and args that spawn this test binary as an
+// upstream helper process in the given mode ("block" or "copy").
+func helperCommand(mode string) (command string, args []string) {
+	return os.Args[0], []string{helperFlag, mode}
+}
+
 // TestRun_ContextCancelUnblocks asserts that cancelling ctx returns Run
 // promptly even when neither STDIO pump has reached EOF: the upstream child
-// stays alive (sleep) and the client→server reader never closes. Cancellation
-// must kill the child and unblock Run.
+// stays alive (block helper) and the client→server reader never closes.
+// Cancellation must kill the child and unblock Run.
 func TestRun_ContextCancelUnblocks(t *testing.T) {
 	// Inject the read end of a pipe as the client reader, holding the write end
 	// open, so the client→server pump blocks on a read that never sees EOF.
@@ -29,10 +85,11 @@ func TestRun_ContextCancelUnblocks(t *testing.T) {
 		_ = w.Close()
 	})
 
-	// `sleep 30` neither reads stdin nor writes stdout, so the server→client
-	// pump blocks on the child's stdout (no EOF) and the child stays alive —
-	// only ctx cancel can end Run.
-	p := New("sleep", []string{"30"}, nil)
+	// The block helper neither reads stdin nor writes stdout, so the
+	// server→client pump blocks on the child's stdout (no EOF) and the child
+	// stays alive — only ctx cancel can end Run.
+	command, args := helperCommand("block")
+	p := New(command, args, nil)
 	p.clientReader = r
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -42,14 +99,30 @@ func TestRun_ContextCancelUnblocks(t *testing.T) {
 		done <- p.Run(ctx)
 	}()
 
-	// Let the pumps reach their blocking reads before cancelling.
-	time.Sleep(100 * time.Millisecond)
+	// Guard against a false positive: if the child failed to start, Run returns
+	// early with a startup error and the test would "pass" without exercising
+	// cancellation. Require Run to still be blocked before we cancel.
+	select {
+	case err := <-done:
+		t.Fatalf("Run returned before cancel (early/startup failure): %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// Run is blocked in the pumps, as intended — now cancel.
+	}
 	cancel()
 
 	select {
-	case <-done:
-		// Run returned promptly after cancel — success. The error is the
-		// expected "signal: killed" from killing the upstream child.
+	case err := <-done:
+		// Run returned promptly after cancel. Cancellation kills the live
+		// upstream child, so Wait reports the kill signal — a non-nil, non-startup
+		// error. A nil error would mean the child had already exited on its own
+		// before cancel (so cancellation was never actually exercised), and a
+		// startup error would mean Run never reached the pumps at all.
+		if err == nil {
+			t.Fatal("Run returned nil after cancel: child exited on its own, cancellation was not exercised")
+		}
+		if isStartupError(err) {
+			t.Fatalf("Run returned a startup error, not the cancel path: %v", err)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not return within 5s after context cancel")
 	}
@@ -57,20 +130,24 @@ func TestRun_ContextCancelUnblocks(t *testing.T) {
 
 // TestRun_StdinEOFEndsRun asserts the normal STDIO path is preserved: when the
 // client closes its end (EOF) the client→server pump exits and Run returns
-// without any signal, exactly as before context threading was added.
+// without any context cancellation, exactly as before context threading was
+// added.
 func TestRun_StdinEOFEndsRun(t *testing.T) {
-	// A reader at EOF models a client that closed its end of the pipe to end the
-	// session. Inject it as the client reader; ctx is never cancelled, so Run
-	// must return on EOF alone.
+	// A pipe whose write end is held open models a live client session; closing
+	// it later delivers EOF on the read end. ctx is never cancelled, so Run must
+	// return on EOF alone.
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
-	_ = w.Close() // immediate EOF on the read end
+	t.Cleanup(func() { _ = r.Close() })
 
-	// `cat` keeps its stdout open until its stdin closes; the proxy closes the
-	// child's stdin when the client→server pump hits EOF, so cat then exits.
-	p := New("cat", nil, nil)
+	// The copy helper keeps its stdout open until its stdin closes; the proxy
+	// closes the child's stdin when the client→server pump hits EOF, so the
+	// helper unblocks. The client→server pump exiting on EOF is what ends Run —
+	// the clean STDIO-session-close path, distinct from a startup failure.
+	command, args := helperCommand("copy")
+	p := New(command, args, nil)
 	p.clientReader = r
 
 	done := make(chan error, 1)
@@ -78,11 +155,38 @@ func TestRun_StdinEOFEndsRun(t *testing.T) {
 		done <- p.Run(context.Background())
 	}()
 
+	// Guard against a false positive: confirm Run is live (the child started and
+	// the pumps are running) before we deliver EOF. An early startup failure
+	// would surface here instead of masquerading as a clean EOF return.
 	select {
-	case <-done:
-		// Run returned on EOF without any cancellation — normal flow intact.
+	case err := <-done:
+		t.Fatalf("Run returned before EOF (early/startup failure): %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// Run is live — deliver EOF by closing the client's write end.
+	}
+	_ = w.Close()
+
+	select {
+	case err := <-done:
+		// Run returned on EOF without any cancellation. After the first pump
+		// exits, Run kills the upstream child, so the child Wait reports
+		// "signal: killed" — not nil. The honest distinction from a false pass
+		// is that this happened only after EOF (the guard above proved Run was
+		// live) and the error is the expected child-kill, not a startup error.
+		if err != nil && isStartupError(err) {
+			t.Fatalf("Run returned a startup error on the EOF path: %v", err)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not return within 5s on stdin EOF")
 	}
-	_ = r.Close()
+}
+
+// isStartupError reports whether err is one of Run's pre-pump startup failures
+// (pipe creation or child Start). These would surface as an early return rather
+// than the EOF/cancel shutdown paths the shutdown tests mean to exercise.
+func isStartupError(err error) bool {
+	msg := err.Error()
+	return strings.HasPrefix(msg, "stdin pipe:") ||
+		strings.HasPrefix(msg, "stdout pipe:") ||
+		strings.HasPrefix(msg, "start server:")
 }


### PR DESCRIPTION
## What

Harden the two proxy shutdown tests (`TestRun_ContextCancelUnblocks`, `TestRun_StdinEOFEndsRun`) in `mcp-proxy/internal/proxy/proxy_shutdown_test.go`. Test-only change; no production code touched.

Closes #692

## Why

Copilot flagged two robustness gaps:

1. **Tests could false-positive pass.** Both tests asserted only that `Run` returned. If the upstream child fails to *start*, `Run` returns early with a startup error and the test passes without exercising the cancel/EOF path it is meant to cover.
2. **Non-portable external binaries.** The tests shelled out to `sleep` and `cat`, which are not guaranteed to exist (or behave identically) across environments.

## False-positive fixes

- **Pre-shutdown live guard (both tests).** Before driving shutdown, each test now asserts `Run` has *not* already returned within a short window. A pre-cancel / pre-EOF early return is now caught as a failure rather than masquerading as success.
- **Cancel test return check.** After `cancel()`, the test requires a non-nil, non-startup error (the expected `signal: killed`). A `nil` return would mean the child exited on its own before cancel — i.e. cancellation was never actually exercised — and is now caught.
- **EOF test return check.** The EOF return is rejected if it is a startup error, distinguishing the clean STDIO-session-close path from an early `start server:`/pipe failure.
- A small `isStartupError` helper centralises detection of `Run`'s pre-pump startup failures (`stdin pipe:`, `stdout pipe:`, `start server:`).

These assertions were sanity-checked by deliberately breaking the helper (nonexistent upstream command, and helpers that exit immediately) and confirming each break fails the relevant test, then reverting.

## Helper-process pattern

Replaces `sleep`/`cat` with a portable Go helper process using the standard `TestMain` pattern (there is exactly one `TestMain` for the package's test binary):

- `TestMain` reruns this test binary (`os.Args[0]`) as the upstream command when invoked with a sentinel first arg (`-mcp-proxy-test-helper <mode>`); otherwise it runs `m.Run()`.
- Two modes:
  - `block` — reads stdin forever (parked in a syscall until the proxy kills the child); never writes stdout. Replaces `sleep` for the cancellation test. (A blocking read is used rather than `select {}`, which the Go runtime would abort as a deadlock.)
  - `copy` — pipes stdin to stdout until EOF, then exits. Replaces `cat` for the EOF test.

The helper reads/writes the inherited stdin/stdout fds, so the proxy's pump goroutines behave exactly as before.

## Gate (run in `mcp-proxy/`)

- `go test ./...` — pass
- `go test -race ./...` — pass
- `go vet ./...` — clean
- `go build ./cmd/mcp-proxy` — ok (stray binary removed)
- `gofmt -l` — clean on the touched file
- `go test -run 'TestRun_' ./internal/proxy/ -v` — all pass