### PR TITLE
fix(site): point GitHub nav link to the ar repo

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -51,7 +51,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/agent-receipts",
+          href: "https://github.com/agent-receipts/ar",
         },
       ],
       components: {


### PR DESCRIPTION
The GitHub icon in the site header linked to the org root (`github.com/agent-receipts`). This updates it to link directly to the repository (`github.com/agent-receipts/ar`).

The `rel="me"` identity link and the `sameAs` schema.org field retain the org URL, which is appropriate for those contexts.