### PR TITLE
docs(dashboard): clarify verification scope, complete options table

### DIFF
--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -37,12 +37,16 @@ dashboard
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
+If port 8080 is already in use, `dashboard` exits immediately with `bind: address already in use` — pass `-port <n>` to pick another (e.g. `dashboard -port 9090`).
+
 ### Options
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-db` | `~/.local/share/agent-receipts/receipts.db` | Path to a receipt SQLite database |
+| `-host` | `127.0.0.1` | Address to bind the web server to |
 | `-port` | `8080` | Port to serve on |
+| `-poll-interval` | `5s` | How often to poll the database for new receipts |
 
 ### Example
 

--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -28,7 +28,7 @@ The dashboard's chain verification checks **hash linkage and sequence ordering o
 :::
 
 :::caution[Known issue: false negatives]
-The dashboard (v0.3.0) can report a chain as **broken** when `agent-receipts verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalisation. If the dashboard flags a break, confirm with `agent-receipts verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).
+The dashboard (v0.3.0) can report a chain as **broken** when `agent-receipts verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalization. If the dashboard flags a break, confirm with `agent-receipts verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).
 :::
 
 ## How it works

--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -21,6 +21,16 @@ The Agent Receipts Dashboard is a lightweight, read-only web UI for browsing rec
 - Receipt detail view with raw JSON
 - Dark theme with risk-level color coding
 
+## What "verify" checks
+
+:::caution[The dashboard does not verify signatures]
+The dashboard's chain verification checks **hash linkage and sequence ordering only — it does not verify Ed25519 signatures**, despite the button being labelled "Verify signatures". A green "valid" means the receipts link and are correctly ordered, **not** that their signatures were checked. For full cryptographic verification, use [`agent-receipts verify`](/reference/cli-commands/), which re-derives each hash *and* checks the signature against the public key.
+:::
+
+:::caution[Known issue: false negatives]
+The dashboard (v0.3.0) can report a chain as **broken** when `agent-receipts verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalisation. If the dashboard flags a break, confirm with `agent-receipts verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).
+:::
+
 ## How it works
 
 The dashboard opens your SQLite receipt database in **read-only** mode and serves a web UI at localhost. It never modifies your data.


### PR DESCRIPTION
## What

Docs-only fixes from **running the dashboard getting-started journey end-to-end** (doc e2e fleet, "Priya" persona). Companion to the HIGH bug filed as #719.

## Changes

**`dashboard/overview.mdx`** — two caution blocks under a new "What 'verify' checks" heading:
- **No signature verification.** The dashboard checks hash linkage + sequence ordering only and does **not** verify Ed25519 signatures, even though the UI button says "Verify signatures". A reader (especially a security reviewer) could otherwise read a green "valid" as "signatures checked". Points to `agent-receipts verify` for the real thing. Verified: `/api/chains/default/verify` per-receipt keys are exactly `index` / `receipt_id` / `hash_link_valid` / `sequence_valid` — no signature field; the spec's verification algorithm (step 2a) does mandate an Ed25519 check.
- **Known false-negative.** The dashboard (v0.3.0) can report a valid chain as broken (`agent-receipts verify` → `VALID (3 receipts)` while `/api/chains/default/verify` → `valid:false, broken_at:1`). Tells readers to confirm with the CLI. Tracked in #719.

**`dashboard/installation.mdx`**
- Added the `-host` (`127.0.0.1`) and `-poll-interval` (`5s`) flags — both shown by `dashboard -h` but missing from the Options table.
- Added a note that `dashboard` exits with `bind: address already in use` if port 8080 is taken; pass `-port`.

## Scope notes

- The verification false-negative and the "Verify signatures" relabel are **code** fixes in `agent-receipts/dashboard` (out of this repo); this PR is the docs-side mitigation, and #719 tracks the code bug.
- The other commands in the journey (`-db`, no-flag default, `-port`) all worked verbatim.