### PR TITLE
docs(dashboard): correct verify-signatures description to reflect two-mode behaviour

### DIFF
--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -17,15 +17,21 @@ The Agent Receipts Dashboard is a lightweight, read-only web UI for browsing rec
 
 - Browse receipts stored in any Agent Receipts SQLite database
 - Filter by action type, risk level, status, time range, and chain ID
-- Chain verification — validates hash linkage and sequence ordering
+- Chain verification — hash linkage, sequence ordering, and Ed25519 signature verification when a public key is supplied
 - Receipt detail view with raw JSON
 - Dark theme with risk-level color coding
 
 ## What "verify" checks
 
-:::caution[The dashboard does not verify signatures]
-The dashboard's chain verification checks **hash linkage and sequence ordering only — it does not verify Ed25519 signatures**, despite the button being labelled "Verify signatures". A green "valid" means the receipts link and are correctly ordered, **not** that their signatures were checked. For full cryptographic verification, use [`agent-receipts verify`](/reference/cli-commands/), which re-derives each hash *and* checks the signature against the public key.
-:::
+Clicking **Verify signatures** on a chain runs one of two modes depending on whether a public key is supplied:
+
+**Without a public key — structural verification only**
+Checks hash linkage and sequence ordering. A green "valid" means the receipts link and are correctly ordered; signatures are not checked.
+
+**With a public key — full cryptographic verification**
+Enter your Ed25519 public key in PEM format in the textarea beside the **Verify signatures** button. The dashboard passes the key to `/api/chains/:id/verify`, which calls the SDK's `receipt.Verify` for each receipt — re-deriving each hash *and* validating the Ed25519 signature. Each receipt in the response carries a `SignatureValid` flag.
+
+For command-line verification, [`agent-receipts verify`](/reference/cli-commands/) provides the same full check without a browser.
 
 :::caution[Known issue: false negatives]
 The dashboard (v0.3.0) can report a chain as **broken** when `agent-receipts verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalization. If the dashboard flags a break, confirm with `agent-receipts verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).

--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -29,7 +29,7 @@ Clicking **Verify signatures** on a chain runs one of two modes depending on whe
 Checks hash linkage and sequence ordering. A green "valid" means the receipts link and are correctly ordered; signatures are not checked.
 
 **With a public key — full cryptographic verification**
-Enter your Ed25519 public key in PEM format in the textarea beside the **Verify signatures** button. The dashboard passes the key to `/api/chains/:id/verify`, which calls the SDK's `receipt.Verify` for each receipt — re-deriving each hash *and* validating the Ed25519 signature. Each receipt in the response carries a `SignatureValid` flag.
+Enter your Ed25519 public key in PEM format in the textarea beside the **Verify signatures** button. The dashboard passes the key to `/api/chains/:id/verify`, which performs hash linkage and sequence checks as usual and additionally calls the SDK's `receipt.Verify` for each receipt to validate its Ed25519 signature. Each receipt in the response carries a `signature_valid` field.
 
 For command-line verification, [`agent-receipts verify`](/reference/cli-commands/) provides the same full check without a browser.
 


### PR DESCRIPTION
## Summary

Fixes #733.

The overview page stated the dashboard never verifies Ed25519 signatures. In reality it does — when a public key is supplied via the PEM textarea, the server calls `receipt.Verify` for each receipt and returns a `SignatureValid` flag per receipt. Without a key it falls back to structural checks only (hash linkage + sequence ordering).

- Rewrites the "What 'verify' checks" section to describe both modes accurately
- Updates the features bullet to mention Ed25519 verification when a public key is supplied
- Retains the #719 false-negative caution (still open)

## Changes

- `site/src/content/docs/dashboard/overview.mdx` — one file, docs only