### PR TITLE
fix(goreleaser): add conflicts_with alpha sibling to stable formula custom_block

### DIFF
--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -148,6 +148,8 @@ brews:
         EOS
       end
 
+      conflicts_with "agent-receipts-daemon-alpha", because: "both install the same binaries"
+
       livecheck do
         url "https://github.com/agent-receipts/ar"
         strategy :github_releases

--- a/hook/.goreleaser.yaml
+++ b/hook/.goreleaser.yaml
@@ -85,6 +85,8 @@ brews:
     # scans all releases; regex extracts version from the `hook/vX.Y.Z`
     # tag prefix.
     custom_block: |
+      conflicts_with "agent-receipts-hook-alpha", because: "both install the same binary"
+
       livecheck do
         url "https://github.com/agent-receipts/ar"
         strategy :github_releases

--- a/mcp-proxy/.goreleaser.yaml
+++ b/mcp-proxy/.goreleaser.yaml
@@ -79,6 +79,8 @@ brews:
     # scans all releases; regex extracts version from the `mcp-proxy/vX.Y.Z`
     # tag prefix.
     custom_block: |
+      conflicts_with "mcp-proxy-alpha", because: "both install the same binary"
+
       livecheck do
         url "https://github.com/agent-receipts/ar"
         strategy :github_releases


### PR DESCRIPTION
## Summary

GoReleaser regenerates the tap formula from `custom_block` on each stable release. Without this change, every stable release would overwrite the `conflicts_with` declaration that was manually patched in homebrew-tap PR #52 — leading to the same audit failure on the next stable bump.

- `hook/.goreleaser.yaml` — stable formula gets `conflicts_with "agent-receipts-hook-alpha"`
- `daemon/.goreleaser.yaml` — stable formula gets `conflicts_with "agent-receipts-daemon-alpha"`
- `mcp-proxy/.goreleaser.yaml` — stable formula gets `conflicts_with "mcp-proxy-alpha"`

The alpha formula `custom_block` already has the reciprocal declaration. This closes the loop so both sides are always in sync.

## Related

- homebrew-tap #52 — immediate fix to existing stable formulas in the tap
- homebrew-tap #50/#51 — alpha formula bump PRs blocked by the audit failure

## Test plan

- [ ] `go vet` passes (YAML-only change, no Go code affected)
- [ ] GoReleaser dry-run on `hook` produces a formula with both `conflicts_with` declarations