### PR TITLE
chore(release): bump sdk-ts to 0.12.0-alpha.1 and sdk-py to 0.12.0a1

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.11.1"
+version = "0.12.0a1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.11.1",
+	"version": "0.12.0-alpha.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## Summary

Version files weren't bumped before the alpha tags were pushed, causing release workflow failures. This fixes that.

- `sdk/ts/package.json`: `0.11.1` → `0.12.0-alpha.1`
- `sdk/py/pyproject.toml`: `0.11.1` → `0.12.0a1`

After merge, the existing `sdk-ts-v0.12.0-alpha.1` and `sdk-py-v0.12.0a1` tags need to be moved to the new HEAD before re-triggering the release workflows.