### PR TITLE
docs(mcp-proxy): Linux pgrep, Go version, and 0750-warning notes

### DIFF
--- a/site/src/content/docs/mcp-proxy/claude-desktop.mdx
+++ b/site/src/content/docs/mcp-proxy/claude-desktop.mdx
@@ -191,4 +191,4 @@ SEQ  TIMESTAMP             CHAIN    TOOL / ACTION TYPE
 
 **Chain IDs are daemon-managed.** The proxy no longer has a `-chain` flag — chain IDs are assigned by `agent-receipts-daemon`. By default the daemon writes all receipts to the `default` chain. Use `--chain-id` (or `AGENTRECEIPTS_CHAIN_ID`) on `agent-receipts` read and verify commands when working with a multi-chain store.
 
-**No receipts appearing?** The daemon must be running *before* Claude Desktop launches the proxied server, or emits fail. Confirm with `pgrep agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.
+**No receipts appearing?** The daemon must be running *before* Claude Desktop launches the proxied server, or emits fail. Confirm with `pgrep -f agent-receipts-daemon`, and see the [daemon troubleshooting guide](/getting-started/daemon-setup/#troubleshooting). If you run the daemon on a non-default socket, set `AGENTRECEIPTS_SOCKET` for both the daemon and the proxy.

--- a/site/src/content/docs/mcp-proxy/configuration.mdx
+++ b/site/src/content/docs/mcp-proxy/configuration.mdx
@@ -204,3 +204,7 @@ mcp-proxy -name github -http 127.0.0.1:8082 ... /path/to/server
 `127.0.0.1:0` picks a random free port automatically — fine when the approver parses the stderr discovery event at startup.
 
 All proxy instances forward to the same `agent-receipts-daemon`, so every client's calls land in one unified, hash-chained receipt store. Point a proxy at a different daemon — and thus a separate audit trail — with `--socket` (or `AGENTRECEIPTS_SOCKET`); see [Daemon Setup](/getting-started/daemon-setup/).
+
+### `data directory … has mode 0750` warning at startup
+
+The proxy logs `[WARNING] data directory … has mode 0750 (group/other-accessible)` when the daemon's data directory (the signing key and `receipts.db`) is readable by group or other. It is **advisory, not fatal** — the proxy still starts and emits normally. To restrict the directory to your user, run `chmod 0700 "${XDG_DATA_HOME:-$HOME/.local/share}/agent-receipts"`. The check exists because that directory holds the signing key and receipt store, which should not be readable by other local accounts.

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -21,7 +21,7 @@ Download a tarball for your platform (darwin/linux, amd64/arm64) from the [relea
 go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 ```
 
-Requires Go 1.26.1+. No CGO or external C libraries — the proxy uses pure Go SQLite.
+Requires Go 1.26.1+. No CGO or external C libraries needed — the proxy builds as a single static binary. (It holds no store of its own; the receipt database lives in `agent-receipts-daemon`.)
 
 ## Verify installation
 

--- a/site/src/content/docs/mcp-proxy/installation.mdx
+++ b/site/src/content/docs/mcp-proxy/installation.mdx
@@ -21,7 +21,7 @@ Download a tarball for your platform (darwin/linux, amd64/arm64) from the [relea
 go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@latest
 ```
 
-Requires Go 1.26+. No CGO or external C libraries — the proxy uses pure Go SQLite.
+Requires Go 1.26.1+. No CGO or external C libraries — the proxy uses pure Go SQLite.
 
 ## Verify installation
 


### PR DESCRIPTION
## What

Three MCP-proxy doc papercuts found by **executing** the proxy journey on headless Linux (doc e2e runner, Nina/MCP-proxy persona). She installed the proxy + daemon, wrapped the filesystem MCP server, drove real `tools/call`s through it, and verified the resulting signed receipts (`VALID (3 receipts)`) — these are the rough edges around that working path.

## Fixes

- **`claude-desktop.mdx`** — `pgrep agent-receipts-daemon` fails on Linux (the 22-char process name exceeds `pgrep`&#39;s 15-char `comm` match limit; it warns and returns nothing even when the daemon runs). → `pgrep -f agent-receipts-daemon`. This is the same bug #715 fixed in `daemon-setup.mdx`; this is the other occurrence.
- **`installation.mdx`** — &#34;Requires Go 1.26+&#34; → **&#34;Go 1.26.1+&#34;**, matching the module&#39;s actual `go &gt;= 1.26.1` constraint (the toolchain auto-switched to 1.26.3 on install) and `daemon-setup.mdx`.
- **`configuration.mdx`** — document the advisory `[WARNING] data directory … has mode 0750 (group/other-accessible)` the proxy logs at startup: it&#39;s **not fatal**, and `chmod 0700` on the data dir silences it. Previously undocumented, so a first-time operator could mistake it for a misconfiguration.

## Notes

- Docs-only.
- Verified against current `main` (mcp-proxy v0.13.0, daemon v0.14.0): the documented `mcp-proxy ` wiring, `doctor`, `list`/`show`/`verify`, and `init` snippet all worked; these are the papercuts alongside.