### PR TITLE
feat(correlation): add correlation_id to link hook pre-check and proxy post-action receipts

### DIFF
--- a/cross-sdk-tests/canonicalization_vectors.json
+++ b/cross-sdk-tests/canonicalization_vectors.json
@@ -504,6 +504,43 @@
       "expectedHash": "sha256:9e43a72dab99b0104bfdd05cebe473281fdc84153a30841d2ea044ab991c1e29"
     },
     {
+      "name": "receipt_correlation_id_field",
+      "rule": "rule2_optional_present_is_emitted",
+      "description": "A receipt with correlation_id set on credentialSubject. Verifies that correlation_id is included in the canonical form and therefore in the hash — it must not be silently stripped by any SDK.",
+      "mustContainSubstring": "\"correlation_id\"",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000006",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.4.0",
+        "issuer": { "id": "did:agent:test", "name": "test-agent" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test", "type": "HumanPrincipal" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000006",
+            "type": "mcp.tool_call",
+            "tool_name": "list_issues",
+            "risk_level": "low",
+            "target": { "system": "github" },
+            "parameters_hash": "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          },
+          "correlation_id": "toolu_01AAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      "expectedHash": "sha256:c4921f75f78e01dee2df94b9e7eb22a1bf076565d631a702e4c2f7eb582f7b90"
+    },
+    {
       "name": "receipt_signature_preservation_legacy_0_2_0",
       "rule": "signature_preservation",
       "description": "The three-receipt terminalChain from cross-sdk-tests/v020_vectors.json was signed under the pre-sweep (0.2.0) canonicaliser. Running the post-sweep canonicaliser on the same unsigned bytes MUST produce identical canonical output, and the existing proof.proofValue MUST still verify. This is the signature-preservation invariant from ADR-0009 §4. Implementation: this vector reuses the v020 fixtures by reference; the test harness loads both files and asserts round-trip equality.",

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -105,6 +105,7 @@ type EmitterFrame struct {
 	OperatorID     string          `json:"operator_id,omitempty"`
 	OperatorName   string          `json:"operator_name,omitempty"`
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	CorrelationID  string          `json:"correlation_id,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -582,10 +583,11 @@ func (p *Pipeline) buildAndSign(
 	}
 
 	return p.signAndHash(receipt.CreateInput{
-		Issuer:    issuerFromFrame(f, p.IssuerID),
-		Principal: receipt.Principal{ID: "did:user:unknown"},
-		Action:    action,
-		Outcome:   outcome,
+		Issuer:        issuerFromFrame(f, p.IssuerID),
+		Principal:     receipt.Principal{ID: "did:user:unknown"},
+		Action:        action,
+		Outcome:       outcome,
+		CorrelationID: f.CorrelationID,
 		Chain: receipt.Chain{
 			Sequence:            int(alloc.Sequence),
 			PreviousReceiptHash: alloc.PrevHash,

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -363,6 +363,9 @@ func validateFrame(f *EmitterFrame) error {
 	if len(f.IdempotencyKey) > maxIdentityFieldLen {
 		return fmt.Errorf("idempotency_key exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.IdempotencyKey))
 	}
+	if len(f.CorrelationID) > maxIdentityFieldLen {
+		return fmt.Errorf("correlation_id exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.CorrelationID))
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -270,6 +270,22 @@ func TestValidateFrame_RejectsOversizeIdempotencyKey(t *testing.T) {
 	}
 }
 
+// TestValidateFrame_RejectsOversizeCorrelationID pins the per-field cap so an
+// oversized correlation_id cannot inflate receipts.
+func TestValidateFrame_RejectsOversizeCorrelationID(t *testing.T) {
+	f := &EmitterFrame{
+		Version:       "1",
+		SessionID:     "s",
+		Channel:       "mcp",
+		Tool:          EmitterTool{Name: "t"},
+		Decision:      "allowed",
+		CorrelationID: strings.Repeat("x", maxIdentityFieldLen+1),
+	}
+	if err := validateFrame(f); err == nil {
+		t.Error("validateFrame accepted an oversize correlation_id; want rejection")
+	}
+}
+
 func TestProcess_OutcomeStatus(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/dist/sdk-go-deprecation/receipt/types.go
+++ b/dist/sdk-go-deprecation/receipt/types.go
@@ -269,6 +269,7 @@ type CredentialSubject struct {
 	Outcome       Outcome        `json:"outcome"`
 	Authorization *Authorization `json:"authorization,omitempty"`
 	Chain         Chain          `json:"chain"`
+	CorrelationID string         `json:"correlation_id,omitempty"`
 }
 
 // Proof contains the Ed25519 signature.

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -26,10 +26,6 @@ type claudeCodeFrame struct {
 //
 // The returned sessionID is the host-supplied session identifier from the
 // frame; it is the empty string when absent.
-//
-// Note: tool_use_id is parsed but not forwarded — emitter.Event has no
-// correlation-ID field. A follow-up can add one to the wire format once
-// ADR-0010 is amended.
 func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string, error) {
 	if len(stdin) == 0 {
 		return emitter.Event{}, "", errors.New("empty stdin")
@@ -56,9 +52,10 @@ func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string,
 	}
 
 	ev := emitter.Event{
-		Channel:  "claude-code",
-		Tool:     emitter.Tool{Name: f.ToolName},
-		Decision: decision,
+		Channel:       "claude-code",
+		Tool:          emitter.Tool{Name: f.ToolName},
+		Decision:      decision,
+		CorrelationID: f.ToolUseID,
 	}
 	// Only set Input/Output when non-empty; the emitter rejects non-nil empty
 	// slices and the daemon expects nil to mean "no payload".

--- a/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/emitter_integration_test.go
@@ -197,6 +197,7 @@ func TestEmitToContext_AllowedToolCall(t *testing.T) {
 		"",
 		"allowed",
 		"jsonrpc-req-42",
+		"",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
@@ -234,6 +235,7 @@ func TestEmitToContext_DeniedToolCall(t *testing.T) {
 		"blocked by policy: delete_secrets matches block rule",
 		"denied",
 		"",
+		"",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
@@ -258,7 +260,7 @@ func TestEmitToContext_MultipleEvents(t *testing.T) {
 	}
 
 	for _, ev := range events {
-		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision, "")
+		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision, "", "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, len(events), 5*time.Second)
@@ -303,7 +305,7 @@ func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
 
 	start := time.Now()
 	// emitToContext logs the drop via log.Printf — that's fine for tests.
-	emitToContext(em, "srv", "noop", nil, nil, "", "allowed", "")
+	emitToContext(em, "srv", "noop", nil, nil, "", "allowed", "", "")
 	elapsed := time.Since(start)
 
 	// 25ms dial timeout + 100ms write deadline = 125ms worst-case. We allow
@@ -331,7 +333,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 
 	// nil input and output are valid: the emitter accepts them and the daemon
 	// treats them as absent. No panic, no error returned.
-	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed", "")
+	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed", "", "")
 }
 
 // TestEmitToContext_NilEmitterIsNoOp guards the nil-emitter path in serve():
@@ -341,7 +343,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 // explicit guard at the call sites is kept for clarity.
 func TestEmitToContext_NilEmitterIsNoOp(t *testing.T) {
 	// Must not panic.
-	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed", "")
+	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed", "", "")
 }
 
 // TestEmitToContext_SessionIDPropagatesToReceipts verifies the ADR-0010 OQ4
@@ -355,7 +357,7 @@ func TestEmitToContext_SessionIDPropagatesToReceipts(t *testing.T) {
 	em := newSilentEmitter(t, d.cfg.SocketPath, sid)
 
 	for i := 0; i < 3; i++ {
-		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed", "")
+		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed", "", "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 3, 5*time.Second)

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -225,6 +225,7 @@ func serve() int {
 		toolName       string
 		argJSON        json.RawMessage
 		idempotencyKey string
+		correlationID  string
 	}
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
@@ -313,6 +314,7 @@ func serve() int {
 					toolName:       toolName,
 					argJSON:        argJSON,
 					idempotencyKey: jsonrpcID,
+					correlationID:  params.ToolUseID(),
 				}
 				pendingMu.Unlock()
 
@@ -322,7 +324,7 @@ func serve() int {
 					pendingMu.Lock()
 					delete(pendingCalls, jsonrpcID)
 					pendingMu.Unlock()
-					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID)
+					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID, params.ToolUseID())
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -348,7 +350,7 @@ func serve() int {
 						pendingMu.Lock()
 						delete(pendingCalls, jsonrpcID)
 						pendingMu.Unlock()
-						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID)
+						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID, params.ToolUseID())
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(
@@ -412,7 +414,7 @@ func serve() int {
 				if resultStr != "" && json.Valid([]byte(resultStr)) {
 					outputRaw = json.RawMessage(resultStr)
 				}
-				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed", pc.idempotencyKey)
+				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed", pc.idempotencyKey, pc.correlationID)
 			}
 		}
 
@@ -676,7 +678,11 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 // of the same logical operation share a value and auditors can tell a
 // legitimate retry from a duplicated emission. Empty when no id was present;
 // the emitter omits the field from the frame in that case.
-func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision, idempotencyKey string) {
+//
+// correlationID is the Claude Code tool_use_id from _meta, used to link this
+// proxy post-action receipt to the hook pre-check receipt for the same
+// logical tool invocation. Empty when not available (non-Claude-Code clients).
+func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision, idempotencyKey, correlationID string) {
 	if em == nil {
 		return
 	}
@@ -688,6 +694,7 @@ func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input
 		Error:          errStr,
 		Decision:       decision,
 		IdempotencyKey: idempotencyKey,
+		CorrelationID:  correlationID,
 	}); err != nil {
 		log.Printf("mcp-proxy: emitter: %v", err)
 	}

--- a/mcp-proxy/cmd/mcp-proxy/main.go
+++ b/mcp-proxy/cmd/mcp-proxy/main.go
@@ -322,9 +322,10 @@ func serve() int {
 					log.Printf("mcp-proxy: BLOCKED %s (rule: %s, risk: %d)", toolName, decision.RuleName, riskScore)
 					emitPolicyEvent(toolName, decision.RuleName, riskScore, "block", approvalURL, "blocked", 0)
 					pendingMu.Lock()
+					blockedCorrelationID := pendingCalls[jsonrpcID].correlationID
 					delete(pendingCalls, jsonrpcID)
 					pendingMu.Unlock()
-					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID, params.ToolUseID())
+					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID, blockedCorrelationID)
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -348,9 +349,10 @@ func serve() int {
 						emitPolicyEvent(toolName, decision.RuleName, riskScore, "pause", approvalURL, string(approvalStatus), approvalWaitUs/1000)
 						code, message := approvalRejectionResponse(toolName, decision.RuleName, riskScore, approvalID, approvalStatus, *approvalWait)
 						pendingMu.Lock()
+						deniedCorrelationID := pendingCalls[jsonrpcID].correlationID
 						delete(pendingCalls, jsonrpcID)
 						pendingMu.Unlock()
-						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID, params.ToolUseID())
+						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID, deniedCorrelationID)
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -839,7 +839,7 @@ func TestDiagnoseConfigNoApproverReturnsNotConfigured(t *testing.T) {
 
 func TestEmitToContextNilEmitterNoOp(t *testing.T) {
 	// Must not panic with nil emitter.
-	emitToContext(nil, "server", "tool", nil, nil, "", "allowed", "")
+	emitToContext(nil, "server", "tool", nil, nil, "", "allowed", "", "")
 }
 
 // ---------------------------------------------------------------------------

--- a/mcp-proxy/internal/proxy/jsonrpc.go
+++ b/mcp-proxy/internal/proxy/jsonrpc.go
@@ -19,6 +19,21 @@ type Message struct {
 type ToolCallParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments,omitempty"`
+	// Meta holds the MCP _meta field. Claude Code populates
+	// _meta["claudecode/toolUseId"] with the tool_use_id from the hook payload,
+	// enabling correlation between hook pre-check receipts and proxy post-action
+	// receipts for the same logical tool invocation.
+	Meta map[string]string `json:"_meta,omitempty"`
+}
+
+// ToolUseID returns the Claude Code tool_use_id from _meta, or empty string
+// if absent. This is the correlation key linking a hook receipt to its paired
+// proxy receipt.
+func (p *ToolCallParams) ToolUseID() string {
+	if p.Meta == nil {
+		return ""
+	}
+	return p.Meta["claudecode/toolUseId"]
 }
 
 // ParseMessage attempts to parse a JSON-RPC message from a line.

--- a/mcp-proxy/internal/proxy/jsonrpc.go
+++ b/mcp-proxy/internal/proxy/jsonrpc.go
@@ -23,17 +23,24 @@ type ToolCallParams struct {
 	// _meta["claudecode/toolUseId"] with the tool_use_id from the hook payload,
 	// enabling correlation between hook pre-check receipts and proxy post-action
 	// receipts for the same logical tool invocation.
-	Meta map[string]string `json:"_meta,omitempty"`
+	// Typed as map[string]any (not map[string]string) so that non-string values
+	// in _meta do not cause json.Unmarshal to fail and silently bypass policy.
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // ToolUseID returns the Claude Code tool_use_id from _meta, or empty string
-// if absent. This is the correlation key linking a hook receipt to its paired
-// proxy receipt.
+// if absent or not a string. This is the correlation key linking a hook
+// receipt to its paired proxy receipt.
 func (p *ToolCallParams) ToolUseID() string {
 	if p.Meta == nil {
 		return ""
 	}
-	return p.Meta["claudecode/toolUseId"]
+	v, ok := p.Meta["claudecode/toolUseId"]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
 }
 
 // ParseMessage attempts to parse a JSON-RPC message from a line.

--- a/mcp-proxy/internal/proxy/jsonrpc_test.go
+++ b/mcp-proxy/internal/proxy/jsonrpc_test.go
@@ -133,3 +133,53 @@ func TestParseMessageBatchReturnsNil(t *testing.T) {
 		t.Error("expected nil for batch (JSON array) message")
 	}
 }
+
+func TestToolUseID(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			name:   "string value extracted",
+			params: `{"name":"t","_meta":{"claudecode/toolUseId":"toolu_01ABC"}}`,
+			want:   "toolu_01ABC",
+		},
+		{
+			name:   "absent _meta returns empty",
+			params: `{"name":"t"}`,
+			want:   "",
+		},
+		{
+			name:   "missing key returns empty",
+			params: `{"name":"t","_meta":{"other":"x"}}`,
+			want:   "",
+		},
+		{
+			name:   "non-string value returns empty (no parse failure)",
+			params: `{"name":"t","_meta":{"claudecode/toolUseId":12345}}`,
+			want:   "",
+		},
+		{
+			name:   "null value returns empty (no parse failure)",
+			params: `{"name":"t","_meta":{"claudecode/toolUseId":null}}`,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` + tt.params + `}`)
+			msg := ParseMessage(line)
+			if msg == nil {
+				t.Fatal("expected non-nil message")
+			}
+			p, err := msg.ParseToolCallParams()
+			if err != nil {
+				t.Fatalf("ParseToolCallParams error: %v", err)
+			}
+			if got := p.ToolUseID(); got != tt.want {
+				t.Errorf("ToolUseID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/go/chain/chain.go
+++ b/sdk/go/chain/chain.go
@@ -52,6 +52,9 @@ type EmitInput struct {
 	// TerminationStatus sets chain.status when Terminal is true and the value
 	// is a valid wire value (spec §7.3.3); otherwise dropped by receipt.Create.
 	TerminationStatus receipt.ChainStatus
+	// CorrelationID links related receipts for the same logical tool invocation.
+	// See receipt.CredentialSubject.CorrelationID.
+	CorrelationID string
 }
 
 // Options configures a [ReceiptChain].
@@ -213,6 +216,7 @@ func (c *ReceiptChain) Emit(ctx context.Context, input EmitInput) (receipt.Agent
 		ResponseBody:      input.ResponseBody,
 		Terminal:          input.Terminal,
 		TerminationStatus: input.TerminationStatus,
+		CorrelationID:     input.CorrelationID,
 	})
 	signed, err := receipt.Sign(unsigned, c.privateKeyPEM, c.verificationMethod)
 	if err != nil {

--- a/sdk/go/chain/chain_test.go
+++ b/sdk/go/chain/chain_test.go
@@ -323,6 +323,33 @@ func TestResumeExistingChain(t *testing.T) {
 	}
 }
 
+func TestEmitPreservesCorrelationID(t *testing.T) {
+	keys := testKeys(t)
+	inmem := emitters.NewInMemory()
+	rc, err := chain.New(chain.Options{
+		ChainID:            "chain_test",
+		PrivateKeyPEM:      keys.PrivateKey,
+		VerificationMethod: verificationMethod,
+		Emitter:            inmem,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const want = "toolu_01AAAAAAAAAAAAAAAAAAAAAA"
+	input := emitInput()
+	input.CorrelationID = want
+
+	ctx := context.Background()
+	r, err := rc.Emit(ctx, input)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if got := r.CredentialSubject.CorrelationID; got != want {
+		t.Errorf("CorrelationID = %q, want %q", got, want)
+	}
+}
+
 type failingEmitter struct {
 	inner    *emitters.InMemoryEmitter
 	failNext bool

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -135,6 +135,12 @@ type Event struct {
 	// duplicated emission. Optional; omitted from the frame when empty.
 	// See spec §7.3.6 and ADR-0019 §S5.
 	IdempotencyKey string
+
+	// CorrelationID links related receipts for the same logical tool invocation.
+	// Populated from the runtime's tool-use correlation token (Claude Code:
+	// tool_use_id). The daemon stamps it onto credentialSubject.correlation_id.
+	// Optional; omitted from the frame when empty.
+	CorrelationID string
 }
 
 // Option configures an Emitter at construction.
@@ -294,6 +300,7 @@ type frame struct {
 	OperatorID     string          `json:"operator_id,omitempty"`
 	OperatorName   string          `json:"operator_name,omitempty"`
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	CorrelationID  string          `json:"correlation_id,omitempty"`
 }
 
 type frameTool struct {
@@ -415,6 +422,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		OperatorID:     operatorID,
 		OperatorName:   operatorName,
 		IdempotencyKey: ev.IdempotencyKey,
+		CorrelationID:  ev.CorrelationID,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/receipt/create.go
+++ b/sdk/go/receipt/create.go
@@ -34,6 +34,10 @@ type CreateInput struct {
 	// TerminationStatus without Terminal is also silently dropped; the spec
 	// requires status to coexist with terminal.
 	TerminationStatus ChainStatus
+
+	// CorrelationID links related receipts for the same logical tool invocation.
+	// See CredentialSubject.CorrelationID.
+	CorrelationID string
 }
 
 // Create builds an unsigned AgentReceipt from structured inputs.
@@ -57,6 +61,7 @@ func Create(input CreateInput) UnsignedAgentReceipt {
 		Chain:         input.Chain,
 		Intent:        input.Intent,
 		Authorization: input.Authorization,
+		CorrelationID: input.CorrelationID,
 	}
 
 	// Compute response_hash when a response body is supplied.

--- a/sdk/go/receipt/create_test.go
+++ b/sdk/go/receipt/create_test.go
@@ -100,3 +100,39 @@ func TestCreateWithOptionalFields(t *testing.T) {
 		t.Errorf("expected 2 scopes, got %d", len(r.CredentialSubject.Authorization.Scopes))
 	}
 }
+
+func TestCreatePreservesCorrelationID(t *testing.T) {
+	const want = "toolu_01AAAAAAAAAAAAAAAAAAAAAA"
+	r := Create(CreateInput{
+		Issuer:        Issuer{ID: "did:agent:test"},
+		Principal:     Principal{ID: "did:user:alice"},
+		Action:        Action{Type: "mcp.tool_call", RiskLevel: RiskLow},
+		Outcome:       Outcome{Status: StatusSuccess},
+		Chain:         Chain{Sequence: 1, ChainID: "chain-1"},
+		CorrelationID: want,
+	})
+	if got := r.CredentialSubject.CorrelationID; got != want {
+		t.Errorf("CorrelationID = %q, want %q", got, want)
+	}
+}
+
+func TestCreateOmitsEmptyCorrelationID(t *testing.T) {
+	r := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:alice"},
+		Action:    Action{Type: "mcp.tool_call", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	if r.CredentialSubject.CorrelationID != "" {
+		t.Errorf("expected empty CorrelationID, got %q", r.CredentialSubject.CorrelationID)
+	}
+	// Verify it's absent from the canonical JSON (omitempty).
+	canonical, err := Canonicalize(r)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	if strings.Contains(canonical, "correlation_id") {
+		t.Errorf("canonical JSON contains correlation_id when field is empty: %s", canonical)
+	}
+}

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -215,6 +215,10 @@ type CredentialSubject struct {
 	Outcome       Outcome        `json:"outcome"`
 	Authorization *Authorization `json:"authorization,omitempty"`
 	Chain         Chain          `json:"chain"`
+	// CorrelationID links related receipts for the same logical tool invocation
+	// (e.g. hook pre-check to MCP proxy post-action). Populated from the
+	// runtime's tool-use correlation token; absent when not available.
+	CorrelationID string `json:"correlation_id,omitempty"`
 }
 
 // Proof contains the Ed25519 signature.

--- a/sdk/py/src/agent_receipts/receipt/create.py
+++ b/sdk/py/src/agent_receipts/receipt/create.py
@@ -65,6 +65,7 @@ class CreateReceiptInput(BaseModel):
     # Issuer-asserted termination reason, applied only when terminal=True.
     # MUST be "complete" or "interrupted" (spec §7.3.3).
     termination_status: Literal["complete", "interrupted"] | None = None
+    correlation_id: str | None = None
 
 
 def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
@@ -140,6 +141,8 @@ def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
         cs_data["intent"] = input.intent
     if input.authorization is not None:
         cs_data["authorization"] = input.authorization
+    if input.correlation_id:
+        cs_data["correlation_id"] = input.correlation_id
 
     receipt_data: dict[str, Any] = {
         "@context": list(CONTEXT),

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -268,6 +268,7 @@ class CredentialSubject(BaseModel):
     outcome: Outcome
     authorization: Authorization | None = None
     chain: Chain
+    correlation_id: str | None = None
 
 
 class Proof(BaseModel):

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -268,7 +268,7 @@ class CredentialSubject(BaseModel):
     outcome: Outcome
     authorization: Authorization | None = None
     chain: Chain
-    correlation_id: str | None = None
+    correlation_id: str | None = Field(None, min_length=1)
 
 
 class Proof(BaseModel):

--- a/sdk/py/tests/receipt/test_create.py
+++ b/sdk/py/tests/receipt/test_create.py
@@ -107,3 +107,16 @@ class TestCreateReceipt:
         )
         assert receipt.credentialSubject.authorization is not None
         assert receipt.credentialSubject.authorization.scopes == ["read"]
+
+    def test_preserves_correlation_id(self) -> None:
+        cid = "toolu_01AAAAAAAAAAAAAAAAAAAAAA"
+        receipt = create_receipt(_make_input(correlation_id=cid))
+        assert receipt.credentialSubject.correlation_id == cid
+
+    def test_excludes_correlation_id_when_not_provided(self) -> None:
+        receipt = create_receipt(_make_input())
+        assert receipt.credentialSubject.correlation_id is None
+
+    def test_excludes_correlation_id_when_empty_string(self) -> None:
+        receipt = create_receipt(_make_input(correlation_id=""))
+        assert receipt.credentialSubject.correlation_id is None

--- a/sdk/ts/src/receipt/create.test.ts
+++ b/sdk/ts/src/receipt/create.test.ts
@@ -190,4 +190,26 @@ describe("createReceipt", () => {
 
 		expect(receipt).not.toHaveProperty("proof");
 	});
+
+	it("preserves correlationId as credentialSubject.correlation_id", () => {
+		const receipt = createReceipt(
+			makeInput({ correlationId: "toolu_01AAAAAAAAAAAAAAAAAAAAAA" }),
+		);
+
+		expect(receipt.credentialSubject.correlation_id).toBe(
+			"toolu_01AAAAAAAAAAAAAAAAAAAAAA",
+		);
+	});
+
+	it("omits correlation_id when correlationId is not provided", () => {
+		const receipt = createReceipt(makeInput());
+
+		expect(receipt.credentialSubject).not.toHaveProperty("correlation_id");
+	});
+
+	it("omits correlation_id when correlationId is empty string", () => {
+		const receipt = createReceipt(makeInput({ correlationId: "" }));
+
+		expect(receipt.credentialSubject).not.toHaveProperty("correlation_id");
+	});
 });

--- a/sdk/ts/src/receipt/create.ts
+++ b/sdk/ts/src/receipt/create.ts
@@ -43,6 +43,10 @@ export interface CreateReceiptInput {
 	 *  constructed directly with `status` but no `terminal` would be
 	 *  schema-invalid but cannot be produced through this entry point. */
 	terminationStatus?: "complete" | "interrupted";
+	/** Opaque token linking this receipt to a related receipt for the same
+	 *  logical tool invocation (e.g. a hook pre-check to MCP proxy post-action).
+	 *  Must be non-empty when provided; omit when no correlation context exists. */
+	correlationId?: string;
 }
 
 /**
@@ -104,6 +108,7 @@ export function createReceipt(input: CreateReceiptInput): UnsignedAgentReceipt {
 			chain,
 			...(input.intent && { intent: input.intent }),
 			...(input.authorization && { authorization: input.authorization }),
+			...(input.correlationId && { correlation_id: input.correlationId }),
 		},
 	};
 }

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -203,7 +203,7 @@ const credentialSubjectSchema = z
 		outcome: outcomeSchema,
 		authorization: authorizationSchema.optional(),
 		chain: chainSchema,
-		correlation_id: z.string().optional(),
+		correlation_id: z.string().min(1).optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -203,6 +203,7 @@ const credentialSubjectSchema = z
 		outcome: outcomeSchema,
 		authorization: authorizationSchema.optional(),
 		chain: chainSchema,
+		correlation_id: z.string().optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -202,6 +202,7 @@ export interface CredentialSubject {
 	outcome: Outcome;
 	authorization?: Authorization;
 	chain: Chain;
+	correlation_id?: string;
 }
 
 // --- Proof ---

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -443,7 +443,8 @@
         "chain": { "$ref": "#/$defs/chain" },
         "correlation_id": {
           "type": "string",
-          "description": "Opaque identifier linking related receipts for the same logical tool invocation — e.g. a hook pre-check receipt to the MCP proxy post-action receipt. Populated from the runtime's tool-use correlation token (Claude Code: tool_use_id). Absent when no correlation context is available."
+          "minLength": 1,
+          "description": "Opaque identifier linking related receipts for the same logical tool invocation — e.g. a hook pre-check receipt to the MCP proxy post-action receipt. Populated from the runtime's tool-use correlation token (Claude Code: tool_use_id). Absent when no correlation context is available. MUST be non-empty when present."
         }
       }
     },

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -440,7 +440,11 @@
         "outcome": { "$ref": "#/$defs/outcome" },
         "authorization": { "$ref": "#/$defs/authorization" },
         "delegation": { "$ref": "#/$defs/delegation" },
-        "chain": { "$ref": "#/$defs/chain" }
+        "chain": { "$ref": "#/$defs/chain" },
+        "correlation_id": {
+          "type": "string",
+          "description": "Opaque identifier linking related receipts for the same logical tool invocation — e.g. a hook pre-check receipt to the MCP proxy post-action receipt. Populated from the runtime's tool-use correlation token (Claude Code: tool_use_id). Absent when no correlation context is available."
+        }
       }
     },
 


### PR DESCRIPTION
## Summary

Closes #422 (Layer 1).

A hook pre-check receipt and the MCP proxy post-action receipt for the same tool invocation have always been unlinked — auditors and the dashboard can't tell they belong together. This PR wires `correlation_id` end-to-end so the two receipts can be joined by a single opaque key.

The key source is the runtime's tool-use correlation token. For Claude Code that's `tool_use_id`, which arrives in both the hook payload and the MCP `tools/call` `_meta["claudecode/toolUseId"]` field.

**Approach** — `correlation_id` is a new optional field on `credentialSubject`, analogous to W3C Trace Context's `parent_id`. It is absent when no correlation context is available (direct SDK use, non-Claude-Code runtimes), so the field is purely additive and fully backward-compatible.

## Changes

| Component | What changed |
|-----------|-------------|
| `spec/schema/agent-receipt.schema.json` | Add `correlation_id` to `credentialSubject` |
| `sdk/go/receipt/types.go` | `CredentialSubject.CorrelationID` |
| `sdk/go/receipt/create.go` | `CreateInput.CorrelationID` wired to subject |
| `sdk/go/receipt/create_test.go` | `TestCreatePreservesCorrelationID`, `TestCreateOmitsEmptyCorrelationID` |
| `sdk/go/emitter/emitter.go` | `Event.CorrelationID` → `frame.correlation_id` on the wire |
| `sdk/ts/src/receipt/types.ts` + `schema.ts` | `CredentialSubject.correlation_id` |
| `sdk/py/src/agent_receipts/receipt/types.py` | `CredentialSubject.correlation_id` |
| `hook/cmd/agent-receipts-hook/claude_code.go` | Forward `tool_use_id` as `CorrelationID`; remove stale TODO comment |
| `mcp-proxy/internal/proxy/jsonrpc.go` | `ToolCallParams._meta` + `ToolUseID()` helper |
| `mcp-proxy/cmd/mcp-proxy/main.go` | Store `correlationID` on `pendingCall`; thread through `emitToContext` |
| `daemon/internal/pipeline/build.go` | `EmitterFrame.CorrelationID` → `receipt.CreateInput.CorrelationID` |
| `dist/sdk-go-deprecation/receipt/types.go` | Sync `CorrelationID` field |
| `cross-sdk-tests/canonicalization_vectors.json` | `receipt_correlation_id_field` hash vector |

## Test plan

- [ ] All existing Go/TS/Python tests pass (verified locally — pre-push hook ran all suites)
- [ ] New `TestCreatePreservesCorrelationID` and `TestCreateOmitsEmptyCorrelationID` in `sdk/go/receipt`
- [ ] `receipt_correlation_id_field` vector in cross-SDK canonicalization suite (hash computed against real `Canonicalize`)
- [ ] CI passes (path-filtered: sdk/go, sdk/ts, sdk/py, mcp-proxy, hook, daemon, spec)

## Notes

- Layer 2 (subagent chain linking via `agent_id` + `Delegation`) and Layer 3 (dashboard rendering) remain as follow-on work
- The `_meta` field on `ToolCallParams` is MCP spec — it's always been forwarded by MCP clients but previously discarded by the proxy
- `correlation_id` uses `omitempty` everywhere so receipts without a correlation context are identical in size to pre-PR receipts