### PR TITLE
docs(sdk-py): add Linux/source daemon install alongside Homebrew

### DIFF
--- a/site/src/content/docs/sdk-py/installation.mdx
+++ b/site/src/content/docs/sdk-py/installation.mdx
@@ -27,7 +27,12 @@ CLI (`list`, `show`, `verify`). Install it on macOS or Linux — Windows is not
 supported yet:
 
 ```bash
+# macOS (Homebrew)
 brew install agent-receipts/tap/agent-receipts-daemon
+
+# Linux / from source (requires Go 1.26.1+) — builds the daemon and the agent-receipts CLI
+go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest
+go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts@latest
 ```
 
 See [Daemon Setup](/getting-started/daemon-setup/) for other install methods,


### PR DESCRIPTION
## What

`sdk-py/installation.mdx` (&#34;You also need the daemon&#34;) gave only the macOS Homebrew command inline, so a Linux reader had to click through to Daemon Setup to find the install. Add the `go install …@latest` commands (daemon + `agent-receipts` CLI) next to `brew`, matching `daemon-setup.mdx`.

## Why

Found by the doc e2e runner (Theo/Python persona) executing the journey on Linux — the page left a Linux reader without an inline install path.

Docs-only; the `@latest` form matches the rest of the docs and the daemon and CLI share one module, so the two installs stay on the same version.