### PR TITLE
feat(release): add alpha-track Homebrew formulae for daemon, hook, mcp-proxy

### DIFF
--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -153,3 +153,80 @@ brews:
         strategy :github_releases
         regex(/^daemon\/v?(\d+(?:\.\d+)+)$/i)
       end
+
+  # Alpha-track formula — updated on every release (stable and pre-release).
+  # `brew install agent-receipts/tap/agent-receipts-daemon-alpha` always gives
+  # the latest cut; conflicts with the stable formula since both install the
+  # same binaries.
+  - name: agent-receipts-daemon-alpha
+    repository:
+      owner: agent-receipts
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "bump-{{.ProjectName}}-alpha-{{.Version}}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+    directory: Formula
+    url_template: "https://github.com/agent-receipts/ar/releases/download/daemon%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/agent-receipts/ar/tree/main/daemon"
+    description: "Agent Receipts daemon and companion verify CLI (alpha/beta track)"
+    license: "Apache-2.0"
+    commit_author:
+      name: agent-receipts-bot
+      email: bot@agentreceipts.ai
+    commit_msg_template: "chore(daemon): bump alpha to v{{ .Version }}"
+    install: |
+      bin.install "agent-receipts-daemon"
+      bin.install "agent-receipts"
+    test: |
+      system "#{bin}/agent-receipts-daemon", "--version"
+      system "#{bin}/agent-receipts", "--help"
+    custom_block: |
+      conflicts_with "agent-receipts-daemon", because: "both install the same binaries"
+
+      def post_install
+        (var/"log/agent-receipts").mkpath
+      end
+
+      service do
+        run opt_bin/"agent-receipts-daemon"
+        keep_alive crashed: true
+        log_path var/"log/agent-receipts/daemon.log"
+        error_log_path var/"log/agent-receipts/daemon.log"
+      end
+
+      def caveats
+        <<~EOS
+          This is the alpha/beta track — it tracks every release including pre-releases.
+          For stable-only installs use: brew install agent-receipts/tap/agent-receipts-daemon
+
+          Before starting the service for the first time, generate your signing key:
+            agent-receipts-daemon --init
+
+          Then start the daemon:
+            brew services start agent-receipts/tap/agent-receipts-daemon-alpha
+
+          Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
+                             (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)
+                             Override: AGENTRECEIPTS_DB
+          Signing key:       $XDG_DATA_HOME/agent-receipts/signing.key
+                             (falls back to ~/.local/share/agent-receipts/signing.key when $XDG_DATA_HOME is unset or relative)
+                             Override: AGENTRECEIPTS_KEY
+          Socket (macOS):    $XDG_DATA_HOME/agent-receipts/events.sock
+                             (falls back to ~/.local/share/agent-receipts/events.sock when $XDG_DATA_HOME is unset or relative)
+                             Override: AGENTRECEIPTS_SOCKET
+          Socket (Linux):    $XDG_RUNTIME_DIR/agentreceipts/events.sock
+                             (falls back to /run/agentreceipts/events.sock when $XDG_RUNTIME_DIR is unset)
+                             Override: AGENTRECEIPTS_SOCKET
+          Daemon logs:       #{var}/log/agent-receipts/daemon.log
+                             (stdout + stderr, written by launchd when started via `brew services`)
+        EOS
+      end
+
+      livecheck do
+        url "https://github.com/agent-receipts/ar"
+        strategy :github_releases
+        regex(/^daemon\/v?(\d+(?:\.\d+)+(?:-[a-z0-9.]+)?)$/i)
+      end

--- a/hook/.goreleaser.yaml
+++ b/hook/.goreleaser.yaml
@@ -90,3 +90,39 @@ brews:
         strategy :github_releases
         regex(/^hook\/v?(\d+(?:\.\d+)+)$/i)
       end
+
+  # Alpha-track formula — updated on every release (stable and pre-release).
+  # `brew install agent-receipts/tap/agent-receipts-hook-alpha` always gives
+  # the latest cut; conflicts with the stable formula since both install the
+  # same binary.
+  - name: agent-receipts-hook-alpha
+    repository:
+      owner: agent-receipts
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "bump-{{.ProjectName}}-alpha-{{.Version}}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+    directory: Formula
+    url_template: "https://github.com/agent-receipts/ar/releases/download/hook%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/agent-receipts/ar/tree/main/hook"
+    description: "Claude Code PostToolUse hook that forwards tool-call events to agent-receipts-daemon (alpha/beta track)"
+    license: "Apache-2.0"
+    commit_author:
+      name: agent-receipts-bot
+      email: bot@agentreceipts.ai
+    commit_msg_template: "chore(hook): bump alpha to v{{ .Version }}"
+    install: |
+      bin.install "agent-receipts-hook"
+    test: |
+      system "#{bin}/agent-receipts-hook", "--version"
+    custom_block: |
+      conflicts_with "agent-receipts-hook", because: "both install the same binary"
+
+      livecheck do
+        url "https://github.com/agent-receipts/ar"
+        strategy :github_releases
+        regex(/^hook\/v?(\d+(?:\.\d+)+(?:-[a-z0-9.]+)?)$/i)
+      end

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -84,3 +84,38 @@ brews:
         strategy :github_releases
         regex(/^mcp-proxy\/v?(\d+(?:\.\d+)+)$/i)
       end
+
+  # Alpha-track formula — updated on every release (stable and pre-release).
+  # `brew install agent-receipts/tap/mcp-proxy-alpha` always gives the latest
+  # cut; conflicts with the stable formula since both install the same binary.
+  - name: mcp-proxy-alpha
+    repository:
+      owner: agent-receipts
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "bump-{{.ProjectName}}-alpha-{{.Version}}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+    directory: Formula
+    url_template: "https://github.com/agent-receipts/ar/releases/download/mcp-proxy%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/agent-receipts/ar/tree/main/mcp-proxy"
+    description: "MCP proxy with action receipts, policy engine, and intent tracking (alpha/beta track)"
+    license: "Apache-2.0"
+    commit_author:
+      name: agent-receipts-bot
+      email: bot@agentreceipts.ai
+    commit_msg_template: "chore(mcp-proxy): bump alpha to v{{ .Version }}"
+    install: |
+      bin.install "mcp-proxy"
+    test: |
+      system "#{bin}/mcp-proxy", "--version"
+    custom_block: |
+      conflicts_with "mcp-proxy", because: "both install the same binary"
+
+      livecheck do
+        url "https://github.com/agent-receipts/ar"
+        strategy :github_releases
+        regex(/^mcp-proxy\/v?(\d+(?:\.\d+)+(?:-[a-z0-9.]+)?)$/i)
+      end


### PR DESCRIPTION
## Summary

Adds a second `brews:` entry to each `.goreleaser.yaml` (daemon, hook, mcp-proxy) without `skip_upload`, so GoReleaser publishes an alpha-track formula on every release — stable and pre-release alike. The stable formula retains `skip_upload: auto` and continues to track only stable tags.

Install the latest cut (including alphas/betas) with:
```
brew install agent-receipts/tap/agent-receipts-daemon-alpha
brew install agent-receipts/tap/agent-receipts-hook-alpha
brew install agent-receipts/tap/mcp-proxy-alpha
```

When a stable release ships, the alpha formula advances to that stable version too — so the alpha track is always "latest", not "frozen at last alpha".

## Design choices

- **`conflicts_with` the stable sibling** — both formulas install the same binary names, so Homebrew prevents them being installed simultaneously. Users choose one track.
- **`livecheck` regex extended** — matches pre-release suffixes (e.g. `0.17.0-alpha.1`) so `brew outdated` and `brew livecheck` work correctly on the alpha track.
- **Branch naming** — `bump-<project>-alpha-<version>` to distinguish alpha-track tap PRs from stable-track PRs at a glance.

## Test plan

- [ ] Dry-run a GoReleaser build locally against a pre-release tag and confirm both formulae are generated
- [ ] After next alpha tag is pushed, verify tap PRs are opened for both the stable (skipped) and alpha (published) formulae