### PR TITLE
ci(release): add SDK output schema-conformance gate (#653)

### DIFF
--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - run: python3 -m pip install --quiet jsonschema
+      - run: python3 -m pip install --quiet "jsonschema[format-nongpl]==4.26.0"
       - name: Verify emitted receipt conforms to schema (Gate #6)
         run: |
           VERSION="${GITHUB_REF_NAME#sdk/go/v}"

--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -102,3 +102,28 @@ jobs:
           python3 scripts/release_verify/check.py --lang go --version "$VERSION"
       - name: Run unit tests for release-verify gate
         run: python3 scripts/release_verify/test_check.py
+
+  # Gate #6: the receipt the just-published module emits must validate against
+  # the published JSON Schema. Emits via the module fetched from the Go proxy
+  # and validates with spec/schema/agent-receipt.schema.json; output that
+  # drifts from the schema turns the release red.
+  schema-conformance:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - run: python3 -m pip install --quiet jsonschema
+      - name: Verify emitted receipt conforms to schema (Gate #6)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/schema_conformance/check.py --lang go --version "$VERSION"
+      - name: Run unit tests for schema-conformance gate
+        run: python3 scripts/schema_conformance/test_check.py

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - run: python3 -m pip install --quiet jsonschema
+      - run: python3 -m pip install --quiet "jsonschema[format-nongpl]==4.26.0"
       - name: Verify emitted receipt conforms to schema (Gate #6)
         run: |
           VERSION="${GITHUB_REF_NAME#sdk-py-v}"

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -112,3 +112,25 @@ jobs:
           python3 scripts/release_verify/check.py --lang py --version "$VERSION"
       - name: Run unit tests for release-verify gate
         run: python3 scripts/release_verify/test_check.py
+
+  # Gate #6: the receipt the just-published package emits must validate against
+  # the published JSON Schema. Emits via the package installed from PyPI and
+  # validates with spec/schema/agent-receipt.schema.json; output that drifts
+  # from the schema turns the release red.
+  schema-conformance:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - run: python3 -m pip install --quiet jsonschema
+      - name: Verify emitted receipt conforms to schema (Gate #6)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-py-v}"
+          python3 scripts/schema_conformance/check.py --lang py --version "$VERSION"
+      - name: Run unit tests for schema-conformance gate
+        run: python3 scripts/schema_conformance/test_check.py

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - run: python3 -m pip install --quiet jsonschema
+      - run: python3 -m pip install --quiet "jsonschema[format-nongpl]==4.26.0"
       - name: Verify emitted receipt conforms to schema (Gate #6)
         run: |
           VERSION="${GITHUB_REF_NAME#sdk-ts-v}"

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -128,3 +128,28 @@ jobs:
           python3 scripts/release_verify/check.py --lang ts --version "$VERSION"
       - name: Run unit tests for release-verify gate
         run: python3 scripts/release_verify/test_check.py
+
+  # Gate #6: the receipt the just-published package emits must validate against
+  # the published JSON Schema. Emits via the package installed from npm and
+  # validates with spec/schema/agent-receipt.schema.json; output that drifts
+  # from the schema turns the release red.
+  schema-conformance:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - run: python3 -m pip install --quiet jsonschema
+      - name: Verify emitted receipt conforms to schema (Gate #6)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
+          python3 scripts/schema_conformance/check.py --lang ts --version "$VERSION"
+      - name: Run unit tests for schema-conformance gate
+        run: python3 scripts/schema_conformance/test_check.py

--- a/scripts/schema_conformance/AGENTS.md
+++ b/scripts/schema_conformance/AGENTS.md
@@ -1,0 +1,56 @@
+# schema_conformance
+
+Gate #6 from ADR-0024: SDK output schema-conformance at release time.
+
+After a release is published to PyPI / npm / the Go proxy, this gate emits a
+representative signed receipt using the **published** SDK artifact and
+validates it against the repo's published JSON Schema
+(`spec/schema/agent-receipt.schema.json`). A release whose SDK emits output
+that drifts from the schema turns red here, before the version is treated as
+good.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Installs the released version, emits one receipt via the SDK's public API, and validates it against the schema. |
+| `test_check.py` | Unit tests for the schema-validation core and stdout parsing (no SDK install, no network). |
+
+## Run locally
+
+```sh
+python3 scripts/schema_conformance/test_check.py          # unit tests (no network)
+python3 scripts/schema_conformance/check.py --lang py --version 0.10.0
+python3 scripts/schema_conformance/check.py --lang ts --version 0.10.0
+python3 scripts/schema_conformance/check.py --lang go --version 0.12.0
+```
+
+`check.py` and `test_check.py` need the `jsonschema` library, which is already
+a dev dependency of the Python SDK (`sdk/py/pyproject.toml`). The CI jobs
+install it explicitly so the gate does not depend on the SDK's dev extras
+being present.
+
+## What this gate checks
+
+The SDK being released emits a receipt that conforms to the published JSON
+Schema. Validation uses Draft 2020-12 with format assertion enabled, matching
+`AssertFormat` in the in-tree Go validator
+(`cross-sdk-tests/spec_schema_test.go`), so a regression to a non-RFC3339
+timestamp fails here too.
+
+## Targeted spec version
+
+There is a single repo-tracked schema file. It validates every protocol
+`version` it lists in its `version` enum, and each receipt carries its own
+`version`. The schema ships from the same commit as the SDK, so the schema
+validated against is the one released alongside the SDK (ADR-0021
+coordination); no separate version selection is required.
+
+## Relationship to Gates #1 and #2
+
+Gate #1 (`readme-snippets`) checks documented snippets compile/run against the
+published artifact. Gate #2 (`release-verify`) checks the registry resolved
+exactly the tagged version. Gate #6 adds the output-shape assertion: the
+receipt the published SDK actually emits validates against the schema. All
+three jobs depend only on `release` and run in parallel; each must pass for a
+release to be considered green.

--- a/scripts/schema_conformance/check.py
+++ b/scripts/schema_conformance/check.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Gate #6: SDK output schema-conformance at release time.
+
+After a release is published, emit a representative signed receipt using the
+*published* SDK artifact and validate it against the repo's published JSON
+Schema (``spec/schema/agent-receipt.schema.json``). A release whose SDK emits
+output that drifts from the schema turns red here, before the version is
+treated as good.
+
+This is the release-time enforcement of the property ADR-0024 D1 records:
+"each SDK emits receipts conforming to the published schema." The in-tree
+cross-SDK suite (``cross-sdk-tests/spec_schema_test.go``) checks the same
+property at PR time against committed vectors; this gate closes the gap at
+release time against the artifact consumers actually install.
+
+What "the targeted spec version" means here: the schema validates every
+protocol ``version`` it lists in its ``version`` enum (v0.1 .. v0.4 today), and
+the receipt under test carries its own ``version`` field, which the schema
+keys its per-version constraints off. The single repo-tracked schema file is
+the source of truth — it ships from this same commit, so the schema validated
+against is the one released alongside the SDK (ADR-0021 coordination).
+
+Validation uses the ``jsonschema`` library (already a dev dependency of the
+Python SDK) configured for Draft 2020-12 with format assertion enabled — the
+same draft and the same format-checking posture as the Go validator in
+``cross-sdk-tests/spec_schema_test.go`` (``Draft2020`` + ``AssertFormat``), so
+a regression to a non-RFC3339 timestamp fails here too.
+
+Usage:
+    check.py --lang {go,ts,py} --version X.Y.Z [--schema PATH] [--workdir DIR]
+
+Exit codes:
+    0  emitted receipt validates against the schema
+    1  emit failed, or the emitted receipt violates the schema
+    2  usage error (missing args, unknown lang)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+TS_PACKAGE = "@agnt-rcpt/sdk-ts"
+PY_PACKAGE = "agent-receipts"
+
+# Default schema location relative to the repo root (two levels up from here).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_SCHEMA = os.path.join(_REPO_ROOT, "spec", "schema", "agent-receipt.schema.json")
+
+# How many times to retry a registry fetch before failing. The public
+# registries have occasional propagation lag after a new version is pushed;
+# retries cover the window between "tag pushed" and "version installable".
+REGISTRY_RETRIES = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    cmd: list[str],
+    cwd: str,
+    env: dict[str, str] | None = None,
+    retries: int = 0,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    full_env = {**os.environ, **(env or {})}
+    for attempt in range(retries + 1):
+        print(f"  $ {' '.join(cmd)}  (cwd={cwd})", flush=True)
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=full_env,
+            text=True,
+            capture_output=capture_output,
+        )
+        if proc.returncode == 0 or attempt == retries:
+            return proc
+        wait = 2 ** (attempt + 1)
+        print(f"  command failed (rc={proc.returncode}); retrying in {wait}s", flush=True)
+        time.sleep(wait)
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Schema validation (shared, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def validate_receipt(receipt: object, schema: dict) -> list[str]:
+    """Validate *receipt* against *schema*; return a list of violation messages.
+
+    An empty list means the receipt conforms. This is the core of the gate and
+    is exercised by the unit tests with controlled inputs (no emit, no network).
+
+    Uses Draft 2020-12 with a FormatChecker so ``"format": "date-time"``
+    constraints (issuanceDate, proof.created) are asserted, not annotation-only
+    — matching ``AssertFormat`` in the Go validator. A regression to a
+    non-RFC3339 timestamp is therefore caught here.
+    """
+    # Imported lazily so the unit tests can import this module without the
+    # jsonschema dependency present unless they actually validate.
+    from jsonschema import Draft202012Validator, FormatChecker
+
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(receipt), key=lambda e: list(e.absolute_path))
+    messages = []
+    for err in errors:
+        location = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        messages.append(f"{location}: {err.message}")
+    return messages
+
+
+def _load_schema(path: str) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _assert_conforms(lang: str, receipt: object, schema: dict) -> int:
+    """Validate an emitted receipt and report. Returns 0 on conformance, 1 otherwise."""
+    violations = validate_receipt(receipt, schema)
+    if violations:
+        print(
+            f"ERROR: receipt emitted by the published {lang} SDK does not validate "
+            "against spec/schema/agent-receipt.schema.json:"
+        )
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print(f"OK: receipt emitted by the published {lang} SDK validates against the schema")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Emit drivers — install the published artifact and emit one receipt as JSON
+# ---------------------------------------------------------------------------
+
+# Each driver writes a tiny program that uses only the SDK's public emit API
+# (mirroring the README quick-start, which Gate #1 keeps in sync with the
+# released surface) and prints exactly one signed receipt as JSON to stdout.
+
+_PY_EMIT = """\
+import json
+from agent_receipts import (
+    ActionInput,
+    CreateReceiptInput,
+    Chain,
+    Issuer,
+    Outcome,
+    Principal,
+    create_receipt,
+    generate_key_pair,
+    sign_receipt,
+)
+
+keys = generate_key_pair()
+unsigned = create_receipt(
+    CreateReceiptInput(
+        issuer=Issuer(id="did:agent:schema-conformance"),
+        principal=Principal(id="did:user:release-gate"),
+        action=ActionInput(type="filesystem.file.read", risk_level="low"),
+        outcome=Outcome(status="success"),
+        chain=Chain(
+            sequence=1,
+            previous_receipt_hash=None,
+            chain_id="schema-conformance-1",
+        ),
+    )
+)
+receipt = sign_receipt(unsigned, keys.private_key, "did:agent:schema-conformance#key-1")
+wire = receipt.model_dump(by_alias=True, exclude_none=True)
+# previous_receipt_hash is required-nullable per spec; exclude_none strips it,
+# but the wire form (what the SDK signs and consumers receive) keeps it as null.
+# Mirror the SDK's own serialization (see sdk/py .../receipt/signing.py).
+chain = wire["credentialSubject"]["chain"]
+chain.setdefault("previous_receipt_hash", None)
+print(json.dumps(wire))
+"""
+
+_TS_EMIT = """\
+import {
+  type CreateReceiptInput,
+  createReceipt,
+  generateKeyPair,
+  signReceipt,
+} from "@agnt-rcpt/sdk-ts";
+
+const keys = generateKeyPair();
+const input: CreateReceiptInput = {
+  issuer: { id: "did:agent:schema-conformance" },
+  principal: { id: "did:user:release-gate" },
+  action: { type: "filesystem.file.read", risk_level: "low" },
+  outcome: { status: "success" },
+  chain: { sequence: 1, previous_receipt_hash: null, chain_id: "schema-conformance-1" },
+};
+const unsigned = createReceipt(input);
+const receipt = signReceipt(unsigned, keys.privateKey, "did:agent:schema-conformance#key-1");
+console.log(JSON.stringify(receipt));
+"""
+
+_GO_EMIT = """\
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+func main() {
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	unsigned := receipt.Create(receipt.CreateInput{
+		Issuer:    receipt.Issuer{ID: "did:agent:schema-conformance"},
+		Principal: receipt.Principal{ID: "did:user:release-gate"},
+		Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow},
+		Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain:     receipt.Chain{Sequence: 1, ChainID: "schema-conformance-1"},
+	})
+	signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:schema-conformance#key-1")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	out, err := json.Marshal(signed)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}
+"""
+
+
+def _parse_emitted(lang: str, stdout: str) -> object | None:
+    """Pull the single JSON receipt object out of an emit program's stdout."""
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                return None
+    print(f"ERROR: {lang} emit program produced no JSON receipt on stdout")
+    return None
+
+
+def emit_py(version: str, workdir: str) -> object | None:
+    venv = os.path.join(workdir, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=workdir).returncode != 0:
+        return None
+    py = os.path.join(venv, "bin", "python")
+    spec = f"{PY_PACKAGE}=={version}"
+    print(f"\n--- Installing {spec} from PyPI")
+    if (
+        _run([py, "-m", "pip", "install", "--quiet", spec], cwd=workdir, retries=REGISTRY_RETRIES).returncode
+        != 0
+    ):
+        print(f"ERROR: failed to install {spec} from PyPI")
+        return None
+    prog = os.path.join(workdir, "emit.py")
+    with open(prog, "w", encoding="utf-8") as fh:
+        fh.write(_PY_EMIT)
+    print("\n--- Emitting a receipt with the published Python SDK")
+    result = _run([py, prog], cwd=workdir, capture_output=True)
+    if result.returncode != 0:
+        print(f"ERROR: Python emit program failed\n{result.stderr}")
+        return None
+    return _parse_emitted("py", result.stdout)
+
+
+def emit_ts(version: str, workdir: str) -> object | None:
+    package_json = {
+        "name": "schema-conformance",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: version},
+    }
+    with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+    print(f"\n--- Installing {TS_PACKAGE}@{version} from npm")
+    if (
+        _run(["npm", "install", "--no-audit", "--no-fund"], cwd=workdir, retries=REGISTRY_RETRIES).returncode
+        != 0
+    ):
+        print(f"ERROR: npm install {TS_PACKAGE}@{version} failed")
+        return None
+    prog = os.path.join(workdir, "emit.ts")
+    with open(prog, "w", encoding="utf-8") as fh:
+        fh.write(_TS_EMIT)
+    print("\n--- Emitting a receipt with the published TypeScript SDK")
+    # Node strips types directly (Node 22.18+ / 24); no separate compile step.
+    result = _run(
+        ["node", "--experimental-strip-types", "emit.ts"],
+        cwd=workdir,
+        env={"NODE_NO_WARNINGS": "1"},
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: TypeScript emit program failed\n{result.stderr}")
+        return None
+    return _parse_emitted("ts", result.stdout)
+
+
+def emit_go(version: str, workdir: str) -> object | None:
+    go_mod = [
+        "module example.com/schema-conformance\n",
+        "go 1.26.1\n",
+        f"require {GO_MODULE} v{version}\n",
+    ]
+    with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
+        fh.writelines(go_mod)
+    with open(os.path.join(workdir, "main.go"), "w", encoding="utf-8") as fh:
+        fh.write(_GO_EMIT)
+    # Pin GOPROXY to the public proxy with no `direct` fallback so the emit
+    # exercises the module consumers actually resolve, not a VCS checkout.
+    env = {
+        "GOFLAGS": "-mod=mod",
+        "GOWORK": "off",
+        "GOPROXY": "https://proxy.golang.org",
+    }
+    print(f"\n--- Fetching {GO_MODULE}@v{version} and emitting a receipt")
+    if _run(["go", "mod", "tidy"], cwd=workdir, env=env, retries=REGISTRY_RETRIES).returncode != 0:
+        print(f"ERROR: go mod tidy for {GO_MODULE}@v{version} failed")
+        return None
+    result = _run(["go", "run", "."], cwd=workdir, env=env, capture_output=True)
+    if result.returncode != 0:
+        print(f"ERROR: Go emit program failed\n{result.stderr}")
+        return None
+    return _parse_emitted("go", result.stdout)
+
+
+_EMITTERS = {"go": emit_go, "ts": emit_ts, "py": emit_py}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--lang", required=True, choices=["go", "ts", "py"])
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Released version string (no leading 'v'), e.g. 0.12.0 or 0.12.0-alpha.1",
+    )
+    parser.add_argument(
+        "--schema",
+        default=DEFAULT_SCHEMA,
+        help=f"Path to the JSON Schema to validate against (default: {DEFAULT_SCHEMA})",
+    )
+    parser.add_argument(
+        "--workdir",
+        default=None,
+        help="Working directory for the temporary project (default: auto-created tmpdir)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.version.startswith("v"):
+        parser.error(f"--version must not have a leading 'v' (got {args.version!r})")
+
+    schema = _load_schema(args.schema)
+
+    cleanup = False
+    if args.workdir:
+        workdir = os.path.abspath(args.workdir)
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = tempfile.mkdtemp(prefix="schema-conformance-")
+        cleanup = True
+
+    print("Gate #6 — SDK output schema-conformance")
+    print(f"  lang    : {args.lang}")
+    print(f"  version : {args.version}")
+    print(f"  schema  : {args.schema}")
+    print(f"  workdir : {workdir}")
+
+    try:
+        receipt = _EMITTERS[args.lang](args.version, workdir)
+        if receipt is None:
+            rc = 1
+        else:
+            rc = _assert_conforms(args.lang, receipt, schema)
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    if rc == 0:
+        print(f"\nGate #6 PASSED for {args.lang} {args.version}")
+    else:
+        print(f"\nGate #6 FAILED for {args.lang} {args.version} (see errors above)")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/schema_conformance/check.py
+++ b/scripts/schema_conformance/check.py
@@ -256,7 +256,11 @@ def _parse_emitted(lang: str, stdout: str) -> object | None:
         if line.startswith("{"):
             try:
                 return json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
+                print(
+                    f"ERROR: {lang} emit program produced a non-JSON receipt line: {exc}\n"
+                    f"  offending line: {line}"
+                )
                 return None
     print(f"ERROR: {lang} emit program produced no JSON receipt on stdout")
     return None

--- a/scripts/schema_conformance/test_check.py
+++ b/scripts/schema_conformance/test_check.py
@@ -142,8 +142,8 @@ class TestAssertConforms:
 # ---------------------------------------------------------------------------
 
 
-class TestSpecExamplesValidate:
-    def test_all_v04_capable_examples_validate(self) -> None:
+class TestCanonicalReceiptValidates:
+    def test_canonical_good_receipt_validates(self) -> None:
         # Sanity-check the validator against the canonical good fixture so a
         # broken validator (e.g. schema fails to load, refs unresolved) is
         # caught here rather than silently passing every release.
@@ -164,7 +164,7 @@ def _run_all() -> int:
         TestValidateReceipt,
         TestParseEmitted,
         TestAssertConforms,
-        TestSpecExamplesValidate,
+        TestCanonicalReceiptValidates,
     ]
     for suite_cls in suites:
         suite = suite_cls()

--- a/scripts/schema_conformance/test_check.py
+++ b/scripts/schema_conformance/test_check.py
@@ -1,0 +1,188 @@
+"""Unit tests for the Gate #6 SDK output schema-conformance verifier.
+
+These tests exercise the schema-validation core (`validate_receipt`) against
+the real `spec/schema/agent-receipt.schema.json` using a known-good spec
+example as the fixture. No SDK is installed and no network call is made — the
+emit drivers (which do install the published artifact) are exercised
+end-to-end by CI at release time, not here.
+
+The core invariant under test: `validate_receipt` returns no violations for a
+schema-conforming receipt and at least one violation for a receipt that drops
+a required field or carries a non-RFC3339 timestamp. The failure cases are a
+direct implementation of ADR-0024 D6 (a gate must be observed to fail on a
+deliberately-broken input).
+
+Run with:
+    python3 -m pytest scripts/schema_conformance/test_check.py
+    python3 scripts/schema_conformance/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+_GOOD_RECEIPT = os.path.join(
+    check._REPO_ROOT, "spec", "examples", "minimal-receipt.json"
+)
+
+
+def _schema() -> dict:
+    return check._load_schema(check.DEFAULT_SCHEMA)
+
+
+def _good_receipt() -> dict:
+    with open(_GOOD_RECEIPT, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# validate_receipt — the core gate logic
+# ---------------------------------------------------------------------------
+
+
+class TestValidateReceipt:
+    def test_conforming_receipt_has_no_violations(self) -> None:
+        assert check.validate_receipt(_good_receipt(), _schema()) == []
+
+    def test_missing_required_proof_is_violation(self) -> None:
+        receipt = _good_receipt()
+        del receipt["proof"]
+        violations = check.validate_receipt(receipt, _schema())
+        assert violations
+        assert any("proof" in v for v in violations)
+
+    def test_missing_required_issuer_is_violation(self) -> None:
+        receipt = _good_receipt()
+        del receipt["issuer"]
+        assert check.validate_receipt(receipt, _schema())
+
+    def test_unknown_top_level_field_is_violation(self) -> None:
+        # additionalProperties: false at the root must reject stray fields.
+        receipt = _good_receipt()
+        receipt["unexpected_field"] = "value"
+        assert check.validate_receipt(receipt, _schema())
+
+    def test_non_rfc3339_issuance_date_is_violation(self) -> None:
+        # Mirrors AssertFormat in the Go validator: a non-RFC3339 date-time
+        # must fail, otherwise the format constraint is annotation-only.
+        receipt = _good_receipt()
+        receipt["issuanceDate"] = "2026/04/22 00:00:00"
+        assert check.validate_receipt(receipt, _schema())
+
+    def test_bad_receipt_id_is_violation(self) -> None:
+        # urn:receipt:<uuid> pattern must be enforced.
+        receipt = _good_receipt()
+        receipt["id"] = "not-a-urn"
+        assert check.validate_receipt(receipt, _schema())
+
+    def test_violation_messages_include_location(self) -> None:
+        receipt = _good_receipt()
+        del receipt["proof"]
+        violations = check.validate_receipt(receipt, _schema())
+        # Each message is "<location>: <message>"; a root-level miss is "<root>".
+        assert all(": " in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# _parse_emitted — pulling the JSON receipt out of an emit program's stdout
+# ---------------------------------------------------------------------------
+
+
+class TestParseEmitted:
+    def test_parses_single_json_object(self) -> None:
+        obj = {"id": "urn:receipt:x", "type": ["VerifiableCredential", "AgentReceipt"]}
+        assert check._parse_emitted("py", json.dumps(obj)) == obj
+
+    def test_ignores_leading_log_lines(self) -> None:
+        obj = {"id": "urn:receipt:x"}
+        stdout = "installing...\nbuilding...\n" + json.dumps(obj) + "\n"
+        assert check._parse_emitted("go", stdout) == obj
+
+    def test_no_json_returns_none(self) -> None:
+        assert check._parse_emitted("ts", "just some logs\nno receipt here\n") is None
+
+    def test_malformed_json_returns_none(self) -> None:
+        assert check._parse_emitted("py", "{ not valid json") is None
+
+    def test_empty_stdout_returns_none(self) -> None:
+        assert check._parse_emitted("go", "") is None
+
+    def test_picks_last_json_line(self) -> None:
+        # If the SDK ever prints more than one object, the receipt is the last.
+        first = json.dumps({"id": "first"})
+        last = json.dumps({"id": "last"})
+        assert check._parse_emitted("py", first + "\n" + last + "\n") == {"id": "last"}
+
+
+# ---------------------------------------------------------------------------
+# _assert_conforms — pass/fail reporting wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestAssertConforms:
+    def test_conforming_receipt_returns_zero(self) -> None:
+        assert check._assert_conforms("py", _good_receipt(), _schema()) == 0
+
+    def test_violating_receipt_returns_one(self) -> None:
+        receipt = _good_receipt()
+        del receipt["proof"]
+        assert check._assert_conforms("py", receipt, _schema()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: every spec example validates (the emit drivers must produce
+# receipts no less conformant than the committed examples)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecExamplesValidate:
+    def test_all_v04_capable_examples_validate(self) -> None:
+        # Sanity-check the validator against the canonical good fixture so a
+        # broken validator (e.g. schema fails to load, refs unresolved) is
+        # caught here rather than silently passing every release.
+        schema = _schema()
+        receipt = _good_receipt()
+        # A deep copy guards against accidental shared mutation between tests.
+        assert check.validate_receipt(copy.deepcopy(receipt), schema) == []
+
+
+# ---------------------------------------------------------------------------
+# Self-runner (no pytest dependency required)
+# ---------------------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    suites = [
+        TestValidateReceipt,
+        TestParseEmitted,
+        TestAssertConforms,
+        TestSpecExamplesValidate,
+    ]
+    for suite_cls in suites:
+        suite = suite_cls()
+        for name in sorted(dir(suite_cls)):
+            if not name.startswith("test_"):
+                continue
+            fn = getattr(suite, name)
+            try:
+                fn()
+                print(f"ok   {suite_cls.__name__}.{name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {suite_cls.__name__}.{name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {suite_cls.__name__}.{name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## What

Implements **Gate #6** from ADR-0024 (project verification contract): *"Each SDK release produces a receipt and validates it against the published JSON Schema before the release goes out."*

Adds a release-blocking `schema-conformance` job to each of the three `release-sdk-*.yml` workflows. After the SDK is published, the job:

1. Installs/fetches the **published** artifact (PyPI / npm / Go proxy) at the tagged version.
2. Emits a representative signed receipt using the SDK's public emit API.
3. Validates that receipt against `spec/schema/agent-receipt.schema.json`.
4. Fails the job — and the release — on any schema violation.

> [!IMPORTANT]
> This adds a **RELEASE-BLOCKING** gate to all three `release-sdk-*.yml` workflows. A schema-non-conforming SDK release will turn red on this job. Flagging for human review since it edits release CI.

## Why

Per ADR-0024 D1, every property the project asserts must have a gate that fails when the property is false. The project asserts that each SDK emits receipts conforming to the published schema; until now there was no release-time enforcement of that, so a release could ship an SDK whose output had drifted from the schema. This gate is the release-time enforcement. It is a sibling of Gate #2 (`release-verify`, round-trip) and Gate #7 (cross-SDK byte-identity), all release-time gates.

## Approach

Per-SDK job + shared helper, mirroring the existing `scripts/release_verify/` (Gate #2) conventions:

- **`scripts/schema_conformance/check.py`** — `--lang {go,ts,py} --version X.Y.Z`. Installs the released artifact, emits one receipt via a tiny program built on the SDK's public API (`create*` + `sign*`, mirroring the README quick-start that Gate #1 keeps in sync), and validates it.
- **`scripts/schema_conformance/test_check.py`** — unit tests for the validation core and stdout parsing; no SDK install, no network. The failure cases (missing required field, bad `urn:receipt` id, non-RFC3339 date, unknown top-level field) are a direct implementation of ADR-0024 D6 (a gate must be observed to fail on a deliberately-broken input).
- **`scripts/schema_conformance/AGENTS.md`** — layout + relationship to Gates #1/#2, mirroring `release_verify/AGENTS.md`.

Each new job is `needs: release` and runs in parallel with the existing `readme-snippets` (Gate #1) and `release-verify` (Gate #2) jobs — same position in the release sequence, same runner setup.

### Reuses existing tooling, no new schema validator

Validation uses the `jsonschema` library (already a dev dependency of the Python SDK) on **Draft 2020-12 with format assertion enabled**, matching the in-tree Go validator in `cross-sdk-tests/spec_schema_test.go` (`Draft2020` + `AssertFormat`) — so a regression to a non-RFC3339 timestamp fails here too. No new schema-validation dependency was introduced.

### Targeted spec version

There is a single repo-tracked schema file (`spec/schema/agent-receipt.schema.json`) that validates every protocol `version` in its enum (v0.1 .. v0.4 today); each receipt carries its own `version`. The schema ships from the same commit as the SDK, so the schema validated against is the one released alongside it (ADR-0021 coordination). No separate version selection is needed; the job reads the version from the release tag exactly as the existing gates do.

## How tested

- **Validation core (unit):** `python3 scripts/schema_conformance/test_check.py` and via pytest — 16 tests pass. Proves PASS on a conforming receipt and FAIL on receipts missing a required field, with a bad id pattern, a non-RFC3339 date, or an unknown top-level field.
- **End-to-end emit → validate (all three SDKs):** ran each embedded emit program against the in-tree SDK and validated the output.
  - **PASS path:** Go, TS, and Python each emit a v0.4.0 receipt that validates (rc 0).
  - **FAIL path:** a receipt with `proof` removed fails validation (rc 1), proving the gate blocks the release on a violation.
- Existing `cross-sdk-tests` schema integration tests still pass (no regression).

A real finding while building this: a naive `model_dump(by_alias=True, exclude_none=True)` strips the required-nullable `chain.previous_receipt_hash`, which the schema rejects — exactly the drift class this gate exists to catch. The emit driver mirrors the SDK's own wire serialization (re-adding the field), matching `sdk/py/.../receipt/signing.py`.

Closes #653.

References ADR-0024 Gate #6 (`docs/adr/0024-project-verification-contract.md`).