### PR TITLE
docs(hook): correct the exit-code contract (not "always 0")

### DIFF
--- a/hook/README.md
+++ b/hook/README.md
@@ -1,6 +1,6 @@
 # agent-receipts-hook
 
-Short-lived hook binary for [Agent Receipts](https://github.com/agent-receipts/ar). Invoked by agent runtimes on `PostToolUse` events — reads a JSON frame from stdin, maps it to an audit event, and forwards it to `agent-receipts-daemon` over a Unix-domain socket. Always exits 0 so it never blocks the agent.
+Short-lived hook binary for [Agent Receipts](https://github.com/agent-receipts/ar). Invoked by agent runtimes on `PostToolUse` events — reads a JSON frame from stdin, maps it to an audit event, and forwards it to `agent-receipts-daemon` over a Unix-domain socket. It exits 0 silently when the frame is unreadable or the runtime isn't recognised; once the runtime is identified, a failure to record the receipt exits 1 with a stderr message (surfacing a broken audit pipeline rather than dropping receipts). It never pauses or modifies the tool call.
 
 ## Install
 

--- a/site/src/content/docs/hook/claude-code.mdx
+++ b/site/src/content/docs/hook/claude-code.mdx
@@ -84,5 +84,6 @@ Claude Code passes the same `session_id` across all tool calls in a session. Bot
 | Flag | Description |
 |---|---|
 | `--format` | Force a specific input format. Defaults to auto-detection via `hook_event_name` in the stdin payload or the `CLAUDE_SESSION_ID` environment variable. Currently supported: `claude-code`. |
+| `--version` | Print the version and exit. |
 
 The `--format` flag is intended for testing and future runtime support. In normal Claude Code usage, auto-detection is sufficient.

--- a/site/src/content/docs/hook/overview.mdx
+++ b/site/src/content/docs/hook/overview.mdx
@@ -29,9 +29,9 @@ The hook binary:
 1. Reads and parses the stdin frame
 2. Creates an `emitter.Event` with `channel: "claude-code"`, the tool name, input, output, and `decision: "allowed"` (PostToolUse fires only after the tool ran)
 3. Forwards the event to the daemon over a Unix socket
-4. Exits 0 — always, regardless of success or failure
+4. Exits 0 on success
 
-The hook never blocks the agent. Emit failures (daemon not running, socket missing, oversized payload) are silently dropped, consistent with ADR-0010 §"Failure model".
+The hook does not pause or modify the tool call. If the stdin frame is unreadable or the calling runtime isn't recognised, it exits 0 silently — the event isn't ours to record. But once the runtime **is** identified, a failure to record the receipt (daemon not running, socket missing, malformed or oversized frame) exits 1 with a message on stderr. This is deliberate: a broken audit pipeline is surfaced to the runtime rather than silently dropping receipts, the same surface-don't-drop stance as the SDK [emit-failure contract](https://github.com/agent-receipts/ar/blob/main/docs/adr/0025-emit-failure-contract.md).
 
 ## Difference from mcp-proxy
 

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -208,10 +208,10 @@ agent-receipts-hook [--format=<name>]
 
 | Flag | Description |
 |---|---|
-| `--format` | Force a specific input format (default: auto-detected from environment variables). Currently supported: `claude-code`. |
+| `--format` | Force a specific input format (default: auto-detected from the stdin frame's `hook_event_name` or the `CLAUDE_SESSION_ID` environment variable). Currently supported: `claude-code`. |
 
 **Exit behaviour:** Exits 0 silently when the stdin frame is unreadable or the calling runtime isn't recognised (the event isn't ours). Once the runtime is identified, a failure to record the receipt (daemon not running, socket missing, malformed frame) exits 1 with a message on stderr — surfacing a broken audit pipeline rather than silently losing receipts. The hook never pauses or modifies the tool call itself.
 
-**Auto-detection:** When `--format` is omitted, the binary inspects environment variables to identify the calling runtime. `CLAUDE_SESSION_ID` set → `claude-code` format.
+**Auto-detection:** When `--format` is omitted, the binary identifies the calling runtime from two signals: the `CLAUDE_SESSION_ID` environment variable, or the stdin frame's `hook_event_name` (`PostToolUse` / `PreToolUse`). Either resolves to the `claude-code` format — Claude Code itself uses the stdin `hook_event_name` route, since it does not set `CLAUDE_SESSION_ID` in the environment.
 
 See [Hook: Claude Code](/hook/claude-code/) for wiring instructions.

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -210,7 +210,7 @@ agent-receipts-hook [--format=<name>]
 |---|---|
 | `--format` | Force a specific input format (default: auto-detected from environment variables). Currently supported: `claude-code`. |
 
-**Exit behaviour:** Always exits 0. Emit failures (daemon not running, socket missing, malformed frame) are dropped silently — the hook never blocks the agent.
+**Exit behaviour:** Exits 0 silently when the stdin frame is unreadable or the calling runtime isn't recognised (the event isn't ours). Once the runtime is identified, a failure to record the receipt (daemon not running, socket missing, malformed frame) exits 1 with a message on stderr — surfacing a broken audit pipeline rather than silently losing receipts. The hook never pauses or modifies the tool call itself.
 
 **Auto-detection:** When `--format` is omitted, the binary inspects environment variables to identify the calling runtime. `CLAUDE_SESSION_ID` set → `claude-code` format.
 


### PR DESCRIPTION
## What

Corrects the `agent-receipts-hook` exit-code contract, which was documented wrong in three places. Found by **executing** the hook journey (doc e2e runner, Omar/hook persona) and confirmed against source.

## The bug

The docs said the hook **&#34;always exits 0&#34;** and **&#34;silently drops&#34;** emit failures. The binary actually does the opposite once it knows who&#39;s calling it:

- `hook/cmd/agent-receipts-hook/main.go:6-11` (intent comment) and exits at `116/122/135/141`.
- Reproduced: `AGENTRECEIPTS_SOCKET=…/nonexistent.sock agent-receipts-hook &lt; frame.json` → `agent-receipts-hook: emit failed: …` on **stderr, exit 1**.

Real contract:
- **stdin unreadable, or runtime not recognised** → silent **exit 0** (the event isn&#39;t ours).
- **runtime identified, then recording fails** (unsupported format, unparseable payload, emitter create, emit) → **exit 1 + stderr**.
- success → exit 0.

This matters: the old wording told operators a misconfigured daemon could never disrupt their Claude Code session, but Claude Code does receive the non-zero exit + stderr.

## Fix

- `hook/overview.mdx`, `reference/cli-commands.mdx`, `hook/README.md` — describe the real two-case contract, and frame it as deliberate (surface a broken audit pipeline rather than silently losing receipts — same stance as the SDK [emit-failure contract / ADR-0025](https://github.com/agent-receipts/ar/blob/main/docs/adr/0025-emit-failure-contract.md)). Dropped the now-inaccurate &#34;ADR-0010 §Failure model / always exits 0&#34; framing.
- `hook/claude-code.mdx` — add the `--version` flag to the flags table (the binary supports it; `--help` lists it).

## Notes

- Docs/README only; no code change. (Confirmed with you that the exit-1 behaviour is intended, so the docs were the stale side.)