### PR TITLE
docs(quick-start): make the Go journey build (go mod init + emitter package)

### DIFF
--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -159,10 +159,11 @@ here — otherwise `verify` reads the `default` chain at the default paths.
 ### 1. Install
 
 Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setup/)
-for your platform), then the Go SDK:
+for your platform), then add the Go SDK to a module:
 
 ```bash
-go get github.com/agent-receipts/ar/sdk/go
+go mod init example.com/myapp   # in a fresh directory, if you don't already have a module
+go get github.com/agent-receipts/ar/sdk/go/emitter
 ```
 
 ### 2. Start the daemon
@@ -208,6 +209,12 @@ func main() {
 		log.Fatal(err)
 	}
 }
+```
+
+Run it:
+
+```bash
+go run .
 ```
 
 ### 4. Verify


### PR DESCRIPTION
## What

The Go quick-start didn&#39;t build as written. Found by **executing** the Go journey on Linux (doc e2e runner, Raj/Go persona).

## Finding → fix

Following the Go section verbatim:
1. `go get github.com/agent-receipts/ar/sdk/go`
2. paste `main.go`
3. build →
```
missing go.sum entry for module providing package github.com/google/uuid
(imported by .../sdk/go/emitter); to add:
go get github.com/agent-receipts/ar/sdk/go/emitter@v0.14.0
```
It only compiled after an **undocumented `go mod tidy`**. The page also never showed `go mod init` (so a fresh reader has no module) or a run command.

**Fix:**
- Step 1: `go mod init example.com/myapp`, then `go get github.com/agent-receipts/ar/sdk/go/emitter` — the package the program actually imports, which is exactly what `go build` suggested and which records the transitive `go.sum` so the build succeeds with no extra `tidy`.
- Step 3: add an explicit `go run .` so the emit step runs.

## Verified

After this flow on current `main` (Go 1.26, daemon v0.14.0, SDK v0.14.0): `go run .` emits, `agent-receipts verify` → `VALID (1 receipt)`, `list`/`show` show the receipt.

## Notes

- Docs-only; the Go snippet stays `snippet-check: no-run`.
- Left `sdk-go/installation.mdx` alone — its module-root `go get` is correct for &#34;add the SDK to your module&#34;; this build gap is specific to the runnable quick-start journey.
- The daemon-setup root/container socket nuance Raj also noted is largely covered by the Linux `/run` note in #715; not duplicating it here.