### PR TITLE
docs(disclosure): cross-SDK forensic recovery + emit-with-parameters + operational notes

### DIFF
--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -308,6 +308,9 @@ If you start the daemon and an emitter on different socket paths, the emitter ca
 **Key not initialised error.**
 If the daemon exits immediately with an error about a missing key or database, run `agent-receipts-daemon --init` first. The daemon will not auto-create the key on first start — initialisation is intentionally explicit so key generation is a deliberate action, not a side effect.
 
+**`chain "…" tail is already terminal` on startup.**
+A chain tail becomes terminal (`chain.status="interrupted"`) when a daemon advanced the chain and then exited — for example after the deliberate "disclosure enabled but no forensic key" refusal, or any mid-chain shutdown. The next daemon refuses to append to a terminal tail to avoid forking the chain. Continue on a fresh chain with `--chain-id <new-id>` (or point at a fresh `--db`); the original chain stays intact and verifiable.
+
 **`go install` binary not found.**
 After `go install`, the binary lands in `$GOBIN` (or `$(go env GOPATH)/bin`, usually `~/go/bin`). Add it to your `$PATH`:
 

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -309,7 +309,7 @@ If you start the daemon and an emitter on different socket paths, the emitter ca
 If the daemon exits immediately with an error about a missing key or database, run `agent-receipts-daemon --init` first. The daemon will not auto-create the key on first start — initialisation is intentionally explicit so key generation is a deliberate action, not a side effect.
 
 **`chain "…" tail (seq N) is already terminal` on startup.**
-A chain tail becomes terminal (`chain.status="interrupted"`) when a daemon advanced the chain and then exited — for example after the deliberate "disclosure enabled but no forensic key" refusal, or any mid-chain shutdown. The next daemon refuses to append to a terminal tail to avoid forking the chain. Continue on a fresh chain with `--chain-id <new-id>` (or point at a fresh `--db`); the original chain stays intact and verifiable.
+When a running daemon is stopped by a signal (SIGTERM/SIGINT) with an open chain, it emits an interrupted-chain terminator (`chain.status="interrupted"`) to close that chain cleanly. A later daemon refuses to append after a terminal receipt, since that would produce a chain that fails verification. Continue on a fresh chain with `--chain-id <new-id>` (or point at a fresh `--db`); the original chain stays intact and verifiable.
 
 **`go install` binary not found.**
 After `go install`, the binary lands in `$GOBIN` (or `$(go env GOPATH)/bin`, usually `~/go/bin`). Add it to your `$PATH`:

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -308,7 +308,7 @@ If you start the daemon and an emitter on different socket paths, the emitter ca
 **Key not initialised error.**
 If the daemon exits immediately with an error about a missing key or database, run `agent-receipts-daemon --init` first. The daemon will not auto-create the key on first start — initialisation is intentionally explicit so key generation is a deliberate action, not a side effect.
 
-**`chain "…" tail is already terminal` on startup.**
+**`chain "…" tail (seq N) is already terminal` on startup.**
 A chain tail becomes terminal (`chain.status="interrupted"`) when a daemon advanced the chain and then exited — for example after the deliberate "disclosure enabled but no forensic key" refusal, or any mid-chain shutdown. The next daemon refuses to append to a terminal tail to avoid forking the chain. Continue on a fresh chain with `--chain-id <new-id>` (or point at a fresh `--db`); the original chain stays intact and verifiable.
 
 **`go install` binary not found.**

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -71,6 +71,7 @@ with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
         channel="my-app",
         tool_name="filesystem.file.read",
         decision="allowed",
+        input='{"path": "/etc/hosts"}',  # raw JSON; the daemon hashes it (and HPKE-encrypts it when parameter disclosure is on)
     )
 ```
 
@@ -127,6 +128,7 @@ async function main() {
       channel: "my-app",
       tool: { name: "filesystem.file.read" },
       decision: "allowed",
+      input: JSON.stringify({ path: "/etc/hosts" }), // raw JSON; hashed by the daemon (and HPKE-encrypted when parameter disclosure is on)
     });
     if (err) throw err;
   } finally {
@@ -189,6 +191,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 
 	"github.com/agent-receipts/ar/sdk/go/emitter"
@@ -205,6 +208,7 @@ func main() {
 		Channel:  "my-app",
 		Tool:     emitter.Tool{Name: "filesystem.file.read"},
 		Decision: "allowed",
+		Input:    json.RawMessage(`{"path":"/etc/hosts"}`), // raw JSON; hashed by the daemon (and HPKE-encrypted when parameter disclosure is on)
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -356,16 +356,23 @@ of the receipt JSON at `credentialSubject.action.parameters_disclosure`:
 ```go
 import (
     "encoding/json"
+    "log"
     "os"
 
     receipt "github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
 // raw 32-byte private key written by --init-forensic-key (kept offline)
-priv, _ := os.ReadFile("/path/to/forensic.key")
+priv, err := os.ReadFile("/path/to/forensic.key")
+if err != nil {
+    log.Fatal(err)
+}
 
 // from: agent-receipts show <seq> --chain-id default --json > receipt.json
-data, _ := os.ReadFile("receipt.json")
+data, err := os.ReadFile("receipt.json")
+if err != nil {
+    log.Fatal(err)
+}
 var rec struct {
     CredentialSubject struct {
         Action struct {
@@ -373,9 +380,14 @@ var rec struct {
         } `json:"action"`
     } `json:"credentialSubject"`
 }
-_ = json.Unmarshal(data, &rec)
+if err := json.Unmarshal(data, &rec); err != nil {
+    log.Fatal(err)
+}
 
 params, err := receipt.DecryptDisclosure(rec.CredentialSubject.Action.ParametersDisclosure, priv)
+if err != nil {
+    log.Fatal(err)
+}
 // params holds the original tool-call parameters
 ```
 

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -345,6 +345,40 @@ fp2, err := receipt.ForensicKeyFingerprint(pub)
 // fp2 == fingerprint
 ```
 
+#### Recovering a stored disclosure
+
+In practice the envelope comes from a **stored receipt** and the private key from
+the file `agent-receipts-daemon --init-forensic-key` wrote — a raw 32-byte X25519
+key, not PEM, so read it as bytes and pass it straight in. Pull the envelope out
+of the receipt JSON at `credentialSubject.action.parameters_disclosure`:
+
+{/* snippet-check: skip */}
+```go
+import (
+    "encoding/json"
+    "os"
+
+    receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+// raw 32-byte private key written by --init-forensic-key (kept offline)
+priv, _ := os.ReadFile("/path/to/forensic.key")
+
+// from: agent-receipts show <seq> --chain-id default --json > receipt.json
+data, _ := os.ReadFile("receipt.json")
+var rec struct {
+    CredentialSubject struct {
+        Action struct {
+            ParametersDisclosure *receipt.DisclosureEnvelope `json:"parameters_disclosure"`
+        } `json:"action"`
+    } `json:"credentialSubject"`
+}
+_ = json.Unmarshal(data, &rec)
+
+params, err := receipt.DecryptDisclosure(rec.CredentialSubject.Action.ParametersDisclosure, priv)
+// params holds the original tool-call parameters
+```
+
 ### Types (disclosure)
 
 #### `ForensicKeyPair`

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -474,10 +474,12 @@ import json
 from agent_receipts import decrypt_disclosure
 
 # raw 32-byte private key written by --init-forensic-key (kept offline)
-priv = open("/path/to/forensic.key", "rb").read()
+with open("/path/to/forensic.key", "rb") as f:
+    priv = f.read()
 
 # from: agent-receipts show <seq> --chain-id default --json > receipt.json
-receipt = json.load(open("receipt.json"))
+with open("receipt.json") as f:
+    receipt = json.load(f)
 envelope = receipt["credentialSubject"]["action"]["parameters_disclosure"]
 
 params = decrypt_disclosure(envelope, priv)

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -461,6 +461,29 @@ params = decrypt_disclosure(env, kp.private_key)
 # params == {"mode": "r", "path": "/etc/passwd"}
 ```
 
+### Recovering a stored disclosure
+
+In practice the envelope comes from a **stored receipt** and the private key from the
+file `agent-receipts-daemon --init-forensic-key` wrote — a raw 32-byte X25519 key,
+not PEM, so read it as bytes and pass it straight in. Pull the envelope out of the
+receipt JSON at `credentialSubject.action.parameters_disclosure`:
+
+{/* snippet-check: no-run */}
+```python
+import json
+from agent_receipts import decrypt_disclosure
+
+# raw 32-byte private key written by --init-forensic-key (kept offline)
+priv = open("/path/to/forensic.key", "rb").read()
+
+# from: agent-receipts show <seq> --chain-id default --json > receipt.json
+receipt = json.load(open("receipt.json"))
+envelope = receipt["credentialSubject"]["action"]["parameters_disclosure"]
+
+params = decrypt_disclosure(envelope, priv)
+print(params)  # the original tool-call parameters
+```
+
 ### Types
 
 #### `ForensicKeyPair`

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -353,6 +353,29 @@ const params = await decryptDisclosure(env, kp.privateKey);
 // params == { mode: "r", path: "/etc/passwd" }
 ```
 
+### Recovering a stored disclosure
+
+In practice the envelope comes from a **stored receipt** and the private key from
+the file `agent-receipts-daemon --init-forensic-key` wrote — a raw 32-byte X25519
+key, not PEM, so read it as bytes and pass it straight in. Pull the envelope out
+of the receipt JSON at `credentialSubject.action.parameters_disclosure`:
+
+{/* snippet-check: skip */}
+```typescript
+import { readFileSync } from "node:fs";
+import { decryptDisclosure } from "@agnt-rcpt/sdk-ts";
+
+// raw 32-byte private key written by --init-forensic-key (kept offline)
+const priv = new Uint8Array(readFileSync("/path/to/forensic.key"));
+
+// from: agent-receipts show <seq> --chain-id default --json > receipt.json
+const receipt = JSON.parse(readFileSync("receipt.json", "utf8"));
+const env = receipt.credentialSubject.action.parameters_disclosure;
+
+const params = await decryptDisclosure(env, priv);
+// params holds the original tool-call parameters
+```
+
 ### Types
 
 #### `ForensicKeyPair`

--- a/site/src/content/docs/specification/parameter-disclosure.mdx
+++ b/site/src/content/docs/specification/parameter-disclosure.mdx
@@ -218,7 +218,7 @@ The dashboard feature is the intended forensic-recovery UX for the envelope. CLI
 
 ### Recover from code today
 
-You don't need the dashboard (or the planned forensic CLI) to read an envelope. **All three SDKs ship a decrypt helper that works today** — Python [`decrypt_disclosure`](/sdk-py/api-reference/#recovering-a-stored-disclosure), Go [`DecryptDisclosure`](/sdk-go/api-reference/#recovering-a-stored-disclosure), and TypeScript [`decryptDisclosure`](/sdk-ts/api-reference/#recovering-a-stored-disclosure). The file `--init-forensic-key` wrote is the raw 32-byte X25519 private key (no PEM, no decoding); pass it together with the envelope from `agent-receipts show <seq> --json` — found at `credentialSubject.action.parameters_disclosure` — to your SDK's helper. The plaintext lives only in your process; nothing is written back to the store.
+You don't need the dashboard (or the planned forensic CLI) to read an envelope. **All three SDKs ship a decrypt helper that works today** — Python [`decrypt_disclosure`](/sdk-py/api-reference/#recovering-a-stored-disclosure), Go [`DecryptDisclosure`](/sdk-go/api-reference/#recovering-a-stored-disclosure), and TypeScript [`decryptDisclosure`](/sdk-ts/api-reference/#recovering-a-stored-disclosure). The file `--init-forensic-key` wrote is the raw 32-byte X25519 private key (no PEM, no decoding); pass it together with the envelope from `agent-receipts show <seq> --chain-id <id> --json` — found at `credentialSubject.action.parameters_disclosure` — to your SDK's helper. The plaintext lives only in your process; nothing is written back to the store.
 
 ## GDPR and data handling
 

--- a/site/src/content/docs/specification/parameter-disclosure.mdx
+++ b/site/src/content/docs/specification/parameter-disclosure.mdx
@@ -175,12 +175,12 @@ The flag and environment variable have no array type, so the allowlist form is a
 ```bash
 # keyword mode
 AGENTRECEIPTS_PARAMETER_DISCLOSURE=high \
-AGENTRECEIPTS_FORENSIC_PUBLIC_KEY=/path/to/forensic.pub \
+AGENTRECEIPTS_FORENSIC_PUBLIC_KEY=/path/to/forensic.key.pub \
   agent-receipts-daemon
 
 # allowlist mode (comma-separated)
 agent-receipts-daemon \
-  --forensic-public-key /path/to/forensic.pub \
+  --forensic-public-key /path/to/forensic.key.pub \
   --parameter-disclosure system.command.execute,filesystem.file.delete
 ```
 

--- a/site/src/content/docs/specification/parameter-disclosure.mdx
+++ b/site/src/content/docs/specification/parameter-disclosure.mdx
@@ -128,7 +128,7 @@ The `"high"` mode uses the taxonomy's risk classification. The allowlist is a se
 </Aside>
 
 <Aside type="caution">
-Risk-based `"high"` only works when the emitter declares a taxonomic `action_type`. The daemon resolves an action's risk from its type via the taxonomy; if the emitter sends only a raw tool name, the daemon constructs a synthetic `<channel>.<tool>` type that does not match the taxonomy and resolves to `medium` — so `"high"` will not fire. Emitters that forward the resolved action type (the SDK, MCP proxy, and hook do this where they can) make `"high"` effective. If your emitter does not, prefer the explicit action-type allowlist or `true`. The daemon always resolves risk itself and never trusts an emitter-supplied risk, so an emitter cannot downgrade risk to dodge disclosure.
+Risk-based `"high"` only works when the emitter declares a taxonomic `action_type`. The daemon resolves an action's risk from its type via the taxonomy; if the emitter sends only a raw tool name, the daemon constructs a synthetic `<channel>.<tool>` type that does not match the taxonomy and resolves to `medium` — so `"high"` will not fire. Emitters that forward the resolved action type (the SDK, MCP proxy, and hook do this where they can) make `"high"` effective. If your emitter does not, prefer the explicit action-type allowlist or `true`. The daemon always resolves risk itself and never trusts an emitter-supplied risk, so an emitter cannot downgrade risk to dodge disclosure. **For a first smoke test, set `--parameter-disclosure true`** so every action is enveloped regardless of risk classification — otherwise `"high"` may legitimately produce no envelope and look like nothing happened.
 </Aside>
 
 ## Daemon configuration
@@ -218,7 +218,7 @@ The dashboard feature is the intended forensic-recovery UX for the envelope. CLI
 
 ### Recover from code today
 
-You don't need the dashboard (or the planned forensic CLI) to read an envelope. The **Python SDK** ships a decrypt helper that works today: the file `--init-forensic-key` wrote is the raw 32-byte X25519 private key (no PEM, no decoding), and you pass it together with the envelope from `agent-receipts show <seq> --json` — found at `credentialSubject.action.parameters_disclosure` — to [`decrypt_disclosure`](/sdk-py/api-reference/#recovering-a-stored-disclosure). The plaintext lives only in your process; nothing is written back to the store.
+You don't need the dashboard (or the planned forensic CLI) to read an envelope. **All three SDKs ship a decrypt helper that works today** — Python [`decrypt_disclosure`](/sdk-py/api-reference/#recovering-a-stored-disclosure), Go [`DecryptDisclosure`](/sdk-go/api-reference/#recovering-a-stored-disclosure), and TypeScript [`decryptDisclosure`](/sdk-ts/api-reference/#recovering-a-stored-disclosure). The file `--init-forensic-key` wrote is the raw 32-byte X25519 private key (no PEM, no decoding); pass it together with the envelope from `agent-receipts show <seq> --json` — found at `credentialSubject.action.parameters_disclosure` — to your SDK's helper. The plaintext lives only in your process; nothing is written back to the store.
 
 ## GDPR and data handling
 

--- a/site/src/content/docs/specification/parameter-disclosure.mdx
+++ b/site/src/content/docs/specification/parameter-disclosure.mdx
@@ -165,7 +165,7 @@ In TOML, `parameter_disclosure` accepts a boolean, a keyword string, or an array
 parameter_disclosure = "high"
 
 # Path to the forensic X25519 public key file (the raw 32-byte key)
-forensic_public_key = "/home/me/.local/share/agent-receipts/forensic.pub"
+forensic_public_key = "/home/me/.local/share/agent-receipts/forensic.key.pub"
 ```
 
 ### Environment variables / flags
@@ -215,6 +215,10 @@ Plaintext is never persisted. It exists only transiently in the forensic respond
 </Aside>
 
 The dashboard feature is the intended forensic-recovery UX for the envelope. CLI-based recovery for automated forensic pipelines is also planned (see ADR-0012 Phase B).
+
+### Recover from code today
+
+You don't need the dashboard (or the planned forensic CLI) to read an envelope. The **Python SDK** ships a decrypt helper that works today: the file `--init-forensic-key` wrote is the raw 32-byte X25519 private key (no PEM, no decoding), and you pass it together with the envelope from `agent-receipts show <seq> --json` — found at `credentialSubject.action.parameters_disclosure` — to [`decrypt_disclosure`](/sdk-py/api-reference/#recovering-a-stored-disclosure). The plaintext lives only in your process; nothing is written back to the store.
 
 ## GDPR and data handling
 


### PR DESCRIPTION
## What

Documentation fixes from running the HPKE parameter-disclosure journey end-to-end across **all three SDKs** (doc e2e fleet — Theo/Python, Raj/Go, Maya/TS). **The feature itself holds up everywhere**: emit → opaque `parameters_disclosure` envelope → SDK recovery all passed verbatim, and Maya cross-checked that re-canonicalizing recovered params reproduces `parameters_hash`. These address the doc-coherence gaps all three personas hit.

## Changes

**Forensic recovery is documented as working today, in every SDK**
- `parameter-disclosure.mdx` — the "Forensic recovery" section framed recovery as dashboard-only with a CLI "planned (ADR-0012 Phase B)", omitting that the SDKs already decrypt today. Added a "Recover from code today" note naming **Python `decrypt_disclosure`, Go `DecryptDisclosure`, TS `decryptDisclosure`**. (All three personas independently flagged this understatement.)
- `sdk-py` / `sdk-go` / `sdk-ts` api-reference — the `decrypt_disclosure`/`DecryptDisclosure`/`decryptDisclosure` examples only used an in-memory keypair. Added a "Recovering a stored disclosure" snippet to each: load the raw 32-byte `forensic.key` and pull the envelope from `agent-receipts show <seq> --json` (`credentialSubject.action.parameters_disclosure`).

**Emit with parameters**
- `quick-start.mdx` — the Python/TS/Go emit examples now pass tool-call parameters via the emit `input` field. Without it a docs-only adopter can't produce a non-empty disclosure envelope (Raj and Maya both had to read the SDK type definitions to discover `input`).

**Operational notes**
- `parameter-disclosure.mdx` — note to use `--parameter-disclosure true` for a first smoke test (`"high"` only fires on high-risk action types, so it can look like nothing happened).
- `daemon-setup.mdx` — troubleshooting entry for `chain "…" tail is already terminal` (a chain goes terminal after a mid-chain daemon exit, e.g. the disclosure-without-key refusal); recover with a new `--chain-id`.

**Key filename fix**
- `parameter-disclosure.mdx` `daemon.toml` example pointed `forensic_public_key` at `forensic.pub`, but `--init-forensic-key` writes `forensic.key.pub` — a verbatim copy pointed at a nonexistent file. Fixed.

## Verification

All three personas recovered real plaintext via the SDK helper; daemon-refusal-without-key, the opaque envelope, and chain validity all confirmed. Docs-only; no `spec/` protocol changes.

_Not included (per maintainer): Raj's Go `installation.mdx`/`overview.mdx` `go get`-target and packages-table nits — left for a separate call._