### PR TITLE
Add Gate #8: daemon ↔ SDK protocol compatibility check

### DIFF
--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -82,3 +82,41 @@ jobs:
             daemon/dist/*.tar.gz \
             daemon/dist/checksums.txt \
             --clobber
+
+  # Gate #8: the just-released daemon must declare a protocol-version range that
+  # intersects each released SDK's declared range, and complete a live
+  # handshake with it. For each SDK language it reads the SDK's declared range
+  # from the latest published package and the daemon's spoken range from the
+  # tarball just uploaded to this release, asserts they intersect, then boots
+  # the released daemon and emits one event through the published SDK; a pair
+  # that cannot talk turns the release red. A language whose SDK has not been
+  # published yet is skipped (nothing to pair against).
+  daemon-protocol:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [go, ts, py]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - if: matrix.lang == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - if: matrix.lang == 'ts'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify daemon ↔ SDK protocol compatibility (Gate #8)
+        run: |
+          VERSION="${GITHUB_REF_NAME#daemon/v}"
+          python3 scripts/daemon_protocol/check.py \
+            --sdk-lang ${{ matrix.lang }} --sdk-version latest --daemon-version "$VERSION"
+      - name: Run unit tests for daemon-protocol gate
+        run: python3 scripts/daemon_protocol/test_check.py

--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -151,3 +151,31 @@ jobs:
           python3 scripts/byte_identity/check.py --lang go --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #8: the just-published SDK and the latest released daemon must declare
+  # intersecting protocol-version ranges and complete a live handshake. Reads
+  # the SDK's declared range from the module fetched from the Go proxy and the
+  # daemon's spoken range from the released daemon tarball, asserts they
+  # intersect, then boots the daemon and emits one event through the published
+  # SDK; a pair that cannot talk turns the release red. Skips when no daemon has
+  # been released yet (nothing to pair against).
+  daemon-protocol:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify daemon ↔ SDK protocol compatibility (Gate #8)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/go/v}"
+          python3 scripts/daemon_protocol/check.py \
+            --sdk-lang go --sdk-version "$VERSION" --daemon-version latest
+      - name: Run unit tests for daemon-protocol gate
+        run: python3 scripts/daemon_protocol/test_check.py

--- a/.github/workflows/release-sdk-py.yml
+++ b/.github/workflows/release-sdk-py.yml
@@ -155,3 +155,28 @@ jobs:
           python3 scripts/byte_identity/check.py --lang py --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #8: the just-published package and the latest released daemon must
+  # declare intersecting protocol-version ranges and complete a live handshake.
+  # Reads the SDK's declared range from the package installed from PyPI and the
+  # daemon's spoken range from the released daemon tarball, asserts they
+  # intersect, then boots the daemon and emits one event through the published
+  # SDK; a pair that cannot talk turns the release red. Skips when no daemon has
+  # been released yet (nothing to pair against).
+  daemon-protocol:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify daemon ↔ SDK protocol compatibility (Gate #8)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-py-v}"
+          python3 scripts/daemon_protocol/check.py \
+            --sdk-lang py --sdk-version "$VERSION" --daemon-version latest
+      - name: Run unit tests for daemon-protocol gate
+        run: python3 scripts/daemon_protocol/test_check.py

--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -177,3 +177,31 @@ jobs:
           python3 scripts/byte_identity/check.py --lang ts --version "$VERSION"
       - name: Run unit tests for byte-identity gate
         run: python3 scripts/byte_identity/test_check.py
+
+  # Gate #8: the just-published package and the latest released daemon must
+  # declare intersecting protocol-version ranges and complete a live handshake.
+  # Reads the SDK's declared range from the package installed from npm and the
+  # daemon's spoken range from the released daemon tarball, asserts they
+  # intersect, then boots the daemon and emits one event through the published
+  # SDK; a pair that cannot talk turns the release red. Skips when no daemon has
+  # been released yet (nothing to pair against).
+  daemon-protocol:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Verify daemon ↔ SDK protocol compatibility (Gate #8)
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk-ts-v}"
+          python3 scripts/daemon_protocol/check.py \
+            --sdk-lang ts --sdk-version "$VERSION" --daemon-version latest
+      - name: Run unit tests for daemon-protocol gate
+        run: python3 scripts/daemon_protocol/test_check.py

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -43,10 +44,11 @@ func resolveVersion() string {
 // The action fields are mutually exclusive top-level requests that short-circuit
 // before the daemon starts; cfg is the merged daemon configuration.
 type resolved struct {
-	cfg         daemon.Config
-	showVersion bool
-	initKeys    bool
-	printConfig bool
+	cfg          daemon.Config
+	showVersion  bool
+	showProtocol bool
+	initKeys     bool
+	printConfig  bool
 }
 
 func main() {
@@ -61,6 +63,19 @@ func main() {
 
 	if r.showVersion {
 		fmt.Printf("agent-receipts-daemon %s\n", resolveVersion())
+		return
+	}
+
+	if r.showProtocol {
+		// Machine-readable spoken-range surface for ADR-0024 Gate #8. The gate
+		// reads this from the released binary and asserts it intersects the
+		// range each released SDK declares it can emit.
+		out, err := json.Marshal(daemon.SpokenProtocolVersion())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "agent-receipts-daemon --protocol-version: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
 		return
 	}
 
@@ -121,6 +136,7 @@ func resolveConfig(args []string, getenv func(string) string, errOut io.Writer) 
 	configPath := fs.String("config", "", "Path to a TOML config file (default: $XDG_DATA_HOME/agent-receipts/daemon.toml; ignored if absent)")
 	initKeys := fs.Bool("init", false, "Generate a new signing key pair and exit (must not exist)")
 	showVersion := fs.Bool("version", false, "Print version and exit")
+	showProtocol := fs.Bool("protocol-version", false, "Print the daemon's spoken wire-protocol version range as JSON and exit")
 	printConfigFlag := fs.Bool("print-config", false, "Print the resolved config (file < env < flags) and exit")
 
 	// Layer 1 + 2: start from per-OS defaults, then overlay the config file
@@ -169,10 +185,11 @@ func resolveConfig(args []string, getenv func(string) string, errOut io.Writer) 
 	}
 
 	return resolved{
-		cfg:         cfg,
-		showVersion: *showVersion,
-		initKeys:    *initKeys,
-		printConfig: *printConfigFlag,
+		cfg:          cfg,
+		showVersion:  *showVersion,
+		showProtocol: *showProtocol,
+		initKeys:     *initKeys,
+		printConfig:  *printConfigFlag,
 	}, nil
 }
 

--- a/daemon/cmd/agent-receipts-daemon/main_test.go
+++ b/daemon/cmd/agent-receipts-daemon/main_test.go
@@ -1,6 +1,39 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func discardEnv(string) string { return "" }
+
+// TestResolveConfig_ProtocolVersionFlag pins that --protocol-version is parsed
+// into the resolved action so main() can short-circuit and print the spoken
+// range Gate #8 reads.
+func TestResolveConfig_ProtocolVersionFlag(t *testing.T) {
+	r, err := resolveConfig([]string{"--protocol-version"}, discardEnv, &strings.Builder{})
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if !r.showProtocol {
+		t.Error("showProtocol = false, want true with --protocol-version")
+	}
+	if r.showVersion || r.initKeys || r.printConfig {
+		t.Error("--protocol-version set an unrelated action flag")
+	}
+}
+
+// TestResolveConfig_NoProtocolByDefault is the negative: absent the flag, the
+// daemon starts normally rather than printing the protocol range.
+func TestResolveConfig_NoProtocolByDefault(t *testing.T) {
+	r, err := resolveConfig(nil, discardEnv, &strings.Builder{})
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if r.showProtocol {
+		t.Error("showProtocol = true with no flags")
+	}
+}
 
 // TestResolveVersion_PrefersLDFlagInjection pins the precedence the
 // release pipeline relies on: a -ldflags "-X main.version=..." build

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -38,6 +38,23 @@ const maxIdentityFieldLen = 256
 // misinterpret future fields.
 const SupportedFrameVersion = "1"
 
+// SpokenFrameVersionMin and SpokenFrameVersionMax bound, inclusive, the set of
+// emitter-frame schema versions this daemon can interpret — its "spoken range"
+// in the ADR-0024 Gate #8 sense. Today the daemon speaks exactly one version,
+// so min == max and the value equals SupportedFrameVersion; when a future
+// version ships with a daemon-side translator for an older shape, the max
+// widens and the accept check above widens with it. Gate #8 reads this range
+// (via `agent-receipts-daemon --protocol-version`) and asserts it intersects
+// the range each released SDK declares it can emit, so a release can never
+// ship an SDK/daemon pair that cannot talk to each other. Keeping these as the
+// single source of the daemon's spoken range — alongside a test that ties them
+// to SupportedFrameVersion — stops the declaration drifting from the bytes the
+// daemon actually accepts.
+const (
+	SpokenFrameVersionMin = 1
+	SpokenFrameVersionMax = 1
+)
+
 // actionTypeEventsDropped is the action type for the daemon-synthesised
 // events_dropped receipt. The "agent_receipts" namespace identifies the daemon
 // as the source rather than a user-facing tool channel.

--- a/daemon/protocol.go
+++ b/daemon/protocol.go
@@ -1,0 +1,33 @@
+package daemon
+
+import "github.com/agent-receipts/ar/daemon/internal/pipeline"
+
+// VersionRange is an inclusive range of integer protocol versions. An empty
+// intersection between two ranges means the two peers cannot talk.
+type VersionRange struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+// ProtocolVersion describes the wire protocol this daemon speaks. It is the
+// machine-readable surface ADR-0024 Gate #8 reads (via the
+// `agent-receipts-daemon --protocol-version` flag) to assert the released
+// daemon's spoken range intersects the range each released SDK declares it can
+// emit.
+type ProtocolVersion struct {
+	// FrameVersion is the range of emitter-frame schema versions (the `v`
+	// field on the wire) the daemon can interpret.
+	FrameVersion VersionRange `json:"frame_version"`
+}
+
+// SpokenProtocolVersion returns the daemon's spoken protocol range, sourced
+// from the pipeline that actually accepts frames so the declaration cannot
+// drift from the bytes the daemon honours.
+func SpokenProtocolVersion() ProtocolVersion {
+	return ProtocolVersion{
+		FrameVersion: VersionRange{
+			Min: pipeline.SpokenFrameVersionMin,
+			Max: pipeline.SpokenFrameVersionMax,
+		},
+	}
+}

--- a/daemon/protocol_test.go
+++ b/daemon/protocol_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/agent-receipts/ar/daemon/internal/pipeline"
+)
+
+// TestSpokenProtocolVersionMirrorsPipeline asserts the exported spoken range
+// reflects the pipeline constants — the single source of truth for which frame
+// versions the daemon accepts.
+func TestSpokenProtocolVersionMirrorsPipeline(t *testing.T) {
+	pv := SpokenProtocolVersion()
+	if pv.FrameVersion.Min != pipeline.SpokenFrameVersionMin {
+		t.Errorf("Min = %d, want %d", pv.FrameVersion.Min, pipeline.SpokenFrameVersionMin)
+	}
+	if pv.FrameVersion.Max != pipeline.SpokenFrameVersionMax {
+		t.Errorf("Max = %d, want %d", pv.FrameVersion.Max, pipeline.SpokenFrameVersionMax)
+	}
+}
+
+// TestSpokenRangeWellFormed guards the range invariant: min <= max.
+func TestSpokenRangeWellFormed(t *testing.T) {
+	if pipeline.SpokenFrameVersionMin > pipeline.SpokenFrameVersionMax {
+		t.Fatalf("spoken range is inverted: min %d > max %d",
+			pipeline.SpokenFrameVersionMin, pipeline.SpokenFrameVersionMax)
+	}
+}
+
+// TestSpokenRangeCoversAcceptedVersion ties the declared range to the version
+// the daemon actually accepts. SupportedFrameVersion must parse to an integer
+// inside [min, max]; otherwise the daemon would advertise a range that does not
+// match the bytes it honours, defeating the point of Gate #8. While the daemon
+// speaks a single version, min == max == that version.
+func TestSpokenRangeCoversAcceptedVersion(t *testing.T) {
+	v, err := strconv.Atoi(pipeline.SupportedFrameVersion)
+	if err != nil {
+		t.Fatalf("SupportedFrameVersion %q is not an integer: %v", pipeline.SupportedFrameVersion, err)
+	}
+	if v < pipeline.SpokenFrameVersionMin || v > pipeline.SpokenFrameVersionMax {
+		t.Fatalf("SupportedFrameVersion %d is outside spoken range [%d, %d]",
+			v, pipeline.SpokenFrameVersionMin, pipeline.SpokenFrameVersionMax)
+	}
+	if pipeline.SpokenFrameVersionMin != v {
+		t.Fatalf("daemon accepts only %q but advertises min %d; widen the accept check and the range together",
+			pipeline.SupportedFrameVersion, pipeline.SpokenFrameVersionMin)
+	}
+	if pipeline.SpokenFrameVersionMax != v {
+		t.Fatalf("daemon accepts only %q but advertises max %d; widen the accept check and the range together",
+			pipeline.SupportedFrameVersion, pipeline.SpokenFrameVersionMax)
+	}
+}
+
+// TestSpokenProtocolVersionJSON pins the wire shape the gate parses.
+func TestSpokenProtocolVersionJSON(t *testing.T) {
+	got, err := json.Marshal(SpokenProtocolVersion())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"frame_version":{"min":1,"max":1}}`
+	if string(got) != want {
+		t.Errorf("JSON = %s, want %s", got, want)
+	}
+}

--- a/scripts/daemon_protocol/AGENTS.md
+++ b/scripts/daemon_protocol/AGENTS.md
@@ -1,0 +1,85 @@
+# daemon_protocol
+
+Gate #8 from ADR-0024: daemon ↔ SDK protocol compatibility at release time.
+
+ADR-0010 (daemon process separation) and ADR-0022 (daemon-mediated primary
+deployment) make the daemon the primary path, so "this SDK works with the
+daemon" is a compatibility claim the project asserts. Per ADR-0024 D1 that claim
+needs a gate, so a release cannot ship an SDK/daemon pair that cannot talk to
+each other.
+
+## The protocol-version surface
+
+Both sides declare an inclusive integer range of emitter-frame schema versions
+(the `v` field on the wire, currently `"1"`):
+
+| Side | Declaration | Read by the gate via |
+|------|-------------|----------------------|
+| Daemon (spoken range) | `pipeline.SpokenFrameVersionMin`/`Max` | `agent-receipts-daemon --protocol-version` → `{"frame_version":{"min":N,"max":M}}` |
+| Go SDK (declared range) | `emitter.DaemonProtocolMin`/`Max` | the SDK driver's `range` mode → `{"min":N,"max":M}` |
+| TS SDK | `DAEMON_PROTOCOL_RANGE` | same |
+| Python SDK | `DAEMON_PROTOCOL_RANGE` | same |
+
+Today every side speaks exactly one version, so all ranges are `[1, 1]`. Each
+side has a test that ties its declared range to the version it actually emits or
+accepts, so the declaration cannot drift from the bytes on the wire.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Downloads the released daemon tarball + installs the released SDK, asserts their ranges intersect, then runs a live handshake (boot daemon → emit from the SDK → assert a receipt lands). |
+| `test_check.py` | Unit tests for the pure core (range intersection, semver "latest" selection, asset-URL construction, stdout parsing, receipt counting). No download, no install, no network. |
+
+## Run locally
+
+```sh
+python3 scripts/daemon_protocol/test_check.py             # unit tests (no network)
+python3 scripts/daemon_protocol/check.py --sdk-lang go --sdk-version 0.10.0 --daemon-version 0.8.0
+python3 scripts/daemon_protocol/check.py --sdk-lang ts --sdk-version latest --daemon-version latest
+python3 scripts/daemon_protocol/check.py --sdk-lang py --sdk-version latest --daemon-version latest
+```
+
+`--sdk-version`/`--daemon-version` accept an explicit `X.Y.Z` (no leading `v`)
+or `latest`, which resolves from the registry / GitHub releases. Pass
+`--allow-prerelease` to let `latest` consider pre-release tags.
+
+`check.py` and `test_check.py` use only the Python standard library
+(`urllib`, `json`, `tarfile`, `subprocess`); there is no third-party dependency
+to install. The gate does need the toolchain for the SDK it is testing on
+`PATH` (`go`, or `node`, or `python3` + `pip`) so it can install and run the
+published SDK driver, and a `linux/amd64` runner for the daemon tarball.
+
+## What this gate checks
+
+1. **Static intersection.** The released SDK's declared range overlaps the
+   released daemon's spoken range. A non-overlapping pair (e.g. an SDK that only
+   speaks `v2` against a daemon that only speaks `v1`) turns the release red
+   before either is treated as good.
+2. **Live handshake.** Backs the static claim with the real thing: it boots the
+   released daemon on a throwaway socket/db/key (`--unsafe-socket-path`, since a
+   tmpdir socket is outside the per-platform safe set), emits one event through
+   the released SDK, and asserts a receipt lands in the store — read back via
+   the daemon's `agent-receipts list` companion. A pair that passes the static
+   check but cannot actually exchange a frame still turns the release red.
+
+## Which versions are paired
+
+The gate runs from both release sides so either half landing turns a broken
+pair red:
+
+- An **SDK release** runs the gate with `--sdk-version <the just-released SDK>`
+  and `--daemon-version latest` (the daemon consumers already have).
+- A **daemon release** runs the gate for each SDK with
+  `--daemon-version <the just-released daemon>` and `--sdk-version latest`.
+
+## Relationship to the in-tree daemon integration tests and the other gates
+
+The daemon's in-tree integration tests (`daemon/tests_*_test.go`) exercise the
+same emitter → socket → daemon → DB pipeline at PR time against in-tree source —
+never release-blocking, and using the in-tree emitter rather than the published
+SDK artifact. Gate #8 moves the assertion to a release-blocking position against
+the artifacts consumers actually install and run. It runs alongside Gate #1
+(`readme-snippets`), Gate #2 (`release-verify`), Gate #6 (`schema-conformance`),
+and Gate #7 (`byte-identity`); each must pass for a release to be considered
+green.

--- a/scripts/daemon_protocol/check.py
+++ b/scripts/daemon_protocol/check.py
@@ -83,6 +83,14 @@ DAEMON_ASSET_ARCH = "amd64"
 # between "tag pushed" and "version installable".
 REGISTRY_RETRIES = 4
 
+# How many pages of the GitHub releases list to scan when resolving the latest
+# daemon. This repo cuts releases for several components into one newest-first
+# list, so the most recent daemon release can sit below 100 other-component
+# releases; scanning a single page would make the gate silently skip. We page
+# until daemon releases appear (or this many pages are exhausted) — 10×100 =
+# 1000 releases is far more history than "latest daemon" ever needs.
+MAX_RELEASE_PAGES = 10
+
 # How long to wait for the booted daemon's socket to appear, and for the emitted
 # receipt to land in the store. Generous because CI runners are contended; the
 # happy path resolves in well under a second.
@@ -179,18 +187,44 @@ def daemon_asset_url(version: str) -> str:
     return f"https://github.com/{REPO}/releases/download/daemon%2Fv{version}/{asset}"
 
 
-def _semver_key(version: str) -> tuple:
-    """Sort key for an X.Y.Z[-prerelease] version.
+class NoStableReleaseError(Exception):
+    """No version satisfying the stable/prerelease filter exists among candidates.
 
-    A release sorts above any prerelease of the same X.Y.Z (the ``(1,)`` vs
-    ``(0, ...)`` tuple tail), matching SemVer §11 ordering enough for "pick the
-    newest stable" selection.
+    Distinct from a malformed-tag parse error: this is the legitimate "nothing
+    to pick" outcome (e.g. only pre-releases exist and they are excluded), which
+    callers translate into a skip. A version string that is not dotted-numeric
+    semver is *not* this — such tags are ignored individually rather than
+    collapsing the whole selection.
     """
-    core, _, pre = version.partition("-")
+
+
+def _prerelease_id_key(ident: str) -> tuple:
+    """Per-identifier precedence key for a prerelease dot-identifier (SemVer §11).
+
+    Numeric identifiers compare numerically and rank below alphanumeric ones;
+    alphanumeric identifiers compare in ASCII order. The leading 0/1 flag keeps
+    int and str out of the same comparison slot (Python can't order them).
+    """
+    if ident.isdigit():
+        return (0, int(ident), "")
+    return (1, 0, ident)
+
+
+def _semver_key(version: str) -> tuple:
+    """Sort key for an X.Y.Z[-prerelease][+build] version (SemVer precedence).
+
+    A release sorts above any prerelease of the same core (the ``(1,)`` vs
+    ``(0, ...)`` tail). Prerelease identifiers are compared per SemVer §11 — so
+    ``alpha.2`` sorts *below* ``alpha.10`` (numeric identifiers compared
+    numerically, not lexically). Build metadata is ignored (SemVer §10). Raises
+    ``ValueError`` if the core is not dotted integers.
+    """
+    core = version.partition("-")[0].partition("+")[0]
     nums = tuple(int(p) for p in core.split("."))
+    pre = version.partition("-")[2].partition("+")[0]
     if not pre:
         return (nums, (1,))
-    return (nums, (0,) + tuple(pre.split(".")))
+    return (nums, (0,) + tuple(_prerelease_id_key(p) for p in pre.split(".")))
 
 
 def is_prerelease(version: str) -> bool:
@@ -200,14 +234,24 @@ def is_prerelease(version: str) -> bool:
 def pick_latest(versions: list[str], allow_prerelease: bool) -> str:
     """Return the newest version, excluding prereleases unless allowed.
 
-    Raises ``ValueError`` if no candidate remains after filtering.
+    A candidate whose string is not dotted-numeric semver is skipped
+    individually (so one stray tag like ``vnightly`` cannot break or silently
+    disarm resolution). Raises ``NoStableReleaseError`` if no parseable version
+    remains after filtering.
     """
-    candidates = [v for v in versions if allow_prerelease or not is_prerelease(v)]
-    if not candidates:
-        raise ValueError(
-            f"no {'' if allow_prerelease else 'stable '}version among {versions!r}"
+    keyed: list[tuple[tuple, str]] = []
+    for v in versions:
+        if not allow_prerelease and is_prerelease(v):
+            continue
+        try:
+            keyed.append((_semver_key(v), v))
+        except ValueError:
+            continue  # not dotted-numeric semver — ignore this tag, keep the rest
+    if not keyed:
+        raise NoStableReleaseError(
+            f"no {'' if allow_prerelease else 'stable '}semver version among {versions!r}"
         )
-    return max(candidates, key=_semver_key)
+    return max(keyed, key=lambda kv: kv[0])[1]
 
 
 # ---------------------------------------------------------------------------
@@ -263,20 +307,35 @@ def _http_json(url: str) -> dict | list:
 def resolve_latest_daemon(allow_prerelease: bool) -> str:
     """Newest released daemon version (no leading v) from the GitHub releases.
 
-    Raises ``NoReleaseError`` if no ``daemon/v*`` release exists at all (so the
-    gate skips rather than blocking a release with no daemon to pair against).
+    Pages the newest-first releases list until ``daemon/v*`` tags satisfying the
+    stable/prerelease filter appear (or ``MAX_RELEASE_PAGES`` are exhausted), so
+    the most recent daemon release is found even when many other-component
+    releases sit above it. Raises ``NoReleaseError`` if no such release exists
+    (so the gate skips rather than blocking a release with no daemon to pair
+    against). A network/HTTP error from the fetch is NOT caught here — it
+    propagates and fails the gate, rather than masquerading as "no release".
     """
-    releases = _http_json(f"https://api.github.com/repos/{REPO}/releases?per_page=100")
     versions: list[str] = []
-    for rel in releases if isinstance(releases, list) else []:
-        tag = rel.get("tag_name", "")
-        if tag.startswith("daemon/v"):
-            versions.append(tag[len("daemon/v") :])
+    for page in range(1, MAX_RELEASE_PAGES + 1):
+        batch = _http_json(
+            f"https://api.github.com/repos/{REPO}/releases?per_page=100&page={page}"
+        )
+        if not isinstance(batch, list) or not batch:
+            break  # ran off the end of the releases list
+        for rel in batch:
+            tag = rel.get("tag_name", "")
+            if tag.startswith("daemon/v"):
+                versions.append(tag[len("daemon/v") :])
+        # Releases are newest-first, so once a daemon version matching the filter
+        # has appeared we have the most recent ones — stop rather than page
+        # through the entire release history of every other component.
+        if any(allow_prerelease or not is_prerelease(v) for v in versions):
+            break
     if not versions:
-        raise NoReleaseError("no daemon/v* release exists yet")
+        raise NoReleaseError("no daemon/v* release found in recent releases")
     try:
         return pick_latest(versions, allow_prerelease)
-    except ValueError as exc:  # only pre-releases exist and they are excluded
+    except NoStableReleaseError as exc:  # only pre-releases exist, excluded
         raise NoReleaseError(str(exc)) from exc
 
 

--- a/scripts/daemon_protocol/check.py
+++ b/scripts/daemon_protocol/check.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""Gate #8: daemon ↔ SDK protocol compatibility at release time.
+
+ADR-0024 D1 records the property: a release must not ship an SDK/daemon pair
+that cannot talk to each other. ADR-0010 (daemon process separation) and
+ADR-0022 (daemon-mediated primary deployment) make the daemon the primary path,
+so "this SDK works with the daemon" is a compatibility claim the project
+asserts — and an asserted property needs a gate.
+
+The protocol surface this gate reads:
+
+- Each SDK declares the inclusive range of emitter-frame schema versions it can
+  speak to the daemon — its *declared range* (Go ``emitter.DaemonProtocolMin``/
+  ``Max``, TS ``DAEMON_PROTOCOL_RANGE``, Python ``DAEMON_PROTOCOL_RANGE``).
+- The daemon declares the inclusive range of frame versions it can interpret —
+  its *spoken range* (``agent-receipts-daemon --protocol-version`` prints
+  ``{"frame_version":{"min":N,"max":M}}``).
+
+The gate, against the *published* artifacts:
+
+1. Downloads the released daemon tarball, runs ``--protocol-version`` to read
+   the spoken range.
+2. Installs the released SDK and runs a tiny driver that prints the declared
+   range.
+3. Asserts the two ranges intersect (the *static* check). A non-overlapping
+   pair turns the release red.
+4. Backs the static claim with a *live handshake*: boots the released daemon on
+   a throwaway socket/db/key, has the released SDK emit one event, and asserts a
+   receipt lands in the store (read back via the daemon's ``agent-receipts list``
+   companion). A pair that passes the static check but cannot actually exchange
+   a frame still turns the release red.
+
+The pure comparison/parse core (range intersection, semver selection, asset-URL
+construction, stdout parsing, receipt counting) takes no network and no
+subprocess, so the unit tests exercise it directly; the download/install/boot
+drivers are exercised end-to-end by CI at release time.
+
+Usage:
+    check.py --sdk-lang {go,ts,py} --sdk-version X.Y.Z|latest
+             --daemon-version X.Y.Z|latest
+             [--allow-prerelease] [--workdir DIR]
+
+Exit codes:
+    0  the SDK's declared range intersects the daemon's spoken range AND the
+       live handshake produced a receipt
+    1  a download/install/boot/driver step failed, the ranges do not intersect,
+       or the handshake produced no receipt
+    2  usage error (missing args, unknown lang)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GO_SDK_MODULE = "github.com/agent-receipts/ar/sdk/go"
+GO_DAEMON_MODULE = "github.com/agent-receipts/ar/daemon"
+TS_PACKAGE = "@agnt-rcpt/sdk-ts"
+PY_PACKAGE = "agent-receipts"
+
+REPO = "agent-receipts/ar"
+
+# The daemon GoReleaser archive is named daemon_<version>_<os>_<arch>.tar.gz and
+# uploaded to the GitHub release for the prefixed tag daemon/v<version>. The
+# gate runs on linux/amd64.
+DAEMON_ASSET_OS = "linux"
+DAEMON_ASSET_ARCH = "amd64"
+
+# Registries occasionally lag a freshly pushed version; retries cover the window
+# between "tag pushed" and "version installable".
+REGISTRY_RETRIES = 4
+
+# How long to wait for the booted daemon's socket to appear, and for the emitted
+# receipt to land in the store. Generous because CI runners are contended; the
+# happy path resolves in well under a second.
+SOCKET_WAIT_SECONDS = 15.0
+RECEIPT_WAIT_SECONDS = 15.0
+_POLL_INTERVAL = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Pure comparison / parse core (shared, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def ranges_intersect(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    """Return True if the inclusive integer ranges *a* and *b* overlap.
+
+    Each range is ``(min, max)`` with ``min <= max``. The intersection is
+    non-empty iff ``a.min <= b.max`` and ``b.min <= a.max``.
+    """
+    a_min, a_max = a
+    b_min, b_max = b
+    return a_min <= b_max and b_min <= a_max
+
+
+def parse_spoken_range(stdout: str) -> tuple[int, int]:
+    """Pull the daemon's spoken frame-version range out of --protocol-version.
+
+    Expects a line of ``{"frame_version":{"min":N,"max":M}}``. Raises
+    ``ValueError`` if no such object is present or it is malformed.
+    """
+    obj = _last_json_object(stdout)
+    fv = obj.get("frame_version")
+    if not isinstance(fv, dict):
+        raise ValueError(f"daemon --protocol-version output missing frame_version: {obj!r}")
+    return _range_from_minmax(fv)
+
+
+def parse_declared_range(stdout: str) -> tuple[int, int]:
+    """Pull an SDK's declared range out of its driver's ``range`` output.
+
+    Expects a line of ``{"min":N,"max":M}``. Raises ``ValueError`` if no such
+    object is present or it is malformed.
+    """
+    return _range_from_minmax(_last_json_object(stdout))
+
+
+def _range_from_minmax(obj: dict) -> tuple[int, int]:
+    try:
+        lo = int(obj["min"])
+        hi = int(obj["max"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"malformed version range {obj!r}: {exc}") from exc
+    if lo > hi:
+        raise ValueError(f"inverted version range: min {lo} > max {hi}")
+    return lo, hi
+
+
+def _last_json_object(stdout: str) -> dict:
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            obj = json.loads(line)
+            if not isinstance(obj, dict):
+                raise ValueError(f"expected a JSON object, got {type(obj).__name__}")
+            return obj
+    raise ValueError("no JSON object found on stdout")
+
+
+def count_receipts(list_json_stdout: str) -> int:
+    """Return the number of receipts in ``agent-receipts list --json`` output.
+
+    The companion CLI prints a JSON array (``[]`` when empty). Anything that is
+    not a JSON array is treated as zero receipts so a transient CLI hiccup reads
+    as "not yet landed" rather than crashing the poll loop.
+    """
+    stripped = list_json_stdout.strip()
+    if not stripped:
+        return 0
+    try:
+        arr = json.loads(stripped)
+    except json.JSONDecodeError:
+        return 0
+    return len(arr) if isinstance(arr, list) else 0
+
+
+def daemon_asset_url(version: str) -> str:
+    """Build the GitHub release download URL for the daemon tarball.
+
+    ``version`` carries no leading ``v``; the tag is ``daemon/v<version>`` and
+    the asset is ``daemon_<version>_<os>_<arch>.tar.gz``.
+    """
+    asset = f"daemon_{version}_{DAEMON_ASSET_OS}_{DAEMON_ASSET_ARCH}.tar.gz"
+    # The tag's slash is percent-encoded in the download path.
+    return f"https://github.com/{REPO}/releases/download/daemon%2Fv{version}/{asset}"
+
+
+def _semver_key(version: str) -> tuple:
+    """Sort key for an X.Y.Z[-prerelease] version.
+
+    A release sorts above any prerelease of the same X.Y.Z (the ``(1,)`` vs
+    ``(0, ...)`` tuple tail), matching SemVer §11 ordering enough for "pick the
+    newest stable" selection.
+    """
+    core, _, pre = version.partition("-")
+    nums = tuple(int(p) for p in core.split("."))
+    if not pre:
+        return (nums, (1,))
+    return (nums, (0,) + tuple(pre.split(".")))
+
+
+def is_prerelease(version: str) -> bool:
+    return "-" in version
+
+
+def pick_latest(versions: list[str], allow_prerelease: bool) -> str:
+    """Return the newest version, excluding prereleases unless allowed.
+
+    Raises ``ValueError`` if no candidate remains after filtering.
+    """
+    candidates = [v for v in versions if allow_prerelease or not is_prerelease(v)]
+    if not candidates:
+        raise ValueError(
+            f"no {'' if allow_prerelease else 'stable '}version among {versions!r}"
+        )
+    return max(candidates, key=_semver_key)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess / network helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    cmd: list[str],
+    cwd: str,
+    env: dict[str, str] | None = None,
+    retries: int = 0,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    full_env = {**os.environ, **(env or {})}
+    proc: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(retries + 1):
+        print(f"  $ {' '.join(cmd)}  (cwd={cwd})", flush=True)
+        proc = subprocess.run(
+            cmd, cwd=cwd, env=full_env, text=True, capture_output=capture_output
+        )
+        if proc.returncode == 0 or attempt == retries:
+            return proc
+        wait = 2 ** (attempt + 1)
+        print(f"  command failed (rc={proc.returncode}); retrying in {wait}s", flush=True)
+        time.sleep(wait)
+    assert proc is not None
+    return proc
+
+
+class NoReleaseError(Exception):
+    """Raised when a `latest` counterpart has never been released.
+
+    Distinct from a network/HTTP failure: a release whose counterpart does not
+    exist yet (e.g. the first SDK release before any daemon ships) has no pair
+    to be incompatible with, so the gate skips rather than failing. A transient
+    network error is *not* this — it propagates and fails the gate, because
+    skipping on a fetch error would silently disarm the gate.
+    """
+
+
+def _http_json(url: str) -> dict | list:
+    req = urllib.request.Request(url, headers={"User-Agent": "ar-gate8"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Version resolution ("latest")
+# ---------------------------------------------------------------------------
+
+
+def resolve_latest_daemon(allow_prerelease: bool) -> str:
+    """Newest released daemon version (no leading v) from the GitHub releases.
+
+    Raises ``NoReleaseError`` if no ``daemon/v*`` release exists at all (so the
+    gate skips rather than blocking a release with no daemon to pair against).
+    """
+    releases = _http_json(f"https://api.github.com/repos/{REPO}/releases?per_page=100")
+    versions: list[str] = []
+    for rel in releases if isinstance(releases, list) else []:
+        tag = rel.get("tag_name", "")
+        if tag.startswith("daemon/v"):
+            versions.append(tag[len("daemon/v") :])
+    if not versions:
+        raise NoReleaseError("no daemon/v* release exists yet")
+    try:
+        return pick_latest(versions, allow_prerelease)
+    except ValueError as exc:  # only pre-releases exist and they are excluded
+        raise NoReleaseError(str(exc)) from exc
+
+
+def resolve_latest_sdk(lang: str) -> str:
+    """Newest released version of the given SDK (no leading v) from its registry.
+
+    Raises ``NoReleaseError`` if the registry reports the package does not exist
+    (HTTP 404) — the SDK has never been published, so there is no pair to check.
+    """
+    try:
+        if lang == "go":
+            info = _http_json(f"https://proxy.golang.org/{GO_SDK_MODULE}/@latest")
+            return str(info["Version"]).lstrip("v")  # type: ignore[index]
+        if lang == "ts":
+            doc = _http_json(f"https://registry.npmjs.org/{TS_PACKAGE}")
+            return str(doc["dist-tags"]["latest"])  # type: ignore[index]
+        if lang == "py":
+            doc = _http_json(f"https://pypi.org/pypi/{PY_PACKAGE}/json")
+            return str(doc["info"]["version"])  # type: ignore[index]
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 410):
+            raise NoReleaseError(f"{lang} SDK has never been published ({exc.code})") from exc
+        raise
+    raise ValueError(f"unknown lang {lang!r}")
+
+
+def _resolve(value: str, lang: str, allow_prerelease: bool, *, is_daemon: bool) -> str:
+    if value != "latest":
+        return value.lstrip("v")
+    if is_daemon:
+        return resolve_latest_daemon(allow_prerelease)
+    return resolve_latest_sdk(lang)
+
+
+# ---------------------------------------------------------------------------
+# Daemon: download the released tarball and read its spoken range
+# ---------------------------------------------------------------------------
+
+
+class DaemonBinaries:
+    """Paths to the two binaries unpacked from the daemon release tarball."""
+
+    def __init__(self, daemon: str, cli: str) -> None:
+        self.daemon = daemon
+        self.cli = cli
+
+
+def download_daemon(version: str, workdir: str) -> DaemonBinaries:
+    """Fetch + extract the released daemon tarball; return the binary paths."""
+    url = daemon_asset_url(version)
+    tarball = os.path.join(workdir, "daemon.tar.gz")
+    print(f"\n--- Downloading the released daemon\n    {url}")
+    last_err: Exception | None = None
+    for attempt in range(REGISTRY_RETRIES + 1):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "ar-gate8"})
+            with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+                with open(tarball, "wb") as fh:
+                    shutil.copyfileobj(resp, fh)
+            break
+        except urllib.error.URLError as exc:
+            last_err = exc
+            if attempt == REGISTRY_RETRIES:
+                raise RuntimeError(f"failed to download {url}: {exc}") from exc
+            wait = 2 ** (attempt + 1)
+            print(f"  download failed ({exc}); retrying in {wait}s", flush=True)
+            time.sleep(wait)
+    extract_dir = os.path.join(workdir, "daemon-bin")
+    os.makedirs(extract_dir, exist_ok=True)
+    with tarfile.open(tarball) as tf:
+        _safe_extract(tf, extract_dir)
+    daemon_bin = os.path.join(extract_dir, "agent-receipts-daemon")
+    cli_bin = os.path.join(extract_dir, "agent-receipts")
+    for path in (daemon_bin, cli_bin):
+        if not os.path.exists(path):
+            raise RuntimeError(f"expected binary not found in tarball: {path}")
+        os.chmod(path, 0o755)
+    return DaemonBinaries(daemon_bin, cli_bin)
+
+
+def _safe_extract(tf: tarfile.TarFile, dest: str) -> None:
+    """Extract guarding against path traversal (the tarball is trusted, but a
+    defensive extract is cheap and keeps the gate honest)."""
+    dest_abs = os.path.abspath(dest)
+    for member in tf.getmembers():
+        target = os.path.abspath(os.path.join(dest, member.name))
+        if not (target == dest_abs or target.startswith(dest_abs + os.sep)):
+            raise RuntimeError(f"tar member escapes extract dir: {member.name}")
+    tf.extractall(dest)  # noqa: S202 (members validated above)
+
+
+def read_spoken_range(bins: DaemonBinaries, workdir: str) -> tuple[int, int]:
+    print("\n--- Reading the daemon's spoken protocol range")
+    result = _run([bins.daemon, "--protocol-version"], cwd=workdir, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"daemon --protocol-version failed:\n{result.stderr}")
+    return parse_spoken_range(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# SDK drivers: print declared range, and emit one event in the live handshake
+# ---------------------------------------------------------------------------
+
+_GO_DRIVER = """\
+package main
+
+import (
+\t"context"
+\t"encoding/json"
+\t"fmt"
+\t"os"
+
+\t"github.com/agent-receipts/ar/sdk/go/emitter"
+)
+
+func fail(err error) {
+\tfmt.Fprintln(os.Stderr, err)
+\tos.Exit(1)
+}
+
+func main() {
+\tif len(os.Args) < 2 {
+\t\tfmt.Fprintln(os.Stderr, "usage: driver range|emit <socket>")
+\t\tos.Exit(2)
+\t}
+\tswitch os.Args[1] {
+\tcase "range":
+\t\tout, _ := json.Marshal(map[string]int{"min": emitter.DaemonProtocolMin, "max": emitter.DaemonProtocolMax})
+\t\tfmt.Println(string(out))
+\tcase "emit":
+\t\te, err := emitter.NewDaemon(emitter.WithSocketPath(os.Args[2]))
+\t\tif err != nil {
+\t\t\tfail(err)
+\t\t}
+\t\tdefer e.Close()
+\t\tif err := e.Emit(context.Background(), emitter.Event{
+\t\t\tChannel:  "gate8",
+\t\t\tTool:     emitter.Tool{Name: "handshake"},
+\t\t\tDecision: "allowed",
+\t\t\tInput:    json.RawMessage(`{"probe":true}`),
+\t\t}); err != nil {
+\t\t\tfail(err)
+\t\t}
+\tdefault:
+\t\tos.Exit(2)
+\t}
+}
+"""
+
+_TS_DRIVER = """\
+import { DAEMON_PROTOCOL_RANGE, DaemonEmitter } from "@agnt-rcpt/sdk-ts";
+
+const mode = process.argv[2];
+if (mode === "range") {
+  console.log(
+    JSON.stringify({ min: DAEMON_PROTOCOL_RANGE.min, max: DAEMON_PROTOCOL_RANGE.max }),
+  );
+} else if (mode === "emit") {
+  const emitter = new DaemonEmitter({ socketPath: process.argv[3] });
+  const err = await emitter.emit({
+    channel: "gate8",
+    tool: { name: "handshake" },
+    decision: "allowed",
+    input: '{"probe":true}',
+  });
+  emitter.close();
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+} else {
+  process.exit(2);
+}
+"""
+
+_PY_DRIVER = """\
+import json
+import sys
+
+from agent_receipts import DAEMON_PROTOCOL_RANGE, DaemonEmitter
+
+mode = sys.argv[1]
+if mode == "range":
+    print(json.dumps({"min": DAEMON_PROTOCOL_RANGE.min, "max": DAEMON_PROTOCOL_RANGE.max}))
+elif mode == "emit":
+    emitter = DaemonEmitter(socket_path=sys.argv[2])
+    try:
+        emitter.emit(
+            channel="gate8",
+            tool_name="handshake",
+            decision="allowed",
+            input='{"probe":true}',
+        )
+    finally:
+        emitter.close()
+else:
+    sys.exit(2)
+"""
+
+
+class SDKDriver:
+    """An installed published SDK plus a way to run its range/emit driver."""
+
+    def __init__(self, run_driver) -> None:
+        self._run_driver = run_driver
+
+    def declared_range(self) -> tuple[int, int]:
+        result = self._run_driver(["range"])
+        if result.returncode != 0:
+            raise RuntimeError(f"SDK range driver failed:\n{result.stderr}")
+        return parse_declared_range(result.stdout)
+
+    def emit(self, socket_path: str) -> None:
+        result = self._run_driver(["emit", socket_path])
+        if result.returncode != 0:
+            raise RuntimeError(f"SDK emit driver failed:\n{result.stderr}")
+
+
+def install_go_sdk(version: str, workdir: str) -> SDKDriver:
+    proj = os.path.join(workdir, "go-sdk")
+    os.makedirs(proj, exist_ok=True)
+    with open(os.path.join(proj, "go.mod"), "w", encoding="utf-8") as fh:
+        fh.writelines(
+            [
+                "module example.com/gate8\n",
+                "go 1.26.1\n",
+                f"require {GO_SDK_MODULE} v{version}\n",
+            ]
+        )
+    with open(os.path.join(proj, "main.go"), "w", encoding="utf-8") as fh:
+        fh.write(_GO_DRIVER)
+    env = {"GOFLAGS": "-mod=mod", "GOWORK": "off", "GOPROXY": "https://proxy.golang.org"}
+    print(f"\n--- Fetching {GO_SDK_MODULE}@v{version}")
+    if _run(["go", "mod", "tidy"], cwd=proj, env=env, retries=REGISTRY_RETRIES).returncode != 0:
+        raise RuntimeError(f"go mod tidy for {GO_SDK_MODULE}@v{version} failed")
+    # Pre-build so the emit path is not paying a compile under the socket
+    # timeout; `go run` would otherwise compile on first invocation.
+    if _run(["go", "build", "-o", "driver", "."], cwd=proj, env=env).returncode != 0:
+        raise RuntimeError("building the Go SDK driver failed")
+    driver = os.path.join(proj, "driver")
+
+    def run_driver(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return _run([driver, *args], cwd=proj, env=env, capture_output=True)
+
+    return SDKDriver(run_driver)
+
+
+def install_ts_sdk(version: str, workdir: str) -> SDKDriver:
+    proj = os.path.join(workdir, "ts-sdk")
+    os.makedirs(proj, exist_ok=True)
+    package_json = {
+        "name": "gate8",
+        "private": True,
+        "type": "module",
+        "dependencies": {TS_PACKAGE: version},
+    }
+    with open(os.path.join(proj, "package.json"), "w", encoding="utf-8") as fh:
+        json.dump(package_json, fh, indent=2)
+    with open(os.path.join(proj, "driver.ts"), "w", encoding="utf-8") as fh:
+        fh.write(_TS_DRIVER)
+    print(f"\n--- Installing {TS_PACKAGE}@{version} from npm")
+    if _run(["npm", "install", "--no-audit", "--no-fund"], cwd=proj, retries=REGISTRY_RETRIES).returncode != 0:
+        raise RuntimeError(f"npm install {TS_PACKAGE}@{version} failed")
+
+    def run_driver(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return _run(
+            ["node", "--experimental-strip-types", "driver.ts", *args],
+            cwd=proj,
+            env={"NODE_NO_WARNINGS": "1"},
+            capture_output=True,
+        )
+
+    return SDKDriver(run_driver)
+
+
+def install_py_sdk(version: str, workdir: str) -> SDKDriver:
+    proj = os.path.join(workdir, "py-sdk")
+    os.makedirs(proj, exist_ok=True)
+    venv = os.path.join(proj, "venv")
+    if _run([sys.executable, "-m", "venv", venv], cwd=proj).returncode != 0:
+        raise RuntimeError("creating the Python venv failed")
+    py = os.path.join(venv, "bin", "python")
+    spec = f"{PY_PACKAGE}=={version}"
+    print(f"\n--- Installing {spec} from PyPI")
+    if _run([py, "-m", "pip", "install", "--quiet", spec], cwd=proj, retries=REGISTRY_RETRIES).returncode != 0:
+        raise RuntimeError(f"failed to install {spec} from PyPI")
+    with open(os.path.join(proj, "driver.py"), "w", encoding="utf-8") as fh:
+        fh.write(_PY_DRIVER)
+
+    def run_driver(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return _run([py, "driver.py", *args], cwd=proj, capture_output=True)
+
+    return SDKDriver(run_driver)
+
+
+_INSTALLERS = {"go": install_go_sdk, "ts": install_ts_sdk, "py": install_py_sdk}
+
+
+# ---------------------------------------------------------------------------
+# Live handshake: boot the daemon, emit from the SDK, assert a receipt lands
+# ---------------------------------------------------------------------------
+
+
+def _wait_for(predicate, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(_POLL_INTERVAL)
+    return predicate()
+
+
+def live_handshake(bins: DaemonBinaries, sdk: SDKDriver, workdir: str) -> bool:
+    """Boot the daemon, emit one event from the SDK, assert a receipt lands."""
+    run_dir = os.path.join(workdir, "handshake")
+    os.makedirs(run_dir, exist_ok=True)
+    socket_path = os.path.join(run_dir, "events.sock")
+    db_path = os.path.join(run_dir, "receipts.db")
+    key_path = os.path.join(run_dir, "signing.key")
+    log_path = os.path.join(run_dir, "daemon.log")
+
+    print("\n--- Live handshake: generating the daemon signing key")
+    init = _run([bins.daemon, "--init", "--key", key_path], cwd=run_dir, capture_output=True)
+    if init.returncode != 0:
+        print(f"ERROR: daemon --init failed:\n{init.stderr}")
+        return False
+
+    print("--- Live handshake: booting the released daemon")
+    log = open(log_path, "w", encoding="utf-8")
+    proc = subprocess.Popen(
+        [
+            bins.daemon,
+            "--socket", socket_path,
+            "--db", db_path,
+            "--key", key_path,
+            # A throwaway tmpdir socket is outside the per-platform safe set;
+            # opt in deliberately for the test rather than write under the
+            # operator's real runtime dir.
+            "--unsafe-socket-path",
+        ],
+        cwd=run_dir,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        if not _wait_for(lambda: os.path.exists(socket_path), SOCKET_WAIT_SECONDS):
+            print(f"ERROR: daemon socket never appeared at {socket_path}")
+            _dump_log(log_path)
+            return False
+
+        print("--- Live handshake: emitting one event from the published SDK")
+        sdk.emit(socket_path)
+
+        def landed() -> bool:
+            result = _run(
+                [bins.cli, "list", "--json", "--db", db_path],
+                cwd=run_dir,
+                capture_output=True,
+            )
+            return result.returncode == 0 and count_receipts(result.stdout) >= 1
+
+        if not _wait_for(landed, RECEIPT_WAIT_SECONDS):
+            print("ERROR: no receipt landed in the store after emit")
+            _dump_log(log_path)
+            return False
+
+        print("OK: the released SDK emitted a frame the released daemon turned into a receipt")
+        return True
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        log.close()
+
+
+def _dump_log(log_path: str) -> None:
+    try:
+        with open(log_path, encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError:
+        return
+    if content.strip():
+        print("  daemon log:")
+        for line in content.splitlines():
+            print(f"    {line}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_gate(
+    lang: str,
+    sdk_version: str,
+    daemon_version: str,
+    workdir: str,
+) -> int:
+    bins = download_daemon(daemon_version, workdir)
+    spoken = read_spoken_range(bins, workdir)
+    print(f"  daemon {daemon_version} spoken range: [{spoken[0]}, {spoken[1]}]")
+
+    sdk = _INSTALLERS[lang](sdk_version, workdir)
+    declared = sdk.declared_range()
+    print(f"  {lang} SDK {sdk_version} declared range: [{declared[0]}, {declared[1]}]")
+
+    if not ranges_intersect(declared, spoken):
+        print(
+            f"\nERROR: the {lang} SDK {sdk_version} declared range "
+            f"[{declared[0]}, {declared[1]}] does not intersect the daemon "
+            f"{daemon_version} spoken range [{spoken[0]}, {spoken[1]}]; this "
+            "pair cannot exchange frames"
+        )
+        return 1
+    print(
+        f"\nOK: declared range [{declared[0]}, {declared[1]}] intersects spoken "
+        f"range [{spoken[0]}, {spoken[1]}]"
+    )
+
+    if not live_handshake(bins, sdk, workdir):
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--sdk-lang", required=True, choices=["go", "ts", "py"])
+    parser.add_argument(
+        "--sdk-version",
+        required=True,
+        help="Released SDK version (no leading 'v'), or 'latest' to resolve from the registry",
+    )
+    parser.add_argument(
+        "--daemon-version",
+        required=True,
+        help="Released daemon version (no leading 'v'), or 'latest' to resolve from GitHub releases",
+    )
+    parser.add_argument(
+        "--allow-prerelease",
+        action="store_true",
+        help="When resolving 'latest', consider pre-release versions too",
+    )
+    parser.add_argument("--workdir", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        sdk_version = _resolve(args.sdk_version, args.sdk_lang, args.allow_prerelease, is_daemon=False)
+        daemon_version = _resolve(args.daemon_version, args.sdk_lang, args.allow_prerelease, is_daemon=True)
+    except NoReleaseError as exc:
+        # No counterpart to pair against yet (e.g. the first SDK release before
+        # any daemon ships). Nothing can be incompatible, so skip rather than
+        # block the release. A network failure during resolution is a different
+        # exception and is NOT caught here — it fails the gate.
+        print(f"Gate #8 SKIPPED: {exc}; nothing to pair against")
+        return 0
+
+    cleanup = False
+    if args.workdir:
+        workdir = os.path.abspath(args.workdir)
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = tempfile.mkdtemp(prefix="gate8-")
+        cleanup = True
+
+    print("Gate #8 — daemon ↔ SDK protocol compatibility")
+    print(f"  sdk     : {args.sdk_lang} {sdk_version}")
+    print(f"  daemon  : {daemon_version}")
+    print(f"  workdir : {workdir}")
+
+    try:
+        rc = run_gate(args.sdk_lang, sdk_version, daemon_version, workdir)
+    except (RuntimeError, ValueError, OSError) as exc:
+        print(f"\nERROR: {exc}")
+        rc = 1
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    if rc == 0:
+        print(f"\nGate #8 PASSED for {args.sdk_lang} {sdk_version} ↔ daemon {daemon_version}")
+    else:
+        print(f"\nGate #8 FAILED for {args.sdk_lang} {sdk_version} ↔ daemon {daemon_version} (see errors above)")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/daemon_protocol/test_check.py
+++ b/scripts/daemon_protocol/test_check.py
@@ -1,0 +1,192 @@
+"""Unit tests for the Gate #8 daemon ↔ SDK protocol-compatibility verifier.
+
+These tests exercise the pure comparison/parse core — range intersection,
+semver "latest" selection, asset-URL construction, the daemon and SDK stdout
+parsers, and receipt counting. No artifact is downloaded or installed and no
+network call is made; the download/install/boot drivers are exercised
+end-to-end by CI at release time, not here.
+
+The core invariant under test: `ranges_intersect` is true exactly when two
+inclusive ranges overlap, the parsers recover the pinned ranges from real
+wire-shaped output and reject malformed input, and `count_receipts` reads the
+`agent-receipts list --json` array. The failure cases — a disjoint range, an
+inverted range, malformed JSON — are a direct implementation of ADR-0024 D6 (a
+gate must be observed to fail on a deliberately-broken input).
+
+Run with:
+    python3 -m pytest scripts/daemon_protocol/test_check.py
+    python3 scripts/daemon_protocol/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+
+class TestRangesIntersect:
+    def test_identical_single_point(self) -> None:
+        assert check.ranges_intersect((1, 1), (1, 1))
+
+    def test_overlapping(self) -> None:
+        assert check.ranges_intersect((1, 3), (2, 5))
+
+    def test_touching_at_boundary(self) -> None:
+        assert check.ranges_intersect((1, 2), (2, 4))
+
+    def test_one_contains_the_other(self) -> None:
+        assert check.ranges_intersect((1, 9), (3, 4))
+
+    def test_disjoint_sdk_ahead(self) -> None:
+        # SDK speaks only v2; daemon speaks only v1 — incompatible.
+        assert not check.ranges_intersect((2, 2), (1, 1))
+
+    def test_disjoint_daemon_ahead(self) -> None:
+        assert not check.ranges_intersect((1, 1), (2, 3))
+
+
+class TestParseSpokenRange:
+    def test_parses_wire_shape(self) -> None:
+        out = '{"frame_version":{"min":1,"max":1}}'
+        assert check.parse_spoken_range(out) == (1, 1)
+
+    def test_parses_wider_range(self) -> None:
+        out = '{"frame_version":{"min":1,"max":3}}'
+        assert check.parse_spoken_range(out) == (1, 3)
+
+    def test_ignores_leading_log_lines(self) -> None:
+        out = "booting...\nready\n{\"frame_version\":{\"min\":2,\"max\":4}}"
+        assert check.parse_spoken_range(out) == (2, 4)
+
+    def test_missing_frame_version_raises(self) -> None:
+        try:
+            check.parse_spoken_range('{"something_else":1}')
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for missing frame_version")
+
+    def test_no_json_raises(self) -> None:
+        try:
+            check.parse_spoken_range("not json at all")
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError when no JSON object is present")
+
+
+class TestParseDeclaredRange:
+    def test_parses_minmax(self) -> None:
+        assert check.parse_declared_range('{"min":1,"max":1}') == (1, 1)
+
+    def test_inverted_range_raises(self) -> None:
+        try:
+            check.parse_declared_range('{"min":5,"max":2}')
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for inverted range")
+
+    def test_missing_key_raises(self) -> None:
+        try:
+            check.parse_declared_range('{"min":1}')
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for missing max")
+
+
+class TestCountReceipts:
+    def test_empty_array(self) -> None:
+        assert check.count_receipts("[]") == 0
+
+    def test_empty_string(self) -> None:
+        assert check.count_receipts("   ") == 0
+
+    def test_one_receipt(self) -> None:
+        assert check.count_receipts('[{"id":"a"}]') == 1
+
+    def test_several_receipts(self) -> None:
+        assert check.count_receipts('[{"id":"a"},{"id":"b"},{"id":"c"}]') == 3
+
+    def test_non_array_reads_as_zero(self) -> None:
+        assert check.count_receipts('{"oops":true}') == 0
+
+    def test_garbage_reads_as_zero(self) -> None:
+        assert check.count_receipts("not json") == 0
+
+
+class TestDaemonAssetURL:
+    def test_url_shape(self) -> None:
+        url = check.daemon_asset_url("0.8.0")
+        assert url == (
+            "https://github.com/agent-receipts/ar/releases/download/"
+            "daemon%2Fv0.8.0/daemon_0.8.0_linux_amd64.tar.gz"
+        )
+
+    def test_prerelease_version(self) -> None:
+        url = check.daemon_asset_url("0.9.0-alpha.1")
+        assert "daemon%2Fv0.9.0-alpha.1/" in url
+        assert url.endswith("daemon_0.9.0-alpha.1_linux_amd64.tar.gz")
+
+
+class TestPickLatest:
+    def test_picks_highest_stable(self) -> None:
+        assert check.pick_latest(["0.8.0", "0.10.0", "0.9.0"], False) == "0.10.0"
+
+    def test_numeric_not_lexicographic(self) -> None:
+        # "0.10.0" must beat "0.9.0" even though "9" > "1" lexicographically.
+        assert check.pick_latest(["0.9.0", "0.10.0"], False) == "0.10.0"
+
+    def test_excludes_prerelease_by_default(self) -> None:
+        assert check.pick_latest(["0.8.0", "0.9.0-alpha.1"], False) == "0.8.0"
+
+    def test_release_beats_its_own_prerelease(self) -> None:
+        assert check.pick_latest(["0.9.0", "0.9.0-alpha.1"], True) == "0.9.0"
+
+    def test_allows_prerelease_when_only_option(self) -> None:
+        assert check.pick_latest(["0.9.0-alpha.1", "0.9.0-alpha.2"], True) == "0.9.0-alpha.2"
+
+    def test_no_stable_candidate_raises(self) -> None:
+        try:
+            check.pick_latest(["0.9.0-alpha.1"], False)
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError when no stable version exists")
+
+
+# ---------------------------------------------------------------------------
+# Self-runner (no pytest dependency required)
+# ---------------------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    suites = [
+        TestRangesIntersect,
+        TestParseSpokenRange,
+        TestParseDeclaredRange,
+        TestCountReceipts,
+        TestDaemonAssetURL,
+        TestPickLatest,
+    ]
+    for suite_cls in suites:
+        suite = suite_cls()
+        for name in sorted(dir(suite_cls)):
+            if not name.startswith("test_"):
+                continue
+            fn = getattr(suite, name)
+            try:
+                fn()
+                print(f"ok   {suite_cls.__name__}.{name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {suite_cls.__name__}.{name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {suite_cls.__name__}.{name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/scripts/daemon_protocol/test_check.py
+++ b/scripts/daemon_protocol/test_check.py
@@ -147,12 +147,40 @@ class TestPickLatest:
     def test_allows_prerelease_when_only_option(self) -> None:
         assert check.pick_latest(["0.9.0-alpha.1", "0.9.0-alpha.2"], True) == "0.9.0-alpha.2"
 
-    def test_no_stable_candidate_raises(self) -> None:
+    def test_prerelease_numeric_identifiers_ordered_numerically(self) -> None:
+        # SemVer §11: alpha.2 < alpha.10 (numeric identifiers compared as
+        # numbers, not lexically). The lexical bug returned alpha.2.
+        assert check.pick_latest(["0.9.0-alpha.2", "0.9.0-alpha.10"], True) == "0.9.0-alpha.10"
+
+    def test_prerelease_alpha_below_beta(self) -> None:
+        assert check.pick_latest(["0.9.0-beta.1", "0.9.0-alpha.9"], True) == "0.9.0-beta.1"
+
+    def test_build_metadata_ignored(self) -> None:
+        # Build metadata (+...) does not affect precedence (SemVer §10); the
+        # higher core still wins and parsing must not choke on the '+'.
+        assert check.pick_latest(["0.9.0+ci.7", "0.10.0+ci.1"], False) == "0.10.0+ci.1"
+
+    def test_ignores_unparseable_tag_keeps_valid_latest(self) -> None:
+        # A stray non-semver tag must not break or silently disarm resolution;
+        # the well-formed versions still win.
+        assert check.pick_latest(["0.9.0", "nightly", "0.10.0"], False) == "0.10.0"
+
+    def test_no_stable_candidate_raises_typed(self) -> None:
+        # Must raise the dedicated NoStableReleaseError (which resolve_* maps to
+        # a skip), NOT a bare ValueError — a malformed-tag ValueError instead
+        # propagates and fails the gate closed.
         try:
             check.pick_latest(["0.9.0-alpha.1"], False)
-        except ValueError:
+        except check.NoStableReleaseError:
             return
-        raise AssertionError("expected ValueError when no stable version exists")
+        raise AssertionError("expected NoStableReleaseError when no stable version exists")
+
+    def test_all_unparseable_raises_no_stable(self) -> None:
+        try:
+            check.pick_latest(["nightly", "edge"], True)
+        except check.NoStableReleaseError:
+            return
+        raise AssertionError("expected NoStableReleaseError when no parseable version exists")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -69,6 +69,18 @@ const MaxIdentityFieldLen = 256
 // translator, so a single supported value is the only safe contract.
 const SupportedFrameVersion = "1"
 
+// DaemonProtocolMin and DaemonProtocolMax bound, inclusive, the emitter-frame
+// schema versions this SDK can speak to the daemon — its declared daemon-
+// protocol range in the ADR-0024 Gate #8 sense. Today the SDK emits exactly one
+// version (SupportedFrameVersion), so min == max and the value equals it. Gate
+// #8 reads this range from the published SDK and asserts it intersects the
+// released daemon's spoken range, so a release cannot ship an SDK/daemon pair
+// that cannot talk to each other.
+const (
+	DaemonProtocolMin = 1
+	DaemonProtocolMax = 1
+)
+
 // dialTimeout caps how long Emit blocks attempting to reach the daemon.
 // 25ms is well under the fire-and-forget budget but still tolerant of
 // slow filesystems on contended hosts; net.DialTimeout on AF_UNIX

--- a/sdk/go/emitter/protocol_test.go
+++ b/sdk/go/emitter/protocol_test.go
@@ -1,0 +1,36 @@
+package emitter
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestDaemonProtocolRangeWellFormed guards the range invariant: min <= max.
+func TestDaemonProtocolRangeWellFormed(t *testing.T) {
+	if DaemonProtocolMin > DaemonProtocolMax {
+		t.Fatalf("declared daemon-protocol range is inverted: min %d > max %d",
+			DaemonProtocolMin, DaemonProtocolMax)
+	}
+}
+
+// TestDaemonProtocolRangeCoversEmittedVersion ties the declared range to the
+// version the SDK actually stamps on the wire. SupportedFrameVersion must parse
+// to an integer inside [min, max]; otherwise the SDK would advertise a range
+// that does not match the frames it emits, defeating Gate #8. While the SDK
+// emits a single version, min == max == that version.
+func TestDaemonProtocolRangeCoversEmittedVersion(t *testing.T) {
+	v, err := strconv.Atoi(SupportedFrameVersion)
+	if err != nil {
+		t.Fatalf("SupportedFrameVersion %q is not an integer: %v", SupportedFrameVersion, err)
+	}
+	if v < DaemonProtocolMin || v > DaemonProtocolMax {
+		t.Fatalf("SupportedFrameVersion %d is outside declared range [%d, %d]",
+			v, DaemonProtocolMin, DaemonProtocolMax)
+	}
+	if DaemonProtocolMin != v {
+		t.Fatalf("SDK emits only %q but advertises min %d", SupportedFrameVersion, DaemonProtocolMin)
+	}
+	if DaemonProtocolMax != v {
+		t.Fatalf("SDK emits only %q but advertises max %d", SupportedFrameVersion, DaemonProtocolMax)
+	}
+}

--- a/sdk/py/src/agent_receipts/__init__.py
+++ b/sdk/py/src/agent_receipts/__init__.py
@@ -2,7 +2,9 @@
 
 from agent_receipts._version import VERSION
 from agent_receipts.daemon_emitter import (
+    DAEMON_PROTOCOL_RANGE,
     DaemonEmitter,
+    DaemonProtocolRange,
     EmitTransportError,
     default_socket_path,
 )
@@ -167,6 +169,9 @@ __all__ = [
     "DaemonEmitter",
     "EmitTransportError",
     "default_socket_path",
+    # Daemon-protocol range (ADR-0024 Gate #8)
+    "DAEMON_PROTOCOL_RANGE",
+    "DaemonProtocolRange",
     # Emitter abstraction (ADR-0020) — signed-receipt delivery
     "ApiKeyAuth",
     "BearerAuth",

--- a/sdk/py/src/agent_receipts/daemon_emitter.py
+++ b/sdk/py/src/agent_receipts/daemon_emitter.py
@@ -30,6 +30,7 @@ import struct
 import threading
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import cast
 
@@ -40,6 +41,24 @@ MAX_FRAME_SIZE = 1 << 20
 
 # SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
 SUPPORTED_FRAME_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class DaemonProtocolRange:
+    """Inclusive range of emitter-frame schema versions, ``min`` to ``max``."""
+
+    min: int
+    max: int
+
+
+# DAEMON_PROTOCOL_RANGE is the range of emitter-frame schema versions this SDK
+# can speak to the daemon — its declared daemon-protocol range in the ADR-0024
+# Gate #8 sense. Today the SDK emits exactly one version
+# (``SUPPORTED_FRAME_VERSION``), so ``min == max`` and the value equals it.
+# Gate #8 reads this range from the published SDK and asserts it intersects the
+# released daemon's spoken range, so a release cannot ship an SDK/daemon pair
+# that cannot talk to each other.
+DAEMON_PROTOCOL_RANGE = DaemonProtocolRange(min=1, max=1)
 
 # Dial timeout: 25ms. Well under the fire-and-forget budget.
 _DIAL_TIMEOUT = 0.025

--- a/sdk/py/tests/daemon_emitter/test_protocol_range.py
+++ b/sdk/py/tests/daemon_emitter/test_protocol_range.py
@@ -1,0 +1,24 @@
+"""Tests for the declared daemon-protocol range surface (ADR-0024 Gate #8)."""
+
+from __future__ import annotations
+
+from agent_receipts import DAEMON_PROTOCOL_RANGE, DaemonProtocolRange
+from agent_receipts.daemon_emitter import SUPPORTED_FRAME_VERSION
+
+
+def test_range_is_well_formed() -> None:
+    assert DAEMON_PROTOCOL_RANGE.min <= DAEMON_PROTOCOL_RANGE.max
+
+
+def test_range_is_immutable() -> None:
+    # A frozen dataclass: callers cannot mutate the declared range at runtime.
+    assert isinstance(DAEMON_PROTOCOL_RANGE, DaemonProtocolRange)
+
+
+def test_range_covers_emitted_version() -> None:
+    # While the SDK emits a single version, min == max == that version. A
+    # mismatch would advertise a range that does not match the frames the SDK
+    # puts on the wire, defeating Gate #8.
+    emitted = int(SUPPORTED_FRAME_VERSION)
+    assert DAEMON_PROTOCOL_RANGE.min == emitted
+    assert DAEMON_PROTOCOL_RANGE.max == emitted

--- a/sdk/ts/src/daemon-emitter.test.ts
+++ b/sdk/ts/src/daemon-emitter.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	DAEMON_PROTOCOL_RANGE,
 	DaemonEmitter,
 	defaultSocketPath,
 	type EmitEvent,
@@ -27,6 +28,24 @@ import {
 	type SocketPathDeps,
 	SUPPORTED_FRAME_VERSION,
 } from "./daemon-emitter.js";
+
+describe("DAEMON_PROTOCOL_RANGE — declared daemon-protocol range (Gate #8)", () => {
+	it("is well-formed (min <= max)", () => {
+		expect(DAEMON_PROTOCOL_RANGE.min).toBeLessThanOrEqual(
+			DAEMON_PROTOCOL_RANGE.max,
+		);
+	});
+
+	it("covers the version the SDK actually emits", () => {
+		// While the SDK emits a single version, min === max === that version.
+		// A mismatch would advertise a range that does not match the frames the
+		// SDK puts on the wire, defeating Gate #8.
+		const emitted = Number(SUPPORTED_FRAME_VERSION);
+		expect(Number.isInteger(emitted)).toBe(true);
+		expect(DAEMON_PROTOCOL_RANGE.min).toBe(emitted);
+		expect(DAEMON_PROTOCOL_RANGE.max).toBe(emitted);
+	});
+});
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 

--- a/sdk/ts/src/daemon-emitter.ts
+++ b/sdk/ts/src/daemon-emitter.ts
@@ -32,6 +32,16 @@ export const MAX_FRAME_SIZE = 1 << 20;
 /** Wire format version. Must match daemon's pipeline.SupportedFrameVersion. */
 export const SUPPORTED_FRAME_VERSION = "1";
 
+/**
+ * Inclusive range of emitter-frame schema versions this SDK can speak to the
+ * daemon — its declared daemon-protocol range in the ADR-0024 Gate #8 sense.
+ * Today the SDK emits exactly one version ({@link SUPPORTED_FRAME_VERSION}), so
+ * `min === max`. Gate #8 reads this range from the published SDK and asserts it
+ * intersects the released daemon's spoken range, so a release cannot ship an
+ * SDK/daemon pair that cannot talk to each other.
+ */
+export const DAEMON_PROTOCOL_RANGE = { min: 1, max: 1 } as const;
+
 /** Dial timeout in milliseconds — caps how long emit() blocks reaching the daemon. */
 const DIAL_TIMEOUT_MS = 25;
 

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	DAEMON_PROTOCOL_RANGE,
 	DaemonEmitter,
 	type DaemonEmitterOptions,
 	defaultSocketPath,


### PR DESCRIPTION
## What

Implements Gate #8 from ADR-0024: a release-time gate that verifies the daemon and each SDK declare intersecting protocol-version ranges and can successfully exchange frames in a live handshake.

The gate:
1. Downloads the released daemon tarball and reads its spoken frame-version range via `--protocol-version`
2. Installs the released SDK and reads its declared range via a driver script
3. Asserts the ranges intersect (static check)
4. Boots the daemon and emits one event through the SDK, verifying a receipt lands (live handshake)

## Why

ADR-0010 (daemon process separation) and ADR-0022 (daemon-mediated primary deployment) make the daemon the primary path. Per ADR-0024 D1, &#34;a release must not ship an SDK/daemon pair that cannot talk to each other&#34; — this is an asserted property that requires a gate to enforce.

Without this gate, an incompatible SDK/daemon pair could ship undetected, breaking users&#39; deployments.

## Implementation

**Core logic** (`scripts/daemon_protocol/check.py`):
- Pure comparison/parse functions: range intersection, semver &#34;latest&#34; selection, asset-URL construction, stdout parsing, receipt counting
- Subprocess/network helpers for downloading, installing, and running binaries
- Version resolution from GitHub releases (daemon) and package registries (SDKs)
- Live handshake orchestration: daemon initialization, socket setup, event emission, receipt verification

**Protocol surface** (new constants and exports):
- Daemon: `SpokenProtocolVersion()` returns `{&#34;frame_version&#34;:{&#34;min&#34;:N,&#34;max&#34;:M}}`
- Go SDK: `DaemonProtocolMin`/`Max` constants
- TS SDK: `DAEMON_PROTOCOL_RANGE` export
- Python SDK: `DAEMON_PROTOCOL_RANGE` and `DaemonProtocolRange` class

**Tests**:
- Unit tests (`test_check.py`) exercise the pure core with no network/subprocess
- Protocol-range tests in each SDK/daemon verify the declared range covers the version actually emitted/accepted
- CI workflows trigger the gate on each release

**CI integration**:
- Added `daemon-protocol` job to `release-daemon.yml`, `release-sdk-go.yml`, `release-sdk-ts.yml`, `release-sdk-py.yml`
- Each job tests the just-released component against the latest counterpart
- Skips gracefully when a counterpart has not been released yet (e.g., first SDK release before any daemon)

## Checklist

- [x] Tests pass for all changed components
- [x] Unit tests for pure core (range intersection, semver selection, parsing, receipt counting)
- [x] Protocol-range tests in daemon and each SDK
- [x] No real keys or secrets in the diff
- [x] AGENTS.md added documenting the gate and how to run it locally
- [x] Linter passes (Python scripts use standard library only, no third-party deps)

## Security

- [x] No crypto, auth, or secrets handling in the gate itself
- [x] Tarball extraction guards against path traversal
- [x] All inputs (version strings, JSON) are validated before use
- [x] Live handshake uses throwaway socket/db/key in a temporary directory