### PR TITLE
chore(release): prep sdk-ts/0.11.1 and sdk-py/0.11.1

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -11,6 +11,12 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-03
+
+### Added
+
+- **`DAEMON_PROTOCOL_RANGE` re-export** ([#655](https://github.com/agent-receipts/ar/pull/655), Gate #8). Exposes the SDK's declared daemon-protocol version range (`DaemonProtocolRange(min=1, max=1)`) at the package root so the release-time daemon ↔ SDK compatibility check (`scripts/daemon_protocol/check.py`) can read it. The constant was added in source for 0.11.0 but merged to main after the 0.11.0 tag was cut, so the published 0.11.0 package did not include it — this release publishes the export.
+
 ## [0.11.0] - 2026-06-02
 
 ### Breaking Changes

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.11.0"
+version = "0.11.1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -11,6 +11,12 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-03
+
+### Added
+
+- **`DAEMON_PROTOCOL_RANGE` re-export** ([#655](https://github.com/agent-receipts/ar/pull/655), Gate #8). Exposes the SDK's declared daemon-protocol version range (`{ min: 1, max: 1 }`) at the package root so the release-time daemon ↔ SDK compatibility check (`scripts/daemon_protocol/check.py`) can read it. The constant was added in source for 0.11.0 but merged to main after the 0.11.0 tag was cut, so the published 0.11.0 package did not include it — this release publishes the export.
+
 ## [0.11.0] - 2026-06-02
 
 ### Breaking Changes

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## Summary

Patch release that publishes the `DAEMON_PROTOCOL_RANGE` re-export to npm and PyPI, which has been missing from every published 0.11.x package.

## Why

Gate #8 (daemon ↔ SDK protocol compatibility, `scripts/daemon_protocol/check.py`) imports `DAEMON_PROTOCOL_RANGE` from the latest published TS and Python SDK packages. The constant was added to both SDKs' source in #655 but merged to main **after** the \`sdk-ts/0.11.0\` and \`sdk-py/0.11.0\` tags were cut on 2026-06-01, so the published 0.11.0 packages do not contain the export.

As a result, Gate #8 has been failing on every daemon release since \`daemon/v0.14.0\`:

- \`daemon/v0.14.0\` release: failed
- \`daemon/v0.15.0\` release: failed
- \`daemon/v0.16.0\` release: failed (run [26858330770](https://github.com/agent-receipts/ar/actions/runs/26858330770))

The release jobs themselves succeed (binaries are published); only the compatibility-check jobs fail. This PR ships the export so subsequent daemon releases pass Gate #8.

## Changes

- Bump \`sdk/ts/package.json\` 0.11.0 → 0.11.1
- Bump \`sdk/py/pyproject.toml\` 0.11.0 → 0.11.1 (\`uv.lock\` regenerated)
- Add a 0.11.1 entry to both CHANGELOGs documenting the missing export

No functional changes. The source code already re-exports \`DAEMON_PROTOCOL_RANGE\` from both \`sdk/ts/src/index.ts\` and \`sdk/py/src/agent_receipts/__init__.py\` — this release just publishes what's already there.

## Test plan

- [x] \`pnpm test\` — 419 / 419 passed
- [x] \`uv run pytest -q\` — 445 passed, 7 skipped
- [ ] After merge: tag \`sdk-ts-v0.11.1\` and \`sdk-py-v0.11.1\` (one at a time per release-tag-push convention)
- [ ] Re-run Gate #8 against the next daemon release (or manually) to confirm green