### PR TITLE
docs(getting-started): runtime-agnostic TS run step; Linux pgrep & socket notes

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -303,7 +303,7 @@ Exit codes are stable for scripting: `0` when the receipt is found and printed, 
 The most common cause is that the daemon is not running when the emitter starts. By default, emitters surface an error when the socket is unreachable, so check your application logs for emit failures — then confirm `agent-receipts-daemon` is running and that the socket path matches. Confirm the daemon is alive and the socket exists:
 
 ```bash
-pgrep agent-receipts-daemon
+pgrep -f agent-receipts-daemon   # -f matches the full command line; the name exceeds pgrep's 15-char limit
 ls -la ~/.local/share/agent-receipts/events.sock             # macOS (default fallback)
 ls -la "${XDG_RUNTIME_DIR:-/run}/agentreceipts/events.sock"  # Linux
 ```

--- a/site/src/content/docs/getting-started/end-to-end.mdx
+++ b/site/src/content/docs/getting-started/end-to-end.mdx
@@ -54,11 +54,17 @@ async function main() {
 main().catch(console.error);
 ```
 
-Run it:
+Run it. This walkthrough uses [`tsx`](https://www.npmjs.com/package/tsx), a
+zero-config TypeScript runner — `npx` fetches it on first use, so this step needs
+network access:
 
 ```sh
 npx tsx emit.ts
 ```
+
+Any TypeScript runtime works just as well: `bun emit.ts`, Node 22.6+'s native
+`node --experimental-strip-types emit.ts`, or compile with `tsc` and run the
+emitted `.js` with `node`.
 
 The daemon receives the event over its Unix socket, signs it with its Ed25519
 key, chains it to any previous receipt in the same chain, and persists it to the

--- a/site/src/content/docs/getting-started/end-to-end.mdx
+++ b/site/src/content/docs/getting-started/end-to-end.mdx
@@ -62,9 +62,9 @@ network access:
 npx tsx emit.ts
 ```
 
-Any TypeScript runtime works just as well: `bun emit.ts`, Node 22.6+'s native
-`node --experimental-strip-types emit.ts`, or compile with `tsc` and run the
-emitted `.js` with `node`.
+Any TypeScript runtime works just as well: `bun emit.ts`, Node 22.11+'s native
+`node --experimental-strip-types emit.ts` (22.11 is the SDK's minimum), or
+compile with `tsc` and run the emitted `.js` with `node`.
 
 The daemon receives the event over its Unix socket, signs it with its Ed25519
 key, chains it to any previous receipt in the same chain, and persists it to the

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -49,8 +49,8 @@ pip install agent-receipts
 ### 2. Start the daemon
 
 Generate the signing key once, then run the daemon. It listens on the per-OS default
-socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
-service installation.
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths (on Linux
+without `XDG_RUNTIME_DIR`, that's under `/run`) and service installation.
 
 ```bash
 agent-receipts-daemon --init   # one-time: creates the signing key
@@ -102,8 +102,8 @@ npm install @agnt-rcpt/sdk-ts
 ### 2. Start the daemon
 
 Generate the signing key once, then run the daemon. It listens on the per-OS default
-socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
-service installation.
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths (on Linux
+without `XDG_RUNTIME_DIR`, that's under `/run`) and service installation.
 
 ```bash
 agent-receipts-daemon --init   # one-time: creates the signing key
@@ -168,8 +168,8 @@ go get github.com/agent-receipts/ar/sdk/go
 ### 2. Start the daemon
 
 Generate the signing key once, then run the daemon. It listens on the per-OS default
-socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths and
-service installation.
+socket — see [Daemon Setup](/getting-started/daemon-setup/) for socket paths (on Linux
+without `XDG_RUNTIME_DIR`, that's under `/run`) and service installation.
 
 ```bash
 agent-receipts-daemon --init   # one-time: creates the signing key


### PR DESCRIPTION
## What

Fixes getting-started doc issues found by **executing** the TypeScript journey on Linux (the doc e2e runner, Maya/TS persona).

## Findings → fixes

- **(Medium) `tsx` was an undocumented dependency.** `end-to-end.mdx` told the reader to run `npx tsx emit.ts` but never introduced `tsx`, and the SDK is ESM/strict-TS with no run guidance. It only worked because `npx` silently downloads `tsx` (breaks offline).
  → Introduce `tsx` (and note `npx` fetches it / needs network), and make the run step **runtime-agnostic**: `bun emit.ts`, Node 22.6+'s native `node --experimental-strip-types emit.ts`, or `tsc` + `node`. (Kept `tsx` as the shown default — the persona is a Node/TS dev, so a zero-config Node runner fits; `bun` is offered as an alternative rather than imposed as a new runtime.)
- **(Low) `pgrep agent-receipts-daemon` always fails on Linux.** The process name (21 chars) exceeds `pgrep`'s 15-char `comm` match limit, so the documented troubleshooting command returns nothing even when the daemon is running.
  → `pgrep -f agent-receipts-daemon` (matches the full command line), with a short inline note.
- **(Low) Linux socket surprise.** The quick-start "Start the daemon" step showed only the bare command; on Linux without `XDG_RUNTIME_DIR` the socket lands under `/run` with no inline heads-up.
  → Added a one-clause Linux note to all three (Python/TS/Go) start blocks.

## Notes

- Docs-only; bash/`sh` snippets aren't executed by snippet CI.
- Verified end-to-end against current `main` (daemon v0.14.0, SDK v0.11.0, Node 22): emit → `verify VALID` → `list`/`show` all pass; these are the doc gaps around that working path.