### PR TITLE
fix(site): restore GFM tables in MDX under Astro 6

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,6 +5,13 @@ import rehypeMermaid from "rehype-mermaid";
 export default defineConfig({
   site: "https://agentreceipts.ai",
   markdown: {
+    // Astro 6 dropped the implicit `markdown.gfm` default, expecting the new
+    // `unified()` processor to supply it. @astrojs/mdx (5.x) is not yet
+    // processor-aware — it reads `markdown.gfm` directly — so without this it
+    // sees `undefined` and silently drops remark-gfm, breaking every table
+    // (and strikethrough/autolinks) in .mdx files. Set it explicitly until the
+    // MDX integration adopts the processor model.
+    gfm: true,
     syntaxHighlight: {
       type: "shiki",
       excludeLangs: ["mermaid"],


### PR DESCRIPTION
## Problem

Every table on the docs site renders as raw `| pipe | text |` instead of an HTML table — e.g. the [ecosystem landscape](https://agentreceipts.ai/ecosystem/landscape/) page. This affects **all `.mdx` files site-wide**, not just one page (also breaks strikethrough and autolinks).

## Root cause

This is an Astro 6 regression, confirmed by reading the installed package internals and reproducing locally:

- Astro 6.4.2 deprecated `markdown.gfm` and **removed its implicit default** (`core/config/schemas/base.js` → `gfm: z.boolean().optional()`, no default). The new `unified()` processor is meant to supply the default.
- The regular `.md` pipeline recovers GFM via that processor fallback. But **`@astrojs/mdx` 5.0.4 is not processor-aware** — `markdownConfigToMdxOptions` reads `config.markdown.gfm` directly, which is now `undefined`, so `gfm: options.gfm ?? defaults.gfm` resolves falsy and `remark-gfm` is never registered for MDX (`plugins.js`). That silently drops every table.

## Fix

Set `markdown.gfm: true` explicitly in `astro.config.mjs` so the value flows into the MDX integration, with a comment documenting the version mismatch. This is the right bridge until `@astrojs/mdx` adopts the processor model.

## Verification

Built and ran the dev server locally:

- Landscape page: **0 → 9 rendered `<table>` elements**, with correct headers and cells.
- Confirmed other `.mdx` pages (e.g. `specification/risk-levels`) and a minimal repro page also recovered.

## Notes

- A full `pnpm build` separately fails because `rehype-mermaid` needs a Playwright Chromium browser that can&#39;t be downloaded in the sandboxed environment — unrelated to this change (the affected pages have no mermaid diagrams).