### PR TITLE
docs: surface DaemonEmitter in the Python SDK docs; correct receipt schema version

### DIFF
--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -84,9 +84,10 @@ agent-receipts-daemon          # start the daemon (leave it running)
 signs, and chains the receipt. By default `emit()` surfaces transport failure
 (ADR-0025): an unreachable daemon is logged at `DEBUG` and raised as
 `EmitTransportError` rather than dropped silently, so start the daemon before
-your app. The call stays non-blocking (bounded by the dial + write timeout);
-pass `best_effort=True` to opt into loss-tolerant emission (`emit()` returns
-`None` on transport failure).
+your app. The call stays non-blocking (bounded by the dial + write timeout); construct the
+emitter as `DaemonEmitter(best_effort=True)` to opt into loss-tolerant emission
+(`emit()` then returns `None` on transport failure). `best_effort` is a
+constructor argument, not an `emit()` argument.
 
 <!-- snippet-check: no-run -->
 ```python
@@ -395,13 +396,16 @@ from agent_receipts import (
 
 ```python
 from agent_receipts import (
-    ActionReceipt,        # Signed receipt with proof
-    UnsignedActionReceipt,  # Receipt before signing
+    AgentReceipt,         # Signed receipt with proof
+    UnsignedAgentReceipt,  # Receipt before signing
     Action, ActionTarget, Authorization, Chain,
     CredentialSubject, Intent, Issuer, Operator,
     Outcome, Principal, Proof, StateChange,
 )
 ```
+
+`ActionReceipt` / `UnsignedActionReceipt` remain as deprecated aliases for
+backwards compatibility — prefer `AgentReceipt` / `UnsignedAgentReceipt`.
 
 ### Subpackage imports
 

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -86,7 +86,7 @@ signs, and chains the receipt. By default `emit()` surfaces transport failure
 `EmitTransportError` rather than dropped silently, so start the daemon before
 your app. The call stays non-blocking (bounded by the dial + write timeout); construct the
 emitter as `DaemonEmitter(best_effort=True)` to opt into loss-tolerant emission
-(`emit()` then returns `None` on transport failure). `best_effort` is a
+(`emit()` swallows the error and returns `None` instead of raising). `best_effort` is a
 constructor argument, not an `emit()` argument.
 
 <!-- snippet-check: no-run -->

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -3,6 +3,94 @@ title: API Reference
 description: Python SDK API reference.
 ---
 
+## Daemon emitter
+
+The canonical way to record receipts: send tool-call events to a running
+`agent-receipts-daemon`, which holds the signing key, builds the receipt, signs
+it, and chains it. Your process never touches the key. See
+[Daemon Setup](/getting-started/daemon-setup/) to start the daemon and
+[Quick Start](/getting-started/quick-start/) for the full emit → list → verify loop.
+
+```python
+from agent_receipts import DaemonEmitter, EmitTransportError, default_socket_path
+```
+
+### `DaemonEmitter`
+
+```python
+class DaemonEmitter:
+    def __init__(
+        self,
+        *,
+        socket_path: str = "",
+        session_id: str = "",
+        log: logging.Logger | None = None,
+        best_effort: bool = False,
+    ) -> None: ...
+```
+
+Connect to the daemon socket. With `socket_path=""` the emitter resolves
+`default_socket_path()` (the per-OS default, or `AGENTRECEIPTS_SOCKET` if set);
+pass an explicit path on platforms other than macOS/Linux. Supply `session_id`
+to propagate the host's session id across frames — a UUID v4 is generated
+otherwise. By default a transport failure raises `EmitTransportError` (the emit
+failure contract, ADR-0025); pass `best_effort=True` to drop unreachable-daemon
+events silently instead. Use it as a context manager, or call `close()` when done.
+
+#### `emit`
+
+```python
+def emit(
+    self,
+    *,
+    channel: str,
+    tool_name: str,
+    decision: str,
+    tool_server: str = "",
+    input: bytes | str | None = None,
+    output: bytes | str | None = None,
+    error: str = "",
+) -> None
+```
+
+Send one tool-call event. `channel` is your integration namespace and becomes the
+prefix of the stored action type (e.g. `my-app.filesystem.file.read`). `decision`
+is one of `"allowed"`, `"denied"`, or `"pending"`. `input` / `output` accept raw
+JSON (passed verbatim; the daemon hashes them). Returns `None` on success.
+
+Raises `ValueError` for caller bugs (empty `channel` / `tool_name`, invalid
+`decision`, invalid JSON, oversized frame), `RuntimeError` if the emitter is
+closed, and `EmitTransportError` when the daemon is unreachable — unless the
+emitter was constructed with `best_effort=True`.
+
+{/* snippet-check: no-run */}
+```python
+from agent_receipts import DaemonEmitter
+
+with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
+    e.emit(
+        channel="my-app",
+        tool_name="filesystem.file.read",
+        decision="allowed",
+    )
+```
+
+### `EmitTransportError`
+
+Raised by `emit()` when the daemon socket cannot be dialled or the write fails,
+unless the emitter was constructed with `best_effort=True`.
+
+### `default_socket_path`
+
+```python
+def default_socket_path() -> str
+```
+
+The per-OS default daemon socket path (an empty string on platforms without one).
+Honours `AGENTRECEIPTS_SOCKET` when set.
+
+---
+
 ## Receipts
 
 ```python
@@ -255,7 +343,7 @@ OutcomeStatus = Literal["success", "failure", "pending"]
 
 CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
-RECEIPT_VERSION: str        # "0.3.0" (receipt schema)
+RECEIPT_VERSION: str        # "0.4.0" (receipt schema)
 VERSION: str                # current package version
 ```
 

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -30,8 +30,10 @@ class DaemonEmitter:
 ```
 
 Connect to the daemon socket. With `socket_path=""` the emitter resolves
-`default_socket_path()` (the per-OS default, or `AGENTRECEIPTS_SOCKET` if set);
-pass an explicit path on platforms other than macOS/Linux. Supply `session_id`
+`default_socket_path()` (the per-OS default, or `AGENTRECEIPTS_SOCKET` if set).
+If neither yields a path — for example on Windows, or on macOS/Linux when `$HOME`
+is unset and `AGENTRECEIPTS_SOCKET` is not configured — the constructor raises
+`ValueError`; pass an explicit `socket_path` in those cases. Supply `session_id`
 to propagate the host's session id across frames — a UUID v4 is generated
 otherwise. By default a transport failure raises `EmitTransportError` (the emit
 failure contract, ADR-0025); pass `best_effort=True` to drop unreachable-daemon
@@ -56,7 +58,7 @@ def emit(
 Send one tool-call event. `channel` is your integration namespace and becomes the
 prefix of the stored action type (e.g. `my-app.filesystem.file.read`). `decision`
 is one of `"allowed"`, `"denied"`, or `"pending"`. `input` / `output` accept raw
-JSON (passed verbatim; the daemon hashes them). Returns `None` on success.
+JSON (passed verbatim; the daemon hashes them). Returns `None`.
 
 Raises `ValueError` for caller bugs (empty `channel` / `tool_name`, invalid
 `decision`, invalid JSON, oversized frame), `RuntimeError` if the emitter is
@@ -74,6 +76,16 @@ with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
         decision="allowed",
     )
 ```
+
+#### `close`
+
+```python
+def close(self) -> None
+```
+
+Release the underlying socket connection. Safe to call multiple times. After
+`close()`, any subsequent `emit()` call raises `RuntimeError`. The context
+manager calls `close()` automatically on exit.
 
 ### `EmitTransportError`
 

--- a/site/src/content/docs/sdk-py/installation.mdx
+++ b/site/src/content/docs/sdk-py/installation.mdx
@@ -19,10 +19,21 @@ uv add agent-receipts
 
 - Python 3.11+
 
+## You also need the daemon
+
+`pip install agent-receipts` installs the library only. Receipts are signed by a
+separate `agent-receipts-daemon` process, which also ships the `agent-receipts`
+CLI (`list`, `show`, `verify`). Install it on macOS or Linux — Windows is not
+supported yet:
+
+```bash
+brew install agent-receipts/tap/agent-receipts-daemon
+```
+
+See [Daemon Setup](/getting-started/daemon-setup/) for other install methods,
+socket paths, and running the daemon as a service.
+
 ## Next steps
 
+- [Quick Start](/getting-started/quick-start/) — start the daemon, emit your first receipt, and verify it
 - [API Reference](/sdk-py/api-reference/) for the full API surface
-
-:::note
-This page will be expanded with detailed usage examples as the SDK matures.
-:::

--- a/site/src/content/docs/sdk-py/overview.mdx
+++ b/site/src/content/docs/sdk-py/overview.mdx
@@ -17,6 +17,27 @@ The Python SDK (`agent-receipts`) provides tools for creating, signing, and veri
 
 ## Quick example
 
+Receipts are signed by a separate `agent-receipts-daemon`. Your code sends
+tool-call *events* over a Unix socket; the daemon holds the key, builds the
+receipt, signs it, and chains it. This is the canonical path — reach for it first.
+
+{/* snippet-check: no-run */}
+```python
+from agent_receipts import DaemonEmitter
+
+with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
+    e.emit(
+        channel="my-app",
+        tool_name="filesystem.file.read",
+        decision="allowed",
+    )
+```
+
+Start the daemon first — see [Daemon Setup](/getting-started/daemon-setup/) — then
+[Quick Start](/getting-started/quick-start/) walks the full emit → list → verify loop.
+
+## In-process signing (tutorial and testing only)
+
 :::caution[Not for production]
 This pattern keeps the signing key inside the agent process. Anyone with code execution in the agent can forge receipts. For real deployments, use the [daemon-mediated path](/getting-started/daemon-setup/), where the daemon owns the key and your app only sends events over a socket.
 :::

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -256,7 +256,7 @@ type OutcomeStatus = "success" | "failure" | "pending"
 
 const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 const CREDENTIAL_TYPE: readonly ["VerifiableCredential", "AgentReceipt"]
-const RECEIPT_VERSION: "0.3.0"  // receipt schema
+const RECEIPT_VERSION: "0.4.0"  // receipt schema
 const VERSION: "0.9.0"          // package version
 ```
 


### PR DESCRIPTION
## What

Fixes documentation gaps and a stale version in the Python SDK section (plus the matching TS version), found by walking the docs end-to-end as a first-time Python adopter instrumenting their own agent harness.

The canonical, production path — `DaemonEmitter` — was missing from the Python SDK's reference and section pages, even though it's what Quick Start and the README present as the first thing to reach for. A developer browsing the Python SDK section for depth couldn't find the API they needed.

## Changes

- **`sdk-py/api-reference.mdx`**
  - Add a **Daemon emitter** section documenting `DaemonEmitter` (constructor + `emit()`), `EmitTransportError`, and `default_socket_path`, with the `decision` enum and the `EmitTransportError` / `best_effort` contract. Signatures match `sdk/py/src/agent_receipts/daemon_emitter.py`.
  - Correct `RECEIPT_VERSION` from `0.3.0` to **`0.4.0`** (source: `sdk/py/src/agent_receipts/receipt/types.py` `VERSION = "0.4.0"`).
- **`sdk-py/installation.mdx`** — replace the stub with a note that the daemon/CLI is a **separate install** (`pip install` is library-only), plus links to Daemon Setup and Quick Start.
- **`sdk-py/overview.mdx`** — lead with the canonical `DaemonEmitter` example; demote the in-process signing snippet to a clearly-labelled tutorial/testing-only section.
- **`sdk/py/README.md`** — clarify that `best_effort` is a **constructor** argument (not an `emit()` arg); prefer `AgentReceipt` / `UnsignedAgentReceipt` over the deprecated `ActionReceipt` / `UnsignedActionReceipt` aliases.
- **`sdk-ts/api-reference.mdx`** — correct `RECEIPT_VERSION` `0.3.0` → `0.4.0` to match the TS SDK (`sdk/ts/src/receipt/types.ts` `VERSION = "0.4.0"`) and the Python page.

## Notes

- Docs-only; no SDK code changes.
- Every documented signature/value was verified against `sdk/py` / `sdk/ts` source.
- Runnable daemon examples carry `snippet-check: no-run` (kept under the type-check gate, filtered out of execution), so `mdx-snippets` / `readme-snippets` CI stays green; the Python README snippets type-check cleanly (12/12 locally).
- The adjacent stale package `VERSION: "0.9.0"` on the TS page is intentionally left alone — re-pinning a literal just goes stale again; it's a package version, not the schema version this PR is about.