### PR TITLE
docs: forensic disclosure SDK reference + cross-links

### DIFF
--- a/site/src/content/docs/openclaw/installation.mdx
+++ b/site/src/content/docs/openclaw/installation.mdx
@@ -85,6 +85,8 @@ All configuration is optional. Defaults are shown below:
 
 By default, action parameters are hashed but not stored in plaintext. Enable `parameterDisclosure` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
 
+For the protocol-level model behind this setting — the HPKE envelope, the two-key separation, forensic recovery, and the threat/GDPR considerations — see [Parameter Disclosure](/specification/parameter-disclosure/).
+
 ```jsonc
 {
   "plugins": {

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -235,6 +235,151 @@ const (
 )
 ```
 
+### Parameter disclosure (HPKE)
+
+{/* snippet-check: skip */}
+```go
+import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+```
+
+HPKE-based envelope for encrypting tool-call parameters into a receipt's
+`parameters_disclosure` field (ADR-0012, ciphersuite
+`hpke-x25519-hkdf-sha256-aes-256-gcm`). The emitter holds only the forensic
+public key and never sees the plaintext again after encryption; the private key
+stays offline. For the threat model and operator configuration see the
+[Parameter Disclosure specification](/specification/parameter-disclosure/).
+For the envelope JSON shape see the [schema reference](/specification/agent-receipt-schema/#parameters_disclosure-envelope-hpke).
+
+This is the SDK-direct path. When emitting through the daemon the operator
+provides the public key in daemon config; the daemon calls these helpers
+automatically (ADR-0012 §"Operator config").
+
+#### `GenerateForensicKeyPair`
+
+```go
+func GenerateForensicKeyPair() (ForensicKeyPair, error)
+```
+
+Generate an X25519 key pair for forensic disclosure. `PublicKey` (32 raw bytes)
+is shared with emitters so they can encrypt disclosures. `PrivateKey` (32 raw
+bytes) must be kept offline — separate from the Ed25519 signing key (ADR-0001 /
+ADR-0012). Returns an error if the system CSPRNG fails.
+
+#### `ForensicKeyFingerprint`
+
+```go
+func ForensicKeyFingerprint(publicKey []byte) (string, error)
+```
+
+Return the canonical fingerprint of an X25519 forensic public key in
+`sha256:<lowercase hex>` form (ADR-0015): SHA-256 over the raw 32-byte key.
+This is the value the daemon writes as the recipient `kid` in a
+`DisclosureEnvelope`, and the value a forensic tool recomputes from a held key
+to match receipts. `publicKey` must be the raw 32-byte X25519 key (not
+SPKI/PEM). Returns an error if `len(publicKey) != 32`.
+
+**Go SDK only.** The TS and Py SDKs do not yet export this helper.
+
+#### `ForensicPublicFromPrivate`
+
+```go
+func ForensicPublicFromPrivate(privateKey []byte) ([]byte, error)
+```
+
+Derive the X25519 public key (32 raw bytes) from a 32-byte forensic private
+key. A forensic responder typically holds only the private key; this function
+lets it compute the matching `ForensicKeyFingerprint` and locate receipts
+encrypted to that key without a separate key registry. Returns an error if
+`len(privateKey) != 32` or the key bytes are invalid.
+
+**Go SDK only.** The TS and Py SDKs do not yet export this helper.
+
+#### `EncryptDisclosure`
+
+```go
+func EncryptDisclosure(params map[string]any, recipientPublicKey []byte, kid string) (*DisclosureEnvelope, error)
+```
+
+Encrypt `params` as a v1 HPKE disclosure envelope. `params` is
+RFC 8785 JCS-canonicalized before encryption so all SDKs produce the same
+ciphertext for the same parameters object. `recipientPublicKey` must be 32 raw
+bytes; `kid` is the recipient key identifier (a `sha256:<hex>` fingerprint from
+`ForensicKeyFingerprint`, or a `did:key` DID URL). Returns an error if any
+argument is invalid or if the system CSPRNG fails.
+
+#### `DecryptDisclosure`
+
+```go
+func DecryptDisclosure(env *DisclosureEnvelope, recipientPrivateKey []byte) (map[string]any, error)
+```
+
+Recover the plaintext parameters from a v1 HPKE disclosure envelope.
+`recipientPrivateKey` must be 32 raw bytes. Returns an error if the envelope
+version or algorithm is unsupported, if the key or ciphertext is invalid, or if
+AEAD authentication fails.
+
+#### Usage example
+
+{/* snippet-check: skip */}
+```go
+// Key management (run once offline, store private key securely)
+kp, err := receipt.GenerateForensicKeyPair()
+fingerprint, err := receipt.ForensicKeyFingerprint(kp.PublicKey)
+// fingerprint == "sha256:..." — use as kid and in daemon config
+
+// Emitter side (holds only the public key)
+env, err := receipt.EncryptDisclosure(
+    map[string]any{"path": "/etc/passwd", "mode": "r"},
+    kp.PublicKey,
+    fingerprint,
+)
+// embed env in action.ParametersDisclosure, then sign the receipt
+
+// Forensic / audit side (holds the offline private key)
+params, err := receipt.DecryptDisclosure(env, kp.PrivateKey)
+// params == map[string]any{"mode": "r", "path": "/etc/passwd"}
+
+// Deriving a public key from only the private key (forensic tooling)
+pub, err := receipt.ForensicPublicFromPrivate(kp.PrivateKey)
+fp2, err := receipt.ForensicKeyFingerprint(pub)
+// fp2 == fingerprint
+```
+
+### Types (disclosure)
+
+#### `ForensicKeyPair`
+
+```go
+type ForensicKeyPair struct {
+    PublicKey  []byte // 32 bytes; share with emitters
+    PrivateKey []byte // 32 bytes; keep offline
+}
+```
+
+Raw X25519 key bytes. Unlike `KeyPair` (Ed25519, PEM), these are raw bytes
+because X25519 has no widespread PKCS8 PEM convention and raw bytes compose
+naturally with HPKE library APIs.
+
+#### `DisclosureEnvelope`
+
+```go
+type DisclosureEnvelope struct {
+    V          string                `json:"v"`
+    Alg        string                `json:"alg"`
+    Recipients []DisclosureRecipient `json:"recipients"`
+    CT         string                `json:"ct"`
+}
+
+type DisclosureRecipient struct {
+    KID string `json:"kid"`
+    Enc string `json:"enc"` // unpadded base64url, 43 chars for X25519
+}
+```
+
+v1 HPKE envelope stored in `action.parameters_disclosure`. `CT` is the
+base64url-encoded AEAD ciphertext. Field names in `DisclosureRecipient` follow
+RFC 9180 §4.1 (`enc`, not `encap`).
+
 ---
 
 ## Package `taxonomy`

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -261,6 +261,143 @@ VERSION: str                # current package version
 
 ---
 
+## Parameter disclosure (HPKE)
+
+```python
+from agent_receipts import (
+    generate_forensic_key_pair,
+    encrypt_disclosure,
+    decrypt_disclosure,
+    ForensicKeyPair,
+    DisclosureEnvelope,
+    DisclosureRecipient,
+)
+```
+
+HPKE-based envelope for encrypting tool-call parameters into a receipt's
+`parameters_disclosure` field (ADR-0012, ciphersuite
+`hpke-x25519-hkdf-sha256-aes-256-gcm`). The emitter holds only the forensic
+public key and never sees the plaintext again after encryption; the private key
+stays offline. For the threat model and operator configuration see the
+[Parameter Disclosure specification](/specification/parameter-disclosure/).
+For the envelope JSON shape see the [schema reference](/specification/agent-receipt-schema/#parameters_disclosure-envelope-hpke).
+
+This is the SDK-direct path. When emitting through the daemon the operator
+provides the public key in daemon config; the daemon calls these helpers
+automatically.
+
+### Functions
+
+#### `generate_forensic_key_pair`
+
+```python
+def generate_forensic_key_pair() -> ForensicKeyPair
+```
+
+Generate an X25519 key pair for forensic disclosure. `public_key` (32 raw
+bytes) is shared with emitters. `private_key` (32 raw bytes) must be kept
+offline, separate from the Ed25519 signing key (ADR-0001 / ADR-0012).
+
+#### `encrypt_disclosure`
+
+```python
+def encrypt_disclosure(
+    params: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+) -> DisclosureEnvelope
+```
+
+Encrypt `params` as a v1 HPKE disclosure envelope. `params` is RFC 8785
+JCS-canonicalized before encryption so all SDKs produce the same ciphertext for
+the same parameters object. `params` must be a plain `dict` (Mapping subclasses
+are rejected; convert Pydantic models with `.model_dump()` first).
+`recipient_public_key` must be 32 bytes. `kid` is the recipient key identifier
+(`sha256:<hex>` fingerprint or `did:key` DID URL). Raises `TypeError` for
+non-dict `params`, `ValueError` for other invalid arguments.
+
+#### `decrypt_disclosure`
+
+```python
+def decrypt_disclosure(
+    env: DisclosureEnvelope,
+    recipient_private_key: bytes,
+) -> dict[str, Any]
+```
+
+Recover the plaintext parameters from a v1 HPKE disclosure envelope.
+`recipient_private_key` must be 32 bytes. `env` is re-validated at runtime
+(callers commonly pass dicts from `json.loads`). Raises `ValueError` if the
+envelope version or algorithm is unsupported, if the key or ciphertext is
+malformed, or if AEAD authentication fails.
+
+### Usage example
+
+{/* snippet-check: no-run */}
+```python
+from agent_receipts import (
+    generate_forensic_key_pair,
+    encrypt_disclosure,
+    decrypt_disclosure,
+)
+import hashlib
+
+# Key management (run once offline, store private key securely)
+kp = generate_forensic_key_pair()
+# Share kp.public_key with emitters; keep kp.private_key offline.
+digest = hashlib.sha256(kp.public_key).hexdigest()
+kid = f"sha256:{digest}"  # use as kid and in daemon config
+
+# Emitter side (holds only the public key)
+env = encrypt_disclosure(
+    {"path": "/etc/passwd", "mode": "r"},
+    kp.public_key,
+    kid,
+)
+# embed env in action.parameters_disclosure, then sign the receipt
+
+# Forensic / audit side (holds the offline private key)
+params = decrypt_disclosure(env, kp.private_key)
+# params == {"mode": "r", "path": "/etc/passwd"}
+```
+
+### Types
+
+#### `ForensicKeyPair`
+
+```python
+@dataclass(frozen=True)
+class ForensicKeyPair:
+    public_key: bytes   # 32-byte X25519 public key; share with emitters
+    private_key: bytes  # 32-byte X25519 private key; keep offline
+```
+
+Raw X25519 key bytes. Unlike `KeyPair` (Ed25519, PEM-encoded), these are raw
+bytes because X25519 has no widespread PKCS8 PEM convention.
+
+#### `DisclosureEnvelope` / `DisclosureRecipient`
+
+```python
+class DisclosureEnvelope(TypedDict):
+    v: Literal["1"]
+    alg: Literal["hpke-x25519-hkdf-sha256-aes-256-gcm"]
+    recipients: list[DisclosureRecipient]  # length 1 in v1
+    ct: str  # AEAD ciphertext; unpadded base64url
+
+class DisclosureRecipient(TypedDict):
+    kid: str
+    enc: str  # HPKE encapsulated key; unpadded base64url, 43 chars for X25519
+```
+
+v1 HPKE envelope stored in `action.parameters_disclosure`. Field names follow
+RFC 9180 §4.1 (`enc`, not `encap`).
+
+**Note:** `ForensicKeyFingerprint` and `ForensicPublicFromPrivate` are available
+in the Go SDK only (added in PR #722). Use `hashlib.sha256(public_key).hexdigest()`
+to compute the `sha256:<hex>` fingerprint string in Python.
+
+---
+
 ## Store
 
 ```python

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -262,6 +262,135 @@ const VERSION: "0.9.0"          // package version
 
 ---
 
+## Parameter disclosure (HPKE)
+
+```typescript
+import {
+  generateForensicKeyPair,
+  encryptDisclosure,
+  decryptDisclosure,
+  type ForensicKeyPair,
+  type DisclosureEnvelope,
+  type DisclosureRecipient,
+} from "@agnt-rcpt/sdk-ts";
+```
+
+HPKE-based envelope for encrypting tool-call parameters into a receipt's
+`parameters_disclosure` field (ADR-0012, ciphersuite
+`hpke-x25519-hkdf-sha256-aes-256-gcm`). The emitter holds only the forensic
+public key and never sees the plaintext again after encryption; the private key
+stays offline. For the threat model and operator configuration see the
+[Parameter Disclosure specification](/specification/parameter-disclosure/).
+For the envelope JSON shape see the [schema reference](/specification/agent-receipt-schema/#parameters_disclosure-envelope-hpke).
+
+This is the SDK-direct path. When emitting through the daemon the operator
+provides the public key in daemon config; the daemon calls these helpers
+automatically.
+
+All three functions are `async` (they use `node:crypto` internally).
+
+### Functions
+
+#### `generateForensicKeyPair`
+
+```typescript
+async function generateForensicKeyPair(): Promise<ForensicKeyPair>
+```
+
+Generate an X25519 key pair for forensic disclosure. `publicKey` (32-byte
+`Uint8Array`) is shared with emitters. `privateKey` (32-byte `Uint8Array`) must
+be kept offline, separate from the Ed25519 signing key (ADR-0001 / ADR-0012).
+
+#### `encryptDisclosure`
+
+```typescript
+async function encryptDisclosure(
+  params: Record<string, unknown>,
+  recipientPublicKey: Uint8Array,
+  kid: string,
+): Promise<DisclosureEnvelope>
+```
+
+Encrypt `params` as a v1 HPKE disclosure envelope. `params` is RFC 8785
+JCS-canonicalized before encryption so all SDKs produce the same ciphertext for
+the same parameters object. `params` must be a plain object (not `null` or an
+array). `recipientPublicKey` must be 32 bytes. `kid` is the recipient key
+identifier (`sha256:<hex>` fingerprint or `did:key` DID URL). Throws on invalid
+arguments.
+
+#### `decryptDisclosure`
+
+```typescript
+async function decryptDisclosure(
+  env: DisclosureEnvelope,
+  recipientPrivateKey: Uint8Array,
+): Promise<Record<string, unknown>>
+```
+
+Recover the plaintext parameters from a v1 HPKE disclosure envelope.
+`recipientPrivateKey` must be 32 bytes. Throws if the envelope version or
+algorithm is unsupported, if the key or ciphertext is malformed, or if AEAD
+authentication fails.
+
+### Usage example
+
+```typescript
+// Key management (run once offline, store private key securely)
+const kp = await generateForensicKeyPair();
+// Share kp.publicKey with emitters; keep kp.privateKey offline.
+// Compute the fingerprint manually: sha256(kp.publicKey) → "sha256:..."
+
+// Emitter side (holds only the public key)
+const env = await encryptDisclosure(
+  { path: "/etc/passwd", mode: "r" },
+  kp.publicKey,
+  "sha256:...",
+);
+// embed env in action.parameters_disclosure, then sign the receipt
+
+// Forensic / audit side (holds the offline private key)
+const params = await decryptDisclosure(env, kp.privateKey);
+// params == { mode: "r", path: "/etc/passwd" }
+```
+
+### Types
+
+#### `ForensicKeyPair`
+
+```typescript
+interface ForensicKeyPair {
+  /** 32-byte X25519 public key. Share with emitters to enable encryption. */
+  publicKey: Uint8Array;
+  /** 32-byte X25519 private key. Keep offline; required to decrypt. */
+  privateKey: Uint8Array;
+}
+```
+
+#### `DisclosureEnvelope` / `DisclosureRecipient`
+
+```typescript
+interface DisclosureEnvelope {
+  v: "1";
+  alg: "hpke-x25519-hkdf-sha256-aes-256-gcm";
+  recipients: [DisclosureRecipient]; // length-1 tuple; v1 single-recipient
+  ct: string; // AEAD ciphertext; unpadded base64url
+}
+
+interface DisclosureRecipient {
+  kid: string;
+  enc: string; // HPKE encapsulated key; unpadded base64url, 43 chars for X25519
+}
+```
+
+v1 HPKE envelope stored in `action.parameters_disclosure`. Field names follow
+RFC 9180 §4.1 (`enc`, not `encap`).
+
+**Note:** `ForensicKeyFingerprint` and `ForensicPublicFromPrivate` are available
+in the Go SDK only (added in PR #722). Use `sha256(kp.publicKey)` from the
+existing `sha256` export to compute the fingerprint string in TypeScript.
+
+---
+
 ## Store
 
 ```typescript


### PR DESCRIPTION
Follow-up to #722 (HPKE parameter disclosure). Splits the purely additive documentation out of the feature PR to keep that review focused.

## What this adds

- **SDK API reference** — a &#34;Parameter disclosure (HPKE)&#34; section in each SDK&#39;s reference page documenting the helpers that SDK actually exports:
  - **Go**: `GenerateForensicKeyPair`, `EncryptDisclosure`, `DecryptDisclosure`, plus the Go-only `ForensicKeyFingerprint` and `ForensicPublicFromPrivate` (added in #722).
  - **TypeScript / Python**: the generate/encrypt/decrypt trio. A note points to the Go SDK for the fingerprint helpers and shows the `sha256` path for computing the `kid` elsewhere.
- **Cross-link** from the OpenClaw installation &#34;Parameter disclosure&#34; section to the protocol-level spec page.

The helper availability is deliberately **not** presented as uniform across SDKs — `ForensicKeyFingerprint` / `ForensicPublicFromPrivate` are Go-only for now and are documented as such.

## Dependency

Depends on **#722**, which adds the linked `/specification/parameter-disclosure/` page and the Go helpers documented here. **Merge this after #722** so the cross-links and documented APIs resolve.

## Notes

- Docs-only; no code changes.
- MDX parses and the content collection syncs cleanly. The site build has a pre-existing Playwright/Chromium failure on an unrelated Mermaid page that is not touched here.