### PR TITLE
fix(byte-identity): split on \n not splitlines() to handle U+2028

### DIFF
--- a/scripts/byte_identity/check.py
+++ b/scripts/byte_identity/check.py
@@ -418,7 +418,7 @@ func main() {
 
 def _parse_emitted(lang: str, stdout: str) -> dict | None:
     """Pull the single JSON output object out of a driver's stdout."""
-    for line in reversed(stdout.splitlines()):
+    for line in reversed(stdout.split("\n")):
         line = line.strip()
         if line.startswith("{"):
             try:


### PR DESCRIPTION
## What

One-line fix in `scripts/byte_identity/check.py`: `stdout.splitlines()` → `stdout.split("\n")`.

## Why

Python's `str.splitlines()` treats U+2028 (LINE SEPARATOR) as a line ending. RFC 8785 says U+2028 must **not** be escaped in canonical JSON, so the TS SDK correctly emits a literal U+2028 inside the `string_no_u2028_escape` vector output. This caused `_parse_emitted` to split the single-line JSON object at the U+2028 position, making `json.loads()` fail with "Unterminated string".

The fix uses `split("\n")` which only splits on the newline character the driver actually writes — `console.log` / `print` / `fmt.Println` all terminate with `\n`, never U+2028.

## Observed failure

`sdk-ts-v0.11.0` release run, `byte-identity` job:
```
ERROR: ts driver produced a non-JSON output line: Unterminated string starting at: line 1 column 1054 (char 1053)
Gate #7 FAILED for ts 0.11.0
```

## Test

All 18 existing `test_check.py` unit tests pass. Added a local smoke-test confirming `_parse_emitted` correctly handles a JSON object containing a literal U+2028.