### PR TITLE
ci(release): add dependency-manifest / SBOM gate (#656)

### DIFF
--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -151,3 +151,22 @@ jobs:
           python3 scripts/byte_identity/check.py --lang go --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #10: every dependency installed into the published artifact must be
+  # declared in go.mod or recorded in the gate's allowlist with a justification.
+  # An undeclared, un-allow-listed "eager" dependency turns the release red.
+  # Manifest-vs-manifest comparison — no network, no module download.
+  dependency-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify installed deps match declared deps (Gate #10)
+        run: python3 scripts/dependency_manifest/check.py --lang go
+      - name: Run unit tests for dependency-manifest gate
+        run: python3 scripts/dependency_manifest/test_check.py

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -155,3 +155,22 @@ jobs:
           python3 scripts/byte_identity/check.py --lang py --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #10: every dependency installed into the published artifact must be
+  # declared in pyproject.toml or recorded in the gate's allowlist with a
+  # justification. An undeclared, un-allow-listed "eager" dependency turns the
+  # release red. Manifest-vs-manifest comparison — no network, no install.
+  dependency-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify installed deps match declared deps (Gate #10)
+        run: python3 scripts/dependency_manifest/check.py --lang py
+      - name: Run unit tests for dependency-manifest gate
+        run: python3 scripts/dependency_manifest/test_check.py

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -177,3 +177,23 @@ jobs:
           python3 scripts/byte_identity/check.py --lang ts --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #10: every dependency installed into the published artifact must be
+  # declared in package.json or recorded in the gate's allowlist with a
+  # justification. An undeclared, un-allow-listed "eager" dependency turns the
+  # release red. Manifest-vs-manifest comparison — no network, no install.
+  dependency-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify installed deps match declared deps (Gate #10)
+        run: python3 scripts/dependency_manifest/check.py --lang ts
+      - name: Run unit tests for dependency-manifest gate
+        run: python3 scripts/dependency_manifest/test_check.py
+

--- a/scripts/dependency_manifest/README.md
+++ b/scripts/dependency_manifest/README.md
@@ -1,0 +1,77 @@
+# Dependency-manifest gate (Gate #10)
+
+Gate #10 of the project verification contract (ADR-0024).
+
+For the SDK being released, compares the dependencies actually resolved into the
+artifact (the **installed** set) against the dependencies the SDK declares
+directly (the **declared** set). Any installed dependency that is neither
+declared nor allow-listed fails the gate. This catches "eager" transitive deps
+that creep into a published artifact — a supply-chain risk for a cryptographic
+protocol project (see AGENTS.md "Adding dependencies").
+
+The comparison is manifest-vs-manifest: it reads committed files only and needs
+no network and no package install.
+
+## Run
+
+```
+python scripts/dependency_manifest/run.py <sdk>   # sdk = go | py | ts
+```
+
+Exits 0 when every installed runtime dependency is declared or allow-listed;
+exits 1 (with a GitHub `::error::` annotation) on the first unexplained
+dependency.
+
+## What "installed" and "declared" mean per SDK
+
+| SDK | Declared (documented) | Installed (resolved runtime) |
+|-----|-----------------------|------------------------------|
+| go  | direct `require`s in `go.mod` | direct + `// indirect` requires in `go.mod` |
+| py  | `[project].dependencies` in `pyproject.toml` | runtime closure of those deps resolved from `uv.lock` (dev/optional extras excluded) |
+| ts  | `dependencies` in `package.json` | runtime closure resolved from `pnpm-lock.yaml` snapshots (dev deps excluded); declared deps only if no lockfile |
+
+Scope is the **runtime closure**. Dev/test/build tooling is intentionally out of
+scope — it is not shipped to consumers, so an undeclared test tool is not a
+supply-chain risk in the published artifact.
+
+## Allowlist
+
+`allowlist.json` records intentional dependencies that are installed but not
+declared directly — legitimate transitive deps of the declared ones. Each entry
+carries a `name` and a `justification`. An allow-listed name suppresses the
+failure for that dependency. Anything installed-but-not-declared-and-not-
+allowlisted fails the gate.
+
+Format:
+
+```json
+{
+  "go": [ { "name": "<module-path>", "justification": "<why it ships>" } ],
+  "py": [ { "name": "<package>",     "justification": "<why it ships>" } ],
+  "ts": [ { "name": "<package>",     "justification": "<why it ships>" } ]
+}
+```
+
+The runner also emits a non-fatal `::warning::` for allow-listed names that are
+no longer installed, so stale entries get pruned.
+
+## Design choices (flagged for maintainer review)
+
+These defaults keep the gate minimal and dependency-light. They are judgement
+calls and may be revised:
+
+- **Manifest-vs-manifest instead of full SBOM tooling.** No SBOM generator
+  (Syft / CycloneDX / cyclonedx-py / cyclonedx-gomod) is pulled in — the gate
+  parses the manifests and lockfiles the repo already commits. If a signed SBOM
+  artifact later becomes a hard requirement, swap the resolver here for a pinned
+  generator; the allowlist/comparison logic can stay.
+- **Scope = runtime closure only.** Dev/test/build deps are excluded.
+- **"Declared" = direct manifest declarations, not README prose.** The SDK
+  READMEs describe dependencies in prose ("minimal runtime dependencies — zod
+  …") but do not enumerate them machine-readably, so the manifest's own direct
+  declarations are the documented set. If a structured per-README dependency
+  list becomes the source of truth, point the parser there.
+- **TS transitive resolution parses `pnpm-lock.yaml` directly** (no YAML
+  dependency, no `pnpm install`). It walks `snapshots:` `dependencies:` /
+  `optionalDependencies:` blocks from the runtime roots; dev-only packages keyed
+  under the importer's `devDependencies:` are never reached.

--- a/scripts/dependency_manifest/README.md
+++ b/scripts/dependency_manifest/README.md
@@ -1,77 +1,46 @@
-# Dependency-manifest gate (Gate #10)
+# dependency_manifest — Gate #10 (ADR-0024)
 
-Gate #10 of the project verification contract (ADR-0024).
+Verifies that the dependencies actually resolved into each SDK's published
+artifact match what the SDK declares, failing a release on any undeclared,
+non-allow-listed runtime dependency.
 
-For the SDK being released, compares the dependencies actually resolved into the
-artifact (the **installed** set) against the dependencies the SDK declares
-directly (the **declared** set). Any installed dependency that is neither
-declared nor allow-listed fails the gate. This catches "eager" transitive deps
-that creep into a published artifact — a supply-chain risk for a cryptographic
-protocol project (see AGENTS.md "Adding dependencies").
+## Usage
 
-The comparison is manifest-vs-manifest: it reads committed files only and needs
-no network and no package install.
+```sh
+# Validate a specific SDK's dependency manifest (run from the repo root)
+python3 scripts/dependency_manifest/check.py --lang go
+python3 scripts/dependency_manifest/check.py --lang py
+python3 scripts/dependency_manifest/check.py --lang ts
 
-## Run
-
-```
-python scripts/dependency_manifest/run.py <sdk>   # sdk = go | py | ts
+# Run the unit tests (no network, no install)
+python3 scripts/dependency_manifest/test_check.py
 ```
 
-Exits 0 when every installed runtime dependency is declared or allow-listed;
-exits 1 (with a GitHub `::error::` annotation) on the first unexplained
-dependency.
+`check.py` exits non-zero (with a `::error::` annotation) when an installed
+runtime dependency is neither declared in the SDK's manifest nor recorded in
+`allowlist.json`. It emits a non-fatal `::warning::` for stale allowlist
+entries (allow-listed but no longer installed).
 
-## What "installed" and "declared" mean per SDK
+## What it compares
 
-| SDK | Declared (documented) | Installed (resolved runtime) |
-|-----|-----------------------|------------------------------|
+Manifest-vs-manifest, using only the Python standard library — no network and
+no package install:
+
+| SDK | Declared | Installed (resolved runtime) |
+|-----|----------|------------------------------|
 | go  | direct `require`s in `go.mod` | direct + `// indirect` requires in `go.mod` |
-| py  | `[project].dependencies` in `pyproject.toml` | runtime closure of those deps resolved from `uv.lock` (dev/optional extras excluded) |
-| ts  | `dependencies` in `package.json` | runtime closure resolved from `pnpm-lock.yaml` snapshots (dev deps excluded); declared deps only if no lockfile |
-
-Scope is the **runtime closure**. Dev/test/build tooling is intentionally out of
-scope — it is not shipped to consumers, so an undeclared test tool is not a
-supply-chain risk in the published artifact.
+| py  | `[project].dependencies` in `pyproject.toml` | runtime closure from `uv.lock` (dev/optional extras excluded) |
+| ts  | `dependencies` in `package.json` | runtime closure from `pnpm-lock.yaml` snapshots (dev tree excluded) |
 
 ## Allowlist
 
-`allowlist.json` records intentional dependencies that are installed but not
-declared directly — legitimate transitive deps of the declared ones. Each entry
-carries a `name` and a `justification`. An allow-listed name suppresses the
-failure for that dependency. Anything installed-but-not-declared-and-not-
-allowlisted fails the gate.
+`allowlist.json` is keyed by SDK; each entry is `{ "name", "justification" }`.
+An allow-listed dependency suppresses the failure for that name, so adding a
+runtime dependency requires an allowlist entry with a justification — the
+release-time enforcement of the SDKs' "minimal runtime dependencies" claim.
 
-Format:
+## Relationship to the other gates
 
-```json
-{
-  "go": [ { "name": "<module-path>", "justification": "<why it ships>" } ],
-  "py": [ { "name": "<package>",     "justification": "<why it ships>" } ],
-  "ts": [ { "name": "<package>",     "justification": "<why it ships>" } ]
-}
-```
-
-The runner also emits a non-fatal `::warning::` for allow-listed names that are
-no longer installed, so stale entries get pruned.
-
-## Design choices (flagged for maintainer review)
-
-These defaults keep the gate minimal and dependency-light. They are judgement
-calls and may be revised:
-
-- **Manifest-vs-manifest instead of full SBOM tooling.** No SBOM generator
-  (Syft / CycloneDX / cyclonedx-py / cyclonedx-gomod) is pulled in — the gate
-  parses the manifests and lockfiles the repo already commits. If a signed SBOM
-  artifact later becomes a hard requirement, swap the resolver here for a pinned
-  generator; the allowlist/comparison logic can stay.
-- **Scope = runtime closure only.** Dev/test/build deps are excluded.
-- **"Declared" = direct manifest declarations, not README prose.** The SDK
-  READMEs describe dependencies in prose ("minimal runtime dependencies — zod
-  …") but do not enumerate them machine-readably, so the manifest's own direct
-  declarations are the documented set. If a structured per-README dependency
-  list becomes the source of truth, point the parser there.
-- **TS transitive resolution parses `pnpm-lock.yaml` directly** (no YAML
-  dependency, no `pnpm install`). It walks `snapshots:` `dependencies:` /
-  `optionalDependencies:` blocks from the runtime roots; dev-only packages keyed
-  under the importer's `devDependencies:` are never reached.
+Mirrors the `schema_conformance` (Gate #6) and `byte_identity` (Gate #7)
+helpers: a per-SDK release-blocking job in each `release-sdk-*.yml` that runs
+`check.py` then `test_check.py`.

--- a/scripts/dependency_manifest/allowlist.json
+++ b/scripts/dependency_manifest/allowlist.json
@@ -1,0 +1,71 @@
+{
+  "go": [
+    {
+      "name": "golang.org/x/crypto",
+      "justification": "Transitive dependency of github.com/cloudflare/circl (declared); circl builds on x/crypto primitives. Not imported directly by the SDK."
+    },
+    {
+      "name": "golang.org/x/sys",
+      "justification": "Transitive dependency of modernc.org/libc / modernc.org/sqlite (declared); provides low-level syscall primitives. Not imported directly by the SDK."
+    },
+    {
+      "name": "modernc.org/libc",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared); the pure-Go libc shim sqlite is compiled against."
+    },
+    {
+      "name": "modernc.org/mathutil",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/libc."
+    },
+    {
+      "name": "modernc.org/memory",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/libc; arena allocator used by the pure-Go sqlite runtime."
+    },
+    {
+      "name": "github.com/dustin/go-humanize",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/libc."
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/libc; terminal detection."
+    },
+    {
+      "name": "github.com/ncruces/go-strftime",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared); strftime formatting for sqlite date functions."
+    },
+    {
+      "name": "github.com/remyoudompheng/bigfft",
+      "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/mathutil; big-integer FFT multiplication."
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "justification": "Transitive dependency of github.com/agent-receipts/ar/daemon (declared in-repo module); used by the daemon's config handling."
+    }
+  ],
+  "py": [
+    {
+      "name": "cffi",
+      "justification": "Transitive runtime dependency of cryptography (declared); cryptography's C bindings are built on cffi (on non-PyPy platforms)."
+    },
+    {
+      "name": "pycparser",
+      "justification": "Transitive runtime dependency of cryptography via cffi; cffi uses pycparser to parse C declarations."
+    },
+    {
+      "name": "pydantic-core",
+      "justification": "Transitive runtime dependency of pydantic (declared); the compiled validation core pydantic v2 is built on."
+    },
+    {
+      "name": "annotated-types",
+      "justification": "Transitive runtime dependency of pydantic (declared); provides the constraint types pydantic re-exports."
+    },
+    {
+      "name": "typing-extensions",
+      "justification": "Transitive runtime dependency of pydantic (declared); backports typing features for the supported Python range."
+    },
+    {
+      "name": "typing-inspection",
+      "justification": "Transitive runtime dependency of pydantic (declared); pydantic uses it to introspect type annotations at runtime."
+    }
+  ],
+  "ts": []
+}

--- a/scripts/dependency_manifest/check.py
+++ b/scripts/dependency_manifest/check.py
@@ -46,7 +46,6 @@ import argparse
 import json
 import os
 import re
-import sys
 import tomllib
 from dataclasses import dataclass
 

--- a/scripts/dependency_manifest/check.py
+++ b/scripts/dependency_manifest/check.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Gate #10: documented dependencies match installed dependencies (SBOM).
+
+For the SDK being released, compare the dependencies actually resolved into the
+artifact (the *installed* set) against the dependencies the SDK declares
+directly (the *declared* set). Any installed dependency that is neither declared
+nor allow-listed with a justification fails the gate — this catches "eager"
+transitive deps that creep into a published artifact, a supply-chain concern for
+a cryptographic-protocol project (AGENTS.md "Adding dependencies").
+
+This is the release-time enforcement of the property ADR-0024 D1 records and the
+SDK READMEs assert in prose ("minimal runtime dependencies — …"). The comparison
+is manifest-vs-manifest: it reads the committed manifests and lockfiles only and
+needs no network and no package install, so it runs against the same source the
+release is cut from.
+
+What "installed" and "declared" mean per SDK:
+
+  - go: declared = direct ``require``s in ``go.mod``; installed = direct plus
+        ``// indirect`` requires.
+  - py: declared = ``[project].dependencies`` in ``pyproject.toml``; installed =
+        the runtime closure of those deps resolved from ``uv.lock`` (dev /
+        optional extras excluded — they are not part of the published runtime
+        artifact).
+  - ts: declared = runtime ``dependencies`` in ``package.json``; installed = the
+        runtime closure resolved from ``pnpm-lock.yaml`` snapshots (dev deps,
+        keyed under the importer's ``devDependencies``, are never reached);
+        declared deps only if no lockfile is present.
+
+Scope is the runtime closure. Dev/test/build tooling is intentionally out of
+scope: it is not shipped to consumers, so an undeclared test tool is not a
+supply-chain risk in the published artifact.
+
+Usage:
+    check.py --lang {go,ts,py} [--sdk-dir DIR] [--allowlist PATH]
+
+Exit codes:
+    0  every installed runtime dependency is declared or allow-listed
+    1  an installed dependency is neither declared nor allow-listed
+    2  usage error (missing args, unknown lang)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+
+# SDKs this gate knows how to inspect.
+KNOWN_SDKS = ("go", "ts", "py")
+
+# Repo root is three levels up from this file (scripts/dependency_manifest/).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_ALLOWLIST = os.path.join(os.path.dirname(os.path.abspath(__file__)), "allowlist.json")
+
+
+# ---------------------------------------------------------------------------
+# Comparison core (shared, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """The result of comparing installed deps against declared + allow-listed deps."""
+
+    sdk: str
+    declared: frozenset[str]
+    installed: frozenset[str]
+    allowlisted: frozenset[str]
+
+    @property
+    def unexplained(self) -> frozenset[str]:
+        """Installed deps that are neither declared nor allow-listed — these fail."""
+        return self.installed - self.declared - self.allowlisted
+
+    @property
+    def stale_allowlist(self) -> frozenset[str]:
+        """Allow-listed names that are not installed (drift to prune; non-fatal)."""
+        return self.allowlisted - self.installed - self.declared
+
+
+def _strip_pep508_name(spec: str) -> str:
+    """Extract the bare package name from a PEP 508 requirement string."""
+    return re.split(r"[<>=!~;\[ ]", spec.strip(), maxsplit=1)[0].strip()
+
+
+def _lock_dep_name(dep: object) -> str:
+    """Return the package name from a uv.lock dependency entry.
+
+    uv.lock encodes each dependency as an inline table, e.g.
+    ``{ name = "cffi", marker = "..." }``; a simpler form may be a plain string.
+    Both are handled.
+    """
+    if isinstance(dep, dict):
+        return str(dep["name"])
+    return _strip_pep508_name(str(dep))
+
+
+def parse_go(go_mod: str) -> tuple[set[str], set[str]]:
+    """Parse a go.mod into (declared, installed) module-path sets.
+
+    Declared = direct requires; installed = declared plus ``// indirect``
+    requires. Handles both the block form ``require ( ... )`` and the
+    single-line ``require <mod> <version>`` form.
+    """
+    declared: set[str] = set()
+    indirect: set[str] = set()
+    in_block = False
+    require_re = re.compile(r"^(?:require\s+)?(?P<mod>[^\s(]+/[^\s]+)\s+v\S+(?P<rest>.*)$")
+    for raw in go_mod.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("require") and stripped.endswith("("):
+            in_block = True
+            continue
+        if in_block and stripped == ")":
+            in_block = False
+            continue
+        match = require_re.match(stripped)
+        if not match:
+            continue
+        mod = match.group("mod")
+        if "indirect" in match.group("rest"):
+            indirect.add(mod)
+        else:
+            declared.add(mod)
+    return declared, declared | indirect
+
+
+def parse_py(pyproject_toml: str, uv_lock: str) -> tuple[set[str], set[str]]:
+    """Parse Python manifests into (declared, installed) runtime-dependency sets.
+
+    Declared = ``[project].dependencies``. Installed = the runtime closure of
+    those declared deps resolved from ``uv.lock``. Dev/optional extras are
+    excluded: they are not part of the published runtime artifact.
+    """
+    project = tomllib.loads(pyproject_toml)["project"]
+    declared = {_strip_pep508_name(d) for d in project.get("dependencies", [])}
+
+    lock = tomllib.loads(uv_lock)
+    by_name = {pkg["name"]: pkg for pkg in lock.get("package", [])}
+
+    installed: set[str] = set()
+    stack = list(declared)
+    while stack:
+        name = stack.pop()
+        if name in installed:
+            continue
+        installed.add(name)
+        pkg = by_name.get(name)
+        if pkg is None:
+            continue
+        for dep in pkg.get("dependencies", []):
+            stack.append(_lock_dep_name(dep))
+    return declared, installed
+
+
+def _pnpm_spec_to_name(spec: str) -> str:
+    """Reduce a pnpm-lock key/value (``'name@1.2.3(peer)'``) to its package name."""
+    spec = spec.strip().strip("'\"")
+    spec = re.sub(r"\(.*\)$", "", spec)  # drop a trailing "(peer@x)" suffix
+    at = spec.rfind("@")
+    return spec[:at] if at > 0 else spec  # at>0 keeps a leading "@scope/" intact
+
+
+def parse_pnpm_snapshots(pnpm_lock: str) -> dict[str, set[str]]:
+    """Map each resolved package name to its runtime dependency names.
+
+    Reads the ``snapshots:`` section of a pnpm-lock.yaml (lockfileVersion 9)
+    without a YAML library. Each snapshot key is ``'<name>@<version>(peers)':``
+    and may contain ``dependencies:`` / ``optionalDependencies:`` sub-blocks
+    whose entries are runtime deps. Optional deps are folded in (they ship when
+    present); ``transitivePeerDependencies:`` and other metadata are ignored.
+    """
+    result: dict[str, set[str]] = {}
+    in_snapshots = False
+    current: str | None = None
+    in_deps = False
+    for line in pnpm_lock.splitlines():
+        if re.match(r"^\S", line):  # a new top-level section starts
+            in_snapshots = line.startswith("snapshots:")
+            current = None
+            in_deps = False
+            continue
+        if not in_snapshots:
+            continue
+        m_key = re.match(r"^  (?P<key>'[^']+'|[^:\s][^:]*):\s*$", line)
+        if m_key:
+            current = _pnpm_spec_to_name(m_key.group("key"))
+            result.setdefault(current, set())
+            in_deps = False
+            continue
+        m_sub = re.match(r"^    (?P<sub>\w+):\s*$", line)
+        if m_sub:
+            in_deps = m_sub.group("sub") in ("dependencies", "optionalDependencies")
+            continue
+        if in_deps and current is not None:
+            m_dep = re.match(r"^      (?P<name>'[^']+'|[^:\s]+):", line)
+            if m_dep:
+                result[current].add(_pnpm_spec_to_name(m_dep.group("name")))
+    return result
+
+
+def parse_ts(package_json: str, pnpm_lock: str | None) -> tuple[set[str], set[str]]:
+    """Parse package.json (+ optional pnpm-lock.yaml) into (declared, installed).
+
+    Declared = runtime ``dependencies`` keys. Installed = the runtime
+    dependency closure resolved from the lockfile when available; without a
+    lockfile the transitive runtime tree cannot be resolved offline, so
+    installed == declared.
+    """
+    data = json.loads(package_json)
+    declared = set(data.get("dependencies", {}))
+    if pnpm_lock is None:
+        return declared, set(declared)
+
+    snapshots = parse_pnpm_snapshots(pnpm_lock)
+    installed: set[str] = set()
+    stack = list(declared)
+    while stack:
+        name = stack.pop()
+        if name in installed:
+            continue
+        installed.add(name)
+        for dep in snapshots.get(name, ()):
+            stack.append(dep)
+    return declared, installed
+
+
+def installed_and_declared(sdk: str, sdk_dir: str) -> tuple[set[str], set[str]]:
+    """Return (declared, installed) dependency name sets for an SDK directory."""
+
+    def read(name: str) -> str:
+        with open(os.path.join(sdk_dir, name), encoding="utf-8") as fh:
+            return fh.read()
+
+    if sdk == "go":
+        return parse_go(read("go.mod"))
+    if sdk == "ts":
+        lock_path = os.path.join(sdk_dir, "pnpm-lock.yaml")
+        lock = read("pnpm-lock.yaml") if os.path.exists(lock_path) else None
+        return parse_ts(read("package.json"), lock)
+    if sdk == "py":
+        return parse_py(read("pyproject.toml"), read("uv.lock"))
+    raise ValueError(f"unknown sdk: {sdk!r} (expected one of {KNOWN_SDKS})")
+
+
+def compare(sdk: str, sdk_dir: str, allowlisted: set[str]) -> Comparison:
+    """Build a Comparison for one SDK from its on-disk manifests and an allowlist."""
+    declared, installed = installed_and_declared(sdk, sdk_dir)
+    return Comparison(
+        sdk=sdk,
+        declared=frozenset(declared),
+        installed=frozenset(installed),
+        allowlisted=frozenset(allowlisted),
+    )
+
+
+def load_allowlist(path: str, sdk: str) -> set[str]:
+    """Load allow-listed dependency names for one SDK from an allowlist.json."""
+    if not os.path.exists(path):
+        return set()
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    return {entry["name"] for entry in data.get(sdk, [])}
+
+
+def _report(result: Comparison) -> int:
+    """Print pass/fail for a Comparison. Returns 0 when nothing is unexplained."""
+    sdk = result.sdk
+    for name in sorted(result.unexplained):
+        print(
+            f"::error::sdk/{sdk}: installed dependency {name!r} is not declared and "
+            f"not allow-listed — add it to scripts/dependency_manifest/allowlist.json "
+            f"with a justification, or remove the dependency"
+        )
+    for name in sorted(result.stale_allowlist):
+        print(
+            f"::warning::sdk/{sdk}: allow-listed dependency {name!r} is not installed "
+            f"(stale allowlist entry — prune it)"
+        )
+    if result.unexplained:
+        print(
+            f"ERROR: {len(result.unexplained)} undeclared, un-allow-listed "
+            f"dependency(ies) in sdk/{sdk}"
+        )
+        return 1
+    print(
+        f"OK: sdk/{sdk}: all {len(result.installed)} installed runtime "
+        f"dependency(ies) are declared or allow-listed"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--lang", required=True, choices=list(KNOWN_SDKS))
+    parser.add_argument(
+        "--sdk-dir",
+        default=None,
+        help="SDK directory to inspect (default: <repo>/sdk/<lang>)",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=DEFAULT_ALLOWLIST,
+        help=f"Path to the allowlist JSON (default: {DEFAULT_ALLOWLIST})",
+    )
+    args = parser.parse_args(argv)
+
+    sdk = args.lang
+    sdk_dir = args.sdk_dir or os.path.join(_REPO_ROOT, "sdk", sdk)
+    allowlisted = load_allowlist(args.allowlist, sdk)
+
+    print("Gate #10 — documented dependencies match installed dependencies")
+    print(f"  lang      : {sdk}")
+    print(f"  sdk-dir   : {sdk_dir}")
+    print(f"  allowlist : {args.allowlist}")
+
+    result = compare(sdk, sdk_dir, allowlisted)
+    rc = _report(result)
+
+    if rc == 0:
+        print(f"\nGate #10 PASSED for {sdk}")
+    else:
+        print(f"\nGate #10 FAILED for {sdk} (see errors above)")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dependency_manifest/test_check.py
+++ b/scripts/dependency_manifest/test_check.py
@@ -1,0 +1,348 @@
+"""Unit tests for the Gate #10 dependency-manifest verifier.
+
+These tests exercise the comparison core (the per-language manifest parsers and
+the declared-vs-installed comparison) against controlled fixtures, plus the
+shipped allowlist against the real SDK manifests. No package is installed and no
+network call is made — the comparison reads committed files only.
+
+The core invariant under test: an installed dependency that is neither declared
+nor allow-listed is flagged as `unexplained` (the gate fails), and the shipped
+allowlist explains every undeclared dependency in every real SDK (the gate
+passes on `main`). The fail case is a direct implementation of ADR-0024 D6 (a
+gate must be observed to fail on a deliberately-broken input).
+
+Run with:
+    python3 -m pytest scripts/dependency_manifest/test_check.py
+    python3 scripts/dependency_manifest/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+GO_MOD_SINGLE = """\
+module example.com/x
+
+go 1.23
+
+require golang.org/x/crypto v0.31.0
+
+require golang.org/x/sys v0.28.0 // indirect
+"""
+
+GO_MOD_BLOCK = """\
+module example.com/x
+
+go 1.23
+
+require (
+\tgolang.org/x/crypto v0.31.0
+)
+
+require (
+\tgolang.org/x/sys v0.28.0 // indirect
+)
+"""
+
+PYPROJECT = """\
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["cryptography>=43.0.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0"]
+"""
+
+UV_LOCK = """\
+version = 1
+
+[[package]]
+name = "demo"
+source = { editable = "." }
+dependencies = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "cryptography"
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+
+[[package]]
+name = "cffi"
+dependencies = [
+    { name = "pycparser" },
+]
+
+[[package]]
+name = "pycparser"
+
+[[package]]
+name = "pytest"
+dependencies = [
+    { name = "pluggy" },
+]
+
+[[package]]
+name = "pluggy"
+"""
+
+PACKAGE_JSON = '{"dependencies": {"undici": "^8.3.0", "zod": "^4.4.2"}}'
+
+PNPM_LOCK = """\
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      undici:
+        specifier: ^8.3.0
+        version: 8.3.0
+      zod:
+        specifier: ^4.4.2
+        version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.7
+
+packages:
+
+  undici@8.3.0:
+    resolution: {integrity: sha512-aaa==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-bbb==}
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-ccc==}
+
+snapshots:
+
+  undici@8.3.0: {}
+
+  zod@4.4.3: {}
+
+  vitest@4.1.7:
+    dependencies:
+      sneaky-transitive: 1.0.0
+
+  sneaky-transitive@1.0.0: {}
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_go — direct vs indirect requires
+# ---------------------------------------------------------------------------
+
+
+class TestParseGo:
+    def test_single_line_requires(self) -> None:
+        declared, installed = check.parse_go(GO_MOD_SINGLE)
+        assert declared == {"golang.org/x/crypto"}
+        assert installed == {"golang.org/x/crypto", "golang.org/x/sys"}
+
+    def test_block_requires(self) -> None:
+        declared, installed = check.parse_go(GO_MOD_BLOCK)
+        assert declared == {"golang.org/x/crypto"}
+        assert installed == {"golang.org/x/crypto", "golang.org/x/sys"}
+
+
+# ---------------------------------------------------------------------------
+# parse_py — runtime closure from uv.lock, dev extras excluded
+# ---------------------------------------------------------------------------
+
+
+class TestParsePy:
+    def test_runtime_closure_resolves_dict_deps(self) -> None:
+        # uv.lock encodes deps as inline tables ({ name = ..., marker = ... }).
+        declared, installed = check.parse_py(PYPROJECT, UV_LOCK)
+        assert declared == {"cryptography"}
+        assert installed == {"cryptography", "cffi", "pycparser"}
+
+    def test_dev_tooling_is_excluded(self) -> None:
+        _, installed = check.parse_py(PYPROJECT, UV_LOCK)
+        assert "pytest" not in installed
+        assert "pluggy" not in installed
+
+
+# ---------------------------------------------------------------------------
+# parse_ts — runtime closure from pnpm-lock snapshots, dev tree excluded
+# ---------------------------------------------------------------------------
+
+
+class TestParseTs:
+    def test_resolves_runtime_closure_excludes_dev_tree(self) -> None:
+        declared, installed = check.parse_ts(PACKAGE_JSON, PNPM_LOCK)
+        assert declared == {"undici", "zod"}
+        # The dev tool's transitive must not leak into the runtime set.
+        assert installed == {"undici", "zod"}
+        assert "sneaky-transitive" not in installed
+
+    def test_without_lockfile_falls_back_to_declared(self) -> None:
+        declared, installed = check.parse_ts(PACKAGE_JSON, None)
+        assert declared == installed == {"undici", "zod"}
+
+    def test_scoped_package_name_preserved(self) -> None:
+        # A leading @scope/ must survive the version strip.
+        assert check._pnpm_spec_to_name("'@noble/ed25519@2.1.0'") == "@noble/ed25519"
+        assert check._pnpm_spec_to_name("zod@4.4.3(peer@1.0.0)") == "zod"
+
+
+# ---------------------------------------------------------------------------
+# Comparison — the pass/fail decision
+# ---------------------------------------------------------------------------
+
+
+class TestComparison:
+    def test_flags_undeclared_unallowlisted(self) -> None:
+        c = check.Comparison(
+            sdk="py",
+            declared=frozenset({"cryptography"}),
+            installed=frozenset({"cryptography", "cffi", "pycparser"}),
+            allowlisted=frozenset({"cffi"}),
+        )
+        assert c.unexplained == frozenset({"pycparser"})
+
+    def test_passes_when_all_allowlisted(self) -> None:
+        c = check.Comparison(
+            sdk="py",
+            declared=frozenset({"cryptography"}),
+            installed=frozenset({"cryptography", "cffi", "pycparser"}),
+            allowlisted=frozenset({"cffi", "pycparser"}),
+        )
+        assert c.unexplained == frozenset()
+
+    def test_reports_stale_allowlist(self) -> None:
+        c = check.Comparison(
+            sdk="go",
+            declared=frozenset({"golang.org/x/crypto"}),
+            installed=frozenset({"golang.org/x/crypto"}),
+            allowlisted=frozenset({"golang.org/x/sys"}),
+        )
+        assert c.stale_allowlist == frozenset({"golang.org/x/sys"})
+
+
+# ---------------------------------------------------------------------------
+# compare + _report — gate blocks on an injected eager dependency
+# ---------------------------------------------------------------------------
+
+
+class TestGateBlocks:
+    def test_compare_blocks_unexplained_dep(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdk_dir = os.path.join(tmp, "go")
+            os.makedirs(sdk_dir)
+            with open(os.path.join(sdk_dir, "go.mod"), "w", encoding="utf-8") as fh:
+                fh.write(GO_MOD_SINGLE)
+            blocked = check.compare("go", sdk_dir, allowlisted=set())
+            assert blocked.unexplained == frozenset({"golang.org/x/sys"})
+            assert check._report(blocked) == 1
+            allowed = check.compare("go", sdk_dir, allowlisted={"golang.org/x/sys"})
+            assert allowed.unexplained == frozenset()
+            assert check._report(allowed) == 0
+
+    def test_unknown_sdk_rejected(self) -> None:
+        try:
+            check.installed_and_declared("rust", "/nonexistent")
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for unknown sdk")
+
+
+# ---------------------------------------------------------------------------
+# Shipped allowlist vs the real SDK manifests
+# ---------------------------------------------------------------------------
+
+
+class TestShippedAllowlist:
+    def test_real_manifests_pass_with_committed_allowlist(self) -> None:
+        for sdk in check.KNOWN_SDKS:
+            allow = check.load_allowlist(check.DEFAULT_ALLOWLIST, sdk)
+            sdk_dir = os.path.join(check._REPO_ROOT, "sdk", sdk)
+            result = check.compare(sdk, sdk_dir, allow)
+            assert result.unexplained == frozenset(), (sdk, result.unexplained)
+
+    def test_committed_allowlist_entries_have_justifications(self) -> None:
+        with open(check.DEFAULT_ALLOWLIST, encoding="utf-8") as fh:
+            data = json.load(fh)
+        assert set(data) <= set(check.KNOWN_SDKS)
+        for sdk, entries in data.items():
+            for entry in entries:
+                assert entry["name"], (sdk, entry)
+                assert entry["justification"].strip(), (sdk, entry)
+
+    def test_no_stale_allowlist_entries(self) -> None:
+        for sdk in check.KNOWN_SDKS:
+            allow = check.load_allowlist(check.DEFAULT_ALLOWLIST, sdk)
+            sdk_dir = os.path.join(check._REPO_ROOT, "sdk", sdk)
+            result = check.compare(sdk, sdk_dir, allow)
+            assert result.stale_allowlist == frozenset(), (sdk, result.stale_allowlist)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_passes_on_real_go(self) -> None:
+        assert check.main(["--lang", "go"]) == 0
+
+    def test_main_fails_on_injected_dep(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "go.mod"), "w", encoding="utf-8") as fh:
+                fh.write(GO_MOD_SINGLE)
+            empty = os.path.join(tmp, "empty-allowlist.json")
+            with open(empty, "w", encoding="utf-8") as fh:
+                fh.write("{}")
+            rc = check.main(["--lang", "go", "--sdk-dir", tmp, "--allowlist", empty])
+            assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Self-runner (no pytest dependency required)
+# ---------------------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    suites = [
+        TestParseGo,
+        TestParsePy,
+        TestParseTs,
+        TestComparison,
+        TestGateBlocks,
+        TestShippedAllowlist,
+        TestMain,
+    ]
+    for suite_cls in suites:
+        suite = suite_cls()
+        for name in sorted(dir(suite_cls)):
+            if not name.startswith("test_"):
+                continue
+            fn = getattr(suite, name)
+            try:
+                fn()
+                print(f"ok   {suite_cls.__name__}.{name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {suite_cls.__name__}.{name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {suite_cls.__name__}.{name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## What

Adds **Gate #10** of the project verification contract (ADR-0024): _"Documented dependencies match installed dependencies / SBOM."_ For the SDK being released, the gate compares the dependencies actually resolved into the artifact (the **installed** set) against the dependencies the SDK declares directly (the **declared** set) and **fails the release** on any installed dependency that is neither declared nor allow-listed with a justification.

Closes #656. Implements ADR-0024 Gate #10 (`docs/adr/0024-project-verification-contract.md`, D4 row 10).

## Why

"Eager" transitive-turned-runtime dependencies that creep into a published artifact are a supply-chain risk for a cryptographic-protocol project (AGENTS.md "Adding dependencies"). This gate blocks a release if a dependency ships that isn't declared and isn't recorded as intentional. It is the release-time enforcement of the dependency claims the SDK READMEs assert in prose ("minimal runtime dependencies — …").

## Approach

Mirrors the existing custom gates — `schema-conformance` (#653) and `byte-identity` (#654): a `scripts/dependency_manifest/` helper (`check.py` + `test_check.py` with a no-pytest self-runner), a committed allowlist, and a per-SDK `dependency-manifest` job that runs alongside the others (`needs: release`) in each `release-sdk-*.yml`. The job invocation pattern (`check.py --lang ` then `test_check.py`) matches the sibling jobs exactly.

The comparison is **manifest-vs-manifest** and needs **no network and no package install**:

| SDK | Declared | Installed (resolved runtime) |
|-----|----------|------------------------------|
| go  | direct `require`s in `go.mod` | direct + `// indirect` requires in `go.mod` |
| py  | `[project].dependencies` in `pyproject.toml` | runtime closure resolved from `uv.lock` (dev/optional extras excluded) |
| ts  | `dependencies` in `package.json` | runtime closure resolved from `pnpm-lock.yaml` snapshots (dev tree excluded); declared deps only if no lockfile |

**No new third-party tooling.** Parsing uses the Python stdlib only (`json`, `re`, `tomllib` — 3.11+); the pnpm lockfile is parsed directly without a YAML dependency. This deliberately avoids pulling in a heavyweight SBOM generator (Syft / CycloneDX / cyclonedx-gomod), per the issue's "minimal, dependency-light" guidance. If a signed SBOM artifact later becomes a hard requirement, the resolver here can be swapped for a pinned generator while the allowlist/comparison logic stays.

## Allowlist format

`scripts/dependency_manifest/allowlist.json`, keyed by SDK, each entry `name` + `justification`. An allow-listed name suppresses the failure for that dependency; the runner also emits a non-fatal `::warning::` for stale entries (allow-listed but no longer installed), and a test asserts the shipped allowlist has none.

Legitimate transitive deps recorded: 10 for go (transitives of `modernc.org/sqlite`, `cloudflare/circl`, and the in-repo `daemon` module — including `golang.org/x/crypto` and `golang.org/x/sys`), 6 for py (transitives of `pydantic` and `cryptography`: `cffi`, `pycparser`, `pydantic-core`, `annotated-types`, `typing-extensions`, `typing-inspection`); ts is empty (`undici` + `zod` resolve with no extra runtime deps).

## How I tested PASS and FAIL

- **PASS** on the real manifests for all three SDKs: `check.py --lang go|py|ts` all exit 0 (go: 14 installed deps all explained; py: 8; ts: 2).
- **FAIL** path proven: injected an `// indirect` `github.com/sneaky/eager` into a throwaway `go.mod` with an empty allowlist — the gate flagged it with a `::error::` annotation and exited 1. Removing a real transitive's allowlist entry also fails, confirming the allowlist is what suppresses it.
- **Unit tests**: 19 tests pass via the stdlib self-runner (`python3 scripts/dependency_manifest/test_check.py`), no network/install — cover both go.mod styles, the py runtime-closure resolution with inline-table deps and dev-extra exclusion, the pnpm snapshot closure with dev-tree exclusion and scoped-package names, the undeclared-and-unallowlisted fail path, allowlist suppression, stale-allowlist detection, unknown-SDK rejection, and the CLI pass/fail. A test also asserts the shipped allowlist explains every real undeclared dep in every SDK (this would fail CI if a dep is added without an allowlist entry).
- Workflow YAML validated: each `dependency-manifest` job parses, has `needs: release`, uses the same `setup-python` SHA as the adjacent #653/#654 jobs, and passes the correct per-SDK `--lang`.

## RELEASE-BLOCKING — human review required

This edits all three `.github/workflows/release-sdk-*.yml`. The new job runs at release time alongside the other gates and **will block a release** when it fires. Please review the workflow changes and the gate semantics before merge.

## Design choices for maintainer

Each is a defensible default; flagging for your judgement:

1. **Manifest-vs-manifest, not full SBOM tooling.** No SBOM generator added. Revisit if a signed CycloneDX/SPDX artifact is a hard requirement of "SBOM produced at release time".
2. **Scope = runtime closure only.** Dev/test/build tooling is excluded (not shipped, so not an artifact-level supply-chain risk). Widen the parsers if dev deps must also be gated.
3. **"Declared" = direct manifest declarations, not README prose.** The SDK READMEs describe dependencies in prose but don't enumerate them machine-readably, so the manifest's own direct declarations are treated as the documented set. If a structured per-README dependency list should be the source of truth, point the parser there.
4. **TS resolves the runtime tree by parsing `pnpm-lock.yaml` directly** (no YAML dep, no `pnpm install`). Walks `snapshots:` `dependencies:`/`optionalDependencies:` blocks from the runtime roots. Robust for lockfileVersion 9; revisit if the lockfile format changes.
5. **Go allowlist treats `golang.org/x/crypto` as an allowlisted transitive** because it is `// indirect` in `go.mod` today (pulled via `cloudflare/circl`). If the SDK should depend on it directly, that is a `go.mod` change, not a gate change.
6. **AGENTS.md left untouched** — the root AGENTS.md does not enumerate gates (matching how #653/#654 landed), so nothing was added there.