### PR TITLE
chore(daemon): bump sdk/go to v0.15.0

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.14.0
+	github.com/agent-receipts/ar/sdk/go v0.15.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/sdk/go v0.14.0 h1:07m7Rpr6musEIK6Wd1hom8GI8HHTWDCfOxPTTV3zw2s=
 github.com/agent-receipts/ar/sdk/go v0.14.0/go.mod h1:beOZmNsSk/I9KrU46xJcegIFN3Fo0bdXo8luHhUmeuc=
+github.com/agent-receipts/ar/sdk/go v0.15.0 h1:kMix5RHLn1dhdvPr5CrajluoUHEQVMW4xxKNLQ/PVDs=
+github.com/agent-receipts/ar/sdk/go v0.15.0/go.mod h1:beOZmNsSk/I9KrU46xJcegIFN3Fo0bdXo8luHhUmeuc=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Unblocks `daemon/v0.15.0` release. The daemon's `go.mod` still pinned `sdk/go v0.14.0`; bumping to v0.15.0 picks up `ForensicKeyFingerprint` and `ForensicPublicFromPrivate` (ADR-0012/ADR-0015) which the daemon's pipeline already calls.

All tests pass with `GOWORK=off` (the same isolation the release script uses).