### PR TITLE
ci(release): add cross-SDK byte-identity gate (#654)

### DIFF
--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -127,3 +127,27 @@ jobs:
           python3 scripts/schema_conformance/check.py --lang go --version "$VERSION"
       - name: Run unit tests for schema-conformance gate
         run: python3 scripts/schema_conformance/test_check.py
+
+  # Gate #7: the canonical JSON the just-published module produces must be
+  # byte-identical to the shared canonicalisation vectors (and therefore to the
+  # other SDKs). Runs the vectors through the module fetched from the Go proxy
+  # and compares byte-for-byte; any divergence turns the release red.
+  byte-identity:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify canonicalisation is byte-identical to the vectors (Gate #7)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/byte_identity/check.py --lang go --version "$VERSION"
+      - name: Run unit tests for byte-identity gate
+        run: python3 scripts/byte_identity/test_check.py

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -134,3 +134,24 @@ jobs:
           python3 scripts/schema_conformance/check.py --lang py --version "$VERSION"
       - name: Run unit tests for schema-conformance gate
         run: python3 scripts/schema_conformance/test_check.py
+
+  # Gate #7: the canonical JSON the just-published package produces must be
+  # byte-identical to the shared canonicalisation vectors (and therefore to the
+  # other SDKs). Runs the vectors through the package installed from PyPI and
+  # compares byte-for-byte; any divergence turns the release red.
+  byte-identity:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify canonicalisation is byte-identical to the vectors (Gate #7)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-py-v}"
+          python3 scripts/byte_identity/check.py --lang py --version "$VERSION"
+      - name: Run unit tests for byte-identity gate
+        run: python3 scripts/byte_identity/test_check.py

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -153,3 +153,27 @@ jobs:
           python3 scripts/schema_conformance/check.py --lang ts --version "$VERSION"
       - name: Run unit tests for schema-conformance gate
         run: python3 scripts/schema_conformance/test_check.py
+
+  # Gate #7: the canonical JSON the just-published package produces must be
+  # byte-identical to the shared canonicalisation vectors (and therefore to the
+  # other SDKs). Runs the vectors through the package installed from npm and
+  # compares byte-for-byte; any divergence turns the release red.
+  byte-identity:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify canonicalisation is byte-identical to the vectors (Gate #7)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
+          python3 scripts/byte_identity/check.py --lang ts --version "$VERSION"
+      - name: Run unit tests for byte-identity gate
+        run: python3 scripts/byte_identity/test_check.py

--- a/scripts/byte_identity/AGENTS.md
+++ b/scripts/byte_identity/AGENTS.md
@@ -1,0 +1,69 @@
+# byte_identity
+
+Gate #7 from ADR-0024: cross-SDK byte-identity at release time.
+
+After a release is published to PyPI / npm / the Go proxy, this gate runs the
+shared canonicalisation vectors
+(`cross-sdk-tests/canonicalization_vectors.json`) through the **published** SDK
+artifact's public canonicalisation/hash API and asserts the output is
+byte-identical to the committed expected bytes (and the committed SHA-256
+hashes). A release whose canonicalisation drifts — and therefore diverges from
+the other SDKs, which are pinned to the same vectors — turns red here, before
+the version is treated as good.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Installs the released version, runs the vectors through the SDK's public API, and compares the output to the committed vectors byte-for-byte. |
+| `test_check.py` | Unit tests for the comparison core (`compare_actuals`, `SAME_AS_`/skip resolution, stdout parsing). No SDK install, no network. |
+
+## Run locally
+
+```sh
+python3 scripts/byte_identity/test_check.py            # unit tests (no network)
+python3 scripts/byte_identity/check.py --lang py --version 0.10.0
+python3 scripts/byte_identity/check.py --lang ts --version 0.10.0
+python3 scripts/byte_identity/check.py --lang go --version 0.9.0
+```
+
+`check.py` and `test_check.py` use only the Python standard library
+(`hashlib`, `json`); there is no third-party dependency to install.
+
+## What this gate checks
+
+The SDK being released reproduces, byte-for-byte:
+
+- every `canonicalization_vectors[].canonical` via the SDK's public
+  `canonicalize` (the RFC 8785 property ADR-0002 commits to), and the pinned
+  `expectedHash` SHA-256 where present; and
+- every pinned `receipt_hash_vectors[].expectedHash` via the SDK's public
+  receipt-hash path.
+
+`SAME_AS_<name>` invariants are resolved against the referenced vector's hash;
+`COMPUTE_AT_COMMIT_TIME` placeholders and `receiptsFrom`-only
+signature-preservation vectors carry no byte to compare and are skipped —
+matching the in-tree per-SDK suites.
+
+The Go driver reproduces the receipt hash via the SDK's public `Canonicalize` +
+`SHA256Hash` on a `map[string]any` (after the documented ADR-0009 Rule 2
+null-strip), because the public `HashReceipt` takes a typed
+`receipt.AgentReceipt` that — since the v0.3.0 envelope migration (ADR-0012) —
+cannot round-trip the legacy flat-map shape some vectors pin. The canonicaliser
+remains the unit under test, exactly as in `sdk/go`'s in-tree vectors test.
+
+## Targeted vectors version
+
+There is a single repo-tracked vectors file. It ships from the same commit as
+the SDK, so the vectors compared against are those released alongside the SDK;
+no separate version selection is required.
+
+## Relationship to the in-tree vectors tests and the other gates
+
+The per-SDK in-tree tests (`sdk/{go,ts,py}` canonicalisation-vectors tests)
+check the same property at PR time against in-tree source — never
+release-blocking. Gate #7 moves the assertion to a release-blocking position
+against the artifact consumers actually install. It runs alongside Gate #1
+(`readme-snippets`), Gate #2 (`release-verify`), and Gate #6
+(`schema-conformance`); all four depend only on `release` and run in parallel,
+and each must pass for a release to be considered green.

--- a/scripts/byte_identity/check.py
+++ b/scripts/byte_identity/check.py
@@ -64,7 +64,7 @@ GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
 TS_PACKAGE = "@agnt-rcpt/sdk-ts"
 PY_PACKAGE = "agent-receipts"
 
-# Default vectors location relative to the repo root (two levels up from here).
+# Default vectors location relative to the repo root (three levels up from here).
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DEFAULT_VECTORS = os.path.join(
     _REPO_ROOT, "cross-sdk-tests", "canonicalization_vectors.json"

--- a/scripts/byte_identity/check.py
+++ b/scripts/byte_identity/check.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Gate #7: cross-SDK byte-identity at release time.
+
+After a release is published, run the shared canonicalisation vectors
+(``cross-sdk-tests/canonicalization_vectors.json``) through the *published* SDK
+artifact's public canonicalisation/hashing API and assert the output is
+byte-identical to the committed expected bytes (and the committed SHA-256
+hashes). A release whose canonicalisation diverges from the vectors — and
+therefore from the other SDKs, which are pinned to the same vectors — turns red
+here, before the version is treated as good.
+
+This is the release-time enforcement of the property ADR-0024 D1 records and
+ADR-0002 / ADR-0005 commit to: all three SDKs produce byte-identical canonical
+JSON (RFC 8785) for the same input. The in-tree per-SDK suites
+(``sdk/{go,ts,py}`` canonicalisation-vectors tests) check the same property at
+PR time against the in-tree source; this gate closes the gap at release time
+against the artifact consumers actually install.
+
+How the gate works:
+
+1. The published SDK is installed into a throwaway project.
+2. A tiny driver program (one per language) loads the committed vectors and
+   feeds each one through the SDK's *public* API — ``canonicalize`` for the
+   ``canonicalization_vectors`` array and the receipt-hash path for the
+   ``receipt_hash_vectors`` array — then prints the SDK's actual output as a
+   JSON object on stdout.
+3. The comparison core in this module (``compare_actuals``) loads the same
+   committed vectors and asserts the driver's output matches byte-for-byte,
+   resolving ``SAME_AS_`` invariants and skipping the placeholders the in-tree
+   suites also skip (``COMPUTE_AT_COMMIT_TIME``, ``receiptsFrom``-only
+   signature-preservation vectors).
+
+The comparison core takes no SDK and no network, so the unit tests exercise it
+directly with controlled inputs; the install/emit drivers are exercised
+end-to-end by CI at release time.
+
+Usage:
+    check.py --lang {go,ts,py} --version X.Y.Z [--vectors PATH] [--workdir DIR]
+
+Exit codes:
+    0  every vector's canonicalisation/hash is byte-identical to the committed
+       expected value
+    1  the driver failed, or at least one output diverged
+    2  usage error (missing args, unknown lang)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+TS_PACKAGE = "@agnt-rcpt/sdk-ts"
+PY_PACKAGE = "agent-receipts"
+
+# Default vectors location relative to the repo root (two levels up from here).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_VECTORS = os.path.join(
+    _REPO_ROOT, "cross-sdk-tests", "canonicalization_vectors.json"
+)
+
+# Placeholders the in-tree per-SDK suites also skip. COMPUTE_AT_COMMIT_TIME is a
+# not-yet-pinned hash; SAME_AS_<name> is an equality invariant resolved against
+# the named vector's hash rather than a literal.
+_COMPUTE_AT_COMMIT_TIME = "COMPUTE_AT_COMMIT_TIME"
+_SAME_AS_PREFIX = "SAME_AS_"
+
+# How many times to retry a registry fetch before failing. The public
+# registries have occasional propagation lag after a new version is pushed;
+# retries cover the window between "tag pushed" and "version installable".
+REGISTRY_RETRIES = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    cmd: list[str],
+    cwd: str,
+    env: dict[str, str] | None = None,
+    retries: int = 0,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    full_env = {**os.environ, **(env or {})}
+    for attempt in range(retries + 1):
+        print(f"  $ {' '.join(cmd)}  (cwd={cwd})", flush=True)
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=full_env,
+            text=True,
+            capture_output=capture_output,
+        )
+        if proc.returncode == 0 or attempt == retries:
+            return proc
+        wait = 2 ** (attempt + 1)
+        print(f"  command failed (rc={proc.returncode}); retrying in {wait}s", flush=True)
+        time.sleep(wait)
+    return proc
+
+
+def _sha256(data: str) -> str:
+    """Return ``sha256:<hex>`` of the UTF-8 bytes of *data* — the receipt-hash
+    prefix every SDK's ``sha256`` helper emits."""
+    return "sha256:" + hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Comparison core (shared, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_receipt_hashes(receipt_vectors: list[dict]) -> dict[str, str]:
+    """Map each ``receipt_hash_vectors`` name to its concrete expected hash.
+
+    A first pass collects literal hashes; a second pass resolves ``SAME_AS_``
+    invariants against them. ``COMPUTE_AT_COMMIT_TIME`` placeholders and
+    ``receiptsFrom``-only vectors (which carry no ``receipt`` to hash) are
+    omitted — they have no byte to compare here.
+    """
+    literal: dict[str, str] = {}
+    for v in receipt_vectors:
+        eh = v.get("expectedHash")
+        if eh and eh != _COMPUTE_AT_COMMIT_TIME and not eh.startswith(_SAME_AS_PREFIX):
+            literal[v["name"]] = eh
+
+    resolved: dict[str, str] = {}
+    for v in receipt_vectors:
+        if "receipt" not in v:
+            continue  # e.g. receiptsFrom signature-preservation vectors
+        eh = v.get("expectedHash", _COMPUTE_AT_COMMIT_TIME)
+        if eh == _COMPUTE_AT_COMMIT_TIME:
+            continue
+        if eh.startswith(_SAME_AS_PREFIX):
+            ref = eh[len(_SAME_AS_PREFIX) :]
+            if ref not in literal:
+                # Reference hash not pinned yet — nothing to assert.
+                continue
+            eh = literal[ref]
+        resolved[v["name"]] = eh
+    return resolved
+
+
+def compare_actuals(vectors: dict, actuals: dict) -> list[str]:
+    """Compare an SDK's driver output against the committed vectors.
+
+    *vectors* is the parsed ``canonicalization_vectors.json``. *actuals* is the
+    driver's emitted object: ``{"canonical": {name: str}, "receipt_hash":
+    {name: str}}``. Returns a list of human-readable divergence messages; an
+    empty list means every committed expectation was reproduced byte-for-byte.
+
+    This is the core of the gate and is exercised by the unit tests with
+    controlled inputs (no install, no network). For each
+    ``canonicalization_vectors`` entry it asserts the SDK's ``canonicalize``
+    output equals the committed ``canonical`` byte-for-byte, and — where the
+    vector pins an ``expectedHash`` — that ``sha256:hex(canonical)`` equals it.
+    For each ``receipt_hash_vectors`` entry with a pinned hash it asserts the
+    SDK's receipt-hash output equals it.
+    """
+    diffs: list[str] = []
+
+    actual_canon = actuals.get("canonical", {})
+    actual_hash = actuals.get("receipt_hash", {})
+
+    for v in vectors.get("canonicalization_vectors", []):
+        name = v["name"]
+        want = v["canonical"]
+        got = actual_canon.get(name)
+        if got is None:
+            diffs.append(f"canonicalization_vectors[{name}]: SDK produced no output")
+            continue
+        if got != want:
+            diffs.append(
+                f"canonicalization_vectors[{name}]: canonical bytes diverge\n"
+                f"      got:  {got!r}\n"
+                f"      want: {want!r}"
+            )
+            continue
+        # Where the vector pins a hash, the SHA-256 of the canonical bytes must
+        # match it too — guarding against a hash-encoding regression even when
+        # the canonical bytes are right.
+        eh = v.get("expectedHash")
+        if eh and eh != _COMPUTE_AT_COMMIT_TIME:
+            got_hash = _sha256(got)
+            if got_hash != eh:
+                diffs.append(
+                    f"canonicalization_vectors[{name}]: SHA-256 diverges\n"
+                    f"      got:  {got_hash}\n"
+                    f"      want: {eh}"
+                )
+
+    expected_hashes = _resolve_receipt_hashes(
+        vectors.get("receipt_hash_vectors", [])
+    )
+    for name, want in expected_hashes.items():
+        got = actual_hash.get(name)
+        if got is None:
+            diffs.append(f"receipt_hash_vectors[{name}]: SDK produced no output")
+            continue
+        if got != want:
+            diffs.append(
+                f"receipt_hash_vectors[{name}]: receipt hash diverges\n"
+                f"      got:  {got}\n"
+                f"      want: {want}"
+            )
+
+    return diffs
+
+
+def _load_vectors(path: str) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _assert_identical(lang: str, vectors: dict, actuals: dict) -> int:
+    """Compare driver output to the vectors and report. 0 if byte-identical."""
+    diffs = compare_actuals(vectors, actuals)
+    if diffs:
+        print(
+            f"ERROR: the published {lang} SDK's canonicalisation diverges from "
+            "cross-sdk-tests/canonicalization_vectors.json:"
+        )
+        for d in diffs:
+            print(f"  - {d}")
+        return 1
+    n_canon = len(vectors.get("canonicalization_vectors", []))
+    print(
+        f"OK: the published {lang} SDK reproduces all {n_canon} canonicalisation "
+        "vectors (and every pinned receipt hash) byte-for-byte"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Drivers — install the published artifact and emit its actual output
+# ---------------------------------------------------------------------------
+
+# Each driver loads the committed vectors, runs every vector through the SDK's
+# public canonicalisation/hash API, and prints exactly one JSON object on
+# stdout: {"canonical": {name: str}, "receipt_hash": {name: str}}. The
+# comparison core then asserts byte-identity. The vectors path is passed as the
+# program's first argument so the driver reads the same committed file the
+# comparison core does.
+
+_PY_DRIVER = """\
+import json
+import sys
+
+from agent_receipts import canonicalize, hash_receipt
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    vectors = json.load(fh)
+
+canon = {}
+for v in vectors["canonicalization_vectors"]:
+    canon[v["name"]] = canonicalize(v["input"])
+
+receipt_hash = {}
+for v in vectors["receipt_hash_vectors"]:
+    if "receipt" not in v:
+        continue
+    receipt_hash[v["name"]] = hash_receipt(v["receipt"])
+
+print(json.dumps({"canonical": canon, "receipt_hash": receipt_hash}))
+"""
+
+_TS_DRIVER = """\
+import { readFileSync } from "node:fs";
+import { canonicalize, hashReceipt } from "@agnt-rcpt/sdk-ts";
+
+const vectors = JSON.parse(readFileSync(process.argv[2], "utf-8"));
+
+const canonical = {};
+for (const v of vectors.canonicalization_vectors) {
+  canonical[v.name] = canonicalize(v.input);
+}
+
+const receipt_hash = {};
+for (const v of vectors.receipt_hash_vectors) {
+  if (!("receipt" in v)) continue;
+  receipt_hash[v.name] = hashReceipt(v.receipt);
+}
+
+console.log(JSON.stringify({ canonical, receipt_hash }));
+"""
+
+# Go's public HashReceipt takes a typed receipt.AgentReceipt, which (since the
+# v0.3.0 envelope migration, ADR-0012) can no longer round-trip the legacy
+# flat-map parameters_disclosure shape some receipt_hash_vectors pin. The Go
+# driver therefore reproduces the receipt hash via the SDK's public
+# Canonicalize + SHA256Hash on a map[string]any after the documented Rule 2
+# null-strip — exactly as the in-tree Go vectors test does — so the unit under
+# test stays the public canonicaliser, not the typed struct.
+_GO_DRIVER = """\
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+type vectorFile struct {
+	CanonVectors []struct {
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	} `json:"canonicalization_vectors"`
+	ReceiptVectors []struct {
+		Name    string          `json:"name"`
+		Receipt json.RawMessage `json:"receipt"`
+	} `json:"receipt_hash_vectors"`
+}
+
+// requiredNullable reports whether path is the sole required-nullable field the
+// spec keeps as literal null (ADR-0009); every other null is dropped.
+func requiredNullable(path []string) bool {
+	return len(path) == 3 &&
+		path[0] == "credentialSubject" &&
+		path[1] == "chain" &&
+		path[2] == "previous_receipt_hash"
+}
+
+func stripOptionalNulls(node map[string]any, path []string) {
+	for k, v := range node {
+		child := append(append([]string{}, path...), k)
+		if v == nil {
+			if !requiredNullable(child) {
+				delete(node, k)
+			}
+			continue
+		}
+		if sub, ok := v.(map[string]any); ok {
+			stripOptionalNulls(sub, child)
+		}
+	}
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
+
+func main() {
+	data, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fail(err)
+	}
+	var vf vectorFile
+	if err := json.Unmarshal(data, &vf); err != nil {
+		fail(err)
+	}
+
+	canonical := map[string]string{}
+	for _, v := range vf.CanonVectors {
+		var input any
+		if err := json.Unmarshal(v.Input, &input); err != nil {
+			fail(fmt.Errorf("vector %s: %w", v.Name, err))
+		}
+		c, err := receipt.Canonicalize(input)
+		if err != nil {
+			fail(fmt.Errorf("vector %s: %w", v.Name, err))
+		}
+		canonical[v.Name] = c
+	}
+
+	receiptHash := map[string]string{}
+	for _, v := range vf.ReceiptVectors {
+		if len(v.Receipt) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(v.Receipt, &m); err != nil {
+			fail(fmt.Errorf("vector %s: %w", v.Name, err))
+		}
+		stripOptionalNulls(m, nil)
+		delete(m, "proof")
+		cs, _ := m["credentialSubject"].(map[string]any)
+		if cs != nil {
+			if chain, ok := cs["chain"].(map[string]any); ok {
+				if _, present := chain["previous_receipt_hash"]; !present {
+					chain["previous_receipt_hash"] = nil
+				}
+			}
+		}
+		c, err := receipt.Canonicalize(m)
+		if err != nil {
+			fail(fmt.Errorf("vector %s: %w", v.Name, err))
+		}
+		receiptHash[v.Name] = receipt.SHA256Hash(c)
+	}
+
+	out, err := json.Marshal(map[string]any{
+		"canonical":    canonical,
+		"receipt_hash": receiptHash,
+	})
+	if err != nil {
+		fail(err)
+	}
+	fmt.Println(string(out))
+}
+"""
+
+
+def _parse_emitted(lang: str, stdout: str) -> dict | None:
+    """Pull the single JSON output object out of a driver's stdout."""
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError as exc:
+                print(
+                    f"ERROR: {lang} driver produced a non-JSON output line: {exc}\n"
+                    f"  offending line: {line}"
+                )
+                return None
+    print(f"ERROR: {lang} driver produced no JSON output on stdout")
+    return None
+
+
+def emit_py(version: str, vectors_path: str, workdir: str) -> dict | None:
+    venv = os.path.join(workdir, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=workdir).returncode != 0:
+        return None
+    py = os.path.join(venv, "bin", "python")
+    spec = f"{PY_PACKAGE}=={version}"
+    print(f"\n--- Installing {spec} from PyPI")
+    if (
+        _run([py, "-m", "pip", "install", "--quiet", spec], cwd=workdir, retries=REGISTRY_RETRIES).returncode
+        != 0
+    ):
+        print(f"ERROR: failed to install {spec} from PyPI")
+        return None
+    prog = os.path.join(workdir, "driver.py")
+    with open(prog, "w", encoding="utf-8") as fh:
+        fh.write(_PY_DRIVER)
+    print("\n--- Running the vectors through the published Python SDK")
+    result = _run([py, prog, vectors_path], cwd=workdir, capture_output=True)
+    if result.returncode != 0:
+        print(f"ERROR: Python driver failed\n{result.stderr}")
+        return None
+    return _parse_emitted("py", result.stdout)
+
+
+def emit_ts(version: str, vectors_path: str, workdir: str) -> dict | None:
+    package_json = {
+        "name": "byte-identity",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: version},
+    }
+    with open(os.path.join(workdir, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+    print(f"\n--- Installing {TS_PACKAGE}@{version} from npm")
+    if (
+        _run(["npm", "install", "--no-audit", "--no-fund"], cwd=workdir, retries=REGISTRY_RETRIES).returncode
+        != 0
+    ):
+        print(f"ERROR: npm install {TS_PACKAGE}@{version} failed")
+        return None
+    prog = os.path.join(workdir, "driver.ts")
+    with open(prog, "w", encoding="utf-8") as fh:
+        fh.write(_TS_DRIVER)
+    print("\n--- Running the vectors through the published TypeScript SDK")
+    # Node strips types directly (Node 22.18+ / 24); no separate compile step.
+    result = _run(
+        ["node", "--experimental-strip-types", "driver.ts", vectors_path],
+        cwd=workdir,
+        env={"NODE_NO_WARNINGS": "1"},
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: TypeScript driver failed\n{result.stderr}")
+        return None
+    return _parse_emitted("ts", result.stdout)
+
+
+def emit_go(version: str, vectors_path: str, workdir: str) -> dict | None:
+    go_mod = [
+        "module example.com/byte-identity\n",
+        "go 1.26.1\n",
+        f"require {GO_MODULE} v{version}\n",
+    ]
+    with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
+        fh.writelines(go_mod)
+    with open(os.path.join(workdir, "main.go"), "w", encoding="utf-8") as fh:
+        fh.write(_GO_DRIVER)
+    # Pin GOPROXY to the public proxy with no `direct` fallback so the driver
+    # exercises the module consumers actually resolve, not a VCS checkout.
+    env = {
+        "GOFLAGS": "-mod=mod",
+        "GOWORK": "off",
+        "GOPROXY": "https://proxy.golang.org",
+    }
+    print(f"\n--- Fetching {GO_MODULE}@v{version} and running the vectors")
+    if _run(["go", "mod", "tidy"], cwd=workdir, env=env, retries=REGISTRY_RETRIES).returncode != 0:
+        print(f"ERROR: go mod tidy for {GO_MODULE}@v{version} failed")
+        return None
+    result = _run(["go", "run", ".", vectors_path], cwd=workdir, env=env, capture_output=True)
+    if result.returncode != 0:
+        print(f"ERROR: Go driver failed\n{result.stderr}")
+        return None
+    return _parse_emitted("go", result.stdout)
+
+
+_EMITTERS = {"go": emit_go, "ts": emit_ts, "py": emit_py}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--lang", required=True, choices=["go", "ts", "py"])
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Released version string (no leading 'v'), e.g. 0.12.0 or 0.12.0-alpha.1",
+    )
+    parser.add_argument(
+        "--vectors",
+        default=DEFAULT_VECTORS,
+        help=f"Path to the canonicalisation vectors (default: {DEFAULT_VECTORS})",
+    )
+    parser.add_argument(
+        "--workdir",
+        default=None,
+        help="Working directory for the temporary project (default: auto-created tmpdir)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.version.startswith("v"):
+        parser.error(f"--version must not have a leading 'v' (got {args.version!r})")
+
+    vectors = _load_vectors(args.vectors)
+
+    cleanup = False
+    if args.workdir:
+        workdir = os.path.abspath(args.workdir)
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = tempfile.mkdtemp(prefix="byte-identity-")
+        cleanup = True
+
+    print("Gate #7 — cross-SDK byte-identity")
+    print(f"  lang    : {args.lang}")
+    print(f"  version : {args.version}")
+    print(f"  vectors : {args.vectors}")
+    print(f"  workdir : {workdir}")
+
+    try:
+        actuals = _EMITTERS[args.lang](args.version, os.path.abspath(args.vectors), workdir)
+        if actuals is None:
+            rc = 1
+        else:
+            rc = _assert_identical(args.lang, vectors, actuals)
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    if rc == 0:
+        print(f"\nGate #7 PASSED for {args.lang} {args.version}")
+    else:
+        print(f"\nGate #7 FAILED for {args.lang} {args.version} (see errors above)")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/byte_identity/test_check.py
+++ b/scripts/byte_identity/test_check.py
@@ -1,0 +1,238 @@
+"""Unit tests for the Gate #7 cross-SDK byte-identity verifier.
+
+These tests exercise the comparison core (`compare_actuals` and its
+`SAME_AS_`/skip resolution) against the real
+`cross-sdk-tests/canonicalization_vectors.json`. No SDK is installed and no
+network call is made — the drivers (which install the published artifact and
+run the vectors through it) are exercised end-to-end by CI at release time, not
+here.
+
+The core invariant under test: `compare_actuals` returns no divergences when an
+SDK reproduces every committed `canonical` byte and every pinned receipt hash,
+and at least one divergence when any output drifts — a flipped canonical byte,
+a mismatched receipt hash, a broken `SAME_AS_` invariant, or a missing output.
+The failure cases are a direct implementation of ADR-0024 D6 (a gate must be
+observed to fail on a deliberately-broken input).
+
+Run with:
+    python3 -m pytest scripts/byte_identity/test_check.py
+    python3 scripts/byte_identity/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+
+def _vectors() -> dict:
+    return check._load_vectors(check.DEFAULT_VECTORS)
+
+
+def _faithful_actuals(vectors: dict) -> dict:
+    """Build the output a perfectly byte-identical SDK would emit.
+
+    `canonical` echoes each committed `canonical` string. `receipt_hash` echoes
+    each vector's resolved expected hash, so a faithful SDK passes and any
+    mutation a test makes is the only source of divergence.
+    """
+    canonical = {
+        v["name"]: v["canonical"] for v in vectors["canonicalization_vectors"]
+    }
+    receipt_hash = dict(check._resolve_receipt_hashes(vectors["receipt_hash_vectors"]))
+    return {"canonical": canonical, "receipt_hash": receipt_hash}
+
+
+# ---------------------------------------------------------------------------
+# compare_actuals — the core gate logic
+# ---------------------------------------------------------------------------
+
+
+class TestCompareActuals:
+    def test_faithful_output_has_no_divergence(self) -> None:
+        vectors = _vectors()
+        assert check.compare_actuals(vectors, _faithful_actuals(vectors)) == []
+
+    def test_flipped_canonical_byte_is_divergence(self) -> None:
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        # Mutate one vector's canonical output by a single byte.
+        name = vectors["canonicalization_vectors"][2]["name"]
+        actuals["canonical"][name] = actuals["canonical"][name] + " "
+        diffs = check.compare_actuals(vectors, actuals)
+        assert diffs
+        assert any(name in d and "canonical bytes diverge" in d for d in diffs)
+
+    def test_missing_canonical_output_is_divergence(self) -> None:
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        name = vectors["canonicalization_vectors"][0]["name"]
+        del actuals["canonical"][name]
+        diffs = check.compare_actuals(vectors, actuals)
+        assert any(name in d and "no output" in d for d in diffs)
+
+    def test_correct_bytes_wrong_pinned_hash_is_divergence(self) -> None:
+        # A vector that pins an expectedHash: the canonical bytes are right but
+        # the gate also recomputes the SHA-256. Corrupt the committed hash and
+        # confirm the recompute catches it (guards a hash-encoding regression).
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        hashed = next(
+            v for v in vectors["canonicalization_vectors"] if v.get("expectedHash")
+        )
+        vectors = copy.deepcopy(vectors)
+        for v in vectors["canonicalization_vectors"]:
+            if v["name"] == hashed["name"]:
+                v["expectedHash"] = "sha256:" + "0" * 64
+        diffs = check.compare_actuals(vectors, actuals)
+        assert any(hashed["name"] in d and "SHA-256 diverges" in d for d in diffs)
+
+    def test_mismatched_receipt_hash_is_divergence(self) -> None:
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        name = next(iter(actuals["receipt_hash"]))
+        actuals["receipt_hash"][name] = "sha256:" + "0" * 64
+        diffs = check.compare_actuals(vectors, actuals)
+        assert any(name in d and "receipt hash diverges" in d for d in diffs)
+
+    def test_missing_receipt_hash_output_is_divergence(self) -> None:
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        name = next(iter(actuals["receipt_hash"]))
+        del actuals["receipt_hash"][name]
+        diffs = check.compare_actuals(vectors, actuals)
+        assert any(name in d and "no output" in d for d in diffs)
+
+    def test_divergence_messages_show_got_and_want(self) -> None:
+        vectors = _vectors()
+        actuals = _faithful_actuals(vectors)
+        name = vectors["canonicalization_vectors"][1]["name"]
+        actuals["canonical"][name] = "WRONG"
+        diffs = check.compare_actuals(vectors, actuals)
+        assert any("got:" in d and "want:" in d for d in diffs)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_receipt_hashes — SAME_AS_ and skip resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveReceiptHashes:
+    def test_same_as_resolves_to_reference_hash(self) -> None:
+        # The real vectors include receipt_optional_null_becomes_absent ==
+        # SAME_AS_receipt_all_optional_absent; both must resolve to one hash.
+        resolved = check._resolve_receipt_hashes(
+            _vectors()["receipt_hash_vectors"]
+        )
+        assert "receipt_all_optional_absent" in resolved
+        assert (
+            resolved["receipt_optional_null_becomes_absent"]
+            == resolved["receipt_all_optional_absent"]
+        )
+
+    def test_receipts_from_vector_is_omitted(self) -> None:
+        # receipt_signature_preservation_legacy_0_2_0 has no `receipt` field
+        # (it references receipts via receiptsFrom); it carries no byte to
+        # compare and must not appear in the resolved expectations.
+        resolved = check._resolve_receipt_hashes(
+            _vectors()["receipt_hash_vectors"]
+        )
+        assert "receipt_signature_preservation_legacy_0_2_0" not in resolved
+
+    def test_compute_at_commit_time_is_omitted(self) -> None:
+        vectors = [
+            {"name": "a", "receipt": {}, "expectedHash": "COMPUTE_AT_COMMIT_TIME"},
+            {"name": "b", "receipt": {}, "expectedHash": "sha256:" + "1" * 64},
+        ]
+        resolved = check._resolve_receipt_hashes(vectors)
+        assert "a" not in resolved
+        assert resolved["b"] == "sha256:" + "1" * 64
+
+    def test_unresolvable_same_as_is_omitted(self) -> None:
+        # A SAME_AS_ that points at a name with no literal hash cannot be
+        # asserted; it is omitted rather than compared against a missing value.
+        vectors = [
+            {"name": "a", "receipt": {}, "expectedHash": "SAME_AS_nonexistent"},
+        ]
+        assert check._resolve_receipt_hashes(vectors) == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_emitted — pulling the JSON output object out of a driver's stdout
+# ---------------------------------------------------------------------------
+
+
+class TestParseEmitted:
+    def test_parses_single_json_object(self) -> None:
+        obj = {"canonical": {"empty_object": "{}"}, "receipt_hash": {}}
+        assert check._parse_emitted("py", check.json.dumps(obj)) == obj
+
+    def test_ignores_leading_log_lines(self) -> None:
+        obj = {"canonical": {}, "receipt_hash": {}}
+        stdout = "installing...\nbuilding...\n" + check.json.dumps(obj) + "\n"
+        assert check._parse_emitted("go", stdout) == obj
+
+    def test_no_json_returns_none(self) -> None:
+        assert check._parse_emitted("ts", "just some logs\nno output here\n") is None
+
+    def test_malformed_json_returns_none(self) -> None:
+        assert check._parse_emitted("py", "{ not valid json") is None
+
+    def test_empty_stdout_returns_none(self) -> None:
+        assert check._parse_emitted("go", "") is None
+
+
+# ---------------------------------------------------------------------------
+# _sha256 — the receipt-hash prefix helper
+# ---------------------------------------------------------------------------
+
+
+class TestSha256:
+    def test_empty_object_canonical_hash(self) -> None:
+        # sha256 of the two bytes "{}" — a known value; locks the prefix/encoding.
+        assert check._sha256("{}") == (
+            "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        )
+
+    def test_prefix_present(self) -> None:
+        assert check._sha256("anything").startswith("sha256:")
+
+
+# ---------------------------------------------------------------------------
+# Self-runner (no pytest dependency required)
+# ---------------------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    suites = [
+        TestCompareActuals,
+        TestResolveReceiptHashes,
+        TestParseEmitted,
+        TestSha256,
+    ]
+    for suite_cls in suites:
+        suite = suite_cls()
+        for name in sorted(dir(suite_cls)):
+            if not name.startswith("test_"):
+                continue
+            fn = getattr(suite, name)
+            try:
+                fn()
+                print(f"ok   {suite_cls.__name__}.{name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {suite_cls.__name__}.{name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {suite_cls.__name__}.{name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## What

Implements **Gate #7** from [ADR-0024](docs/adr/0024-project-verification-contract.md) (project verification contract): _"Cross-SDK byte-identity at release time — each SDK release runs the canonicalization vectors and asserts byte-identical output before the release goes out."_

Adds a **release-blocking `byte-identity` job to all three `release-sdk-*.yml` workflows**, alongside the existing Gate #1 (`readme-snippets`), Gate #2 (`release-verify`), and Gate #6 (`schema-conformance`) jobs. All four depend only on `release` and run in parallel; each must pass for a release to be green.

> ⚠️ **Human review requested:** this adds a **release-blocking gate** to every `release-sdk-*.yml`. A divergence in canonicalisation will now turn a release red. Please review the gate logic and the three workflow edits before merging.

## Why

ADR-0002 (RFC 8785 canonicalisation) and ADR-0005 (independent SDK implementations) commit the project to byte-identical canonical JSON across the three SDKs. Per ADR-0024 D1, that property needs a release-time gate so a release cannot ship an SDK whose canonicalisation diverges from the others. The existing `cross-sdk-tests/` machinery checks this at PR time only — never release-blocking. This PR moves the assertion to a release-blocking position against the artifact consumers actually install. `Closes #654`.

## Approach

Per-SDK job + shared helper, mirroring the #653 schema-conformance gate:

- **Reuses the existing vectors** — `cross-sdk-tests/canonicalization_vectors.json` (32 `canonicalization_vectors` + the pinned `receipt_hash_vectors`), the same file the in-tree per-SDK tests pin.
- **`scripts/byte_identity/check.py`** installs the published artifact at the tagged version (read from `GITHUB_REF_NAME`, exactly as Gates #2/#6 do), runs each vector through the SDK's **public** canonicalisation/hash API (Go `Canonicalize`/`SHA256Hash`, TS `canonicalize`/`hashReceipt`, Py `canonicalize`/`hash_receipt`), and asserts byte-identity against the committed `canonical` strings and pinned `expectedHash` values. `SAME_AS_` invariants are resolved; `COMPUTE_AT_COMMIT_TIME` and `receiptsFrom`-only vectors are skipped (matching the in-tree suites).
- **`scripts/byte_identity/test_check.py`** unit-tests the comparison core (`compare_actuals`, `SAME_AS_`/skip resolution, stdout parsing) — **no network, no SDK install**, run via a pytest-free self-runner.
- The Go driver reproduces the receipt hash via the public `Canonicalize` + `SHA256Hash` on a `map[string]any` after the documented ADR-0009 Rule 2 null-strip, because the public `HashReceipt` takes a typed `receipt.AgentReceipt` that can't round-trip the legacy flat-map shape some vectors pin (ADR-0012 envelope migration) — matching the in-tree `sdk/go` vectors test.

## Dependencies

**None.** The comparison core is standard-library only (`hashlib`, `json`) — no third-party install in the gate job (unlike #653's `jsonschema[format-nongpl]` pin).

## How I tested PASS and FAIL

Registries are unreachable in the sandbox, so I exercised the **in-tree** path (CI exercises the published path, as #653 did):

- **PASS (end-to-end):** ran the real Go and Python drivers against the in-tree SDKs — both reproduce all 32 canonicalisation vectors and every pinned receipt hash byte-for-byte; comparison core returns exit 0.
- **FAIL (gate blocks):**
  - mutated the SDK canonicalisation output (`{"a"` → `{ "a"`) → divergence reported, exit 1;
  - corrupted committed expected bytes + a receipt hash in the vectors → divergence reported for the vector and its `SAME_AS_` referrers, exit 1.
- **Unit tests:** 20/20 pass via the self-runner (`python3 scripts/byte_identity/test_check.py`), covering faithful output, flipped canonical byte, missing output, wrong pinned hash, mismatched receipt hash, and `SAME_AS_`/skip resolution.

## Files

- `.github/workflows/release-sdk-go.yml`, `release-sdk-py.yml`, `release-sdk-ts.yml` — new `byte-identity` job (`needs: release`).
- `scripts/byte_identity/{check.py,test_check.py,AGENTS.md}` — shared helper + unit test + docs.

Touches only the three release workflows and the new helper — no spec, crypto, SDK source, or unrelated workflow changes.