### PR TITLE
chore(sdk-py): sync uv.lock to package version 0.11.0

### DIFF
--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

`sdk/py/uv.lock` recorded the editable root package as `agent-receipts 0.10.0`, but `sdk/py/pyproject.toml` is at `0.11.0` (bumped in the 0.11.0 release prep; the lock wasn't regenerated). One-line `uv lock` to sync.

## Why

Because the lock was stale, every `uv` invocation (including hook-run ones) regenerated `uv.lock` back to `0.11.0`, leaving the working tree perpetually dirty. This removes that recurring churn.

## Notes

- Single line changed (`version = "0.10.0"` → `"0.11.0"` for the editable root); no dependency changes.
- Produced with `uv lock`; `uv run pytest` stays green.