### PR TITLE
Add usage-signal tool to classify real adopters vs mirrors/CI

### DIFF
--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -1,7 +1,16 @@
 # usage_signal
 
 Tells real adopters apart from mirrors, CI, and scanners across the packages
-this monorepo publishes (npm, PyPI, Go).
+this org publishes (npm, PyPI, Go, and Homebrew-tap binaries).
+
+Tracked by default (edit the `*_PACKAGES` / `GITHUB_REPOS` constants in
+`check.py` to add more):
+
+| Project | Channel(s) |
+|---------|-----------|
+| `agent-receipts` monorepo (`agent-receipts/ar`) | npm `@agnt-rcpt/sdk-ts`, `@agnt-rcpt/sdk-ts-aws`; PyPI `agent-receipts`; Go `sdk/go`; Homebrew/release binaries (daemon, hook, mcp-proxy, collector) |
+| `openclaw` | npm `@agnt-rcpt/openclaw` |
+| `dashboard` (`agent-receipts/dashboard`) | Homebrew tap / release binaries |
 
 For a young package the public download counters are misleading. npm folds in,
 with no opt-out, every registry mirror, security scanner (Socket, Snyk,

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -93,6 +93,14 @@ unavailable rather than aborting the run.
    carries no version multiplier), but a true headcount needs server-side logs
    where a client is identifiable, not this counter.
 
+   The Homebrew section prints a **per-module patch-level timeline** (each
+   version's human-desktop installs, platform split, and a `⚠ CI sweep` flag) and
+   an **install-base estimate**: the peak single build of the *superset* module
+   (the daemon — everyone needs it, since the hook forwards to it), with a
+   per-module peak ladder showing the others as overlapping subsets of the same
+   base. Reading the same ~N across independently-versioned modules is the
+   strongest evidence it's one coherent user base rather than separate pockets.
+
 ## Reading the verdict
 
 `machine-dominated` is the **expected** baseline for a young package and is not

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -44,7 +44,7 @@ Live mode needs egress to `api.npmjs.org`, `pypistats.org`, `pkg.go.dev`, and
 is not required for a public repo. A source that fails to fetch is reported as
 unavailable rather than aborting the run.
 
-## The three signals it reads
+## The four signals it reads
 
 1. **Daily-series shape** (npm, PyPI). Real adoption leaves a persistent,
    weekday-skewed baseline that does not hit zero and is not made of one-day

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -69,6 +69,14 @@ unavailable rather than aborting the run.
    containers. Counts are cumulative per release (GitHub exposes no daily
    series), so this signal is about totals and platform mix, not weekday shape.
 
+   It also detects **CI sweeps**: a release-verification or supply-chain job
+   fetches the *whole* artifact set (the checksums manifest plus the Linux server
+   builds), whereas a human installs one desktop binary via brew and never pulls
+   `checksums.txt`. Any release with a checksums download alongside a Linux
+   download is flagged as swept; one download per binary artifact is attributed
+   to automation and subtracted, so the reported human count discounts your own
+   release gates instead of crediting them as adopters.
+
 ## Reading the verdict
 
 `machine-dominated` is the **expected** baseline for a young package and is not

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -74,8 +74,15 @@ unavailable rather than aborting the run.
    builds), whereas a human installs one desktop binary via brew and never pulls
    `checksums.txt`. Any release with a checksums download alongside a Linux
    download is flagged as swept; one download per binary artifact is attributed
-   to automation and subtracted, so the reported human count discounts your own
-   release gates instead of crediting them as adopters.
+   to automation and subtracted, so the reported count discounts your own release
+   gates instead of crediting them as adopters.
+
+   The headline figure is reported as **install events, not people** — GitHub's
+   `download_count` is an undeduplicated event counter, so it multiplies across
+   version upgrades, modules, machines, and reinstalls. The tool also reports the
+   **peak single (module, version) build** as a distinct-machines proxy (it
+   carries no version multiplier), but a true headcount needs server-side logs
+   where a client is identifiable, not this counter.
 
 ## Reading the verdict
 

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -1,0 +1,83 @@
+# usage_signal
+
+Tells real adopters apart from mirrors, CI, and scanners across the packages
+this monorepo publishes (npm, PyPI, Go).
+
+For a young package the public download counters are misleading. npm folds in,
+with no opt-out, every registry mirror, security scanner (Socket, Snyk,
+Dependabot, Renovate), proxy cache, and your own release CI. PyPI is the same
+minus the mirrors — which it at least lets you subtract. Go publishes no
+download count at all. So the raw total says little; you have to read the
+*shape* of the traffic.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Fetches the signals and prints a machine-vs-human verdict per package. |
+| `test_check.py` | Unit tests for the pure classifiers (`classify_series`, `classify_versions`, `classify_release_assets`, `verdict`). No network. |
+
+`check.py` and `test_check.py` use only the Python standard library. The
+publish-date cross-check additionally calls the `npm` CLI if it is on `PATH`;
+it is skipped silently otherwise.
+
+## Run locally
+
+```sh
+python3 scripts/usage_signal/test_check.py        # unit tests (no network)
+python3 scripts/usage_signal/check.py             # all repo packages, live
+python3 scripts/usage_signal/check.py --json      # machine-readable
+python3 scripts/usage_signal/check.py --npm @agnt-rcpt/sdk-ts --no-pypi --go-off
+```
+
+Live mode needs egress to `api.npmjs.org`, `pypistats.org`, `pkg.go.dev`, and
+`api.github.com`. A `GITHUB_TOKEN` / `GH_TOKEN` raises the GitHub rate limit but
+is not required for a public repo. A source that fails to fetch is reported as
+unavailable rather than aborting the run.
+
+## The three signals it reads
+
+1. **Daily-series shape** (npm, PyPI). Real adoption leaves a persistent,
+   weekday-skewed baseline that does not hit zero and is not made of one-day
+   bursts. Automated traffic is flat across the week (mirrors and scanners
+   don't take weekends off) and dominated by same-day spikes that react to your
+   own publishes and decay within ~48h. The classifier reports the spike share
+   of volume, the weekend/weekday ratio, and the count of zero-download days.
+
+2. **Per-version distribution** (npm). A mirror clones *every* version,
+   including abandoned pre-releases nobody installs fresh, so downloads smear
+   evenly across the history. A human installs the latest one or two. The
+   classifier flags pre-releases still drawing downloads and a low share on the
+   top version.
+
+3. **Adoption-by-reference** (PyPI mirror split, Go imported-by, GitHub
+   dependents). The strongest signal: someone committed your package to their
+   manifest. PyPI's `without_mirrors` series strips mirror noise outright and
+   the tool reports the mirror fraction; Go has no counter, so the tool reports
+   the `pkg.go.dev` imported-by count and links the GitHub dependents graph.
+
+4. **Homebrew / GitHub Release assets**. The binary modules (`hook`,
+   `mcp-proxy`, `daemon`, `collector`) install via a custom Homebrew tap, which
+   gets **no** `formulae.brew.sh` analytics — that only covers `homebrew/core`.
+   But `brew install` fetches the release tarball straight from GitHub, and the
+   per-asset `download_count` is exposed by the API. This is the **cleanest**
+   signal of the set: release binaries are not cloned by registry mirrors or
+   pulled by package scanners, so almost the only thing that downloads
+   `…_darwin_arm64.tar.gz` is a real `brew install`. The tool reads the
+   platform split as a human-vs-CI heuristic — desktop (macOS/Windows) downloads
+   with little Linux are laptop installs; Linux-dominated downloads are CI or
+   containers. Counts are cumulative per release (GitHub exposes no daily
+   series), so this signal is about totals and platform mix, not weekday shape.
+
+## Reading the verdict
+
+`machine-dominated` is the **expected** baseline for a young package and is not
+a failure — it simply means the download number is your own pipeline plus
+mirrors and scanners. The tool earns its keep on the day the shape changes: a
+sustained, weekday-skewed baseline climbing on the latest version is the
+signature of a first real adopter, and it will flip the verdict to
+`human-leaning`.
+
+The classifier weighs heuristics; it is a triage aid, not an oracle. Treat a
+`human-leaning` flag as "go investigate" (check GitHub dependents, code search,
+and docs-site analytics), not as proof on its own.

--- a/scripts/usage_signal/AGENTS.md
+++ b/scripts/usage_signal/AGENTS.md
@@ -69,13 +69,22 @@ unavailable rather than aborting the run.
    containers. Counts are cumulative per release (GitHub exposes no daily
    series), so this signal is about totals and platform mix, not weekday shape.
 
-   It also detects **CI sweeps**: a release-verification or supply-chain job
-   fetches the *whole* artifact set (the checksums manifest plus the Linux server
-   builds), whereas a human installs one desktop binary via brew and never pulls
-   `checksums.txt`. Any release with a checksums download alongside a Linux
-   download is flagged as swept; one download per binary artifact is attributed
-   to automation and subtracted, so the reported count discounts your own release
-   gates instead of crediting them as adopters.
+   It also discounts CI. **Linux downloads are treated as automation** — there
+   are no organic Linux users for a Homebrew-tap Mac CLI, and the release gates
+   pull Linux builds (e.g. Gate #8, the daemon ↔ SDK protocol check, downloads
+   `daemon_<v>_linux_amd64.tar.gz` on ubuntu on every daemon/SDK release). On top
+   of that it detects **CI sweeps**: a release-verification or supply-chain job
+   fetches the *whole* artifact set (checksums manifest plus Linux builds),
+   whereas a human installs one desktop binary via brew and never pulls
+   `checksums.txt`. A release with a checksums download alongside a Linux download
+   is flagged as swept, and one download per desktop artifact in it is also
+   attributed to automation. The reported install-event count therefore discounts
+   your own release gates instead of crediting them as adopters.
+
+   Note on the Homebrew tap's own CI: `agent-receipts/homebrew-tap` runs
+   `brew audit --strict --online` on `macos-latest`, but online audit does
+   URL-liveness HEAD checks, and GitHub increments `download_count` only on a GET
+   of the asset — so the macOS audit job does not inflate `darwin_arm64`.
 
    The headline figure is reported as **install events, not people** — GitHub's
    `download_count` is an undeduplicated event counter, so it multiplies across

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -357,7 +357,7 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
         swept = is_ci_sweep(assets)
         if swept:
             ci_sweep_releases += 1
-        release_events = 0  # human install events for this single build
+        release_events = 0  # human (desktop) install events for this single build
         release_module = ""
         for name, count in assets:
             platform = parse_asset_platform(name)
@@ -367,8 +367,17 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
             module = _asset_module(name)
             by_module[module] = by_module.get(module, 0) + count
             release_module = release_module or module
+            if platform == "linux":
+                # Server platform: no organic users for a Homebrew-tap Mac CLI.
+                # Linux pulls are CI — sweeps, and release gates like Gate #8
+                # (daemon ↔ SDK protocol check) which fetches the linux_amd64
+                # daemon tarball on every daemon/SDK release.
+                ci_downloads += count
+                continue
+            # Desktop platform (darwin / windows). In a swept release the
+            # verification job also pulled one of each desktop artifact.
             if swept:
-                ci_downloads += 1  # the sweep pulled ~1 of each binary artifact
+                ci_downloads += 1
                 release_events += count - 1
             else:
                 release_events += count
@@ -407,8 +416,13 @@ def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
     if metrics.ci_sweep_releases:
         notes.append(
             f"{metrics.ci_sweep_releases} release(s) show a CI sweep "
-            f"(checksums + Linux pulled together) — ~{metrics.ci_downloads} download(s) "
-            f"attributed to automation"
+            "(checksums + Linux pulled together) — full artifact set fetched by automation"
+        )
+    if metrics.server_downloads:
+        notes.append(
+            f"{metrics.server_downloads} Linux download(s) treated as CI (server platform; "
+            "release gates such as the daemon ↔ SDK protocol check pull the linux build) "
+            f"— {metrics.ci_downloads} download(s) total attributed to automation"
         )
     if metrics.install_events > 0 and metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
         label = "human-leaning — desktop installs (likely Homebrew on laptops)"

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -337,15 +337,54 @@ def is_ci_sweep(assets: list[tuple[str, int]]) -> bool:
     return checksums and linux
 
 
+@dataclass
+class ReleaseSplit:
+    """A single release's downloads split into human (desktop) vs CI."""
+
+    module: str
+    human: int  # desktop install events, minus any sweep-pulled desktop artifact
+    ci: int  # Linux pulls + sweep-pulled desktop artifacts
+    swept: bool
+    by_platform: dict[str, int]  # gross darwin / linux / windows for this release
+
+
+def split_release(assets: list[tuple[str, int]]) -> ReleaseSplit:
+    """Split one release's assets into human-desktop installs and CI downloads.
+
+    Linux is always CI (no organic users for a Homebrew-tap Mac CLI, and release
+    gates like Gate #8 pull the linux_amd64 daemon tarball). In a swept release
+    (see ``is_ci_sweep``) the verification job also pulled one of each desktop
+    artifact, so one download per desktop artifact is attributed to CI too.
+    """
+    swept = is_ci_sweep(assets)
+    by_platform: dict[str, int] = {}
+    human = 0
+    ci = 0
+    module = ""
+    for name, count in assets:
+        platform = parse_asset_platform(name)
+        if platform is None or count <= 0:
+            continue
+        by_platform[platform] = by_platform.get(platform, 0) + count
+        module = module or _asset_module(name)
+        if platform == "linux":
+            ci += count
+        elif swept:
+            ci += 1
+            human += count - 1
+        else:
+            human += count
+    return ReleaseSplit(module=module, human=human, ci=ci, swept=swept, by_platform=by_platform)
+
+
 def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMetrics | None:
     """Aggregate per-asset download counts by platform and module across releases.
 
     ``releases`` is a list of releases, each a ``(asset_name, download_count)``
     list (including non-binary assets like checksums, which inform sweep
-    detection but are excluded from the download totals). For any release flagged
-    as a CI sweep (see ``is_ci_sweep``), one download per distinct binary artifact
-    is attributed to automation and subtracted from the human count. Returns
-    ``None`` if no binary asset has ever been downloaded.
+    detection but are excluded from the download totals). Linux pulls and the
+    desktop artifacts of a CI sweep are attributed to automation. Returns ``None``
+    if no binary asset has ever been downloaded.
     """
     by_platform: dict[str, int] = {}
     by_module: dict[str, int] = {}
@@ -354,36 +393,17 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
     peak_build = 0
     peak_build_module = ""
     for assets in releases:
-        swept = is_ci_sweep(assets)
-        if swept:
+        split = split_release(assets)
+        if split.swept:
             ci_sweep_releases += 1
-        release_events = 0  # human (desktop) install events for this single build
-        release_module = ""
-        for name, count in assets:
-            platform = parse_asset_platform(name)
-            if platform is None or count <= 0:
-                continue
+        ci_downloads += split.ci
+        for platform, count in split.by_platform.items():
             by_platform[platform] = by_platform.get(platform, 0) + count
-            module = _asset_module(name)
-            by_module[module] = by_module.get(module, 0) + count
-            release_module = release_module or module
-            if platform == "linux":
-                # Server platform: no organic users for a Homebrew-tap Mac CLI.
-                # Linux pulls are CI — sweeps, and release gates like Gate #8
-                # (daemon ↔ SDK protocol check) which fetches the linux_amd64
-                # daemon tarball on every daemon/SDK release.
-                ci_downloads += count
-                continue
-            # Desktop platform (darwin / windows). In a swept release the
-            # verification job also pulled one of each desktop artifact.
-            if swept:
-                ci_downloads += 1
-                release_events += count - 1
-            else:
-                release_events += count
-        if release_events > peak_build:
-            peak_build = release_events
-            peak_build_module = release_module
+        if split.module:
+            by_module[split.module] = by_module.get(split.module, 0) + sum(split.by_platform.values())
+        if split.human > peak_build:
+            peak_build = split.human
+            peak_build_module = split.module
 
     total = sum(by_platform.values())
     if total == 0:
@@ -403,6 +423,56 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
         peak_build=peak_build,
         peak_build_module=peak_build_module,
     )
+
+
+@dataclass
+class ReleaseInfo:
+    """One GitHub release: its tag and its (asset_name, download_count) list."""
+
+    tag: str
+    assets: list[tuple[str, int]]
+
+
+def module_version_from_tag(tag: str) -> tuple[str, str]:
+    """Split a release tag into (module, version).
+
+    Binary-module tags look like ``hook/v0.12.0`` or ``mcp-proxy/v0.13.0``; SDK
+    tags like ``sdk-ts-v0.10.0``. Returns ("", tag) if no version is found.
+    """
+    m = re.match(r"^(.*?)[/-]v?(\d[\w.\-]*)$", tag)
+    if not m:
+        return "", tag
+    return m.group(1).rstrip("/-"), m.group(2)
+
+
+def _version_key(version: str) -> list:
+    """Sort key: numeric segments ascending, a pre-release sorting before its release."""
+    base, _, pre = version.partition("-")
+    parts: list = [int(p) if p.isdigit() else p for p in base.split(".")]
+    # a release (no pre-release suffix) sorts after its pre-releases
+    parts.append("" if pre else "~")
+    parts.append(pre)
+    return parts
+
+
+def release_timeline(releases: list[ReleaseInfo]) -> dict[str, list[tuple[str, ReleaseSplit]]]:
+    """Per-module list of (version, ReleaseSplit), version-sorted ascending.
+
+    Only releases that carry downloaded binary assets appear (SDK source-only
+    tags drop out). The module label comes from the tag, falling back to the
+    asset-derived module so the two always agree.
+    """
+    timeline: dict[str, list[tuple[str, ReleaseSplit]]] = {}
+    for rel in releases:
+        split = split_release(rel.assets)
+        if not split.by_platform:
+            continue  # no binary downloads for this release
+        module, version = module_version_from_tag(rel.tag)
+        module = module or split.module
+        timeline.setdefault(module, []).append((version, split))
+    for versions in timeline.values():
+        versions.sort(key=lambda vs: _version_key(vs[0]))
+    return timeline
 
 
 def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
@@ -535,17 +605,16 @@ def go_imported_by(module: str) -> int | None:
     return int(m.group(1).replace(",", "")) if m else None
 
 
-def github_release_assets(repo: str) -> list[list[tuple[str, int]]]:
-    """Per-release lists of (asset_name, download_count), across all pages.
+def github_releases(repo: str) -> list[ReleaseInfo]:
+    """All releases (tag + asset download counts) for a repo, across all pages.
 
-    Each element is one release's assets (including checksums, which inform sweep
-    detection). Uses the public REST API; a GITHUB_TOKEN / GH_TOKEN in the
-    environment raises the rate limit but is not required for a public repo.
+    Uses the public REST API; a GITHUB_TOKEN / GH_TOKEN in the environment raises
+    the rate limit but is not required for a public repo.
     """
     import os
 
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    releases: list[list[tuple[str, int]]] = []
+    releases: list[ReleaseInfo] = []
     page = 1
     while True:
         url = f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}"
@@ -559,9 +628,8 @@ def github_release_assets(repo: str) -> list[list[tuple[str, int]]]:
         if not batch:
             break
         for release in batch:
-            releases.append(
-                [(asset["name"], int(asset["download_count"])) for asset in release.get("assets", [])]
-            )
+            assets = [(a["name"], int(a["download_count"])) for a in release.get("assets", [])]
+            releases.append(ReleaseInfo(tag=release.get("tag_name", ""), assets=assets))
         if len(batch) < 100:
             break
         page += 1
@@ -666,28 +734,60 @@ def report_go(module: str) -> dict:
     return {"module": module, "ecosystem": "go", "imported_by": count}
 
 
+def _platform_str(by_platform: dict[str, int]) -> str:
+    order = ("darwin", "windows", "linux")
+    parts = [f"{p}={by_platform[p]}" for p in order if by_platform.get(p)]
+    return " ".join(parts) if parts else "-"
+
+
 def report_github_releases(repo: str) -> dict:
     print(f"\nHomebrew / GitHub Releases  {repo}")
     try:
-        assets = github_release_assets(repo)
+        releases = github_releases(repo)
     except (urllib.error.URLError, TimeoutError, ValueError) as exc:
         print(f"    unavailable: {exc}")
         return {"repo": repo, "ecosystem": "github-releases", "error": str(exc)}
 
-    metrics = classify_release_assets(assets)
+    metrics = classify_release_assets([r.assets for r in releases])
+    timeline = release_timeline(releases)
     label, notes = verdict_release(metrics)
-    if metrics:
-        top = sorted(metrics.by_module.items(), key=lambda kv: kv[1], reverse=True)
-        print("    by module: " + ", ".join(f"{m} {n}" for m, n in top))
+
+    # Install-base anchor: per-module peak human build, and the overall superset.
+    per_module_peak = {
+        module: max((s.human for _, s in versions), default=0)
+        for module, versions in timeline.items()
+    }
+    if per_module_peak:
+        base_module = max(per_module_peak, key=lambda m: per_module_peak[m])
+        base = per_module_peak[base_module]
+        print(
+            f"    install base (distinct Macs ≈ peak single build of the superset "
+            f"module): ~{base}  [{base_module}]"
+        )
+        ladder = ", ".join(
+            f"{m} {n}" for m, n in sorted(per_module_peak.items(), key=lambda kv: -kv[1])
+        )
+        print(f"    per-module peak (overlapping subsets of the same base): {ladder}")
+
+    for module, versions in sorted(timeline.items()):
+        print(f"    {module}:")
+        for version, split in versions:
+            flags = "  ⚠ CI sweep" if split.swept else ""
+            human = f"{split.human} human" if split.human else "0 human"
+            print(f"      {version:<14} {human:<10} [{_platform_str(split.by_platform)}]{flags}")
+
     _print_verdict(label, notes)
     print(
-        "    note: counts are cumulative per release (no daily series), and a custom "
-        "Homebrew tap gets no formulae.brew.sh analytics — this asset count is the signal."
+        "    note: counts are cumulative per release (no daily series); a custom Homebrew "
+        "tap gets no formulae.brew.sh analytics. 'human' = desktop install EVENTS (not "
+        "people): version upgrades, machines, and reinstalls each count once."
     )
     return {
         "repo": repo,
         "ecosystem": "github-releases",
         "metrics": asdict(metrics) if metrics else None,
+        "install_base_estimate": max(per_module_peak.values(), default=0),
+        "per_module_peak": per_module_peak,
         "verdict": label,
         "notes": notes,
     }

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Usage-signal check: tell real adopters apart from mirrors, CI, and scanners.
+
+For a young package the public download counters lie. npm's number folds in,
+with no opt-out, every registry mirror (Cloudflare, Yarn, regional mirrors that
+clone the whole version history), every security scanner (Socket, Snyk,
+Dependabot, Renovate), every proxy cache, and your own release CI. PyPI is the
+same minus the mirrors, which it at least lets you subtract. Go publishes no
+download count at all. So the raw total is close to meaningless on its own — you
+have to read the *shape* of the traffic, not its size.
+
+This tool pulls the shape for every package this monorepo ships and prints a
+machine-vs-human verdict per ecosystem. The three signals it reads:
+
+1. Daily-series shape (npm, PyPI). Real human adoption leaves a persistent,
+   weekday-skewed baseline that does not drop to zero and does not consist of
+   one-day bursts. Automated traffic is the opposite: flat across the week
+   (mirrors and scanners don't take weekends off) and dominated by same-day
+   spikes that react to your own publishes and then decay within ~48h.
+
+2. Per-version distribution (npm). A mirror clones *every* version, including
+   abandoned pre-releases nobody would install fresh, so downloads smear evenly
+   across the whole history. A human installs the latest one or two.
+
+3. Adoption-by-reference (PyPI mirror split, Go imported-by, GitHub dependents).
+   The strongest signal there is: someone committed your package to their
+   manifest. PyPI's ``without_mirrors`` series strips mirror noise outright; Go
+   has no counter but ``pkg.go.dev`` reports an imported-by count.
+
+The classification core (``classify_series``, ``classify_versions``,
+``verdict``) is pure and takes no network, so the unit tests exercise it
+directly with synthetic machine- and human-shaped inputs. The fetchers are thin
+I/O wrappers, best-effort: a source that fails to fetch is reported as
+unavailable rather than aborting the run.
+
+Usage:
+    check.py [--npm PKG ...] [--pypi PKG ...] [--go MODULE ...]
+             [--no-npm] [--no-pypi] [--go-off] [--json]
+
+With no package flags it uses this repo's published packages. Network egress to
+api.npmjs.org, pypistats.org, and pkg.go.dev is required for live data; the
+``npm view`` publish-date lookup additionally needs the npm CLI on PATH.
+
+Exit codes:
+    0  ran and printed a report (even if some sources were unavailable)
+    2  usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import statistics
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+
+# ---------------------------------------------------------------------------
+# Defaults for this monorepo
+
+NPM_PACKAGES = ["@agnt-rcpt/sdk-ts", "@agnt-rcpt/sdk-ts-aws"]
+PYPI_PACKAGES = ["agent-receipts"]
+GO_MODULES = ["github.com/agent-receipts/ar/sdk/go"]
+GITHUB_REPO = "agent-receipts/ar"
+
+# Binary modules shipped as GitHub Release assets and installed via the Homebrew
+# tap (brew install agent-receipts/tap/<module>). brew fetches the release
+# tarball straight from GitHub, so the asset download_count is a clean install
+# signal — registry mirrors and package scanners don't pull release binaries.
+GITHUB_BINARY_MODULES = ["hook", "mcp-proxy", "daemon", "collector"]
+
+# ---------------------------------------------------------------------------
+# Classification thresholds. A "spike" is a publish/mirror reaction day; the
+# default threshold is relative to the package's own baseline so it scales from
+# a 5/day package to a 5000/day one, with an absolute floor so a near-dead
+# package doesn't promote its own noise to "spike".
+
+SPIKE_FACTOR = 10  # a day above SPIKE_FACTOR * median(nonzero) is a spike
+SPIKE_FLOOR = 50  # ...but never below this absolute count
+
+# weekend/weekday ratio bands. Humans install at work, so genuine adoption
+# skews to weekdays (ratio well below 1). A flat week is a machine week.
+FLAT_WEEK_LO, FLAT_WEEK_HI = 0.7, 1.4
+HUMAN_WEEKDAY_RATIO = 0.7  # weekend/weekday below this leans human
+
+# Release-asset platform split. CI and containers are Linux; humans installing a
+# CLI via Homebrew are on macOS/Windows desktops. A desktop-dominated mix with
+# little Linux is a human-laptop signal, not automation.
+DESKTOP_FRACTION_HUMAN = 0.6
+
+HTTP_TIMEOUT = 20
+USER_AGENT = "agent-receipts-usage-signal/1.0 (+https://github.com/agent-receipts/ar)"
+
+
+# ---------------------------------------------------------------------------
+# Pure classification core (no network)
+
+
+@dataclass
+class SeriesMetrics:
+    """Shape metrics for a daily download series over its active window."""
+
+    total: int
+    active_days: int
+    spike_threshold: int
+    spike_days: int
+    spike_share: float  # fraction of all downloads landing on spike days
+    baseline_median: float  # median of non-spike days
+    baseline_mean: float
+    zero_days: int  # non-spike days with literally zero downloads
+    weekday_per_day: float  # mean baseline downloads on Mon-Fri
+    weekend_per_day: float  # mean baseline downloads on Sat-Sun
+    weekend_weekday_ratio: float  # weekend_per_day / weekday_per_day, 0 if N/A
+
+
+def active_window(series: list[tuple[datetime.date, int]]) -> list[tuple[datetime.date, int]]:
+    """Trim leading and trailing all-zero runs (pre-launch / future padding)."""
+    nz = [i for i, (_, n) in enumerate(series) if n > 0]
+    if not nz:
+        return []
+    return series[nz[0] : nz[-1] + 1]
+
+
+def spike_threshold_for(values: list[int]) -> int:
+    """Threshold above which a day counts as a publish/mirror spike."""
+    nonzero = [v for v in values if v > 0]
+    if not nonzero:
+        return SPIKE_FLOOR
+    return max(SPIKE_FLOOR, int(SPIKE_FACTOR * statistics.median(nonzero)))
+
+
+def classify_series(
+    series: list[tuple[datetime.date, int]],
+    spike_threshold: int | None = None,
+) -> SeriesMetrics | None:
+    """Reduce a daily series to shape metrics over its active window.
+
+    Returns ``None`` if the series never had a download (nothing to classify).
+    Weekday/weekend means are computed on baseline (non-spike) days only, so a
+    burst of mirror traffic on a publish day cannot masquerade as a human floor.
+    """
+    window = active_window(series)
+    if not window:
+        return None
+
+    values = [n for _, n in window]
+    threshold = spike_threshold if spike_threshold is not None else spike_threshold_for(values)
+
+    baseline = [(d, n) for d, n in window if n < threshold]
+    spike = [(d, n) for d, n in window if n >= threshold]
+    base_vals = [n for _, n in baseline]
+
+    weekday = [n for d, n in baseline if d.weekday() < 5]
+    weekend = [n for d, n in baseline if d.weekday() >= 5]
+    weekday_per_day = statistics.mean(weekday) if weekday else 0.0
+    weekend_per_day = statistics.mean(weekend) if weekend else 0.0
+    ratio = (weekend_per_day / weekday_per_day) if weekday_per_day else 0.0
+
+    return SeriesMetrics(
+        total=sum(values),
+        active_days=len(window),
+        spike_threshold=threshold,
+        spike_days=len(spike),
+        spike_share=(sum(n for _, n in spike) / sum(values)) if sum(values) else 0.0,
+        baseline_median=statistics.median(base_vals) if base_vals else 0.0,
+        baseline_mean=statistics.mean(base_vals) if base_vals else 0.0,
+        zero_days=sum(1 for n in base_vals if n == 0),
+        weekday_per_day=weekday_per_day,
+        weekend_per_day=weekend_per_day,
+        weekend_weekday_ratio=ratio,
+    )
+
+
+@dataclass
+class VersionMetrics:
+    """Per-version download distribution shape (npm)."""
+
+    versions_with_downloads: int
+    prerelease_versions: int  # pre-releases (X.Y.Z-...) still pulling downloads
+    top_version: str
+    top_share: float  # fraction of the week's downloads on the single top version
+
+
+def classify_versions(version_downloads: dict[str, int]) -> VersionMetrics | None:
+    """Summarise how downloads spread across published versions.
+
+    Pre-releases drawing steady traffic, and a low share on the top version, are
+    mirror fingerprints — no human installs ``X.Y.Z-alpha.1`` once a stable
+    release exists.
+    """
+    active = {v: n for v, n in version_downloads.items() if n > 0}
+    if not active:
+        return None
+    total = sum(active.values())
+    top_version, top_n = max(active.items(), key=lambda kv: kv[1])
+    return VersionMetrics(
+        versions_with_downloads=len(active),
+        prerelease_versions=sum(1 for v in active if "-" in v),
+        top_version=top_version,
+        top_share=top_n / total,
+    )
+
+
+def verdict(
+    metrics: SeriesMetrics | None,
+    versions: VersionMetrics | None = None,
+    mirror_fraction: float | None = None,
+) -> tuple[str, list[str]]:
+    """Weigh the signals into a machine-vs-human leaning and the reasons why."""
+    machine = 0
+    human = 0
+    notes: list[str] = []
+
+    if metrics is None:
+        return "no data", ["no downloads recorded in the window"]
+
+    if metrics.spike_share >= 0.5:
+        machine += 1
+        notes.append(
+            f"{metrics.spike_share:.0%} of traffic is same-day spikes "
+            f"(>= {metrics.spike_threshold}/day) — publish/mirror reactions, not steady use"
+        )
+    if FLAT_WEEK_LO <= metrics.weekend_weekday_ratio <= FLAT_WEEK_HI:
+        machine += 1
+        notes.append(
+            f"flat week: weekend/weekday ratio {metrics.weekend_weekday_ratio:.2f} "
+            "(~1.0) — automated traffic ignores weekends"
+        )
+    elif 0 < metrics.weekend_weekday_ratio < HUMAN_WEEKDAY_RATIO:
+        human += 1
+        notes.append(
+            f"weekday-skewed: weekend/weekday ratio {metrics.weekend_weekday_ratio:.2f} "
+            "(< 0.7) — consistent with humans installing at work"
+        )
+    if metrics.zero_days > 0:
+        machine += 1
+        notes.append(
+            f"{metrics.zero_days} zero-download day(s) in the active window — "
+            "no persistent human floor across timezones"
+        )
+
+    if versions is not None:
+        if versions.prerelease_versions > 0:
+            machine += 1
+            notes.append(
+                f"{versions.prerelease_versions} pre-release version(s) still drawing "
+                "downloads — mirrors cloning the whole history, not humans"
+            )
+        if versions.top_share < 0.5:
+            machine += 1
+            notes.append(
+                f"top version only {versions.top_share:.0%} of weekly downloads "
+                "(smeared across the version history) — mirror fingerprint"
+            )
+        else:
+            human += 1
+            notes.append(
+                f"downloads concentrate on {versions.top_version} "
+                f"({versions.top_share:.0%}) — installs target the latest release"
+            )
+
+    if mirror_fraction is not None:
+        if mirror_fraction >= 0.5:
+            machine += 1
+            notes.append(
+                f"{mirror_fraction:.0%} of PyPI downloads are mirror traffic "
+                "(stripped from the human analysis above)"
+            )
+        else:
+            notes.append(f"{mirror_fraction:.0%} of PyPI downloads are mirror traffic")
+
+    if machine > human:
+        label = "machine-dominated (mirrors / CI / scanners)"
+    elif human > machine:
+        label = "human-leaning — investigate, this may be a real adopter"
+    else:
+        label = "mixed / inconclusive"
+    return label, notes
+
+
+@dataclass
+class ReleaseMetrics:
+    """GitHub Release asset download shape (the Homebrew / binary install path)."""
+
+    total_downloads: int
+    by_platform: dict[str, int]  # darwin / linux / windows / other
+    desktop_downloads: int  # darwin + windows
+    server_downloads: int  # linux
+    desktop_fraction: float
+    by_module: dict[str, int]
+
+
+def parse_asset_platform(name: str) -> str | None:
+    """Platform an asset targets, or None for non-binary assets (checksums, sigs)."""
+    lowered = name.lower()
+    if any(lowered.endswith(ext) for ext in (".txt", ".sig", ".pem", ".sbom", ".json")):
+        return None
+    if "darwin" in lowered or "macos" in lowered:
+        return "darwin"
+    if "linux" in lowered:
+        return "linux"
+    if "windows" in lowered:
+        return "windows"
+    return None
+
+
+def _asset_module(name: str) -> str:
+    """Module an asset belongs to: the name before the first version segment."""
+    return re.split(r"_v?\d", name, maxsplit=1)[0] or name
+
+
+def classify_release_assets(assets: list[tuple[str, int]]) -> ReleaseMetrics | None:
+    """Aggregate per-asset download counts by platform and module.
+
+    ``assets`` is a flat ``(asset_name, download_count)`` list across releases.
+    Non-binary assets (checksums, signatures) are ignored. Returns ``None`` if no
+    binary asset has ever been downloaded.
+    """
+    by_platform: dict[str, int] = {}
+    by_module: dict[str, int] = {}
+    for name, count in assets:
+        platform = parse_asset_platform(name)
+        if platform is None or count <= 0:
+            continue
+        by_platform[platform] = by_platform.get(platform, 0) + count
+        by_module[_asset_module(name)] = by_module.get(_asset_module(name), 0) + count
+
+    total = sum(by_platform.values())
+    if total == 0:
+        return None
+    desktop = by_platform.get("darwin", 0) + by_platform.get("windows", 0)
+    server = by_platform.get("linux", 0)
+    return ReleaseMetrics(
+        total_downloads=total,
+        by_platform=by_platform,
+        desktop_downloads=desktop,
+        server_downloads=server,
+        desktop_fraction=desktop / total,
+        by_module=by_module,
+    )
+
+
+def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
+    """Lean on the desktop-vs-Linux split: desktop installs are humans, Linux is CI."""
+    if metrics is None:
+        return "no data", ["no release binaries downloaded yet"]
+    notes = [
+        f"{metrics.total_downloads} binary download(s): "
+        + ", ".join(f"{p} {n}" for p, n in sorted(metrics.by_platform.items()))
+    ]
+    if metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
+        label = "human-leaning — desktop installs (likely Homebrew on laptops)"
+        notes.append(
+            f"{metrics.desktop_fraction:.0%} of downloads are desktop (macOS/Windows) "
+            f"with {metrics.server_downloads} Linux — release binaries aren't "
+            "mirror-amplified, so this is real install activity, not CI or scanners"
+        )
+    elif metrics.server_downloads > metrics.desktop_downloads:
+        label = "Linux-dominated — likely CI / containers"
+        notes.append(
+            f"{metrics.server_downloads} Linux vs {metrics.desktop_downloads} desktop "
+            "downloads — automation territory"
+        )
+    else:
+        label = "mixed / inconclusive"
+    return label, notes
+
+
+# ---------------------------------------------------------------------------
+# Fetchers (best-effort I/O)
+
+
+def _get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310 (https only)
+        return resp.read()
+
+
+def _get_json(url: str) -> dict:
+    return json.loads(_get(url))
+
+
+def _npm_encode(pkg: str) -> str:
+    return urllib.parse.quote(pkg, safe="@")
+
+
+def npm_daily(pkg: str) -> list[tuple[datetime.date, int]]:
+    data = _get_json(f"https://api.npmjs.org/downloads/range/last-year/{_npm_encode(pkg)}")
+    return [
+        (datetime.date.fromisoformat(row["day"]), int(row["downloads"]))
+        for row in data.get("downloads", [])
+    ]
+
+
+def npm_versions(pkg: str) -> dict[str, int]:
+    data = _get_json(f"https://api.npmjs.org/versions/{_npm_encode(pkg)}/last-week")
+    return {v: int(n) for v, n in data.get("downloads", {}).items()}
+
+
+def npm_publish_dates(pkg: str) -> list[datetime.date]:
+    """Publish date of every version, via the npm CLI. Empty if npm is absent."""
+    try:
+        out = subprocess.run(
+            ["npm", "view", pkg, "time", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=HTTP_TIMEOUT,
+            check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+    times = json.loads(out) if out.strip() else {}
+    dates = []
+    for key, value in times.items():
+        if key in ("created", "modified"):
+            continue
+        dates.append(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).date())
+    return sorted(dates)
+
+
+def pypi_overall(pkg: str) -> tuple[list[tuple[datetime.date, int]], float]:
+    """Daily ``without_mirrors`` series and the mirror fraction over the window.
+
+    PyPI is the one ecosystem that hands you the mirror split directly, so we
+    analyse the human (mirror-free) series and report what fraction was mirrors.
+    """
+    data = _get_json(f"https://pypistats.org/api/packages/{urllib.parse.quote(pkg)}/overall")
+    without: dict[datetime.date, int] = {}
+    with_total = 0
+    without_total = 0
+    for row in data.get("data", []):
+        day = datetime.date.fromisoformat(row["date"])
+        n = int(row["downloads"])
+        if row["category"] == "without_mirrors":
+            without[day] = without.get(day, 0) + n
+            without_total += n
+        elif row["category"] == "with_mirrors":
+            with_total += n
+    series = sorted(without.items())
+    mirror_fraction = ((with_total - without_total) / with_total) if with_total else 0.0
+    return series, mirror_fraction
+
+
+def go_imported_by(module: str) -> int | None:
+    """Imported-by count from pkg.go.dev, or None if it can't be parsed."""
+    try:
+        html = _get(f"https://pkg.go.dev/{module}?tab=importedby").decode("utf-8", "replace")
+    except (urllib.error.URLError, TimeoutError):
+        return None
+    m = re.search(r"Imported By\s*<[^>]*>\s*([\d,]+)", html)
+    if not m:
+        m = re.search(r"([\d,]+)\s*packages? import", html)
+    return int(m.group(1).replace(",", "")) if m else None
+
+
+def github_release_assets(repo: str) -> list[tuple[str, int]]:
+    """Every release asset's (name, download_count) for a repo, across all pages.
+
+    Uses the public REST API. A GITHUB_TOKEN / GH_TOKEN in the environment raises
+    the rate limit but is not required for a public repo.
+    """
+    import os
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    assets: list[tuple[str, int]] = []
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}"
+        req = urllib.request.Request(
+            url, headers={"User-Agent": USER_AGENT, "Accept": "application/vnd.github+json"}
+        )
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+            batch = json.loads(resp.read())
+        if not batch:
+            break
+        for release in batch:
+            for asset in release.get("assets", []):
+                assets.append((asset["name"], int(asset["download_count"])))
+        if len(batch) < 100:
+            break
+        page += 1
+    return assets
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+
+
+def _print_series_block(metrics: SeriesMetrics) -> None:
+    print(
+        f"    window {metrics.active_days}d | total {metrics.total} | "
+        f"spikes {metrics.spike_days}d = {metrics.spike_share:.0%} of traffic "
+        f"(>= {metrics.spike_threshold}/day)"
+    )
+    print(
+        f"    baseline median {metrics.baseline_median:.0f}/day, "
+        f"{metrics.zero_days} zero-day(s) | "
+        f"weekday {metrics.weekday_per_day:.1f}/day vs weekend "
+        f"{metrics.weekend_per_day:.1f}/day (ratio {metrics.weekend_weekday_ratio:.2f})"
+    )
+
+
+def _print_verdict(label: str, notes: list[str]) -> None:
+    print(f"    VERDICT: {label}")
+    for n in notes:
+        print(f"      - {n}")
+
+
+def report_npm(pkg: str) -> dict:
+    print(f"\nnpm  {pkg}")
+    try:
+        series = npm_daily(pkg)
+        versions = npm_versions(pkg)
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        print(f"    unavailable: {exc}")
+        return {"package": pkg, "ecosystem": "npm", "error": str(exc)}
+
+    metrics = classify_series(series)
+    vmetrics = classify_versions(versions)
+    label, notes = verdict(metrics, vmetrics)
+
+    if metrics:
+        _print_series_block(metrics)
+    if vmetrics:
+        print(
+            f"    versions: {vmetrics.versions_with_downloads} drawing downloads, "
+            f"{vmetrics.prerelease_versions} pre-release; "
+            f"top {vmetrics.top_version} = {vmetrics.top_share:.0%}"
+        )
+    publishes = npm_publish_dates(pkg)
+    if publishes and metrics:
+        print(f"    {len(publishes)} published version(s); cross-check spike days against these")
+    _print_verdict(label, notes)
+    return {
+        "package": pkg,
+        "ecosystem": "npm",
+        "metrics": asdict(metrics) if metrics else None,
+        "versions": asdict(vmetrics) if vmetrics else None,
+        "verdict": label,
+        "notes": notes,
+    }
+
+
+def report_pypi(pkg: str) -> dict:
+    print(f"\nPyPI {pkg}")
+    try:
+        series, mirror_fraction = pypi_overall(pkg)
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        print(f"    unavailable: {exc}")
+        return {"package": pkg, "ecosystem": "pypi", "error": str(exc)}
+
+    metrics = classify_series(series)
+    label, notes = verdict(metrics, None, mirror_fraction)
+    if metrics:
+        _print_series_block(metrics)
+    print(f"    mirror traffic: {mirror_fraction:.0%} (excluded from the analysis above)")
+    _print_verdict(label, notes)
+    return {
+        "package": pkg,
+        "ecosystem": "pypi",
+        "metrics": asdict(metrics) if metrics else None,
+        "mirror_fraction": mirror_fraction,
+        "verdict": label,
+        "notes": notes,
+    }
+
+
+def report_go(module: str) -> dict:
+    print(f"\nGo   {module}")
+    count = go_imported_by(module)
+    if count is None:
+        print("    imported-by: unavailable (parse failed or offline)")
+    else:
+        print(f"    imported-by (pkg.go.dev): {count}")
+    print(
+        "    Go publishes no download counts; adoption-by-reference only. "
+        f"Also check: https://pkg.go.dev/{module}?tab=importedby"
+    )
+    print(f"    and GitHub dependents: https://github.com/{GITHUB_REPO}/network/dependents")
+    return {"module": module, "ecosystem": "go", "imported_by": count}
+
+
+def report_github_releases(repo: str) -> dict:
+    print(f"\nHomebrew / GitHub Releases  {repo}")
+    try:
+        assets = github_release_assets(repo)
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        print(f"    unavailable: {exc}")
+        return {"repo": repo, "ecosystem": "github-releases", "error": str(exc)}
+
+    metrics = classify_release_assets(assets)
+    label, notes = verdict_release(metrics)
+    if metrics:
+        top = sorted(metrics.by_module.items(), key=lambda kv: kv[1], reverse=True)
+        print("    by module: " + ", ".join(f"{m} {n}" for m, n in top))
+    _print_verdict(label, notes)
+    print(
+        "    note: counts are cumulative per release (no daily series), and a custom "
+        "Homebrew tap gets no formulae.brew.sh analytics — this asset count is the signal."
+    )
+    return {
+        "repo": repo,
+        "ecosystem": "github-releases",
+        "metrics": asdict(metrics) if metrics else None,
+        "verdict": label,
+        "notes": notes,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--npm", nargs="*", metavar="PKG")
+    parser.add_argument("--pypi", nargs="*", metavar="PKG")
+    parser.add_argument("--go", nargs="*", metavar="MODULE")
+    parser.add_argument("--github", metavar="OWNER/REPO", help="repo for release-asset counts")
+    parser.add_argument("--no-npm", action="store_true")
+    parser.add_argument("--no-pypi", action="store_true")
+    parser.add_argument("--go-off", action="store_true")
+    parser.add_argument("--no-github", action="store_true")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable results")
+    args = parser.parse_args(argv)
+
+    npm_pkgs = args.npm if args.npm is not None else NPM_PACKAGES
+    pypi_pkgs = args.pypi if args.pypi is not None else PYPI_PACKAGES
+    go_mods = args.go if args.go is not None else GO_MODULES
+    gh_repo = args.github if args.github is not None else GITHUB_REPO
+
+    results = []
+    if not args.no_npm:
+        for pkg in npm_pkgs:
+            results.append(report_npm(pkg))
+    if not args.no_pypi:
+        for pkg in pypi_pkgs:
+            results.append(report_pypi(pkg))
+    if not args.go_off:
+        for mod in go_mods:
+            results.append(report_go(mod))
+    if not args.no_github:
+        results.append(report_github_releases(gh_repo))
+
+    if args.json:
+        print("\n" + json.dumps(results, indent=2, default=str))
+    print(
+        "\nReminder: a 'machine-dominated' verdict is the expected baseline for a "
+        "young package. Watch for the shape to change — a sustained, weekday-skewed "
+        "baseline climbing on the latest version is your first real adopter."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -295,7 +295,9 @@ class ReleaseMetrics:
     by_module: dict[str, int]
     ci_sweep_releases: int  # releases whose full artifact set was pulled by automation
     ci_downloads: int  # binary downloads attributed to those sweeps
-    human_downloads: int  # total_downloads - ci_downloads
+    install_events: int  # total_downloads - ci_downloads; download events, NOT people
+    peak_build: int  # most install events on a single (module, version) build
+    peak_build_module: str  # the module that peak belongs to
 
 
 def parse_asset_platform(name: str) -> str | None:
@@ -349,18 +351,30 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
     by_module: dict[str, int] = {}
     ci_sweep_releases = 0
     ci_downloads = 0
+    peak_build = 0
+    peak_build_module = ""
     for assets in releases:
         swept = is_ci_sweep(assets)
         if swept:
             ci_sweep_releases += 1
+        release_events = 0  # human install events for this single build
+        release_module = ""
         for name, count in assets:
             platform = parse_asset_platform(name)
             if platform is None or count <= 0:
                 continue
             by_platform[platform] = by_platform.get(platform, 0) + count
-            by_module[_asset_module(name)] = by_module.get(_asset_module(name), 0) + count
+            module = _asset_module(name)
+            by_module[module] = by_module.get(module, 0) + count
+            release_module = release_module or module
             if swept:
                 ci_downloads += 1  # the sweep pulled ~1 of each binary artifact
+                release_events += count - 1
+            else:
+                release_events += count
+        if release_events > peak_build:
+            peak_build = release_events
+            peak_build_module = release_module
 
     total = sum(by_platform.values())
     if total == 0:
@@ -376,7 +390,9 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
         by_module=by_module,
         ci_sweep_releases=ci_sweep_releases,
         ci_downloads=ci_downloads,
-        human_downloads=total - ci_downloads,
+        install_events=total - ci_downloads,
+        peak_build=peak_build,
+        peak_build_module=peak_build_module,
     )
 
 
@@ -392,14 +408,20 @@ def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
         notes.append(
             f"{metrics.ci_sweep_releases} release(s) show a CI sweep "
             f"(checksums + Linux pulled together) — ~{metrics.ci_downloads} download(s) "
-            f"attributed to automation, leaving ~{metrics.human_downloads} human"
+            f"attributed to automation"
         )
-    if metrics.human_downloads > 0 and metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
+    if metrics.install_events > 0 and metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
         label = "human-leaning — desktop installs (likely Homebrew on laptops)"
         notes.append(
-            f"~{metrics.human_downloads} human install(s) after discounting sweeps, "
-            "essentially all desktop (macOS/Windows) with no organic Linux — release "
-            "binaries aren't mirror-amplified, so this is real activity, not CI or scanners"
+            f"~{metrics.install_events} install events after discounting sweeps, essentially "
+            "all desktop (macOS/Windows) with no organic Linux — release binaries aren't "
+            "mirror-amplified, so this is real activity, not CI or scanners"
+        )
+        notes.append(
+            "install events are DOWNLOADS, not people: each version upgrade, module, machine "
+            f"and reinstall counts separately. Peak single build ({metrics.peak_build_module} "
+            f"= {metrics.peak_build}) is the best distinct-machines proxy; a true headcount "
+            "needs server-side logs (download_count has no de-duplication)"
         )
     elif metrics.server_downloads > metrics.desktop_downloads:
         label = "Linux-dominated — likely CI / containers"

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -63,10 +63,13 @@ from dataclasses import asdict, dataclass
 # ---------------------------------------------------------------------------
 # Defaults for this monorepo
 
-NPM_PACKAGES = ["@agnt-rcpt/sdk-ts", "@agnt-rcpt/sdk-ts-aws"]
+NPM_PACKAGES = ["@agnt-rcpt/sdk-ts", "@agnt-rcpt/sdk-ts-aws", "@agnt-rcpt/openclaw"]
 PYPI_PACKAGES = ["agent-receipts"]
 GO_MODULES = ["github.com/agent-receipts/ar/sdk/go"]
-GITHUB_REPO = "agent-receipts/ar"
+GITHUB_REPO = "agent-receipts/ar"  # repo hosting the Go module (dependents link)
+# Repos whose GitHub release assets are scanned for Homebrew-tap install signal:
+# the monorepo (daemon/hook/mcp-proxy/collector) plus the dashboard tap.
+GITHUB_REPOS = ["agent-receipts/ar", "agent-receipts/dashboard"]
 
 # ---------------------------------------------------------------------------
 # Classification thresholds. A "spike" is a publish/mirror reaction day; the
@@ -844,7 +847,9 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--npm", nargs="*", metavar="PKG")
     parser.add_argument("--pypi", nargs="*", metavar="PKG")
     parser.add_argument("--go", nargs="*", metavar="MODULE")
-    parser.add_argument("--github", metavar="OWNER/REPO", help="repo for release-asset counts")
+    parser.add_argument(
+        "--github", nargs="*", metavar="OWNER/REPO", help="repos for release-asset counts"
+    )
     parser.add_argument("--no-npm", action="store_true")
     parser.add_argument("--no-pypi", action="store_true")
     parser.add_argument("--go-off", action="store_true")
@@ -855,7 +860,7 @@ def main(argv: list[str]) -> int:
     npm_pkgs = args.npm if args.npm is not None else NPM_PACKAGES
     pypi_pkgs = args.pypi if args.pypi is not None else PYPI_PACKAGES
     go_mods = args.go if args.go is not None else GO_MODULES
-    gh_repo = args.github if args.github is not None else GITHUB_REPO
+    gh_repos = args.github if args.github is not None else GITHUB_REPOS
 
     results = []
     if not args.no_npm:
@@ -868,7 +873,8 @@ def main(argv: list[str]) -> int:
         for mod in go_mods:
             results.append(report_go(mod))
     if not args.no_github:
-        results.append(report_github_releases(gh_repo))
+        for repo in gh_repos:
+            results.append(report_github_releases(repo))
 
     if args.json:
         print("\n" + json.dumps(results, indent=2, default=str))

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -10,7 +10,7 @@ download count at all. So the raw total is close to meaningless on its own — y
 have to read the *shape* of the traffic, not its size.
 
 This tool pulls the shape for every package this monorepo ships and prints a
-machine-vs-human verdict per ecosystem. The three signals it reads:
+machine-vs-human verdict per ecosystem. The four signals it reads:
 
 1. Daily-series shape (npm, PyPI). Real human adoption leaves a persistent,
    weekday-skewed baseline that does not drop to zero and does not consist of
@@ -27,15 +27,23 @@ machine-vs-human verdict per ecosystem. The three signals it reads:
    manifest. PyPI's ``without_mirrors`` series strips mirror noise outright; Go
    has no counter but ``pkg.go.dev`` reports an imported-by count.
 
+4. Homebrew / GitHub Release assets. Binaries installed via a custom Homebrew tap
+   are downloaded straight from GitHub Releases, so per-asset download counts are
+   a clean install signal (not mirror-amplified). Linux pulls are CI (release
+   gates), full-artifact "sweeps" are discounted, and the desktop-platform count
+   reads as real installs — reported as events, not people.
+
 The classification core (``classify_series``, ``classify_versions``,
-``verdict``) is pure and takes no network, so the unit tests exercise it
+``classify_release_assets``, ``verdict``) is pure and takes no network, so the
+unit tests exercise it
 directly with synthetic machine- and human-shaped inputs. The fetchers are thin
 I/O wrappers, best-effort: a source that fails to fetch is reported as
 unavailable rather than aborting the run.
 
 Usage:
     check.py [--npm PKG ...] [--pypi PKG ...] [--go MODULE ...]
-             [--no-npm] [--no-pypi] [--go-off] [--json]
+             [--github OWNER/REPO ...] [--no-npm] [--no-pypi] [--go-off]
+             [--no-github] [--json]
 
 With no package flags it uses this repo's published packages. Network egress to
 api.npmjs.org, pypistats.org, and pkg.go.dev is required for live data; the
@@ -51,6 +59,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import json
+import os
 import re
 import statistics
 import subprocess
@@ -659,8 +668,6 @@ def github_releases(repo: str) -> list[ReleaseInfo]:
     Uses the public REST API; a GITHUB_TOKEN / GH_TOKEN in the environment raises
     the rate limit but is not required for a public repo.
     """
-    import os
-
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     releases: list[ReleaseInfo] = []
     page = 1

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -287,12 +287,15 @@ def verdict(
 class ReleaseMetrics:
     """GitHub Release asset download shape (the Homebrew / binary install path)."""
 
-    total_downloads: int
-    by_platform: dict[str, int]  # darwin / linux / windows / other
+    total_downloads: int  # binary downloads (checksums/sigs excluded)
+    by_platform: dict[str, int]  # darwin / linux / windows
     desktop_downloads: int  # darwin + windows
     server_downloads: int  # linux
     desktop_fraction: float
     by_module: dict[str, int]
+    ci_sweep_releases: int  # releases whose full artifact set was pulled by automation
+    ci_downloads: int  # binary downloads attributed to those sweeps
+    human_downloads: int  # total_downloads - ci_downloads
 
 
 def parse_asset_platform(name: str) -> str | None:
@@ -314,21 +317,50 @@ def _asset_module(name: str) -> str:
     return re.split(r"_v?\d", name, maxsplit=1)[0] or name
 
 
-def classify_release_assets(assets: list[tuple[str, int]]) -> ReleaseMetrics | None:
-    """Aggregate per-asset download counts by platform and module.
+def is_ci_sweep(assets: list[tuple[str, int]]) -> bool:
+    """True if a release's full artifact set was pulled by automation.
 
-    ``assets`` is a flat ``(asset_name, download_count)`` list across releases.
-    Non-binary assets (checksums, signatures) are ignored. Returns ``None`` if no
-    binary asset has ever been downloaded.
+    The fingerprint of a release-verification / supply-chain job (vs a human
+    installing via Homebrew) is that it fetches *everything*: the checksums
+    manifest plus the Linux server builds. A human is on one desktop platform,
+    installs via brew, and never downloads checksums.txt (brew verifies against
+    the sha256 pinned in the formula). So: a checksums download together with any
+    Linux download marks the release as swept.
+    """
+    checksums = any(
+        count > 0 and parse_asset_platform(name) is None and "checksum" in name.lower()
+        for name, count in assets
+    )
+    linux = any(count > 0 and parse_asset_platform(name) == "linux" for name, count in assets)
+    return checksums and linux
+
+
+def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMetrics | None:
+    """Aggregate per-asset download counts by platform and module across releases.
+
+    ``releases`` is a list of releases, each a ``(asset_name, download_count)``
+    list (including non-binary assets like checksums, which inform sweep
+    detection but are excluded from the download totals). For any release flagged
+    as a CI sweep (see ``is_ci_sweep``), one download per distinct binary artifact
+    is attributed to automation and subtracted from the human count. Returns
+    ``None`` if no binary asset has ever been downloaded.
     """
     by_platform: dict[str, int] = {}
     by_module: dict[str, int] = {}
-    for name, count in assets:
-        platform = parse_asset_platform(name)
-        if platform is None or count <= 0:
-            continue
-        by_platform[platform] = by_platform.get(platform, 0) + count
-        by_module[_asset_module(name)] = by_module.get(_asset_module(name), 0) + count
+    ci_sweep_releases = 0
+    ci_downloads = 0
+    for assets in releases:
+        swept = is_ci_sweep(assets)
+        if swept:
+            ci_sweep_releases += 1
+        for name, count in assets:
+            platform = parse_asset_platform(name)
+            if platform is None or count <= 0:
+                continue
+            by_platform[platform] = by_platform.get(platform, 0) + count
+            by_module[_asset_module(name)] = by_module.get(_asset_module(name), 0) + count
+            if swept:
+                ci_downloads += 1  # the sweep pulled ~1 of each binary artifact
 
     total = sum(by_platform.values())
     if total == 0:
@@ -342,23 +374,32 @@ def classify_release_assets(assets: list[tuple[str, int]]) -> ReleaseMetrics | N
         server_downloads=server,
         desktop_fraction=desktop / total,
         by_module=by_module,
+        ci_sweep_releases=ci_sweep_releases,
+        ci_downloads=ci_downloads,
+        human_downloads=total - ci_downloads,
     )
 
 
 def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
-    """Lean on the desktop-vs-Linux split: desktop installs are humans, Linux is CI."""
+    """Lean on the desktop-vs-Linux split, discounting detected CI sweeps."""
     if metrics is None:
         return "no data", ["no release binaries downloaded yet"]
     notes = [
         f"{metrics.total_downloads} binary download(s): "
         + ", ".join(f"{p} {n}" for p, n in sorted(metrics.by_platform.items()))
     ]
-    if metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
+    if metrics.ci_sweep_releases:
+        notes.append(
+            f"{metrics.ci_sweep_releases} release(s) show a CI sweep "
+            f"(checksums + Linux pulled together) — ~{metrics.ci_downloads} download(s) "
+            f"attributed to automation, leaving ~{metrics.human_downloads} human"
+        )
+    if metrics.human_downloads > 0 and metrics.desktop_fraction >= DESKTOP_FRACTION_HUMAN:
         label = "human-leaning — desktop installs (likely Homebrew on laptops)"
         notes.append(
-            f"{metrics.desktop_fraction:.0%} of downloads are desktop (macOS/Windows) "
-            f"with {metrics.server_downloads} Linux — release binaries aren't "
-            "mirror-amplified, so this is real install activity, not CI or scanners"
+            f"~{metrics.human_downloads} human install(s) after discounting sweeps, "
+            "essentially all desktop (macOS/Windows) with no organic Linux — release "
+            "binaries aren't mirror-amplified, so this is real activity, not CI or scanners"
         )
     elif metrics.server_downloads > metrics.desktop_downloads:
         label = "Linux-dominated — likely CI / containers"
@@ -458,16 +499,17 @@ def go_imported_by(module: str) -> int | None:
     return int(m.group(1).replace(",", "")) if m else None
 
 
-def github_release_assets(repo: str) -> list[tuple[str, int]]:
-    """Every release asset's (name, download_count) for a repo, across all pages.
+def github_release_assets(repo: str) -> list[list[tuple[str, int]]]:
+    """Per-release lists of (asset_name, download_count), across all pages.
 
-    Uses the public REST API. A GITHUB_TOKEN / GH_TOKEN in the environment raises
-    the rate limit but is not required for a public repo.
+    Each element is one release's assets (including checksums, which inform sweep
+    detection). Uses the public REST API; a GITHUB_TOKEN / GH_TOKEN in the
+    environment raises the rate limit but is not required for a public repo.
     """
     import os
 
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    assets: list[tuple[str, int]] = []
+    releases: list[list[tuple[str, int]]] = []
     page = 1
     while True:
         url = f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}"
@@ -481,12 +523,13 @@ def github_release_assets(repo: str) -> list[tuple[str, int]]:
         if not batch:
             break
         for release in batch:
-            for asset in release.get("assets", []):
-                assets.append((asset["name"], int(asset["download_count"])))
+            releases.append(
+                [(asset["name"], int(asset["download_count"])) for asset in release.get("assets", [])]
+            )
         if len(batch) < 100:
             break
         page += 1
-    return assets
+    return releases
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/usage_signal/check.py
+++ b/scripts/usage_signal/check.py
@@ -68,12 +68,6 @@ PYPI_PACKAGES = ["agent-receipts"]
 GO_MODULES = ["github.com/agent-receipts/ar/sdk/go"]
 GITHUB_REPO = "agent-receipts/ar"
 
-# Binary modules shipped as GitHub Release assets and installed via the Homebrew
-# tap (brew install agent-receipts/tap/<module>). brew fetches the release
-# tarball straight from GitHub, so the asset download_count is a clean install
-# signal — registry mirrors and package scanners don't pull release binaries.
-GITHUB_BINARY_MODULES = ["hook", "mcp-proxy", "daemon", "collector"]
-
 # ---------------------------------------------------------------------------
 # Classification thresholds. A "spike" is a publish/mirror reaction day; the
 # default threshold is relative to the package's own baseline so it scales from
@@ -225,13 +219,17 @@ def verdict(
             f"{metrics.spike_share:.0%} of traffic is same-day spikes "
             f"(>= {metrics.spike_threshold}/day) — publish/mirror reactions, not steady use"
         )
-    if FLAT_WEEK_LO <= metrics.weekend_weekday_ratio <= FLAT_WEEK_HI:
+    if metrics.weekday_per_day == 0:
+        # Only weekend baseline days (or none) — there is no weekly rhythm to read.
+        notes.append("insufficient weekday baseline to read a weekday/weekend rhythm")
+    elif FLAT_WEEK_LO <= metrics.weekend_weekday_ratio <= FLAT_WEEK_HI:
         machine += 1
         notes.append(
             f"flat week: weekend/weekday ratio {metrics.weekend_weekday_ratio:.2f} "
             "(~1.0) — automated traffic ignores weekends"
         )
-    elif 0 < metrics.weekend_weekday_ratio < HUMAN_WEEKDAY_RATIO:
+    elif metrics.weekend_weekday_ratio < HUMAN_WEEKDAY_RATIO:
+        # Includes a 0.0 ratio (weekend-silent traffic), the strongest weekday skew.
         human += 1
         notes.append(
             f"weekday-skewed: weekend/weekday ratio {metrics.weekend_weekday_ratio:.2f} "
@@ -289,15 +287,26 @@ class ReleaseMetrics:
 
     total_downloads: int  # binary downloads (checksums/sigs excluded)
     by_platform: dict[str, int]  # darwin / linux / windows
-    desktop_downloads: int  # darwin + windows
-    server_downloads: int  # linux
-    desktop_fraction: float
     by_module: dict[str, int]
     ci_sweep_releases: int  # releases whose full artifact set was pulled by automation
     ci_downloads: int  # binary downloads attributed to those sweeps
     install_events: int  # total_downloads - ci_downloads; download events, NOT people
     peak_build: int  # most install events on a single (module, version) build
     peak_build_module: str  # the module that peak belongs to
+
+    @property
+    def desktop_downloads(self) -> int:
+        """darwin + windows — the human install platforms."""
+        return self.by_platform.get("darwin", 0) + self.by_platform.get("windows", 0)
+
+    @property
+    def server_downloads(self) -> int:
+        """linux — the CI / server platform."""
+        return self.by_platform.get("linux", 0)
+
+    @property
+    def desktop_fraction(self) -> float:
+        return self.desktop_downloads / self.total_downloads if self.total_downloads else 0.0
 
 
 def parse_asset_platform(name: str) -> str | None:
@@ -314,9 +323,23 @@ def parse_asset_platform(name: str) -> str | None:
     return None
 
 
-def _asset_module(name: str) -> str:
-    """Module an asset belongs to: the name before the first version segment."""
-    return re.split(r"_v?\d", name, maxsplit=1)[0] or name
+def _asset_module_version(name: str) -> tuple[str, str]:
+    """(module, version) parsed from a GoReleaser asset filename.
+
+    e.g. ``daemon_0.13.0_darwin_arm64.tar.gz`` -> ``("daemon", "0.13.0")``. The
+    version is anchored between the module and the platform token and excludes
+    ``_``, so a module name that itself embeds ``_<digit>`` (e.g. ``foo_2``) is
+    kept whole rather than truncated. Returns ``("", "")`` if the name doesn't
+    match the ``module_version_os_arch`` form.
+    """
+    m = re.match(
+        r"^(?P<module>.+)_v?(?P<version>\d[A-Za-z0-9.\-]*)_(?:darwin|linux|windows|macos)_",
+        name,
+        re.IGNORECASE,
+    )
+    if not m:
+        return "", ""
+    return m.group("module"), m.group("version")
 
 
 def is_ci_sweep(assets: list[tuple[str, int]]) -> bool:
@@ -342,6 +365,7 @@ class ReleaseSplit:
     """A single release's downloads split into human (desktop) vs CI."""
 
     module: str
+    version: str  # asset-derived version, "" if unparseable
     human: int  # desktop install events, minus any sweep-pulled desktop artifact
     ci: int  # Linux pulls + sweep-pulled desktop artifacts
     swept: bool
@@ -361,12 +385,14 @@ def split_release(assets: list[tuple[str, int]]) -> ReleaseSplit:
     human = 0
     ci = 0
     module = ""
+    version = ""
     for name, count in assets:
         platform = parse_asset_platform(name)
         if platform is None or count <= 0:
             continue
         by_platform[platform] = by_platform.get(platform, 0) + count
-        module = module or _asset_module(name)
+        if not module:
+            module, version = _asset_module_version(name)
         if platform == "linux":
             ci += count
         elif swept:
@@ -374,17 +400,16 @@ def split_release(assets: list[tuple[str, int]]) -> ReleaseSplit:
             human += count - 1
         else:
             human += count
-    return ReleaseSplit(module=module, human=human, ci=ci, swept=swept, by_platform=by_platform)
+    return ReleaseSplit(
+        module=module, version=version, human=human, ci=ci, swept=swept, by_platform=by_platform
+    )
 
 
-def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMetrics | None:
-    """Aggregate per-asset download counts by platform and module across releases.
+def aggregate_releases(splits: list[ReleaseSplit]) -> ReleaseMetrics | None:
+    """Aggregate already-split releases into overall metrics.
 
-    ``releases`` is a list of releases, each a ``(asset_name, download_count)``
-    list (including non-binary assets like checksums, which inform sweep
-    detection but are excluded from the download totals). Linux pulls and the
-    desktop artifacts of a CI sweep are attributed to automation. Returns ``None``
-    if no binary asset has ever been downloaded.
+    Linux pulls and the desktop artifacts of a CI sweep are attributed to
+    automation. Returns ``None`` if no binary asset has ever been downloaded.
     """
     by_platform: dict[str, int] = {}
     by_module: dict[str, int] = {}
@@ -392,8 +417,7 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
     ci_downloads = 0
     peak_build = 0
     peak_build_module = ""
-    for assets in releases:
-        split = split_release(assets)
+    for split in splits:
         if split.swept:
             ci_sweep_releases += 1
         ci_downloads += split.ci
@@ -408,14 +432,9 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
     total = sum(by_platform.values())
     if total == 0:
         return None
-    desktop = by_platform.get("darwin", 0) + by_platform.get("windows", 0)
-    server = by_platform.get("linux", 0)
     return ReleaseMetrics(
         total_downloads=total,
         by_platform=by_platform,
-        desktop_downloads=desktop,
-        server_downloads=server,
-        desktop_fraction=desktop / total,
         by_module=by_module,
         ci_sweep_releases=ci_sweep_releases,
         ci_downloads=ci_downloads,
@@ -423,6 +442,11 @@ def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMet
         peak_build=peak_build,
         peak_build_module=peak_build_module,
     )
+
+
+def classify_release_assets(releases: list[list[tuple[str, int]]]) -> ReleaseMetrics | None:
+    """Split each release's ``(asset_name, download_count)`` list, then aggregate."""
+    return aggregate_releases([split_release(assets) for assets in releases])
 
 
 @dataclass
@@ -437,42 +461,61 @@ def module_version_from_tag(tag: str) -> tuple[str, str]:
     """Split a release tag into (module, version).
 
     Binary-module tags look like ``hook/v0.12.0`` or ``mcp-proxy/v0.13.0``; SDK
-    tags like ``sdk-ts-v0.10.0``. Returns ("", tag) if no version is found.
+    tags like ``sdk-ts-v0.10.0``; a bare ``v1.2.3`` has no module. Returns
+    ``("", "")`` for a tag with no version at all (empty, or a draft
+    ``untagged-<sha>``), so callers can fall back to the asset-derived version
+    rather than treating the whole tag as a version string.
     """
     m = re.match(r"^(.*?)[/-]v?(\d[\w.\-]*)$", tag)
-    if not m:
-        return "", tag
-    return m.group(1).rstrip("/-"), m.group(2)
+    if m:
+        return m.group(1).rstrip("/-"), m.group(2)
+    m = re.match(r"^v?(\d[\w.\-]*)$", tag)  # bare version, no module prefix
+    if m:
+        return "", m.group(1)
+    return "", ""
 
 
-def _version_key(version: str) -> list:
-    """Sort key: numeric segments ascending, a pre-release sorting before its release."""
+def _version_key(version: str) -> tuple:
+    """Total-orderable sort key for a version string.
+
+    Each segment becomes a uniform ``(kind, int, str)`` triple — numeric segments
+    compare numerically, non-numeric ones as strings, and an int never compares
+    against a str (which would raise ``TypeError``). A pre-release sorts before
+    its release.
+    """
     base, _, pre = version.partition("-")
-    parts: list = [int(p) if p.isdigit() else p for p in base.split(".")]
-    # a release (no pre-release suffix) sorts after its pre-releases
-    parts.append("" if pre else "~")
-    parts.append(pre)
-    return parts
+    nums = tuple((0, int(s), "") if s.isdigit() else (1, 0, s) for s in base.split("."))
+    return (nums, 0 if pre else 1, pre)
 
 
-def release_timeline(releases: list[ReleaseInfo]) -> dict[str, list[tuple[str, ReleaseSplit]]]:
-    """Per-module list of (version, ReleaseSplit), version-sorted ascending.
+def build_timeline(
+    pairs: list[tuple[ReleaseInfo, ReleaseSplit]],
+) -> dict[str, list[tuple[str, ReleaseSplit]]]:
+    """Group already-split releases into a per-module, version-sorted timeline.
 
-    Only releases that carry downloaded binary assets appear (SDK source-only
-    tags drop out). The module label comes from the tag, falling back to the
-    asset-derived module so the two always agree.
+    Releases with no downloaded binary assets drop out (SDK source-only tags).
+    Module and version come from the tag when it parses to a clean version,
+    falling back to the asset-derived values so an untagged/draft release is
+    still placed under its real module rather than an empty bucket.
     """
     timeline: dict[str, list[tuple[str, ReleaseSplit]]] = {}
-    for rel in releases:
-        split = split_release(rel.assets)
+    for rel, split in pairs:
         if not split.by_platform:
             continue  # no binary downloads for this release
         module, version = module_version_from_tag(rel.tag)
+        if not version[:1].isdigit():  # tag carried no clean version
+            module, version = split.module, split.version
         module = module or split.module
+        version = version or split.version
         timeline.setdefault(module, []).append((version, split))
     for versions in timeline.values():
         versions.sort(key=lambda vs: _version_key(vs[0]))
     return timeline
+
+
+def release_timeline(releases: list[ReleaseInfo]) -> dict[str, list[tuple[str, ReleaseSplit]]]:
+    """Per-module list of (version, ReleaseSplit), version-sorted ascending."""
+    return build_timeline([(rel, split_release(rel.assets)) for rel in releases])
 
 
 def verdict_release(metrics: ReleaseMetrics | None) -> tuple[str, list[str]]:
@@ -589,7 +632,9 @@ def pypi_overall(pkg: str) -> tuple[list[tuple[datetime.date, int]], float]:
         elif row["category"] == "with_mirrors":
             with_total += n
     series = sorted(without.items())
-    mirror_fraction = ((with_total - without_total) / with_total) if with_total else 0.0
+    # Clamp: with_mirrors is the superset, but an uneven-date-coverage gap in the
+    # API response could otherwise drive the difference negative.
+    mirror_fraction = max(0.0, (with_total - without_total) / with_total) if with_total else 0.0
     return series, mirror_fraction
 
 
@@ -748,8 +793,9 @@ def report_github_releases(repo: str) -> dict:
         print(f"    unavailable: {exc}")
         return {"repo": repo, "ecosystem": "github-releases", "error": str(exc)}
 
-    metrics = classify_release_assets([r.assets for r in releases])
-    timeline = release_timeline(releases)
+    pairs = [(rel, split_release(rel.assets)) for rel in releases]
+    metrics = aggregate_releases([s for _, s in pairs])
+    timeline = build_timeline(pairs)
     label, notes = verdict_release(metrics)
 
     # Install-base anchor: per-module peak human build, and the overall superset.

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -270,6 +270,18 @@ def test_module_version_from_tag() -> None:
     assert check.module_version_from_tag("mcp-proxy/v0.13.0") == ("mcp-proxy", "0.13.0")
     assert check.module_version_from_tag("daemon/v0.12.1-alpha.1") == ("daemon", "0.12.1-alpha.1")
     assert check.module_version_from_tag("sdk-ts-v0.10.0") == ("sdk-ts", "0.10.0")
+    # bare version (no module prefix): version parsed, module empty
+    assert check.module_version_from_tag("v1.2.3") == ("", "1.2.3")
+    # untagged draft / non-version tags: ("", "") so callers fall back to assets
+    assert check.module_version_from_tag("untagged-deadbeef") == ("", "")
+    assert check.module_version_from_tag("") == ("", "")
+
+
+def test_version_key_no_typeerror_on_mixed_length_or_nonnumeric() -> None:
+    # regression: previously raised TypeError comparing int vs str in the key
+    assert check._version_key("0.12") < check._version_key("0.12.1")  # 2-seg vs 3-seg
+    mixed = sorted(["1.0.0", "0.12", "0.12.1", "1.0.x", "untagged-abc"], key=check._version_key)
+    assert mixed[0] == "0.12"  # well-defined order, no crash
 
 
 def test_version_key_orders_patches_and_prereleases() -> None:

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -265,6 +265,44 @@ def test_release_assets_none_when_undownloaded() -> None:
     assert check.classify_release_assets([[("x_1.0_linux_amd64.tar.gz", 0)]]) is None
 
 
+def test_module_version_from_tag() -> None:
+    assert check.module_version_from_tag("hook/v0.12.0") == ("hook", "0.12.0")
+    assert check.module_version_from_tag("mcp-proxy/v0.13.0") == ("mcp-proxy", "0.13.0")
+    assert check.module_version_from_tag("daemon/v0.12.1-alpha.1") == ("daemon", "0.12.1-alpha.1")
+    assert check.module_version_from_tag("sdk-ts-v0.10.0") == ("sdk-ts", "0.10.0")
+
+
+def test_version_key_orders_patches_and_prereleases() -> None:
+    versions = ["0.13.0", "0.12.0", "0.12.1", "0.12.1-alpha.1"]
+    assert sorted(versions, key=check._version_key) == [
+        "0.12.0",
+        "0.12.1-alpha.1",  # pre-release sorts before its release
+        "0.12.1",
+        "0.13.0",
+    ]
+
+
+def test_release_timeline_groups_and_sorts_by_module_and_version() -> None:
+    # the real daemon patch shape, fetched out of order
+    releases = [
+        check.ReleaseInfo("daemon/v0.13.0", [("daemon_0.13.0_darwin_arm64.tar.gz", 13)]),
+        check.ReleaseInfo("daemon/v0.12.0", [("daemon_0.12.0_darwin_arm64.tar.gz", 10),
+                                             ("daemon_0.12.0_linux_arm64.tar.gz", 1)]),
+        check.ReleaseInfo("daemon/v0.12.1", [("daemon_0.12.1_darwin_arm64.tar.gz", 4)]),
+        check.ReleaseInfo("sdk-ts-v0.11.0", []),  # source-only release: no binaries, dropped
+    ]
+    tl = check.release_timeline(releases)
+    assert list(tl.keys()) == ["daemon"]  # sdk-ts dropped (no binary assets)
+    versions = [v for v, _ in tl["daemon"]]
+    assert versions == ["0.12.0", "0.12.1", "0.13.0"]  # version-sorted ascending
+    humans = {v: s.human for v, s in tl["daemon"]}
+    assert humans == {"0.12.0": 10, "0.12.1": 4, "0.13.0": 13}
+    # the lone linux_arm64 on 0.12.0 is CI, not a human install
+    split_0120 = dict(tl["daemon"])["0.12.0"]
+    assert split_0120.ci == 1
+    assert split_0120.human == 10
+
+
 # --- runner -----------------------------------------------------------------
 
 

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -1,0 +1,223 @@
+"""Unit tests for the usage-signal classifier.
+
+These exercise the pure classification core (`classify_series`,
+`classify_versions`, `verdict`, and the `active_window`/`spike_threshold_for`
+helpers) against synthetic machine- and human-shaped inputs. No network call is
+made — the fetchers that hit api.npmjs.org / pypistats.org / pkg.go.dev are thin
+I/O wrappers exercised against the live services by hand, not here.
+
+The invariant under test: traffic that is flat across the week, dominated by
+publish-day spikes, smeared across pre-release versions, or mostly mirror hits
+classifies as machine-dominated; traffic with a weekday-skewed baseline
+concentrated on the latest version classifies as human-leaning. Both directions
+are asserted, so a classifier that always answers "machine" fails the
+human-shaped cases.
+
+Run with:
+    python3 -m pytest scripts/usage_signal/test_check.py
+    python3 scripts/usage_signal/test_check.py   # quick self-check
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import check  # noqa: E402
+
+MONDAY = datetime.date(2026, 4, 6)  # a known Monday, for weekday-shaped fixtures
+
+
+def _days(start: datetime.date, counts: list[int]) -> list[tuple[datetime.date, int]]:
+    return [(start + datetime.timedelta(days=i), n) for i, n in enumerate(counts)]
+
+
+def _machine_series() -> list[tuple[datetime.date, int]]:
+    """Flat 7/day for 8 weeks, with a 200-download spike every 7th day."""
+    counts = []
+    for i in range(56):
+        counts.append(200 if i % 7 == 0 else 7)
+    return _days(MONDAY, counts)
+
+
+def _human_series() -> list[tuple[datetime.date, int]]:
+    """Weekday-heavy, no spikes: 20/day Mon-Fri, 3/day Sat-Sun, for 8 weeks."""
+    counts = []
+    for i in range(56):
+        dow = (MONDAY + datetime.timedelta(days=i)).weekday()
+        counts.append(3 if dow >= 5 else 20)
+    return _days(MONDAY, counts)
+
+
+# --- active_window / spike_threshold_for -----------------------------------
+
+
+def test_active_window_trims_leading_and_trailing_zeros() -> None:
+    series = _days(datetime.date(2026, 1, 1), [0, 0, 5, 0, 8, 0, 0])
+    window = check.active_window(series)
+    assert [n for _, n in window] == [5, 0, 8], window
+
+
+def test_active_window_all_zero_is_empty() -> None:
+    assert check.active_window(_days(datetime.date(2026, 1, 1), [0, 0, 0])) == []
+
+
+def test_spike_threshold_scales_with_median_but_has_floor() -> None:
+    # tiny package: floor wins
+    assert check.spike_threshold_for([1, 2, 3, 2]) == check.SPIKE_FLOOR
+    # busy package: 10 * median(=100) = 1000 wins over the floor
+    assert check.spike_threshold_for([100] * 9 + [5000]) == 1000
+
+
+# --- classify_series --------------------------------------------------------
+
+
+def test_classify_none_when_no_downloads() -> None:
+    assert check.classify_series(_days(datetime.date(2026, 1, 1), [0, 0, 0])) is None
+
+
+def test_machine_series_is_spiky_and_flat_week() -> None:
+    m = check.classify_series(_machine_series())
+    assert m is not None
+    assert m.spike_days == 8
+    assert m.spike_share > 0.5  # spikes dominate the volume
+    # baseline is a flat 7/day every day -> weekend ~= weekday
+    assert check.FLAT_WEEK_LO <= m.weekend_weekday_ratio <= check.FLAT_WEEK_HI
+
+
+def test_human_series_is_weekday_skewed_no_spikes() -> None:
+    m = check.classify_series(_human_series())
+    assert m is not None
+    assert m.spike_days == 0
+    assert m.zero_days == 0
+    assert m.weekend_weekday_ratio < check.HUMAN_WEEKDAY_RATIO  # 3/20 = 0.15
+
+
+# --- classify_versions ------------------------------------------------------
+
+
+def test_versions_mirror_smear_flags_prereleases_and_low_top_share() -> None:
+    # real last-week distribution: latest is the plurality but a minority,
+    # the rest smeared evenly across stable and abandoned pre-release versions.
+    v = check.classify_versions(
+        {
+            "0.10.0": 27,
+            "0.9.0": 8,
+            "0.9.0-alpha.1": 8,
+            "0.8.0": 4,
+            "0.8.0-alpha.1": 4,
+            "0.8.0-alpha.2": 3,
+            "0.6.0": 3,
+            "0.5.0": 4,
+            "0.4.1": 2,
+            "0.4.0": 4,
+            "0.3.0": 3,
+            "0.2.2": 3,
+            "0.2.1": 3,
+            "0.2.0": 3,
+        }
+    )
+    assert v is not None
+    assert v.prerelease_versions == 3
+    assert v.top_version == "0.10.0"
+    assert v.top_share < 0.5  # 27/79 ~= 0.34, smeared across history
+
+
+def test_versions_human_concentrates_on_latest() -> None:
+    v = check.classify_versions({"0.10.0": 90, "0.9.0": 5, "0.8.0": 5})
+    assert v is not None
+    assert v.prerelease_versions == 0
+    assert v.top_share >= 0.5
+
+
+# --- verdict ----------------------------------------------------------------
+
+
+def test_verdict_machine_for_machine_inputs() -> None:
+    m = check.classify_series(_machine_series())
+    v = check.classify_versions({"0.2.0": 3, "0.3.0": 3, "0.4.0-alpha.1": 4, "0.5.0": 4})
+    label, notes = check.verdict(m, v, mirror_fraction=0.8)
+    assert label.startswith("machine")
+    assert notes
+
+
+def test_verdict_human_for_human_inputs() -> None:
+    m = check.classify_series(_human_series())
+    v = check.classify_versions({"0.10.0": 90, "0.9.0": 5})
+    label, notes = check.verdict(m, v, mirror_fraction=0.1)
+    assert label.startswith("human"), (label, notes)
+
+
+def test_verdict_no_data() -> None:
+    label, _ = check.verdict(None)
+    assert label == "no data"
+
+
+# --- release assets (Homebrew / GitHub Releases) ---------------------------
+
+
+def test_parse_asset_platform_skips_non_binaries() -> None:
+    assert check.parse_asset_platform("checksums.txt") is None
+    assert check.parse_asset_platform("mcp-proxy_0.12.0_darwin_arm64.tar.gz") == "darwin"
+    assert check.parse_asset_platform("agent-receipts-hook_0.12.0_linux_amd64.tar.gz") == "linux"
+
+
+def test_release_assets_desktop_dominated_is_human() -> None:
+    # the real hook + mcp-proxy v0.12.0 shape: all darwin_arm64, zero linux
+    assets = [
+        ("agent-receipts-hook_0.12.0_darwin_arm64.tar.gz", 11),
+        ("agent-receipts-hook_0.12.0_darwin_amd64.tar.gz", 1),
+        ("agent-receipts-hook_0.12.0_linux_amd64.tar.gz", 0),
+        ("mcp-proxy_0.12.0_darwin_arm64.tar.gz", 9),
+        ("mcp-proxy_0.12.0_linux_arm64.tar.gz", 0),
+        ("checksums.txt", 0),
+    ]
+    m = check.classify_release_assets(assets)
+    assert m is not None
+    assert m.total_downloads == 21
+    assert m.server_downloads == 0
+    assert m.by_module == {"agent-receipts-hook": 12, "mcp-proxy": 9}
+    label, _ = check.verdict_release(m)
+    assert label.startswith("human-leaning")
+
+
+def test_release_assets_linux_dominated_is_ci() -> None:
+    assets = [
+        ("mcp-proxy_1.0.0_linux_amd64.tar.gz", 80),
+        ("mcp-proxy_1.0.0_darwin_arm64.tar.gz", 3),
+    ]
+    m = check.classify_release_assets(assets)
+    assert m is not None
+    label, _ = check.verdict_release(m)
+    assert "Linux-dominated" in label
+
+
+def test_release_assets_none_when_undownloaded() -> None:
+    assert check.classify_release_assets([("x_1.0_linux_amd64.tar.gz", 0)]) is None
+
+
+# --- runner -----------------------------------------------------------------
+
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"ok   {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -186,7 +186,10 @@ def test_release_assets_desktop_dominated_is_human() -> None:
     assert m.total_downloads == 21
     assert m.server_downloads == 0
     assert m.ci_sweep_releases == 0
-    assert m.human_downloads == 21
+    assert m.install_events == 21
+    # peak single build is hook 0.12.0 at 12, the distinct-machines proxy
+    assert m.peak_build == 12
+    assert m.peak_build_module == "agent-receipts-hook"
     assert m.by_module == {"agent-receipts-hook": 12, "mcp-proxy": 9}
     label, _ = check.verdict_release(m)
     assert label.startswith("human-leaning")
@@ -215,10 +218,14 @@ def test_release_assets_sweep_detected_and_discounted() -> None:
     assert m is not None
     assert m.ci_sweep_releases == 2
     assert m.ci_downloads == 8  # 4 binary artifacts swept per release
-    assert m.human_downloads == 8  # 16 binary downloads - 8 swept
+    assert m.install_events == 8  # 16 binary downloads - 8 swept
+    # collector's 7 darwin_arm64 minus its 1 swept = 6, the peak human build
+    assert m.peak_build == 6
+    assert m.peak_build_module == "collector"
     label, notes = check.verdict_release(m)
     assert label.startswith("human-leaning")
     assert any("CI sweep" in n for n in notes)
+    assert any("not people" in n for n in notes)
 
 
 def test_release_assets_linux_dominated_is_ci() -> None:

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -166,37 +166,76 @@ def test_parse_asset_platform_skips_non_binaries() -> None:
 
 
 def test_release_assets_desktop_dominated_is_human() -> None:
-    # the real hook + mcp-proxy v0.12.0 shape: all darwin_arm64, zero linux
-    assets = [
-        ("agent-receipts-hook_0.12.0_darwin_arm64.tar.gz", 11),
-        ("agent-receipts-hook_0.12.0_darwin_amd64.tar.gz", 1),
-        ("agent-receipts-hook_0.12.0_linux_amd64.tar.gz", 0),
-        ("mcp-proxy_0.12.0_darwin_arm64.tar.gz", 9),
-        ("mcp-proxy_0.12.0_linux_arm64.tar.gz", 0),
-        ("checksums.txt", 0),
+    # the real hook + mcp-proxy v0.12.0 shape: all darwin_arm64, zero linux,
+    # zero checksums -> no sweep, all human
+    releases = [
+        [
+            ("agent-receipts-hook_0.12.0_darwin_arm64.tar.gz", 11),
+            ("agent-receipts-hook_0.12.0_darwin_amd64.tar.gz", 1),
+            ("agent-receipts-hook_0.12.0_linux_amd64.tar.gz", 0),
+            ("checksums.txt", 0),
+        ],
+        [
+            ("mcp-proxy_0.12.0_darwin_arm64.tar.gz", 9),
+            ("mcp-proxy_0.12.0_linux_arm64.tar.gz", 0),
+            ("checksums.txt", 0),
+        ],
     ]
-    m = check.classify_release_assets(assets)
+    m = check.classify_release_assets(releases)
     assert m is not None
     assert m.total_downloads == 21
     assert m.server_downloads == 0
+    assert m.ci_sweep_releases == 0
+    assert m.human_downloads == 21
     assert m.by_module == {"agent-receipts-hook": 12, "mcp-proxy": 9}
     label, _ = check.verdict_release(m)
     assert label.startswith("human-leaning")
 
 
-def test_release_assets_linux_dominated_is_ci() -> None:
-    assets = [
-        ("mcp-proxy_1.0.0_linux_amd64.tar.gz", 80),
-        ("mcp-proxy_1.0.0_darwin_arm64.tar.gz", 3),
+def test_release_assets_sweep_detected_and_discounted() -> None:
+    # the real mcp-proxy/collector v0.13.0 shape: 1 of every platform + checksums
+    # (CI sweep) alongside the human darwin_arm64 column
+    releases = [
+        [
+            ("mcp-proxy_0.13.0_darwin_amd64.tar.gz", 1),
+            ("mcp-proxy_0.13.0_darwin_arm64.tar.gz", 3),
+            ("mcp-proxy_0.13.0_linux_amd64.tar.gz", 1),
+            ("mcp-proxy_0.13.0_linux_arm64.tar.gz", 1),
+            ("checksums.txt", 1),
+        ],
+        [
+            ("collector_0.13.0_darwin_amd64.tar.gz", 1),
+            ("collector_0.13.0_darwin_arm64.tar.gz", 7),
+            ("collector_0.13.0_linux_amd64.tar.gz", 1),
+            ("collector_0.13.0_linux_arm64.tar.gz", 1),
+            ("checksums.txt", 1),
+        ],
     ]
-    m = check.classify_release_assets(assets)
+    m = check.classify_release_assets(releases)
+    assert m is not None
+    assert m.ci_sweep_releases == 2
+    assert m.ci_downloads == 8  # 4 binary artifacts swept per release
+    assert m.human_downloads == 8  # 16 binary downloads - 8 swept
+    label, notes = check.verdict_release(m)
+    assert label.startswith("human-leaning")
+    assert any("CI sweep" in n for n in notes)
+
+
+def test_release_assets_linux_dominated_is_ci() -> None:
+    releases = [
+        [
+            ("mcp-proxy_1.0.0_linux_amd64.tar.gz", 80),
+            ("mcp-proxy_1.0.0_darwin_arm64.tar.gz", 3),
+        ]
+    ]
+    m = check.classify_release_assets(releases)
     assert m is not None
     label, _ = check.verdict_release(m)
     assert "Linux-dominated" in label
 
 
 def test_release_assets_none_when_undownloaded() -> None:
-    assert check.classify_release_assets([("x_1.0_linux_amd64.tar.gz", 0)]) is None
+    assert check.classify_release_assets([[("x_1.0_linux_amd64.tar.gz", 0)]]) is None
 
 
 # --- runner -----------------------------------------------------------------

--- a/scripts/usage_signal/test_check.py
+++ b/scripts/usage_signal/test_check.py
@@ -228,6 +228,26 @@ def test_release_assets_sweep_detected_and_discounted() -> None:
     assert any("not people" in n for n in notes)
 
 
+def test_release_assets_gate8_lone_linux_is_ci() -> None:
+    # Gate #8 (daemon protocol check) downloads daemon_<v>_linux_amd64.tar.gz on
+    # ubuntu on every daemon/SDK release — no checksums, no darwin. It must be
+    # attributed to CI even though it is not a full "sweep".
+    releases = [
+        [("daemon_0.13.0_darwin_arm64.tar.gz", 13)],  # real Mac humans
+        [
+            ("daemon_0.14.0_linux_amd64.tar.gz", 4),  # Gate #8 pulls
+            ("daemon_0.14.0_darwin_arm64.tar.gz", 0),
+        ],
+    ]
+    m = check.classify_release_assets(releases)
+    assert m is not None
+    assert m.server_downloads == 4
+    assert m.ci_sweep_releases == 0  # a lone Linux pull is not a sweep
+    assert m.ci_downloads == 4  # ...but still CI
+    assert m.install_events == 13  # only the darwin humans
+    assert m.peak_build == 13
+
+
 def test_release_assets_linux_dominated_is_ci() -> None:
     releases = [
         [


### PR DESCRIPTION
## What

Add a new `scripts/usage_signal/check.py` tool that analyzes download patterns across npm, PyPI, Go, and GitHub Releases to distinguish real user adoption from automated traffic (mirrors, CI, security scanners).

The tool reads three primary signals:
1. **Daily series shape**: Real adoption shows persistent weekday-skewed baselines; automated traffic is flat across weeks with publish-day spikes
2. **Per-version distribution**: Humans install the latest version; mirrors clone the entire history including pre-releases
3. **Adoption-by-reference**: PyPI mirror-free downloads, Go imported-by counts, GitHub dependents, and release asset platform splits (desktop vs Linux)

Includes comprehensive unit tests (`test_check.py`) covering the pure classification logic with synthetic machine- and human-shaped inputs, plus documentation in `AGENTS.md`.

## Why

For young packages, raw download counters are misleading. npm includes registry mirrors, security scanners (Socket, Snyk, Dependabot, Renovate), proxy caches, and release CI with no opt-out. PyPI is similar but allows subtracting mirrors. Go publishes no counts at all. This tool reads the *shape* of traffic patterns to identify genuine adoption signals, enabling the team to distinguish real users from noise.

The classification core is pure (no network I/O) and thoroughly tested; fetchers are thin best-effort wrappers that report unavailable sources rather than failing the entire run.

## Checklist

- [x] Tests pass for all changed components (unit tests in `test_check.py` cover all classifiers)
- [x] Linter passes (Python standard library only, no external dependencies)
- [x] No real keys or secrets in the diff
- [x] AGENTS.md updated with tool documentation and usage examples

## Security

- [x] No crypto, auth, or secrets handling in this change