### PR TITLE
docs(getting-started): install daemon with @latest; lead verify with the no-flag form

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -1,15 +1,15 @@
 ---
 title: Daemon Setup
-description: Set up the agent-receipts-daemon for v0.8.0 and connect your emitters.
+description: Set up the agent-receipts-daemon and connect your emitters.
 ---
 
-Starting with v0.8.0, Agent Receipts moves from in-process signing — where each SDK or plugin owned its own Ed25519 key and SQLite database — to a daemon-backed architecture. A single `agent-receipts-daemon` process now holds the signing key and manages the receipt chain for all emitters on the machine. This centralisation is what makes the tamper-evidence guarantee meaningful: a compromised SDK process cannot silently rewrite the chain, because it never holds the key.
+Agent Receipts signs receipts in a separate `agent-receipts-daemon` process rather than in-process — no SDK or plugin holds an Ed25519 key or SQLite database of its own. A single daemon process holds the signing key and manages the receipt chain for all emitters on the machine. This centralisation is what makes the tamper-evidence guarantee meaningful: a compromised SDK process cannot silently rewrite the chain, because it never holds the key.
 
 ## Prerequisites
 
-- `agent-receipts-daemon` v0.8.0 installed (see below)
+- `agent-receipts-daemon` installed (see below)
 - Key initialised with `agent-receipts-daemon --init` (one-time, see below)
-- Emitter SDK or plugin at v0.8.0 or later (see [Connect your emitters](#connect-your-emitters))
+- An emitter SDK or plugin installed (see [Connect your emitters](#connect-your-emitters))
 
 ## Install and start
 
@@ -26,8 +26,17 @@ Homebrew installs both the `agent-receipts-daemon` and `agent-receipts` (verify)
 **From source (macOS/Linux, requires Go 1.26.1+):**
 
 ```bash
-go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@v0.8.0
-go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts@v0.8.0
+go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest
+go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts@latest
+```
+
+Install both from the same `@latest` so the daemon and the `agent-receipts` CLI
+are the same version — they share one module, and a version mismatch can make
+`verify` reject a chain the other wrote. `go install` drops the binaries in
+`$(go env GOPATH)/bin`; add it to your `PATH` if it isn't already:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
 ```
 
 ### Initialise (one-time)
@@ -117,7 +126,7 @@ There is no in-process fallback: if the daemon is unreachable, emit surfaces the
 export AGENTRECEIPTS_SOCKET=/path/to/events.sock   # overrides the platform default
 ```
 
-### Go SDK (v0.8.0)
+### Go SDK
 
 **Option A: explicit socket path**
 
@@ -195,7 +204,7 @@ from agent_receipts import DaemonEmitter
 e = DaemonEmitter()
 ```
 
-### MCP Proxy (v0.8.0-alpha.1)
+### MCP Proxy
 
 Pass `--socket` or set `AGENTRECEIPTS_SOCKET`:
 

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -80,9 +80,7 @@ with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
 signatures — the daemon does not need to be running.
 
 ```bash
-AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
-  agent-receipts verify \
-  --public-key ~/.local/share/agent-receipts/signing.key.pub
+agent-receipts verify   # resolves the default chain at $XDG_DATA_HOME (falls back to ~/.local/share)
 ```
 
 A successful run prints the chain length and confirms the signatures are intact. If you
@@ -148,9 +146,7 @@ main().catch((err) => {
 signatures — the daemon does not need to be running.
 
 ```bash
-AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
-  agent-receipts verify \
-  --public-key ~/.local/share/agent-receipts/signing.key.pub
+agent-receipts verify   # resolves the default chain at $XDG_DATA_HOME (falls back to ~/.local/share)
 ```
 
 A successful run prints the chain length and confirms the signatures are intact. If you
@@ -220,9 +216,7 @@ func main() {
 signatures — the daemon does not need to be running.
 
 ```bash
-AGENTRECEIPTS_DB=~/.local/share/agent-receipts/receipts.db \
-  agent-receipts verify \
-  --public-key ~/.local/share/agent-receipts/signing.key.pub
+agent-receipts verify   # resolves the default chain at $XDG_DATA_HOME (falls back to ~/.local/share)
 ```
 
 A successful run prints the chain length and confirms the signatures are intact. If you


### PR DESCRIPTION
## What

Fixes documentation issues found by **executing** the Python adopter journey end-to-end on Linux (the doc e2e runner) — not just reading it.

## Findings → fixes

- **(High) Stale source-install pin.** `daemon-setup.mdx` pinned the from-source install to `go install …@v0.8.0` for both `agent-receipts-daemon` and `agent-receipts`. v0.8.0's CLI predates `list`/`show` (current daemon is **v0.13.0**), so a reader following the docs in order hits `agent-receipts: unknown command "list"` — the journey's "see what was emitted" step is broken as written.
  → Use **`@latest`** for both. They share one Go module, so `@latest` keeps the daemon and the `agent-receipts` CLI on the **same version** (a mismatch can make `verify` reject a chain the other wrote — observed during the run). `@latest` also can't go stale again, consistent with the unpinned SDK installs (`pip install agent-receipts`, `go get …/sdk/go`).
- **(Low) PATH step buried.** The `go install` bin dir (`$(go env GOPATH)/bin`) was only mentioned in a Troubleshooting section at the bottom, so a first run of `agent-receipts-daemon` gives `command not found`.
  → Add the one-line `PATH` note immediately after the install block.
- **(Low) Verify snippet breaks under `XDG_DATA_HOME`.** `quick-start.mdx` showed verify only with hardcoded `~/.local/share/...` paths; a reader who set `XDG_DATA_HOME` and copy-pastes verbatim gets a confusing `no such file`.
  → Lead with the no-flag `agent-receipts verify` (resolves `$XDG_DATA_HOME` / default paths); the existing note still covers overrides. Applied to the Python, TypeScript, and Go sections.
- Drop the stale `v0.8.0` from the page description and prerequisite (now "v0.8.0 or later"); the historical "Starting with v0.8.0…" architecture note is unchanged.

## Notes

- Docs-only; bash snippets aren't executed by snippet CI, so no snippet-marker changes needed.
- The current daemon version was confirmed against `daemon/CHANGELOG.md` (`[0.13.0] - 2026-05-24`).
- Separate from #706 (Python SDK API-reference / `DaemonEmitter` surface); these are getting-started install/verify ergonomics.