### PR TITLE
docs(sdk-go): promote [Unreleased] to [0.14.0] in CHANGELOG

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,8 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-01
+
 ### Breaking Changes
 
 - **`emitter.Emit` surfaces transport failure by default** ([#599](https://github.com/agent-receipts/ar/issues/599), ADR-0025). When the daemon socket cannot be dialled or a write fails, `Emit` now returns a non-nil error wrapping the new sentinel `emitter.ErrTransport` instead of silently returning nil. Use `errors.Is(err, emitter.ErrTransport)` to distinguish a transport failure (recoverable; a retry or WAL wrapper may help) from a caller-bug error (invalid event, closed emitter) that a retry cannot fix. The `WithStrictErrors()` option is **removed** — surfacing is now the default; pass the new `WithBestEffort()` option to opt back into loss-tolerant emission (`Emit` returns nil on transport failure).


### PR DESCRIPTION
The `sdk/go/v0.14.0` tag was pushed on 2026-06-01 as part of the wave-2 release (#702), but the CHANGELOG heading was left as `[Unreleased]`. This promotes it to `[0.14.0] - 2026-06-01` so the published tag and the changelog agree.

One-line docs fix; no code changes.