### PR TITLE
feat(agent-id): agent_id forwarding, Delegation struct, multi-chain daemon routing

### DIFF
--- a/cross-sdk-tests/canonicalization_vectors.json
+++ b/cross-sdk-tests/canonicalization_vectors.json
@@ -541,6 +541,45 @@
       "expectedHash": "sha256:c4921f75f78e01dee2df94b9e7eb22a1bf076565d631a702e4c2f7eb582f7b90"
     },
     {
+      "name": "receipt_delegation_field",
+      "rule": "rule2_optional_present_is_emitted",
+      "description": "A receipt with delegation set on credentialSubject. Verifies that delegation and all its sub-fields are included in the canonical form — they must not be silently stripped by any SDK. This receipt represents the first receipt of a subagent chain.",
+      "mustContainSubstring": "\"delegation\"",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000007",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.4.0",
+        "issuer": { "id": "did:agent:test", "name": "test-agent" },
+        "issuanceDate": "2026-06-08T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test", "type": "HumanPrincipal" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000007",
+            "type": "mcp.tool_call",
+            "tool_name": "Bash",
+            "risk_level": "low",
+            "timestamp": "2026-06-08T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "root-chain/agent/agent-abc"
+          },
+          "delegation": {
+            "parent_chain_id": "root-chain",
+            "parent_receipt_id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+            "delegator": { "id": "did:agent-receipts-daemon:host" }
+          }
+        }
+      },
+      "expectedHash": "sha256:6982fe89187303748a003e6ec001f13d598b6956d4d328d29c780863c1e6d9b6"
+    },
+    {
       "name": "receipt_signature_preservation_legacy_0_2_0",
       "rule": "signature_preservation",
       "description": "The three-receipt terminalChain from cross-sdk-tests/v020_vectors.json was signed under the pre-sweep (0.2.0) canonicaliser. Running the post-sweep canonicaliser on the same unsigned bytes MUST produce identical canonical output, and the existing proof.proofValue MUST still verify. This is the signature-preservation invariant from ADR-0009 §4. Implementation: this vector reuses the v020 fixtures by reference; the test harness loads both files and asserts round-trip equality.",

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -106,6 +106,7 @@ type EmitterFrame struct {
 	OperatorName   string          `json:"operator_name,omitempty"`
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 	CorrelationID  string          `json:"correlation_id,omitempty"`
+	AgentID        string          `json:"agent_id,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -161,19 +162,89 @@ type Pipeline struct {
 	// chain-allocation lock, so tracing doesn't contend with sequence
 	// allocation; however it does block the processing of that frame.
 	traceMu sync.Mutex
+
+	// rootChainID is the chain ID for the root (session) chain; fixed after New.
+	rootChainID string
+	// agentChains maps agent_id to its per-subagent chain state. Protected by
+	// agentChainsMu. Frames with a non-empty agent_id are routed here; frames
+	// with no agent_id go to State (the root chain).
+	agentChains   map[string]*chain.State
+	agentChainsMu sync.RWMutex
 }
 
 // New returns a Pipeline. Callers configure IssuerID; Now defaults to
 // time.Now.UTC.
 func New(s *chain.State, ks keysource.KeySource, store pipelineStore, issuerID string) *Pipeline {
 	return &Pipeline{
-		State:    s,
-		Keys:     ks,
-		Store:    store,
-		IssuerID: issuerID,
-		Now:      func() time.Time { return time.Now().UTC() },
-		TraceLog: nil,
+		State:       s,
+		Keys:        ks,
+		Store:       store,
+		IssuerID:    issuerID,
+		Now:         func() time.Time { return time.Now().UTC() },
+		TraceLog:    nil,
+		rootChainID: s.ChainID(),
+		agentChains: make(map[string]*chain.State),
 	}
+}
+
+// getOrCreateAgentState returns the chain.State and, on the first receipt for a
+// new agent chain, a Delegation to backlink to the root chain.
+//
+// Frames with no agent_id → (p.State, nil, nil): root chain, no delegation.
+// Frames with a known agent_id → (existing state, nil, nil): already routed.
+// Frames with a new agent_id → (new state, &Delegation{...}, nil) on first
+// call; subsequent calls return the same state with nil delegation.
+//
+// The delegation.parent_receipt_id is the tail receipt of the root chain at
+// the moment the subagent chain is created. If the root chain has no receipts
+// yet, delegation is omitted (nil) — the spec treats it as optional.
+func (p *Pipeline) getOrCreateAgentState(agentID string) (*chain.State, *receipt.Delegation, error) {
+	if agentID == "" {
+		return p.State, nil, nil
+	}
+	// Fast path: chain already exists for this agent.
+	p.agentChainsMu.RLock()
+	if s, ok := p.agentChains[agentID]; ok {
+		p.agentChainsMu.RUnlock()
+		return s, nil, nil
+	}
+	p.agentChainsMu.RUnlock()
+
+	// Slow path: create a new chain for this agent.
+	p.agentChainsMu.Lock()
+	defer p.agentChainsMu.Unlock()
+	if s, ok := p.agentChains[agentID]; ok {
+		// Another goroutine raced us to creation.
+		return s, nil, nil
+	}
+
+	// Chain ID is deterministic: base chain + "/agent/" + agent_id.
+	// This lets the daemon resume an agent chain across restarts when the same
+	// agent reconnects within a session.
+	chainID := p.rootChainID + "/agent/" + agentID
+	s, err := chain.LoadFromStore(p.Store, chainID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load agent chain %q: %w", chainID, err)
+	}
+
+	var del *receipt.Delegation
+	if s.NextSeq() == 1 {
+		// First receipt on this chain — link back to the root chain's current tail.
+		tail, err := p.Store.GetChainTailReceipt(p.rootChainID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get root chain tail for delegation: %w", err)
+		}
+		if tail != nil {
+			del = &receipt.Delegation{
+				ParentChainID:   p.rootChainID,
+				ParentReceiptID: tail.ID,
+				Delegator:       receipt.Delegator{ID: p.IssuerID},
+			}
+		}
+	}
+
+	p.agentChains[agentID] = s
+	return s, del, nil
 }
 
 // Process is the daemon's per-frame entrypoint. It parses the frame, allocates
@@ -216,11 +287,17 @@ func (p *Pipeline) Process(f socket.Frame) error {
 // returned liveAlloc shares the same release Once so deferring liveAlloc.Rollback()
 // covers panics in the second phase; pair.Rollback() becomes a no-op.
 func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) error {
-	pair := p.State.AllocatePair()
+	state, delegation, err := p.getOrCreateAgentState(frame.AgentID)
+	if err != nil {
+		return err
+	}
+	chainID := state.ChainID()
+
+	pair := state.AllocatePair()
 	defer pair.Rollback() // panic-safety: no-op after CommitFirst
 
 	synthetic, synHash, err := p.buildAndSignDropReceipt(
-		frame.DropCount, frame.SessionID, peer, pair.FirstSeq, pair.FirstPrev)
+		frame.DropCount, frame.SessionID, peer, pair.FirstSeq, pair.FirstPrev, chainID)
 	if err != nil {
 		pair.Rollback()
 		p.logError("build events_dropped receipt (drop_count=%d session=%s): %v",
@@ -243,7 +320,7 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 	liveAlloc := pair.CommitFirst(synHash)
 	defer liveAlloc.Rollback() // panic-safety; pair.Rollback defer is now a no-op
 
-	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc)
+	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc, chainID, delegation)
 	if err != nil {
 		liveAlloc.Rollback() // releases lock; chain is at pair.FirstSeq+1
 		return err
@@ -264,10 +341,15 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 // receipt. Used for frames with DropCount == 0 and as fallback when the
 // synthetic insert fails.
 func (p *Pipeline) processLive(frame *EmitterFrame, peer socket.PeerCred) error {
-	alloc := p.State.Allocate()
+	state, delegation, err := p.getOrCreateAgentState(frame.AgentID)
+	if err != nil {
+		return err
+	}
+
+	alloc := state.Allocate()
 	defer alloc.Rollback()
 
-	signed, hash, err := p.buildAndSign(frame, peer, alloc)
+	signed, hash, err := p.buildAndSign(frame, peer, alloc, state.ChainID(), delegation)
 	if err != nil {
 		return err
 	}
@@ -365,6 +447,9 @@ func validateFrame(f *EmitterFrame) error {
 	}
 	if len(f.CorrelationID) > maxIdentityFieldLen {
 		return fmt.Errorf("correlation_id exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.CorrelationID))
+	}
+	if len(f.AgentID) > maxIdentityFieldLen {
+		return fmt.Errorf("agent_id exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.AgentID))
 	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
@@ -467,6 +552,8 @@ func (p *Pipeline) buildAndSign(
 	f *EmitterFrame,
 	peer socket.PeerCred,
 	alloc chain.Allocation,
+	chainID string,
+	delegation *receipt.Delegation,
 ) (receipt.AgentReceipt, string, error) {
 	now := p.Now().Format(time.RFC3339)
 
@@ -591,10 +678,11 @@ func (p *Pipeline) buildAndSign(
 		Action:        action,
 		Outcome:       outcome,
 		CorrelationID: f.CorrelationID,
+		Delegation:    delegation,
 		Chain: receipt.Chain{
 			Sequence:            int(alloc.Sequence),
 			PreviousReceiptHash: alloc.PrevHash,
-			ChainID:             p.State.ChainID(),
+			ChainID:             chainID,
 		},
 	}, now)
 }
@@ -631,6 +719,7 @@ func (p *Pipeline) buildAndSignDropReceipt(
 	peer socket.PeerCred,
 	seq int64,
 	prevHash *string,
+	chainID string,
 ) (receipt.AgentReceipt, string, error) {
 	now := p.Now().Format(time.RFC3339)
 
@@ -659,7 +748,7 @@ func (p *Pipeline) buildAndSignDropReceipt(
 		Chain: receipt.Chain{
 			Sequence:            int(seq),
 			PreviousReceiptHash: prevHash,
-			ChainID:             p.State.ChainID(),
+			ChainID:             chainID,
 		},
 	}, now)
 }
@@ -685,25 +774,44 @@ func buildPeerCred(peer socket.PeerCred) *receipt.PeerCredential {
 
 func ptrUint32(v uint32) *uint32 { return &v }
 
-// EmitTerminator emits an interrupted-chain terminal receipt for the current
-// chain if the chain has at least one receipt and is not already terminated.
-// It is called once, synchronously, after the IPC listener has shut down and
-// all in-flight frames have been processed — the chain state mutex is free.
+// EmitTerminator emits interrupted-chain terminal receipts for all open chains
+// (root chain and any per-agent chains). It is called once, synchronously,
+// after the IPC listener has shut down and all in-flight frames have been
+// processed — all chain state mutexes are free.
 //
 // ctx should carry a short deadline (~200ms). Deadline/cancel errors are
 // non-fatal — the verifier's "unknown" classification is the documented
 // fallback for chains that never receive a terminator. Store or signing
 // failures are returned wrapped so the caller can surface them as fatal.
 func (p *Pipeline) EmitTerminator(ctx context.Context) error {
-	// Fast path: no receipts in this chain (fresh store or first-ever run).
-	if p.State.NextSeq() == 1 {
+	// Terminate agent chains first, then the root chain.
+	p.agentChainsMu.RLock()
+	agentStates := make([]*chain.State, 0, len(p.agentChains))
+	for _, s := range p.agentChains {
+		agentStates = append(agentStates, s)
+	}
+	p.agentChainsMu.RUnlock()
+
+	for _, s := range agentStates {
+		if err := p.emitTerminatorForChain(ctx, s); err != nil {
+			return err
+		}
+	}
+	return p.emitTerminatorForChain(ctx, p.State)
+}
+
+// emitTerminatorForChain emits an interrupted-chain terminal receipt for s if
+// it has at least one receipt and is not already terminated.
+func (p *Pipeline) emitTerminatorForChain(ctx context.Context, s *chain.State) error {
+	// Fast path: no receipts in this chain.
+	if s.NextSeq() == 1 {
 		return nil
 	}
 
 	// Check whether the chain's tail is already a terminal receipt. This
 	// covers the cross-restart case where a previous daemon run emitted an
 	// interrupted terminator that is now the tail.
-	chainID := p.State.ChainID()
+	chainID := s.ChainID()
 	tail, err := p.Store.GetChainTailReceipt(chainID)
 	if err != nil {
 		return fmt.Errorf("check chain tail: %w", err)
@@ -725,7 +833,7 @@ func (p *Pipeline) EmitTerminator(ctx context.Context) error {
 		return fmt.Errorf("deadline exceeded before terminator: %w", context.DeadlineExceeded)
 	}
 
-	alloc := p.State.Allocate()
+	alloc := s.Allocate()
 	defer alloc.Rollback()
 
 	if alloc.Sequence > int64(math.MaxInt) {

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -187,37 +188,46 @@ func New(s *chain.State, ks keysource.KeySource, store pipelineStore, issuerID s
 	}
 }
 
-// getOrCreateAgentState returns the chain.State and, on the first receipt for a
-// new agent chain, a Delegation to backlink to the root chain.
+// getOrCreateAgentState returns the chain.State and, when appropriate, a
+// Delegation to backlink to the root chain.
 //
 // Frames with no agent_id → (p.State, nil, nil): root chain, no delegation.
-// Frames with a known agent_id → (existing state, nil, nil): already routed.
-// Frames with a new agent_id → (new state, &Delegation{...}, nil) on first
-// call; subsequent calls return the same state with nil delegation.
+// Frames with a known agent_id → (existing state, delegation?, nil): delegation
+// is non-nil only while the chain's first receipt has not yet been committed
+// (NextSeq still 1). This covers retries after a rollback and the
+// processWithDrop→processLive fallback — both leave NextSeq at 1 with no
+// committed receipt, and both must carry the delegation on the eventual first
+// receipt of the subagent chain.
+// Frames with a new agent_id → (new state, &Delegation{...}, nil) on creation.
 //
-// The delegation.parent_receipt_id is the tail receipt of the root chain at
-// the moment the subagent chain is created. If the root chain has no receipts
-// yet, delegation is omitted (nil) — the spec treats it as optional.
+// DB I/O (LoadFromStore, buildDelegation) is performed outside the write lock
+// so agentChainsMu is never held across blocking store queries.
 func (p *Pipeline) getOrCreateAgentState(agentID string) (*chain.State, *receipt.Delegation, error) {
 	if agentID == "" {
 		return p.State, nil, nil
 	}
 	// Fast path: chain already exists for this agent.
 	p.agentChainsMu.RLock()
-	if s, ok := p.agentChains[agentID]; ok {
-		p.agentChainsMu.RUnlock()
-		return s, nil, nil
-	}
+	s, ok := p.agentChains[agentID]
 	p.agentChainsMu.RUnlock()
-
-	// Slow path: create a new chain for this agent.
-	p.agentChainsMu.Lock()
-	defer p.agentChainsMu.Unlock()
-	if s, ok := p.agentChains[agentID]; ok {
-		// Another goroutine raced us to creation.
-		return s, nil, nil
+	if ok {
+		// Re-derive delegation when the first receipt has not yet been committed.
+		// NextSeq stays at 1 after a Rollback, so a failed build/sign/insert
+		// attempt on what is logically the first receipt leaves the chain in a
+		// state where the next attempt must still carry the delegation.
+		if s.NextSeq() != 1 {
+			return s, nil, nil
+		}
+		del, err := p.buildDelegation()
+		if err != nil {
+			return nil, nil, err
+		}
+		return s, del, nil
 	}
 
+	// Slow path: load from store outside the write lock so blocking I/O does not
+	// hold agentChainsMu and serialize all concurrent frame goroutines.
+	//
 	// Chain ID is deterministic: base chain + "/agent/" + agent_id.
 	// This lets the daemon resume an agent chain across restarts when the same
 	// agent reconnects within a session.
@@ -226,25 +236,46 @@ func (p *Pipeline) getOrCreateAgentState(agentID string) (*chain.State, *receipt
 	if err != nil {
 		return nil, nil, fmt.Errorf("load agent chain %q: %w", chainID, err)
 	}
-
 	var del *receipt.Delegation
 	if s.NextSeq() == 1 {
-		// First receipt on this chain — link back to the root chain's current tail.
-		tail, err := p.Store.GetChainTailReceipt(p.rootChainID)
+		del, err = p.buildDelegation()
 		if err != nil {
-			return nil, nil, fmt.Errorf("get root chain tail for delegation: %w", err)
-		}
-		if tail != nil {
-			del = &receipt.Delegation{
-				ParentChainID:   p.rootChainID,
-				ParentReceiptID: tail.ID,
-				Delegator:       receipt.Delegator{ID: p.IssuerID},
-			}
+			return nil, nil, err
 		}
 	}
 
+	// Install under write lock; double-check to detect a concurrent creator.
+	p.agentChainsMu.Lock()
+	defer p.agentChainsMu.Unlock()
+	if existing, ok := p.agentChains[agentID]; ok {
+		// Lost the creation race. Reuse the delegation we already computed if the
+		// winner's chain is still at seq 1 (first receipt not yet committed);
+		// otherwise the first receipt already landed without our delegation object.
+		if existing.NextSeq() == 1 {
+			return existing, del, nil
+		}
+		return existing, nil, nil
+	}
 	p.agentChains[agentID] = s
 	return s, del, nil
+}
+
+// buildDelegation queries the root chain tail and returns a Delegation for use
+// on the first receipt of a new subagent chain. Returns nil, nil when the root
+// chain has no receipts yet — delegation is optional per spec.
+func (p *Pipeline) buildDelegation() (*receipt.Delegation, error) {
+	tail, err := p.Store.GetChainTailReceipt(p.rootChainID)
+	if err != nil {
+		return nil, fmt.Errorf("get root chain tail for delegation: %w", err)
+	}
+	if tail == nil {
+		return nil, nil
+	}
+	return &receipt.Delegation{
+		ParentChainID:   p.rootChainID,
+		ParentReceiptID: tail.ID,
+		Delegator:       receipt.Delegator{ID: p.IssuerID},
+	}, nil
 }
 
 // Process is the daemon's per-frame entrypoint. It parses the frame, allocates
@@ -450,6 +481,9 @@ func validateFrame(f *EmitterFrame) error {
 	}
 	if len(f.AgentID) > maxIdentityFieldLen {
 		return fmt.Errorf("agent_id exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.AgentID))
+	}
+	if strings.ContainsAny(f.AgentID, "/\x00") {
+		return fmt.Errorf("agent_id must not contain '/' or null bytes")
 	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
@@ -792,12 +826,19 @@ func (p *Pipeline) EmitTerminator(ctx context.Context) error {
 	}
 	p.agentChainsMu.RUnlock()
 
+	// Attempt all chains; a single failing agent chain must not prevent the
+	// remaining chains (or the root chain) from receiving their terminators.
+	// Return the first error after all attempts complete.
+	var firstErr error
 	for _, s := range agentStates {
-		if err := p.emitTerminatorForChain(ctx, s); err != nil {
-			return err
+		if err := p.emitTerminatorForChain(ctx, s); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	return p.emitTerminatorForChain(ctx, p.State)
+	if err := p.emitTerminatorForChain(ctx, p.State); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 // emitTerminatorForChain emits an interrupted-chain terminal receipt for s if

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -327,8 +327,17 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 	pair := state.AllocatePair()
 	defer pair.Rollback() // panic-safety: no-op after CommitFirst
 
+	// Delegation belongs on the first receipt in the chain. Guard by the
+	// actual allocated sequence so that if a concurrent goroutine committed
+	// seq 1 between getOrCreateAgentState and AllocatePair, we do not
+	// incorrectly attach delegation to a non-first receipt.
+	dropDelegation := delegation
+	if pair.FirstSeq != 1 {
+		dropDelegation = nil
+	}
+
 	synthetic, synHash, err := p.buildAndSignDropReceipt(
-		frame.DropCount, frame.SessionID, peer, pair.FirstSeq, pair.FirstPrev, chainID)
+		frame.DropCount, frame.SessionID, peer, pair.FirstSeq, pair.FirstPrev, chainID, dropDelegation)
 	if err != nil {
 		pair.Rollback()
 		p.logError("build events_dropped receipt (drop_count=%d session=%s): %v",
@@ -351,7 +360,9 @@ func (p *Pipeline) processWithDrop(frame *EmitterFrame, peer socket.PeerCred) er
 	liveAlloc := pair.CommitFirst(synHash)
 	defer liveAlloc.Rollback() // panic-safety; pair.Rollback defer is now a no-op
 
-	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc, chainID, delegation)
+	// The live receipt is always the second in the pair (seq FirstSeq+1) so
+	// delegation never belongs here regardless of agent chain state.
+	live, liveHash, err := p.buildAndSign(frame, peer, liveAlloc, chainID, nil)
 	if err != nil {
 		liveAlloc.Rollback() // releases lock; chain is at pair.FirstSeq+1
 		return err
@@ -379,6 +390,13 @@ func (p *Pipeline) processLive(frame *EmitterFrame, peer socket.PeerCred) error 
 
 	alloc := state.Allocate()
 	defer alloc.Rollback()
+
+	// Guard by actual sequence: a concurrent goroutine may have committed
+	// seq 1 between getOrCreateAgentState and Allocate, so check the
+	// allocated sequence rather than the earlier NextSeq observation.
+	if alloc.Sequence != 1 {
+		delegation = nil
+	}
 
 	signed, hash, err := p.buildAndSign(frame, peer, alloc, state.ChainID(), delegation)
 	if err != nil {
@@ -754,6 +772,7 @@ func (p *Pipeline) buildAndSignDropReceipt(
 	seq int64,
 	prevHash *string,
 	chainID string,
+	delegation *receipt.Delegation,
 ) (receipt.AgentReceipt, string, error) {
 	now := p.Now().Format(time.RFC3339)
 
@@ -767,7 +786,8 @@ func (p *Pipeline) buildAndSignDropReceipt(
 			Type:      "AgentReceiptsDaemon",
 			SessionID: sessionID,
 		},
-		Principal: receipt.Principal{ID: "did:user:unknown"},
+		Principal:  receipt.Principal{ID: "did:user:unknown"},
+		Delegation: delegation,
 		Action: receipt.Action{
 			Type:           actionTypeEventsDropped,
 			ToolName:       "events_dropped",

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1776,6 +1776,121 @@ func TestProcess_NoDelegationWhenRootChainEmpty(t *testing.T) {
 	}
 }
 
+// TestProcess_DelegationPreservedAfterFirstReceiptFailure verifies that when the
+// first receipt for a new subagent chain fails to persist (store error), the
+// retry still carries the delegation. The chain is cached in agentChains after
+// the first call but NextSeq stays at 1 after the rollback, so
+// getOrCreateAgentState must re-derive delegation on the next attempt.
+func TestProcess_DelegationPreservedAfterFirstReceiptFailure(t *testing.T) {
+	ks := newTestKeySource(t)
+	underlying := newTestStore(t)
+	// Insert 1: root receipt (succeeds). Insert 2: first agent attempt (fails).
+	// Insert 3+: retry (succeeds).
+	st := &failOnNthInsert{pipelineStore: underlying, n: 2}
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// Emit a root receipt so the delegation has a backlink target.
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	rootReceipts, err := underlying.GetChain("root")
+	if err != nil || len(rootReceipts) != 1 {
+		t.Fatalf("setup: expected 1 root receipt, err=%v", err)
+	}
+	rootTailID := rootReceipts[0].ID
+
+	// First attempt: store insert fails. Process should return an error and the
+	// chain should have no receipts.
+	if err := p.Process(agentFrame(t, "agent-retry")); err == nil {
+		t.Fatal("expected error from first agent frame (store inject failure); got nil")
+	}
+
+	// Retry: store insert succeeds. The receipt must carry delegation.
+	if err := p.Process(agentFrame(t, "agent-retry")); err != nil {
+		t.Fatalf("retry agent frame failed: %v", err)
+	}
+	agentReceipts, err := underlying.GetChain("root/agent/agent-retry")
+	if err != nil || len(agentReceipts) != 1 {
+		t.Fatalf("expected 1 agent receipt after retry, got %d, err=%v", len(agentReceipts), err)
+	}
+	del := agentReceipts[0].CredentialSubject.Delegation
+	if del == nil {
+		t.Fatal("retry receipt missing delegation; getOrCreateAgentState must re-derive it when NextSeq==1")
+	}
+	if del.ParentChainID != "root" {
+		t.Errorf("delegation.parent_chain_id = %q, want root", del.ParentChainID)
+	}
+	if del.ParentReceiptID != rootTailID {
+		t.Errorf("delegation.parent_receipt_id = %q, want %q", del.ParentReceiptID, rootTailID)
+	}
+}
+
+// TestEmitTerminator_ContinuesAfterAgentChainError verifies that when one agent
+// chain fails to be terminated, EmitTerminator still attempts the remaining
+// chains and the root chain, returning the first error after all attempts.
+func TestEmitTerminator_ContinuesAfterAgentChainError(t *testing.T) {
+	ks := newTestKeySource(t)
+	underlying := newTestStore(t)
+	state := chain.New("root")
+	// Fail insert 3 (the agent terminator): inserts 1=root, 2=agent, then 3=agent
+	// terminator fails. Insert 4 (root terminator) must still proceed.
+	st := &failOnNthInsert{pipelineStore: underlying, n: 3}
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(agentFrame(t, "agent-fail-term")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := p.EmitTerminator(context.Background())
+	if err == nil {
+		t.Error("expected EmitTerminator to return error from the failing agent chain")
+	}
+
+	// Root chain must still be terminated even though the agent chain failed.
+	rootReceipts, qErr := underlying.GetChain("root")
+	if qErr != nil {
+		t.Fatalf("GetChain root: %v", qErr)
+	}
+	tail := rootReceipts[len(rootReceipts)-1]
+	if tail.CredentialSubject.Chain.Terminal == nil || !*tail.CredentialSubject.Chain.Terminal {
+		t.Error("root chain tail must be terminal even when one agent chain terminator failed")
+	}
+}
+
+// TestValidateFrame_RejectsAgentIDWithSlash verifies that an agent_id containing
+// '/' is rejected before chain ID construction to prevent ambiguous chain IDs of
+// the form rootChainID+"/agent/"+agentID.
+func TestValidateFrame_RejectsAgentIDWithSlash(t *testing.T) {
+	cases := []struct {
+		name    string
+		agentID string
+	}{
+		{"single slash", "sub/agent"},
+		{"agent segment", "x/agent/y"},
+		{"null byte", "agent\x00id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &EmitterFrame{
+				Version:   "1",
+				TsEmit:    "2026-05-03T00:00:00Z",
+				SessionID: "s",
+				Channel:   "mcp",
+				Tool:      EmitterTool{Name: "t"},
+				Decision:  "allowed",
+				AgentID:   tc.agentID,
+			}
+			if err := validateFrame(f); err == nil {
+				t.Errorf("validateFrame accepted agent_id %q; want rejection", tc.agentID)
+			}
+		})
+	}
+}
+
 // TestEmitTerminator_TerminatesAgentChains verifies that EmitTerminator closes
 // all open agent chains in addition to the root chain.
 func TestEmitTerminator_TerminatesAgentChains(t *testing.T) {

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/json"
@@ -1636,5 +1637,174 @@ func TestProcess_EmitterDeclaredActionTypeDrivesRisk(t *testing.T) {
 	}
 	if r.CredentialSubject.Action.ParametersDisclosure != nil {
 		t.Error("medium-risk action must not disclose under policy=high")
+	}
+}
+
+// agentFrame returns a socket.Frame whose payload has the given agent_id.
+func agentFrame(t *testing.T, agentID string) socket.Frame {
+	t.Helper()
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-06-08T00:00:00Z",
+		SessionID: "sess-agent-test",
+		Channel:   "claude-code",
+		Tool:      EmitterTool{Name: "Bash"},
+		Decision:  "allowed",
+		AgentID:   agentID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return socket.Frame{Payload: body}
+}
+
+// TestProcess_AgentIDRoutesToSeparateChain verifies that frames with a non-empty
+// agent_id land on a per-agent chain distinct from the root chain.
+func TestProcess_AgentIDRoutesToSeparateChain(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// One root receipt (no agent_id).
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	// One subagent receipt.
+	if err := p.Process(agentFrame(t, "agent-abc")); err != nil {
+		t.Fatal(err)
+	}
+
+	rootReceipts, err := st.GetChain("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rootReceipts) != 1 {
+		t.Errorf("root chain: got %d receipts, want 1", len(rootReceipts))
+	}
+	if rootReceipts[0].CredentialSubject.Chain.ChainID != "root" {
+		t.Errorf("root receipt chain_id = %q", rootReceipts[0].CredentialSubject.Chain.ChainID)
+	}
+
+	agentChainID := "root/agent/agent-abc"
+	agentReceipts, err := st.GetChain(agentChainID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agentReceipts) != 1 {
+		t.Errorf("agent chain: got %d receipts, want 1", len(agentReceipts))
+	}
+	if agentReceipts[0].CredentialSubject.Chain.ChainID != agentChainID {
+		t.Errorf("agent receipt chain_id = %q, want %q",
+			agentReceipts[0].CredentialSubject.Chain.ChainID, agentChainID)
+	}
+}
+
+// TestProcess_DelegationOnFirstAgentReceipt verifies that the first receipt on
+// a subagent chain carries a delegation that links back to the root chain's tail.
+func TestProcess_DelegationOnFirstAgentReceipt(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// Emit a root receipt so there is a tail to backlink to.
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	rootReceipts, err := st.GetChain("root")
+	if err != nil || len(rootReceipts) != 1 {
+		t.Fatalf("setup: expected 1 root receipt, err=%v", err)
+	}
+	rootTailID := rootReceipts[0].ID
+
+	// First subagent receipt — delegation must be present.
+	if err := p.Process(agentFrame(t, "agent-xyz")); err != nil {
+		t.Fatal(err)
+	}
+	agentReceipts, err := st.GetChain("root/agent/agent-xyz")
+	if err != nil || len(agentReceipts) != 1 {
+		t.Fatalf("expected 1 agent receipt, got %d, err=%v", len(agentReceipts), err)
+	}
+	del := agentReceipts[0].CredentialSubject.Delegation
+	if del == nil {
+		t.Fatal("first agent receipt missing delegation")
+	}
+	if del.ParentChainID != "root" {
+		t.Errorf("delegation.parent_chain_id = %q, want root", del.ParentChainID)
+	}
+	if del.ParentReceiptID != rootTailID {
+		t.Errorf("delegation.parent_receipt_id = %q, want %q", del.ParentReceiptID, rootTailID)
+	}
+	if del.Delegator.ID != "did:agent-receipts-daemon:test" {
+		t.Errorf("delegation.delegator.id = %q", del.Delegator.ID)
+	}
+
+	// Second subagent receipt on the same chain — no delegation.
+	if err := p.Process(agentFrame(t, "agent-xyz")); err != nil {
+		t.Fatal(err)
+	}
+	agentReceipts, err = st.GetChain("root/agent/agent-xyz")
+	if err != nil || len(agentReceipts) != 2 {
+		t.Fatalf("expected 2 agent receipts, got %d, err=%v", len(agentReceipts), err)
+	}
+	if agentReceipts[1].CredentialSubject.Delegation != nil {
+		t.Error("second receipt must not carry delegation")
+	}
+}
+
+// TestProcess_NoDelegationWhenRootChainEmpty verifies that if the first event is
+// a subagent frame with no prior root receipt, delegation is omitted rather than
+// panicking or returning an error.
+func TestProcess_NoDelegationWhenRootChainEmpty(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// Subagent frame arrives before any root receipt.
+	if err := p.Process(agentFrame(t, "agent-early")); err != nil {
+		t.Fatal(err)
+	}
+	agentReceipts, err := st.GetChain("root/agent/agent-early")
+	if err != nil || len(agentReceipts) != 1 {
+		t.Fatalf("expected 1 agent receipt, got %d, err=%v", len(agentReceipts), err)
+	}
+	// No root tail → delegation should be omitted, not an error.
+	if agentReceipts[0].CredentialSubject.Delegation != nil {
+		t.Error("expected no delegation when root chain has no receipts yet")
+	}
+}
+
+// TestEmitTerminator_TerminatesAgentChains verifies that EmitTerminator closes
+// all open agent chains in addition to the root chain.
+func TestEmitTerminator_TerminatesAgentChains(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// Populate root and one agent chain.
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(agentFrame(t, "agent-term")); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := p.EmitTerminator(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, chainID := range []string{"root", "root/agent/agent-term"} {
+		receipts, err := st.GetChain(chainID)
+		if err != nil {
+			t.Fatalf("GetChain %q: %v", chainID, err)
+		}
+		tail := receipts[len(receipts)-1]
+		if tail.CredentialSubject.Chain.Terminal == nil || !*tail.CredentialSubject.Chain.Terminal {
+			t.Errorf("chain %q tail is not terminal", chainID)
+		}
 	}
 }

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1753,6 +1753,80 @@ func TestProcess_DelegationOnFirstAgentReceipt(t *testing.T) {
 	}
 }
 
+// TestProcess_DelegationOnFirstAgentDropReceipt verifies that when the first
+// frame for a subagent chain has DropCount>0, the synthetic events_dropped
+// receipt (sequence 1) carries delegation and the following live receipt
+// (sequence 2) does not.
+func TestProcess_DelegationOnFirstAgentDropReceipt(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	// Emit a root receipt so there is a tail to backlink to.
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatal(err)
+	}
+	rootReceipts, err := st.GetChain("root")
+	if err != nil || len(rootReceipts) != 1 {
+		t.Fatalf("setup: expected 1 root receipt, err=%v", err)
+	}
+	rootTailID := rootReceipts[0].ID
+
+	// First subagent frame with drop_count=2: produces a synthetic receipt
+	// (seq 1) followed by the live receipt (seq 2).
+	body, err := json.Marshal(EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-06-08T00:00:00Z",
+		SessionID: "sess-agent-drop",
+		Channel:   "claude-code",
+		Tool:      EmitterTool{Name: "Bash"},
+		Decision:  "allowed",
+		AgentID:   "agent-drop",
+		DropCount: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatal(err)
+	}
+
+	agentChainID := "root/agent/agent-drop"
+	agentReceipts, err := st.GetChain(agentChainID)
+	if err != nil || len(agentReceipts) != 2 {
+		t.Fatalf("expected 2 agent receipts (drop+live), got %d, err=%v", len(agentReceipts), err)
+	}
+
+	// Sequence 1: synthetic events_dropped — must carry delegation.
+	dropR := agentReceipts[0]
+	if dropR.CredentialSubject.Chain.Sequence != 1 {
+		t.Errorf("drop receipt seq = %d, want 1", dropR.CredentialSubject.Chain.Sequence)
+	}
+	del := dropR.CredentialSubject.Delegation
+	if del == nil {
+		t.Fatal("drop receipt (seq 1) missing delegation")
+	}
+	if del.ParentChainID != "root" {
+		t.Errorf("delegation.parent_chain_id = %q, want root", del.ParentChainID)
+	}
+	if del.ParentReceiptID != rootTailID {
+		t.Errorf("delegation.parent_receipt_id = %q, want %q", del.ParentReceiptID, rootTailID)
+	}
+	if del.Delegator.ID != "did:agent-receipts-daemon:test" {
+		t.Errorf("delegation.delegator.id = %q", del.Delegator.ID)
+	}
+
+	// Sequence 2: live receipt — must NOT carry delegation.
+	liveR := agentReceipts[1]
+	if liveR.CredentialSubject.Chain.Sequence != 2 {
+		t.Errorf("live receipt seq = %d, want 2", liveR.CredentialSubject.Chain.Sequence)
+	}
+	if liveR.CredentialSubject.Delegation != nil {
+		t.Error("live receipt (seq 2) must not carry delegation")
+	}
+}
+
 // TestProcess_NoDelegationWhenRootChainEmpty verifies that if the first event is
 // a subagent frame with no prior root receipt, delegation is omitted rather than
 // panicking or returning an error.

--- a/dist/sdk-go-deprecation/receipt/types.go
+++ b/dist/sdk-go-deprecation/receipt/types.go
@@ -259,6 +259,22 @@ func (c Chain) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
+// Delegator identifies the agent whose chain spawned a delegation.
+//
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+type Delegator struct {
+	ID string `json:"id"`
+}
+
+// Delegation records the chain linkage when this chain was spawned by a parent agent.
+//
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+type Delegation struct {
+	ParentChainID   string    `json:"parent_chain_id"`
+	ParentReceiptID string    `json:"parent_receipt_id"`
+	Delegator       Delegator `json:"delegator"`
+}
+
 // CredentialSubject contains the core receipt payload.
 //
 // Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
@@ -270,6 +286,7 @@ type CredentialSubject struct {
 	Authorization *Authorization `json:"authorization,omitempty"`
 	Chain         Chain          `json:"chain"`
 	CorrelationID string         `json:"correlation_id,omitempty"`
+	Delegation    *Delegation    `json:"delegation,omitempty"`
 }
 
 // Proof contains the Ed25519 signature.

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -16,6 +16,7 @@ type claudeCodeFrame struct {
 	ToolName      string          `json:"tool_name"`
 	ToolInput     json.RawMessage `json:"tool_input"`
 	ToolResponse  json.RawMessage `json:"tool_response"`
+	AgentID       string          `json:"agent_id"`
 }
 
 // readClaudeCode parses a Claude Code PostToolUse or PreToolUse stdin frame
@@ -56,6 +57,7 @@ func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string,
 		Tool:          emitter.Tool{Name: f.ToolName},
 		Decision:      decision,
 		CorrelationID: f.ToolUseID,
+		AgentID:       f.AgentID,
 	}
 	// Only set Input/Output when non-empty; the emitter rejects non-nil empty
 	// slices and the daemon expects nil to mean "no payload".

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -141,6 +141,12 @@ type Event struct {
 	// tool_use_id). The daemon stamps it onto credentialSubject.correlation_id.
 	// Optional; omitted from the frame when empty.
 	CorrelationID string
+
+	// AgentID identifies the subagent that generated this event (Claude Code:
+	// agent_id). The daemon uses it to route frames to per-agent chains and to
+	// populate delegation.parent_chain_id on the first receipt of a new agent.
+	// Optional; omitted from the frame when empty (root agent).
+	AgentID string
 }
 
 // Option configures an Emitter at construction.
@@ -301,6 +307,7 @@ type frame struct {
 	OperatorName   string          `json:"operator_name,omitempty"`
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 	CorrelationID  string          `json:"correlation_id,omitempty"`
+	AgentID        string          `json:"agent_id,omitempty"`
 }
 
 type frameTool struct {
@@ -393,12 +400,13 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	for _, f := range [5]struct{ name, val string }{
+	for _, f := range [6]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
 		{"operator_name", operatorName},
 		{"idempotency_key", ev.IdempotencyKey},
+		{"agent_id", ev.AgentID},
 	} {
 		if len(f.val) > MaxIdentityFieldLen {
 			e.dropCount.Add(pendingDrops)
@@ -423,6 +431,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		OperatorName:   operatorName,
 		IdempotencyKey: ev.IdempotencyKey,
 		CorrelationID:  ev.CorrelationID,
+		AgentID:        ev.AgentID,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -400,12 +400,13 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	for _, f := range [6]struct{ name, val string }{
+	for _, f := range [7]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
 		{"operator_name", operatorName},
 		{"idempotency_key", ev.IdempotencyKey},
+		{"correlation_id", ev.CorrelationID},
 		{"agent_id", ev.AgentID},
 	} {
 		if len(f.val) > MaxIdentityFieldLen {

--- a/sdk/go/receipt/create.go
+++ b/sdk/go/receipt/create.go
@@ -38,6 +38,10 @@ type CreateInput struct {
 	// CorrelationID links related receipts for the same logical tool invocation.
 	// See CredentialSubject.CorrelationID.
 	CorrelationID string
+
+	// Delegation records the parent chain when this receipt opens a subagent
+	// chain. Nil on root chains and all receipts after the first in a chain.
+	Delegation *Delegation
 }
 
 // Create builds an unsigned AgentReceipt from structured inputs.
@@ -62,6 +66,7 @@ func Create(input CreateInput) UnsignedAgentReceipt {
 		Intent:        input.Intent,
 		Authorization: input.Authorization,
 		CorrelationID: input.CorrelationID,
+		Delegation:    input.Delegation,
 	}
 
 	// Compute response_hash when a response body is supplied.

--- a/sdk/go/receipt/create_test.go
+++ b/sdk/go/receipt/create_test.go
@@ -136,3 +136,53 @@ func TestCreateOmitsEmptyCorrelationID(t *testing.T) {
 		t.Errorf("canonical JSON contains correlation_id when field is empty: %s", canonical)
 	}
 }
+
+func TestCreatePreservesDelegation(t *testing.T) {
+	del := &Delegation{
+		ParentChainID:   "root-chain",
+		ParentReceiptID: "urn:receipt:parent-uuid",
+		Delegator:       Delegator{ID: "did:agent-receipts-daemon:host"},
+	}
+	r := Create(CreateInput{
+		Issuer:     Issuer{ID: "did:agent:test"},
+		Principal:  Principal{ID: "did:user:alice"},
+		Action:     Action{Type: "mcp.tool_call", RiskLevel: RiskLow},
+		Outcome:    Outcome{Status: StatusSuccess},
+		Chain:      Chain{Sequence: 1, ChainID: "root-chain/agent/abc"},
+		Delegation: del,
+	})
+	got := r.CredentialSubject.Delegation
+	if got == nil {
+		t.Fatal("expected delegation to be set, got nil")
+	}
+	if got.ParentChainID != del.ParentChainID {
+		t.Errorf("ParentChainID = %q, want %q", got.ParentChainID, del.ParentChainID)
+	}
+	if got.ParentReceiptID != del.ParentReceiptID {
+		t.Errorf("ParentReceiptID = %q, want %q", got.ParentReceiptID, del.ParentReceiptID)
+	}
+	if got.Delegator.ID != del.Delegator.ID {
+		t.Errorf("Delegator.ID = %q, want %q", got.Delegator.ID, del.Delegator.ID)
+	}
+}
+
+func TestCreateOmitsNilDelegation(t *testing.T) {
+	r := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:alice"},
+		Action:    Action{Type: "mcp.tool_call", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	if r.CredentialSubject.Delegation != nil {
+		t.Errorf("expected nil Delegation on root-chain receipt, got %+v", r.CredentialSubject.Delegation)
+	}
+	// Verify absent from canonical JSON.
+	canonical, err := Canonicalize(r)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	if strings.Contains(canonical, "delegation") {
+		t.Errorf("canonical JSON contains delegation when nil: %s", canonical)
+	}
+}

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -207,6 +207,20 @@ func (c Chain) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
+// Delegator identifies the agent whose chain spawned a delegation.
+type Delegator struct {
+	ID string `json:"id"`
+}
+
+// Delegation records the chain linkage when this chain was spawned by
+// delegation from another agent. Present only on the first receipt of a
+// subagent chain; absent on root chains. See spec §delegation.
+type Delegation struct {
+	ParentChainID   string    `json:"parent_chain_id"`
+	ParentReceiptID string    `json:"parent_receipt_id"`
+	Delegator       Delegator `json:"delegator"`
+}
+
 // CredentialSubject contains the core receipt payload.
 type CredentialSubject struct {
 	Principal     Principal      `json:"principal"`
@@ -219,6 +233,9 @@ type CredentialSubject struct {
 	// (e.g. hook pre-check to MCP proxy post-action). Populated from the
 	// runtime's tool-use correlation token; absent when not available.
 	CorrelationID string `json:"correlation_id,omitempty"`
+	// Delegation records the parent chain when this receipt opens a subagent
+	// chain. Absent on root chains and all receipts after the first in a chain.
+	Delegation *Delegation `json:"delegation,omitempty"`
 }
 
 // Proof contains the Ed25519 signature.

--- a/sdk/py/src/agent_receipts/receipt/create.py
+++ b/sdk/py/src/agent_receipts/receipt/create.py
@@ -16,6 +16,7 @@ from agent_receipts.receipt.types import (
     Authorization,
     Chain,
     CredentialSubject,
+    Delegation,
     EmitterMetadata,
     Intent,
     Issuer,
@@ -66,6 +67,7 @@ class CreateReceiptInput(BaseModel):
     # MUST be "complete" or "interrupted" (spec §7.3.3).
     termination_status: Literal["complete", "interrupted"] | None = None
     correlation_id: str | None = None
+    delegation: Delegation | None = None
 
 
 def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
@@ -143,6 +145,8 @@ def create_receipt(input: CreateReceiptInput) -> UnsignedAgentReceipt:
         cs_data["authorization"] = input.authorization
     if input.correlation_id:
         cs_data["correlation_id"] = input.correlation_id
+    if input.delegation is not None:
+        cs_data["delegation"] = input.delegation
 
     receipt_data: dict[str, Any] = {
         "@context": list(CONTEXT),

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -259,6 +259,22 @@ class Chain(BaseModel):
         return data
 
 
+class Delegator(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+
+
+class Delegation(BaseModel):
+    """Present on the first receipt of a subagent chain; absent on root chains."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    parent_chain_id: str
+    parent_receipt_id: str
+    delegator: Delegator
+
+
 class CredentialSubject(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -269,6 +285,7 @@ class CredentialSubject(BaseModel):
     authorization: Authorization | None = None
     chain: Chain
     correlation_id: str | None = Field(None, min_length=1)
+    delegation: Delegation | None = None
 
 
 class Proof(BaseModel):

--- a/sdk/py/tests/receipt/test_create.py
+++ b/sdk/py/tests/receipt/test_create.py
@@ -11,6 +11,8 @@ from agent_receipts.receipt.types import (
     VERSION,
     Authorization,
     Chain,
+    Delegation,
+    Delegator,
     Intent,
     Issuer,
     Outcome,
@@ -120,3 +122,16 @@ class TestCreateReceipt:
     def test_excludes_correlation_id_when_empty_string(self) -> None:
         receipt = create_receipt(_make_input(correlation_id=""))
         assert receipt.credentialSubject.correlation_id is None
+
+    def test_preserves_delegation(self) -> None:
+        delegation = Delegation(
+            parent_chain_id="root-chain",
+            parent_receipt_id="urn:receipt:parent-uuid",
+            delegator=Delegator(id="did:agent-receipts-daemon:host"),
+        )
+        receipt = create_receipt(_make_input(delegation=delegation))
+        assert receipt.credentialSubject.delegation == delegation
+
+    def test_excludes_delegation_when_not_provided(self) -> None:
+        receipt = create_receipt(_make_input())
+        assert receipt.credentialSubject.delegation is None

--- a/sdk/ts/src/receipt/create.test.ts
+++ b/sdk/ts/src/receipt/create.test.ts
@@ -212,4 +212,21 @@ describe("createReceipt", () => {
 
 		expect(receipt.credentialSubject).not.toHaveProperty("correlation_id");
 	});
+
+	it("preserves delegation on the first receipt of a subagent chain", () => {
+		const delegation = {
+			parent_chain_id: "root-chain",
+			parent_receipt_id: "urn:receipt:parent-uuid",
+			delegator: { id: "did:agent-receipts-daemon:host" },
+		};
+		const receipt = createReceipt(makeInput({ delegation }));
+
+		expect(receipt.credentialSubject.delegation).toEqual(delegation);
+	});
+
+	it("omits delegation when not provided", () => {
+		const receipt = createReceipt(makeInput());
+
+		expect(receipt.credentialSubject).not.toHaveProperty("delegation");
+	});
 });

--- a/sdk/ts/src/receipt/create.ts
+++ b/sdk/ts/src/receipt/create.ts
@@ -4,6 +4,7 @@ import type {
 	Action,
 	Authorization,
 	Chain,
+	Delegation,
 	Intent,
 	Issuer,
 	Outcome,
@@ -47,6 +48,9 @@ export interface CreateReceiptInput {
 	 *  logical tool invocation (e.g. a hook pre-check to MCP proxy post-action).
 	 *  Must be non-empty when provided; omit when no correlation context exists. */
 	correlationId?: string;
+	/** Records the parent chain when this receipt opens a subagent chain.
+	 *  Only set on the first receipt of a new subagent chain; omit otherwise. */
+	delegation?: Delegation;
 }
 
 /**
@@ -109,6 +113,7 @@ export function createReceipt(input: CreateReceiptInput): UnsignedAgentReceipt {
 			...(input.intent && { intent: input.intent }),
 			...(input.authorization && { authorization: input.authorization }),
 			...(input.correlationId && { correlation_id: input.correlationId }),
+			...(input.delegation && { delegation: input.delegation }),
 		},
 	};
 }

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -193,6 +193,18 @@ const chainSchema = z
 		path: ["status"],
 	});
 
+// --- Delegation ---
+
+const delegatorSchema = z.object({ id: z.string() }).passthrough();
+
+const delegationSchema = z
+	.object({
+		parent_chain_id: z.string(),
+		parent_receipt_id: z.string(),
+		delegator: delegatorSchema,
+	})
+	.passthrough();
+
 // --- Credential Subject ---
 
 const credentialSubjectSchema = z
@@ -204,6 +216,7 @@ const credentialSubjectSchema = z
 		authorization: authorizationSchema.optional(),
 		chain: chainSchema,
 		correlation_id: z.string().min(1).optional(),
+		delegation: delegationSchema.optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -193,6 +193,19 @@ export interface Chain {
 	status?: "complete" | "interrupted";
 }
 
+// --- Delegation ---
+
+export interface Delegator {
+	id: string;
+}
+
+/** Present on the first receipt of a subagent chain; absent on root chains. */
+export interface Delegation {
+	parent_chain_id: string;
+	parent_receipt_id: string;
+	delegator: Delegator;
+}
+
 // --- Credential Subject ---
 
 export interface CredentialSubject {
@@ -203,6 +216,8 @@ export interface CredentialSubject {
 	authorization?: Authorization;
 	chain: Chain;
 	correlation_id?: string;
+	/** Records the parent chain when this receipt opens a subagent chain. */
+	delegation?: Delegation;
 }
 
 // --- Proof ---


### PR DESCRIPTION
## Summary

Layer 2 of the receipt attribution stack (#422). Claude Code sends a distinct `agent_id` per subagent in hook payloads; this PR wires that field end-to-end and implements the `Delegation` struct (already defined in the protocol spec but missing from the code) so subagent chains carry a cryptographically verifiable backlink to the root chain that spawned them.

- **Hook → emitter → daemon**: `agent_id` parsed from `claudeCodeFrame`, forwarded through `emitter.Event` and `frame` wire structs, validated (256-byte cap) in `EmitterFrame`
- **`Delegation` struct** across all three SDKs: `Delegator` + `Delegation` types on `CredentialSubject` and `CreateInput`, wired through all three `create` functions with `omitempty` / `None` serialization
- **Multi-chain daemon routing**: `Pipeline` gains `agentChains map[string]*chain.State` (RW-mutex, double-check locking). `getOrCreateAgentState` routes frames to per-agent chains with deterministic IDs (`"<rootChainID>/agent/<agentID>"`), enables cross-restart resumption, and populates `Delegation` on the first receipt of each new agent chain with a backlink to the root chain's tail at that moment. `EmitTerminator` now terminates all open agent chains before the root chain.
- **Deprecation shim** (`dist/sdk-go-deprecation`): `Delegation` types added so the shim can deserialize receipts produced by the canonical SDK
- **Cross-SDK canonicalization vector**: `receipt_delegation_field` (`sha256:6982fe89...`) verifying `delegation` survives round-trip in all SDKs

## Design notes

**Chain ID format** — `"<rootChainID>/agent/<agentID>"` is deterministic and human-readable, making it possible to resume an agent chain across daemon restarts when the same agent reconnects within a session. The `/agent/` segment makes subagent chains visually distinct from root chains in audit tools.

**Delegation on first receipt only** — `getOrCreateAgentState` returns a non-nil `Delegation` exactly once per agent (when `chain.NextSeq() == 1`). Subsequent calls for the same agent ID return `nil` delegation. If the root chain has no receipts yet when the first agent frame arrives (subagent fires before the root chain has anything), delegation is omitted rather than returning an error.

**Drop receipts inherit agent routing** — `processWithDrop` routes to the same agent `chain.State` as `processLive`, so a synthetic `events_dropped` receipt and its following live receipt are adjacent on the correct chain.

**W3C Trace Context alignment** — `session_id` ≈ `trace_id`, `agent_id`-scoped chain ≈ sub-trace, `correlation_id` ≈ `parent_id` for the pre/post pair. The alignment is semantic; the receipt format stays URN/JSON, not HTTP headers.

## Tests added

- **Go SDK**: `TestCreatePreservesDelegation`, `TestCreateOmitsNilDelegation`
- **Pipeline**: `TestProcess_AgentIDRoutesToSeparateChain`, `TestProcess_DelegationOnFirstAgentReceipt`, `TestProcess_NoDelegationWhenRootChainEmpty`, `TestEmitTerminator_TerminatesAgentChains`
- **TypeScript**: delegation present / absent in `create.test.ts`
- **Python**: `test_preserves_delegation`, `test_excludes_delegation_when_not_provided`
- **Cross-SDK**: `receipt_delegation_field` canonicalization vector

## Follow-up

- Layer 3 (dashboard): collapse pre/post pairs by `correlation_id`, swimlanes by `agent_id`, delegation edges — separate repo
- `sdk/ts/src/receipt/chain.ts`: two pre-existing biome `useOptionalChain` warnings surfaced by the pre-push hook — filed as a separate papercut