### PR TITLE
Gate #8 closure + HPKE disclosure + daemon auto-advance chain ID + sdk 0.11.1 patch

### DIFF
--- a/docs/operations/current.md
+++ b/docs/operations/current.md
@@ -20,7 +20,7 @@
 
 ## Last updated
 
-`2026-06-03` — Closed issues #476 and #488 (implementations had shipped via #671/#670 but issues were never closed). #656 (`sbom-deps-match-gate`) shipped via #699 (merged 2026-06-01), marked done. #655 (`daemon-sdk-protocol-compat-gate`) in-progress: `DAEMON_PROTOCOL_RANGE` constant landed in TS/Python 0.11.1 (#737); gate script pending. ROADMAP updated for #476/#488 via #738.
+`2026-06-03` — Closed issues #476 and #488 (implementations had shipped via #671/#670 but issues were never closed). ROADMAP updated via #738. Gate #10 (#656, `sbom-deps-match-gate`) shipped via #699 (merged 2026-06-01). Gate #8 (#655, `daemon-sdk-protocol-compat-gate`) shipped via #705 (merged 2026-06-01) — `scripts/daemon_protocol/check.py` + protocol-version ranges on all four sides + live handshake, wired into all release workflows. sdk-ts/0.11.1 + sdk-py/0.11.1 prepped via #737 to publish the missing `DAEMON_PROTOCOL_RANGE` export; tags needed after this merges to main.
 
 > **ADR numbering note.** The numbers settled after three landed in close succession: **ADR-0023** = canonical Go module path (#640/#642), **ADR-0024** = project verification contract (#658), **ADR-0025** = emit failure contract (#643, merged). Earlier snapshots had 0024/0025 swapped.
 
@@ -39,7 +39,7 @@ A closure is a coherent piece of work that retires a category of audit findings 
 - **`closure-0` (spec/context versioning) — SHIPPED.**
 - **`closure-1` (Quick Start coherence + Go module identity) — COMPLETE.** All Quick Start / README / ADR nodes shipped, including `homepage-rewrite` (#644) and `ADR-0023-go-module-path` (#640). ADR-0023 follow-ups `collector-tagging` (#638) and `d5-release-verification` (#639) both closed 2026-05-30. Tracker #598 can now close.
 - **`closure-2` (emit failure contract) — SHIPPED.** ADR-0025 implemented across all three SDKs (#643, merged 2026-05-28). Issue #599 closed.
-- **`verification-contract` (ADR-0024) — SHIPPED & BUILDING GATES.** ADR-0024 landed (#658). Gate #1 type-check shipped (#632); Gate #1 execute mode shipped (#666, closes #650). Gate #2 (release round-trip) shipped (#664, closes #651). Gate #5 (MDX snippet execution) shipped (#667, closes #652). Gates #3/#4/#6/#7 are future siblings.
+- **`verification-contract` (ADR-0024) — SHIPPED & BUILDING GATES.** ADR-0024 landed (#658). Gate #1 type-check shipped (#632); Gate #1 execute mode shipped (#666, closes #650). Gate #2 (release round-trip) shipped (#664, closes #651). Gate #5 (MDX snippet execution) shipped (#667, closes #652). Gate #6 (schema-conformance) shipped (#696, closes #653). Gate #7 (byte-identity) shipped (#698, closes #654). Gate #8 (daemon ↔ SDK protocol compatibility) shipped (#705, closes #655). Gate #10 (dependency-manifest/SBOM) shipped (#699, closes #656). Gates #3/#4/#9 tracked under ADR-0021 (#597).
 - **`v1-blockers`** (orthogonal to closures; tracked by `v1-blocker` label) — #534 (AWS KMS signers) shipped for TS + Python (#663); #535 (ephemeral-compute deployment guide) shipped (#660). Foreground for the v1 release path; not part of the audit response.
 - **`daemon-v2`** — Otto's foreground design work. Not yet broken into nodes here; add when it becomes farmable.
 
@@ -391,17 +391,20 @@ A closure is a coherent piece of work that retires a category of audit findings 
 - notes: fail-loud on bare-filename DB path fallback. Closed as not-planned.
 
 #### `daemon-sdk-protocol-compat-gate` (#655)
-- state: in-progress
+- state: shipped
 - depends_on: []
-- issues: #655 (open)
-- notes: Gate #8 (ADR-0024) — declare daemon-protocol version ranges on SDK and daemon sides; assert intersection at release time. `DAEMON_PROTOCOL_RANGE` constant added to TS/Python SDKs and shipped in 0.11.1 (#737); release-gate verification script (`scripts/daemon_protocol/check.py`) still pending.
+- issues: #655 (closed)
+- prs: #705 (merged)
+- artifacts: `scripts/daemon_protocol/check.py`; `daemon/protocol.go`; `sdk/go/emitter/{emitter,protocol_test}.go`; `daemon-protocol` CI job in all four release workflows
+- notes: Gate #8 shipped 2026-06-01. Protocol-version ranges declared on all four sides (daemon, Go SDK, TS SDK, Python SDK). Static range-intersection + live handshake wired into all four release workflows. sdk-ts/0.11.0 and sdk-py/0.11.0 were tagged before #705 landed and lacked the `DAEMON_PROTOCOL_RANGE` re-export; sdk-ts/0.11.1 + sdk-py/0.11.1 patch releases (prepped in #737) fix this once published.
 
 #### `sbom-deps-match-gate` (#656)
 - state: shipped
 - depends_on: []
 - issues: #656 (closed)
 - prs: #699 (merged)
-- notes: Gate #10 (ADR-0024) — per-SDK SBOM at release time; declared-vs-installed assertion. Merged 2026-06-01.
+- artifacts: `scripts/dependency_manifest/check.py`; `dependency-manifest` CI job in all three SDK release workflows
+- notes: Gate #10 shipped 2026-06-01. Per-SDK SBOM at release time; installed deps asserted to match declared deps; unexplained eager dependencies fail the release.
 
 ---
 
@@ -418,11 +421,9 @@ A closure is a coherent piece of work that retires a category of audit findings 
 
 ## Next farmable (computed)
 
-As of `2026-06-03`, wave-1 and wave-2 items are fully shipped. One verification gate remains:
+As of `2026-06-03`, all wave-1 and wave-2 items are shipped. Gate #8 (#655) shipped via #705 and Gate #10 (#656) shipped via #699 — both on 2026-06-01, the day after the ops doc was last updated.
 
-- **`daemon-sdk-protocol-compat-gate` (#655)** — Gate #8: in-progress. `DAEMON_PROTOCOL_RANGE` constant shipped (TS/Python 0.11.1); release-gate verification script still needed.
-
-No other active nodes are blocked.
+No verification-gate nodes remain open. The next farmable work is in the background queue below.
 
 ---
 


### PR DESCRIPTION
## Summary

Corrects the ops doc to reflect Gate #8's actual state: `scripts/daemon_protocol/check.py` shipped in PR #705 (merged 2026-06-01), so #655 is `shipped`, not `in-progress` as PR #738 recorded it. Also adds artifact detail to the #656 node.

### Gate #8 — closes #655

Gate #8 (daemon ↔ SDK protocol compatibility) shipped via #705 on 2026-06-01, but sdk-ts/0.11.0 and sdk-py/0.11.0 were tagged the same day _before_ #705 landed — those packages are missing the `DAEMON_PROTOCOL_RANGE` re-export, so Gate #8 has been failing on every daemon release since v0.14.0. The sdk-ts/0.11.1 + sdk-py/0.11.1 version bumps (prepped in #737, already on main) fix this once tagged.

**After merge:** tag `sdk/ts/v0.11.1` and `sdk/py/v0.11.1` on main; the release workflows publish to npm/PyPI and re-run Gate #8 against the latest daemon.

### What changed

- `docs/operations/current.md`: `daemon-sdk-protocol-compat-gate` (#655) corrected from `in-progress` → `shipped`, PR and artifact details added. `sbom-deps-match-gate` (#656) artifact detail added. Closure summary updated to list Gates #6–#8 and #10 as shipped. "Next farmable" updated — no verification-gate nodes remain open.

## Test plan

- [x] `python3 scripts/daemon_protocol/test_check.py` — 33/33 passed
- [x] `uvx ruff@0.15.15 check scripts/daemon_protocol/` — clean
- [ ] After merge: tag `sdk/ts/v0.11.1` and `sdk/py/v0.11.1` — release workflows publish packages and verify Gate #8 passes against latest daemon

Closes #655