### PR TITLE
feat(issuer): open runtime metadata sub-object (v0.5.0, ADR-0026)

### DIFF
--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -656,6 +656,7 @@ type v050Vectors struct {
 	Version   string                `json:"version"`
 	Keys      keysSection           `json:"keys"`
 	Runtime   runtimeReceiptSection `json:"runtimeReceipt"`
+	Extended  runtimeReceiptSection `json:"extendedRuntimeReceipt"`
 	RootAgent runtimeReceiptSection `json:"rootAgentReceipt"`
 }
 
@@ -848,6 +849,46 @@ func generateV050Vectors(keys keysSection) error {
 		return fmt.Errorf("runtime receipt: %w", err)
 	}
 
+	// --- receipt whose issuer.runtime carries a key beyond the typed members ---
+	// (trace_id) — pins that the open container preserves unknown runtime keys
+	// byte-identically across all three SDKs (ADR-0026 D2). A newer SDK adding
+	// trace_id must not diverge from an older SDK that does not model it.
+	extendedUnsigned := map[string]any{
+		"@context": contextV2,
+		"id":       "urn:receipt:050e0050-0000-4050-a050-000000000003",
+		"type":     []any{"VerifiableCredential", "AgentReceipt"},
+		"version":  "0.5.0",
+		"issuer": map[string]any{
+			"id":         "did:agent-receipts-daemon:test",
+			"session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00",
+			"runtime": map[string]any{
+				"agent_id":   "a3e49db54342a92d4",
+				"agent_type": "general-purpose",
+				"trace_id":   "4bf92f3577b34da6a3ce929d0e0e4736",
+			},
+		},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":         "act_050e0050-0000-4050-a050-000000000003",
+				"type":       "filesystem.file.read",
+				"risk_level": "low",
+				"timestamp":  fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_v050_test/agent/a3e49db54342a92d4",
+			},
+		},
+	}
+	extendedSigned, extendedHash, err := signAndHashMap(extendedUnsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("extended runtime receipt: %w", err)
+	}
+
 	// --- root-agent receipt: issuer omits runtime (backward-compatible shape) ---
 	rootUnsigned := map[string]any{
 		"@context": contextV2,
@@ -880,8 +921,8 @@ func generateV050Vectors(keys keysSection) error {
 		return fmt.Errorf("root receipt: %w", err)
 	}
 
-	// Self-check: both receipts must verify against the shared public key.
-	for label, signed := range map[string]json.RawMessage{"runtime": runtimeSigned, "root": rootSigned} {
+	// Self-check: all receipts must verify against the shared public key.
+	for label, signed := range map[string]json.RawMessage{"runtime": runtimeSigned, "extended": extendedSigned, "root": rootSigned} {
 		var r receipt.AgentReceipt
 		if err := json.Unmarshal(signed, &r); err != nil {
 			return fmt.Errorf("unmarshal %s receipt: %w", label, err)
@@ -900,6 +941,12 @@ func generateV050Vectors(keys keysSection) error {
 			Description:         "Signed v0.5.0 sub-agent receipt whose issuer carries runtime.agent_id and runtime.agent_type.",
 			Receipt:             runtimeSigned,
 			ExpectedReceiptHash: runtimeHash,
+			ExpectedValid:       true,
+		},
+		Extended: runtimeReceiptSection{
+			Description:         "Signed v0.5.0 receipt whose issuer.runtime carries an extra key (trace_id) beyond the typed members. All three SDKs MUST preserve the unknown key and reproduce this hash byte-for-byte (ADR-0026 open-container invariant).",
+			Receipt:             extendedSigned,
+			ExpectedReceiptHash: extendedHash,
 			ExpectedValid:       true,
 		},
 		RootAgent: runtimeReceiptSection{

--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -203,6 +203,13 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("wrote v040_vectors.json")
+
+	// --- v0.5.0 vectors ---
+	if err := generateV050Vectors(tsVectors.Keys); err != nil {
+		fmt.Fprintf(os.Stderr, "generate v050 vectors: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("wrote v050_vectors.json")
 }
 
 // generateV020Vectors builds and writes v020_vectors.json using the shared keypair
@@ -260,6 +267,10 @@ func generateV020Vectors(keys keysSection) error {
 		// that). Without this, every protocol bump silently rewrites the pinned
 		// v020 vector and its signatures.
 		r.Version = "0.2.0"
+		// Pin the JSON-LD context for the same reason: Create stamps the SDK's
+		// current context (v2 since ADR-0026), but a v0.2.0 receipt references
+		// context v1. Without this, a context bump rewrites the pinned vector.
+		r.Context = []string{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"}
 
 		s, err := receipt.Sign(r, keys.PrivateKey, "did:agent:test#key-1")
 		if err != nil {
@@ -636,6 +647,25 @@ type duplicateChainSection struct {
 	ExpectedWarningCount int               `json:"expectedWarningCount"`
 }
 
+// v050Vectors holds the ADR-0026 cross-SDK vectors: a v0.5.0 receipt whose
+// issuer carries the open `runtime` sub-object (agent_id / agent_type), and a
+// root-agent receipt that omits `runtime` entirely. Receipts at 0.5.0 reference
+// JSON-LD context v2.
+type v050Vectors struct {
+	Comment   string                `json:"$comment"`
+	Version   string                `json:"version"`
+	Keys      keysSection           `json:"keys"`
+	Runtime   runtimeReceiptSection `json:"runtimeReceipt"`
+	RootAgent runtimeReceiptSection `json:"rootAgentReceipt"`
+}
+
+type runtimeReceiptSection struct {
+	Description         string          `json:"description"`
+	Receipt             json.RawMessage `json:"receipt"`
+	ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+	ExpectedValid       bool            `json:"expectedValid"`
+}
+
 func generateV040Vectors(keys keysSection) error {
 	const fixedTimestamp = "2026-05-23T00:00:00Z"
 
@@ -772,6 +802,119 @@ func generateV040Vectors(keys keysSection) error {
 		return fmt.Errorf("marshal v040 vectors: %w", err)
 	}
 	return os.WriteFile("v040_vectors.json", append(outBytes, '\n'), 0644)
+}
+
+// generateV050Vectors builds and writes v050_vectors.json: a v0.5.0 receipt
+// whose issuer carries the open `runtime` sub-object (ADR-0026), plus a
+// root-agent receipt that omits `runtime`. Both reference JSON-LD context v2.
+// All three SDKs MUST canonicalise, hash, sign, and verify these byte-for-byte.
+func generateV050Vectors(keys keysSection) error {
+	const fixedTimestamp = "2026-06-09T00:00:00Z"
+	contextV2 := []any{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v2"}
+
+	// --- sub-agent receipt carrying issuer.runtime ---
+	runtimeUnsigned := map[string]any{
+		"@context": contextV2,
+		"id":       "urn:receipt:050e0050-0000-4050-a050-000000000001",
+		"type":     []any{"VerifiableCredential", "AgentReceipt"},
+		"version":  "0.5.0",
+		"issuer": map[string]any{
+			"id":         "did:agent-receipts-daemon:test",
+			"session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00",
+			"runtime": map[string]any{
+				"agent_id":   "a3e49db54342a92d4",
+				"agent_type": "general-purpose",
+			},
+		},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":         "act_050e0050-0000-4050-a050-000000000001",
+				"type":       "filesystem.file.read",
+				"risk_level": "low",
+				"timestamp":  fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_v050_test/agent/a3e49db54342a92d4",
+			},
+		},
+	}
+	runtimeSigned, runtimeHash, err := signAndHashMap(runtimeUnsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("runtime receipt: %w", err)
+	}
+
+	// --- root-agent receipt: issuer omits runtime (backward-compatible shape) ---
+	rootUnsigned := map[string]any{
+		"@context": contextV2,
+		"id":       "urn:receipt:050e0050-0000-4050-a050-000000000002",
+		"type":     []any{"VerifiableCredential", "AgentReceipt"},
+		"version":  "0.5.0",
+		"issuer": map[string]any{
+			"id":         "did:agent-receipts-daemon:test",
+			"session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00",
+		},
+		"issuanceDate": fixedTimestamp,
+		"credentialSubject": map[string]any{
+			"principal": map[string]any{"id": "did:user:test"},
+			"action": map[string]any{
+				"id":         "act_050e0050-0000-4050-a050-000000000002",
+				"type":       "filesystem.file.read",
+				"risk_level": "low",
+				"timestamp":  fixedTimestamp,
+			},
+			"outcome": map[string]any{"status": "success"},
+			"chain": map[string]any{
+				"sequence":              1,
+				"previous_receipt_hash": nil,
+				"chain_id":              "chain_v050_test",
+			},
+		},
+	}
+	rootSigned, rootHash, err := signAndHashMap(rootUnsigned, keys, fixedTimestamp)
+	if err != nil {
+		return fmt.Errorf("root receipt: %w", err)
+	}
+
+	// Self-check: both receipts must verify against the shared public key.
+	for label, signed := range map[string]json.RawMessage{"runtime": runtimeSigned, "root": rootSigned} {
+		var r receipt.AgentReceipt
+		if err := json.Unmarshal(signed, &r); err != nil {
+			return fmt.Errorf("unmarshal %s receipt: %w", label, err)
+		}
+		res := receipt.VerifyChain([]receipt.AgentReceipt{r}, keys.PublicKey)
+		if !res.Valid {
+			return fmt.Errorf("generated %s receipt failed verification: %s", label, res.Error)
+		}
+	}
+
+	out := v050Vectors{
+		Comment: "Cross-SDK v0.5.0 test vectors: pins the open issuer.runtime sub-object (agent_id / agent_type) and JSON-LD context v2 (spec §4.3.1, ADR-0026). runtime is an ordinary nested object under RFC 8785 — its keys sort like any other — so cross-SDK hash/sign/verify must be byte-identical. The root-agent receipt pins that omitting runtime stays backward-compatible.",
+		Version: "0.5.0",
+		Keys:    keys,
+		Runtime: runtimeReceiptSection{
+			Description:         "Signed v0.5.0 sub-agent receipt whose issuer carries runtime.agent_id and runtime.agent_type.",
+			Receipt:             runtimeSigned,
+			ExpectedReceiptHash: runtimeHash,
+			ExpectedValid:       true,
+		},
+		RootAgent: runtimeReceiptSection{
+			Description:         "Signed v0.5.0 root-agent receipt whose issuer omits runtime entirely.",
+			Receipt:             rootSigned,
+			ExpectedReceiptHash: rootHash,
+			ExpectedValid:       true,
+		},
+	}
+
+	outBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal v050 vectors: %w", err)
+	}
+	return os.WriteFile("v050_vectors.json", append(outBytes, '\n'), 0644)
 }
 
 // signAndHashMap signs an unsigned-receipt JSON map with the Ed25519 PEM

--- a/cross-sdk-tests/spec_schema_test.go
+++ b/cross-sdk-tests/spec_schema_test.go
@@ -171,6 +171,49 @@ func TestSpecSchemaRejectsNonRFC3339IssuanceDate(t *testing.T) {
 	}
 }
 
+// TestSpecSchemaCouplesVersionAndContext pins the ADR-0026 allOf binding: a
+// receipt's protocol version and its Agent Receipts @context URI must agree
+// (0.1.0–0.4.0 → context v1; 0.5.0 → v2). Without the coupling, a 0.5.0 receipt
+// could declare context v1 (whose JSON-LD has no runtime term) and validate.
+func TestSpecSchemaCouplesVersionAndContext(t *testing.T) {
+	schema := loadSchema(t)
+
+	load := func() (map[string]any, []any) {
+		full := decodeJSON(t, filepath.Join("..", "spec", "examples", "minimal-receipt.json"))
+		receipt, ok := full.(map[string]any)
+		if !ok {
+			t.Fatalf("minimal-receipt.json is not an object: %T", full)
+		}
+		ctx, ok := receipt["@context"].([]any)
+		if !ok {
+			t.Fatalf("@context is not an array: %T", receipt["@context"])
+		}
+		return receipt, ctx
+	}
+
+	// Baseline: the unmodified example (a pre-0.5.0 version on context v1) validates.
+	base, _ := load()
+	if err := schema.Validate(base); err != nil {
+		t.Fatalf("baseline minimal-receipt.json does not validate: %v", err)
+	}
+
+	// 0.5.0 declaring context v1 — runtime term would be undefined; must reject.
+	mismatch1, _ := load()
+	mismatch1["version"] = "0.5.0"
+	if err := schema.Validate(mismatch1); err == nil {
+		t.Error("schema accepted version 0.5.0 with context v1 — version/context coupling missing")
+	}
+
+	// A pre-0.5.0 version declaring context v2 — must reject (released versions
+	// reference v1 permanently).
+	mismatch2, ctx2 := load()
+	ctx2[1] = "https://agentreceipts.ai/context/v2"
+	mismatch2["@context"] = ctx2
+	if err := schema.Validate(mismatch2); err == nil {
+		t.Error("schema accepted a 0.1.0–0.4.0 version with context v2 — version/context coupling missing")
+	}
+}
+
 // TestCrossSDKVectorsValidateAgainstSchema runs the signed receipts produced
 // by all three SDKs (Go, TS, Py) through the schema. If any SDK regresses to
 // emitting a non-spec field shape, the cross-SDK contract fails here.

--- a/cross-sdk-tests/v050_vectors.json
+++ b/cross-sdk-tests/v050_vectors.json
@@ -57,6 +57,59 @@
     "expectedReceiptHash": "sha256:8a5809dcb62efcc55bc5a3876e4c5b62f85d2932e1633ded1527befb2052ea7c",
     "expectedValid": true
   },
+  "extendedRuntimeReceipt": {
+    "description": "Signed v0.5.0 receipt whose issuer.runtime carries an extra key (trace_id) beyond the typed members. All three SDKs MUST preserve the unknown key and reproduce this hash byte-for-byte (ADR-0026 open-container invariant).",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v2"
+      ],
+      "credentialSubject": {
+        "action": {
+          "id": "act_050e0050-0000-4050-a050-000000000003",
+          "risk_level": "low",
+          "timestamp": "2026-06-09T00:00:00Z",
+          "type": "filesystem.file.read"
+        },
+        "chain": {
+          "chain_id": "chain_v050_test/agent/a3e49db54342a92d4",
+          "previous_receipt_hash": null,
+          "sequence": 1
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "principal": {
+          "id": "did:user:test"
+        }
+      },
+      "id": "urn:receipt:050e0050-0000-4050-a050-000000000003",
+      "issuanceDate": "2026-06-09T00:00:00Z",
+      "issuer": {
+        "id": "did:agent-receipts-daemon:test",
+        "runtime": {
+          "agent_id": "a3e49db54342a92d4",
+          "agent_type": "general-purpose",
+          "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736"
+        },
+        "session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00"
+      },
+      "proof": {
+        "created": "2026-06-09T00:00:00Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "uSs-FqqNiNGDOp1O6zPExRv69m4Fu6C9U1-pSZh-yy5NfVc4F15wPsFI12_UiG_5C0ftcpJTZ-S3Kl1PzUAGdBg",
+        "type": "Ed25519Signature2020",
+        "verificationMethod": "did:agent:test#key-1"
+      },
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.5.0"
+    },
+    "expectedReceiptHash": "sha256:96249aa6691a109a78bfc93bd34abd6f59578c6f5ab7f83415da1b8a1ddc9332",
+    "expectedValid": true
+  },
   "rootAgentReceipt": {
     "description": "Signed v0.5.0 root-agent receipt whose issuer omits runtime entirely.",
     "receipt": {

--- a/cross-sdk-tests/v050_vectors.json
+++ b/cross-sdk-tests/v050_vectors.json
@@ -1,0 +1,108 @@
+{
+  "$comment": "Cross-SDK v0.5.0 test vectors: pins the open issuer.runtime sub-object (agent_id / agent_type) and JSON-LD context v2 (spec §4.3.1, ADR-0026). runtime is an ordinary nested object under RFC 8785 — its keys sort like any other — so cross-SDK hash/sign/verify must be byte-identical. The root-agent receipt pins that omitting runtime stays backward-compatible.",
+  "version": "0.5.0",
+  "keys": {
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAZMzh2Qtdx/p40WlXhD+gKmaTDv3rLGm6TeY7TsJUKSQ=\n-----END PUBLIC KEY-----\n",
+    "privateKey": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJqomA2cjqhLUYPhkMJyg4+A7hU8GiZtVzkN0Yz6jJPF\n-----END PRIVATE KEY-----\n"
+  },
+  "runtimeReceipt": {
+    "description": "Signed v0.5.0 sub-agent receipt whose issuer carries runtime.agent_id and runtime.agent_type.",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v2"
+      ],
+      "credentialSubject": {
+        "action": {
+          "id": "act_050e0050-0000-4050-a050-000000000001",
+          "risk_level": "low",
+          "timestamp": "2026-06-09T00:00:00Z",
+          "type": "filesystem.file.read"
+        },
+        "chain": {
+          "chain_id": "chain_v050_test/agent/a3e49db54342a92d4",
+          "previous_receipt_hash": null,
+          "sequence": 1
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "principal": {
+          "id": "did:user:test"
+        }
+      },
+      "id": "urn:receipt:050e0050-0000-4050-a050-000000000001",
+      "issuanceDate": "2026-06-09T00:00:00Z",
+      "issuer": {
+        "id": "did:agent-receipts-daemon:test",
+        "runtime": {
+          "agent_id": "a3e49db54342a92d4",
+          "agent_type": "general-purpose"
+        },
+        "session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00"
+      },
+      "proof": {
+        "created": "2026-06-09T00:00:00Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "ufp78VVsVq5sPg714ZWf7VN33Rn_smx3mEK2UkINitYUoY0sCW_Lxs8t_qKhQ1vf-TAd9PJ6qOzLoLC5IVwApCQ",
+        "type": "Ed25519Signature2020",
+        "verificationMethod": "did:agent:test#key-1"
+      },
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.5.0"
+    },
+    "expectedReceiptHash": "sha256:8a5809dcb62efcc55bc5a3876e4c5b62f85d2932e1633ded1527befb2052ea7c",
+    "expectedValid": true
+  },
+  "rootAgentReceipt": {
+    "description": "Signed v0.5.0 root-agent receipt whose issuer omits runtime entirely.",
+    "receipt": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://agentreceipts.ai/context/v2"
+      ],
+      "credentialSubject": {
+        "action": {
+          "id": "act_050e0050-0000-4050-a050-000000000002",
+          "risk_level": "low",
+          "timestamp": "2026-06-09T00:00:00Z",
+          "type": "filesystem.file.read"
+        },
+        "chain": {
+          "chain_id": "chain_v050_test",
+          "previous_receipt_hash": null,
+          "sequence": 1
+        },
+        "outcome": {
+          "status": "success"
+        },
+        "principal": {
+          "id": "did:user:test"
+        }
+      },
+      "id": "urn:receipt:050e0050-0000-4050-a050-000000000002",
+      "issuanceDate": "2026-06-09T00:00:00Z",
+      "issuer": {
+        "id": "did:agent-receipts-daemon:test",
+        "session_id": "a9a50488-d6f2-4dee-ac2e-ed3db47b9d00"
+      },
+      "proof": {
+        "created": "2026-06-09T00:00:00Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "uOxndeya87wY5xiYvEz3DqXEitrx2ESkeOlGDcySnrQtkWfcyzAARFUdbL5qwXPFS8KITGsqsPJ7cH9M1xpcyAA",
+        "type": "Ed25519Signature2020",
+        "verificationMethod": "did:agent:test#key-1"
+      },
+      "type": [
+        "VerifiableCredential",
+        "AgentReceipt"
+      ],
+      "version": "0.5.0"
+    },
+    "expectedReceiptHash": "sha256:6d8b3d3d370cdbe665388eecb2731d4a4431d1ebedf69f02b4b021fe06c5de71",
+    "expectedValid": true
+  }
+}

--- a/cross-sdk-tests/v050_vectors_test.go
+++ b/cross-sdk-tests/v050_vectors_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package crosssdk_test
+
+// Test runner for cross-sdk-tests/v050_vectors.json (issuer.runtime open
+// sub-object, spec §4.3.1 / ADR-0026). Pins:
+//
+//   - Schema validation of each v0.5.0 receipt against
+//     spec/schema/agent-receipt.schema.json (issuer.runtime + context v2).
+//   - Signature verification + byte-identical receipt-hash reproduction for the
+//     sub-agent receipt carrying issuer.runtime and the root-agent receipt that
+//     omits it.
+//   - The Go SDK round-trips issuer.runtime.agent_id / agent_type.
+//
+// Gated behind the `integration` build tag like the other vector runners.
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+const v050VectorsPath = "v050_vectors.json"
+
+type v050ReceiptSection struct {
+	Description         string          `json:"description"`
+	Receipt             json.RawMessage `json:"receipt"`
+	ExpectedReceiptHash string          `json:"expectedReceiptHash"`
+	ExpectedValid       bool            `json:"expectedValid"`
+}
+
+type v050File struct {
+	Comment string `json:"$comment"`
+	Version string `json:"version"`
+	Keys    struct {
+		PublicKey  string `json:"publicKey"`
+		PrivateKey string `json:"privateKey"`
+	} `json:"keys"`
+	Runtime   v050ReceiptSection `json:"runtimeReceipt"`
+	RootAgent v050ReceiptSection `json:"rootAgentReceipt"`
+}
+
+func loadV050(t *testing.T) v050File {
+	t.Helper()
+	data, err := os.ReadFile(v050VectorsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", v050VectorsPath, err)
+	}
+	var f v050File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("parse %s: %v", v050VectorsPath, err)
+	}
+	if f.Version != "0.5.0" {
+		t.Fatalf("v050 vectors file version = %q, want 0.5.0", f.Version)
+	}
+	return f
+}
+
+// TestV050VectorsValidateAgainstSchema runs each pinned v0.5.0 receipt through
+// the spec schema, locking in that issuer.runtime and context v2 validate.
+func TestV050VectorsValidateAgainstSchema(t *testing.T) {
+	schema := loadSchema(t)
+	f := loadV050(t)
+
+	for _, sec := range []v050ReceiptSection{f.Runtime, f.RootAgent} {
+		var doc any
+		if err := json.Unmarshal(sec.Receipt, &doc); err != nil {
+			t.Fatalf("unmarshal %q: %v", sec.Description, err)
+		}
+		if err := schema.Validate(doc); err != nil {
+			t.Errorf("%q does not validate against agent-receipt.schema.json:\n%v", sec.Description, err)
+		}
+	}
+}
+
+// TestV050ReceiptHashAndSignature verifies the signature and byte-identical
+// receipt hash of both the runtime-bearing and root-agent receipts.
+func TestV050ReceiptHashAndSignature(t *testing.T) {
+	f := loadV050(t)
+
+	pub, err := parseEd25519PublicPEMTest(f.Keys.PublicKey)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+
+	for _, sec := range []v050ReceiptSection{f.Runtime, f.RootAgent} {
+		var asMap map[string]any
+		if err := json.Unmarshal(sec.Receipt, &asMap); err != nil {
+			t.Fatalf("%q: unmarshal receipt to map: %v", sec.Description, err)
+		}
+		proofMap, ok := asMap["proof"].(map[string]any)
+		if !ok {
+			t.Fatalf("%q: receipt missing proof", sec.Description)
+		}
+		proofValue, _ := proofMap["proofValue"].(string)
+		if len(proofValue) < 2 || proofValue[0] != 'u' {
+			t.Fatalf("%q: proof.proofValue %q missing u multibase prefix", sec.Description, proofValue)
+		}
+		sig, err := base64.RawURLEncoding.DecodeString(proofValue[1:])
+		if err != nil {
+			t.Fatalf("%q: decode proofValue: %v", sec.Description, err)
+		}
+
+		unsigned := make(map[string]any, len(asMap)-1)
+		for k, v := range asMap {
+			if k == "proof" {
+				continue
+			}
+			unsigned[k] = v
+		}
+		canonical, err := receipt.Canonicalize(unsigned)
+		if err != nil {
+			t.Fatalf("%q: canonicalize unsigned: %v", sec.Description, err)
+		}
+		if !ed25519.Verify(pub, []byte(canonical), sig) {
+			t.Errorf("%q: signature does not verify", sec.Description)
+		}
+		h := sha256.Sum256([]byte(canonical))
+		got := "sha256:" + hex.EncodeToString(h[:])
+		if got != sec.ExpectedReceiptHash {
+			t.Errorf("%q: receipt hash\n  got:  %s\n  want: %s", sec.Description, got, sec.ExpectedReceiptHash)
+		}
+	}
+}
+
+// TestV050RuntimeRoundTrips confirms the Go SDK reads issuer.runtime members
+// from the runtime-bearing receipt and that the root-agent receipt has no
+// runtime.
+func TestV050RuntimeRoundTrips(t *testing.T) {
+	f := loadV050(t)
+
+	var runtimeReceipt receipt.AgentReceipt
+	if err := json.Unmarshal(f.Runtime.Receipt, &runtimeReceipt); err != nil {
+		t.Fatalf("unmarshal runtime receipt: %v", err)
+	}
+	rt := runtimeReceipt.Issuer.Runtime
+	if rt == nil {
+		t.Fatal("runtime receipt issuer.runtime is nil, want populated")
+	}
+	if rt.AgentID != "a3e49db54342a92d4" {
+		t.Errorf("runtime.agent_id = %q, want a3e49db54342a92d4", rt.AgentID)
+	}
+	if rt.AgentType != "general-purpose" {
+		t.Errorf("runtime.agent_type = %q, want general-purpose", rt.AgentType)
+	}
+
+	var rootReceipt receipt.AgentReceipt
+	if err := json.Unmarshal(f.RootAgent.Receipt, &rootReceipt); err != nil {
+		t.Fatalf("unmarshal root receipt: %v", err)
+	}
+	if rootReceipt.Issuer.Runtime != nil {
+		t.Errorf("root receipt issuer.runtime = %+v, want nil", rootReceipt.Issuer.Runtime)
+	}
+}

--- a/cross-sdk-tests/v050_vectors_test.go
+++ b/cross-sdk-tests/v050_vectors_test.go
@@ -43,6 +43,7 @@ type v050File struct {
 		PrivateKey string `json:"privateKey"`
 	} `json:"keys"`
 	Runtime   v050ReceiptSection `json:"runtimeReceipt"`
+	Extended  v050ReceiptSection `json:"extendedRuntimeReceipt"`
 	RootAgent v050ReceiptSection `json:"rootAgentReceipt"`
 }
 
@@ -68,7 +69,7 @@ func TestV050VectorsValidateAgainstSchema(t *testing.T) {
 	schema := loadSchema(t)
 	f := loadV050(t)
 
-	for _, sec := range []v050ReceiptSection{f.Runtime, f.RootAgent} {
+	for _, sec := range []v050ReceiptSection{f.Runtime, f.Extended, f.RootAgent} {
 		var doc any
 		if err := json.Unmarshal(sec.Receipt, &doc); err != nil {
 			t.Fatalf("unmarshal %q: %v", sec.Description, err)
@@ -89,7 +90,7 @@ func TestV050ReceiptHashAndSignature(t *testing.T) {
 		t.Fatalf("parse public key: %v", err)
 	}
 
-	for _, sec := range []v050ReceiptSection{f.Runtime, f.RootAgent} {
+	for _, sec := range []v050ReceiptSection{f.Runtime, f.Extended, f.RootAgent} {
 		var asMap map[string]any
 		if err := json.Unmarshal(sec.Receipt, &asMap); err != nil {
 			t.Fatalf("%q: unmarshal receipt to map: %v", sec.Description, err)
@@ -156,5 +157,44 @@ func TestV050RuntimeRoundTrips(t *testing.T) {
 	}
 	if rootReceipt.Issuer.Runtime != nil {
 		t.Errorf("root receipt issuer.runtime = %+v, want nil", rootReceipt.Issuer.Runtime)
+	}
+}
+
+// TestV050ExtendedRuntimePreservedThroughStruct is the open-container gate: a
+// runtime key the Go SDK does not model (trace_id) MUST survive a round-trip
+// through the typed AgentReceipt struct and still hash to the pinned digest.
+// HashReceipt re-marshals the struct (it does not hash raw bytes), so this
+// fails if Runtime drops unknown keys — exactly the cross-SDK divergence the
+// Extra field exists to prevent.
+func TestV050ExtendedRuntimePreservedThroughStruct(t *testing.T) {
+	f := loadV050(t)
+
+	var r receipt.AgentReceipt
+	if err := json.Unmarshal(f.Extended.Receipt, &r); err != nil {
+		t.Fatalf("unmarshal extended receipt: %v", err)
+	}
+	if r.Issuer.Runtime == nil {
+		t.Fatal("extended receipt issuer.runtime is nil, want populated")
+	}
+	raw, ok := r.Issuer.Runtime.Extra["trace_id"]
+	if !ok {
+		t.Fatalf("issuer.runtime.Extra missing trace_id; Extra = %v", r.Issuer.Runtime.Extra)
+	}
+	var traceID string
+	if err := json.Unmarshal(raw, &traceID); err != nil {
+		t.Fatalf("decode trace_id: %v", err)
+	}
+	if traceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Errorf("trace_id = %q, want 4bf92f3577b34da6a3ce929d0e0e4736", traceID)
+	}
+
+	// The struct round-trip (unmarshal → HashReceipt re-marshal) must reproduce
+	// the pinned hash, proving trace_id was not dropped.
+	got, err := receipt.HashReceipt(r)
+	if err != nil {
+		t.Fatalf("hash extended receipt: %v", err)
+	}
+	if got != f.Extended.ExpectedReceiptHash {
+		t.Errorf("extended receipt struct round-trip hash\n  got:  %s\n  want: %s", got, f.Extended.ExpectedReceiptHash)
 	}
 }

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -752,8 +752,13 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 	if f.OperatorID != "" {
 		op = &receipt.Operator{ID: f.OperatorID, Name: f.OperatorName}
 	}
+	// Gate runtime on AgentID alone, matching getOrCreateAgentState's routing
+	// key: a frame routes to a per-agent chain iff agent_id is non-empty, so
+	// only those receipts carry issuer.runtime. A stray agent_type without an
+	// agent_id belongs to the root chain and must stay runtime-free ("absent
+	// for the root agent").
 	var runtime *receipt.Runtime
-	if f.AgentID != "" || f.AgentType != "" {
+	if f.AgentID != "" {
 		runtime = &receipt.Runtime{AgentID: f.AgentID, AgentType: f.AgentType}
 	}
 	return receipt.Issuer{

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -27,10 +27,11 @@ import (
 // (multibase prefix "u") rather than the W3C default base58btc ("z").
 const multibaseBase64URL = "u"
 
-// maxIdentityFieldLen caps the byte length of the four proxy-supplied identity
-// fields (IssuerName, IssuerModel, OperatorID, OperatorName). The 1 MiB socket
-// cap is the only ceiling today — this per-field limit catches runaway values
-// early and keeps error messages legible.
+// maxIdentityFieldLen caps the byte length of the proxy-supplied identity
+// fields (IssuerName, IssuerModel, OperatorID, OperatorName, IdempotencyKey,
+// CorrelationID, AgentID, AgentType). The 1 MiB socket cap is the only other
+// ceiling — this per-field limit catches runaway values early and keeps error
+// messages legible.
 const maxIdentityFieldLen = 256
 
 // SupportedFrameVersion is the only emitter-frame schema this daemon accepts.
@@ -108,6 +109,7 @@ type EmitterFrame struct {
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 	CorrelationID  string          `json:"correlation_id,omitempty"`
 	AgentID        string          `json:"agent_id,omitempty"`
+	AgentType      string          `json:"agent_type,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -503,6 +505,9 @@ func validateFrame(f *EmitterFrame) error {
 	if strings.ContainsAny(f.AgentID, "/\x00") {
 		return fmt.Errorf("agent_id must not contain '/' or null bytes")
 	}
+	if len(f.AgentType) > maxIdentityFieldLen {
+		return fmt.Errorf("agent_type exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.AgentType))
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash
@@ -747,6 +752,10 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 	if f.OperatorID != "" {
 		op = &receipt.Operator{ID: f.OperatorID, Name: f.OperatorName}
 	}
+	var runtime *receipt.Runtime
+	if f.AgentID != "" || f.AgentType != "" {
+		runtime = &receipt.Runtime{AgentID: f.AgentID, AgentType: f.AgentType}
+	}
 	return receipt.Issuer{
 		ID:        daemonID,
 		Type:      "AgentReceiptsDaemon",
@@ -754,6 +763,7 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 		Model:     f.IssuerModel,
 		Operator:  op,
 		SessionID: f.SessionID,
+		Runtime:   runtime,
 	}
 }
 

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1685,6 +1685,9 @@ func TestProcess_AgentIDRoutesToSeparateChain(t *testing.T) {
 	if rootReceipts[0].CredentialSubject.Chain.ChainID != "root" {
 		t.Errorf("root receipt chain_id = %q", rootReceipts[0].CredentialSubject.Chain.ChainID)
 	}
+	if rootReceipts[0].Issuer.Runtime != nil {
+		t.Errorf("root receipt issuer.runtime = %+v; want nil (no agent_id)", rootReceipts[0].Issuer.Runtime)
+	}
 
 	agentChainID := "root/agent/agent-abc"
 	agentReceipts, err := st.GetChain(agentChainID)
@@ -1697,6 +1700,9 @@ func TestProcess_AgentIDRoutesToSeparateChain(t *testing.T) {
 	if agentReceipts[0].CredentialSubject.Chain.ChainID != agentChainID {
 		t.Errorf("agent receipt chain_id = %q, want %q",
 			agentReceipts[0].CredentialSubject.Chain.ChainID, agentChainID)
+	}
+	if rt := agentReceipts[0].Issuer.Runtime; rt == nil || rt.AgentID != "agent-abc" {
+		t.Errorf("agent receipt issuer.runtime = %+v, want AgentID=agent-abc", rt)
 	}
 }
 

--- a/docs/adr/0026-issuer-runtime-open-metadata.md
+++ b/docs/adr/0026-issuer-runtime-open-metadata.md
@@ -62,7 +62,7 @@ The top-level `issuer` object is unchanged and stays closed: `id`, `type`,
 `name`, `operator`, `model`, `session_id` remain `additionalProperties: false`.
 `runtime` is the *only* extensible region.
 
-### D2. `runtime` is open at both the schema and JSON-LD layers
+### D2. `runtime` is open at the schema, JSON-LD, AND SDK-typed layers
 
 This is the load-bearing decision — it is what makes future runtime fields free.
 
@@ -73,6 +73,13 @@ This is the load-bearing decision — it is what makes future runtime fields fre
   treatment `action.parameters_disclosure` already uses. Its contents are an
   opaque JSON literal; JSON-LD never expands the inner keys, so no inner key
   ever requires a term definition.
+- **SDK typed layer:** all three SDKs *preserve* unknown `runtime` keys across a
+  round-trip, so a key a newer SDK adds is not silently dropped by an older one
+  (which would diverge the canonical hash). TS uses an index signature, Python
+  uses `extra="allow"`, and Go gives `Runtime` an `Extra map[string]json.RawMessage`
+  with custom (un)marshalling. This is deliberately *unlike* the rest of the
+  receipt struct, whose unknown fields are dropped (see Go `HashRawReceipt`):
+  `runtime` is the one region that stays open end-to-end.
 
 Consequence: a future runtime field (e.g. `traceparent`) is added to the JSON
 Schema's `runtime` members for documentation, and ships with **no spec-version
@@ -134,16 +141,23 @@ field that a dashboard *correlates or visualizes* with is runtime.
 
 The new structure ships with its enforcement in the same release:
 
-- The cross-SDK byte-identity / signature vectors gain a v0.5.0 case carrying a
-  populated `issuer.runtime`, pinning identical canonicalization and signatures
-  across the Go, TS, and Python SDKs.
+- The cross-SDK byte-identity / signature vectors gain v0.5.0 cases: a receipt
+  carrying a populated `issuer.runtime`, a root receipt that omits it, and an
+  **extended** receipt whose `runtime` carries a key beyond the typed members
+  (`trace_id`). All three SDKs must preserve the unknown key and reproduce the
+  pinned hash — the gate for the D2 open-container invariant. Go's runner hashes
+  the extended receipt *through the typed struct* (`HashReceipt`), so a dropped
+  key fails the test.
 - The schema-conformance suite validates v0.5.0 examples (with and without
-  `runtime`) against the v0.5.0 schema.
+  `runtime`) against the v0.5.0 schema, and a negative test asserts the
+  version↔context `allOf` coupling **rejects** mismatched pairings (0.5.0+v1 or
+  ≤0.4.0+v2).
 - The daemon bounds the runtime fields it writes: `agent_id` keeps its existing
   length + character validation (it is interpolated into chain IDs);
   `agent_type` gets the same `maxIdentityFieldLen` cap the other proxy-supplied
-  identity fields have. Schema openness governs *consumers*; the daemon still
-  validates what it *produces*.
+  identity fields have. `runtime` is gated on `agent_id` alone (matching chain
+  routing), so a root-chain receipt never carries it. Schema openness governs
+  *consumers*; the daemon still validates what it *produces*.
 
 ## Consequences
 

--- a/docs/adr/0026-issuer-runtime-open-metadata.md
+++ b/docs/adr/0026-issuer-runtime-open-metadata.md
@@ -1,0 +1,189 @@
+# ADR-0026: Open `issuer.runtime` Metadata Sub-Object
+
+## Status
+
+Accepted
+
+## Context
+
+Claude Code, and runtimes like it, attach increasing amounts of *runtime
+metadata* to each action: which sub-agent issued it, what type that agent is,
+and — as observability standards mature (W3C Trace Context, OpenTelemetry GenAI
+conventions; see #762) — trace and span identifiers. This metadata belongs on
+the receipt `issuer`: it describes *who/what produced the action*, alongside the
+existing `name`, `model`, `operator`, and `session_id` fields.
+
+The immediate trigger: Claude Code already sends `agent_id` (and `agent_type`)
+in its PostToolUse hook payload for sub-agents, and the hook → emitter → daemon
+pipeline already forwards `agent_id` for chain routing — but the daemon dropped
+it from the signed receipt issuer, so sub-agent receipts were indistinguishable
+from root-agent receipts in the store and dashboard. PR #761 was opened to close
+that gap by adding `agent_id`/`agent_type` as top-level issuer fields.
+
+Adding them top-level surfaced a structural problem. The `issuer` object in the
+JSON Schema is `additionalProperties: false`, and the JSON-LD context
+(`spec/context/v1`) is `@protected` with no `@vocab` fallback — every term must
+be explicitly defined. Under that design:
+
+- **Every** new top-level issuer field is a breaking change for a strict
+  verifier holding a pinned copy of the released schema: an unknown key fails
+  `additionalProperties: false`, independently of whether the signature verifies
+  (schema validation and signature verification are separate gates).
+- A field whose JSON-LD term is undefined in the context (as `agent_id` /
+  `agent_type` would be under v1) is silently dropped on JSON-LD expansion, so a
+  W3C VC processor never sees it (ADR-0003 commits us to VC-valid receipts).
+- Per ADR-0021 D1, released spec versions are immutable; a field addition is a
+  *new spec version*, not an in-place edit. Per ADR-0021 D3, a new term that
+  requires its own JSON-LD definition is a *context version bump*.
+
+So each top-level issuer field costs a spec version, and — when it needs a new
+term — a context version. `session_id` was added; `agent_id`/`agent_type` are
+being added; `traceparent`/`trace_id` are coming with #762. On the current
+trajectory the issuer accretes runtime metadata one expensive version bump at a
+time, forever.
+
+This ADR records a one-time structural change that removes that recurring tax.
+
+## Decision
+
+### D1. Runtime metadata lives in an open `issuer.runtime` sub-object
+
+A new optional object, `issuer.runtime`, holds runtime/observability metadata
+the issuing runtime attaches to an action. Its initially-defined members are:
+
+- `agent_id` — identifier of the sub-agent that issued the receipt. Absent for
+  the root agent.
+- `agent_type` — runtime-reported agent type label (e.g. `"general-purpose"`).
+  Absent for the root agent.
+
+The root agent omits `runtime` entirely (`omitempty` / `None` / absent).
+
+The top-level `issuer` object is unchanged and stays closed: `id`, `type`,
+`name`, `operator`, `model`, `session_id` remain `additionalProperties: false`.
+`runtime` is the *only* extensible region.
+
+### D2. `runtime` is open at both the schema and JSON-LD layers
+
+This is the load-bearing decision — it is what makes future runtime fields free.
+
+- **JSON Schema:** the `runtime` object lists its known members with types and
+  descriptions, but does **not** set `additionalProperties: false`. Unknown keys
+  inside `runtime` validate, rather than failing.
+- **JSON-LD context:** the `runtime` term is typed `"@type": "@json"` — the same
+  treatment `action.parameters_disclosure` already uses. Its contents are an
+  opaque JSON literal; JSON-LD never expands the inner keys, so no inner key
+  ever requires a term definition.
+
+Consequence: a future runtime field (e.g. `traceparent`) is added to the JSON
+Schema's `runtime` members for documentation, and ships with **no spec-version
+or context-version bump** required for JSON-LD/VC validity. The one-time cost of
+introducing `runtime` (D3) buys forward-compatibility for all later runtime
+metadata.
+
+This does not weaken integrity. The signature covers the canonical bytes of the
+whole receipt including `runtime` (RFC 8785, ADR-0002), so runtime values are
+tamper-evident. Openness is a *schema-strictness* property, not an integrity
+one, and it is scoped to the runtime sub-object only — identity-bearing
+top-level fields keep their closed content model.
+
+### D3. Ships as spec v0.5.0 and JSON-LD context v2
+
+Per ADR-0021:
+
+- **Spec v0.5.0** — a new immutable `spec/v0.5.0/spec.md` (D1 of ADR-0021), the
+  `version` enum gains `"0.5.0"`, and `spec/CHANGELOG.md` gets a `[0.5.0]`
+  entry. The released v0.4.0 schema is **not** edited in place.
+- **Context v2** — `runtime` is a new JSON-LD term, which ADR-0021 D3 makes a
+  context bump. `spec/context/v2/context.jsonld` is authored (v1 plus the
+  `runtime` `@json` term). Receipts at v0.5.0 reference
+  `https://agentreceipts.ai/context/v2` in their `@context` array; v1 remains
+  permanent for earlier receipts.
+
+Spec and context versions remain independent (ADR-0021 D3); this release happens
+to bump both because the structural change requires it.
+
+### D4. Migration and compatibility
+
+- v0.4.0 and earlier receipts are unchanged and remain valid. No issuer carries
+  `runtime` below v0.5.0.
+- The `agent_id`/`agent_type` top-level fields proposed in PR #761 are **not**
+  shipped; they move into `runtime`. #761 is reworked to this shape (it is
+  unmerged, so nothing released is broken).
+- The daemon maps its existing emitter-frame `agent_id`/`agent_type` fields into
+  `issuer.runtime` when building a v0.5.0 receipt. Emitter-frame and hook wire
+  formats keep their flat `agent_id`/`agent_type` fields — only the *receipt*
+  issuer structure nests them.
+- New receipts SHOULD emit `"version": "0.5.0"`; verifiers MUST accept `0.5.0`.
+
+### D5. What belongs in `runtime` vs. top-level issuer
+
+To keep D2's openness from becoming a dumping ground:
+
+- **Top-level issuer (closed, strict):** stable, identity-bearing facts about the
+  issuing party — `id`, `operator`, `model`, `session_id`. New fields here are
+  deliberate, versioned, term-defined additions.
+- **`issuer.runtime` (open):** ephemeral, runtime-attested, observability-
+  oriented metadata that is expected to track external standards (agent/span
+  identifiers, trace context). Fields here are documentation in the schema, not
+  gates.
+
+When in doubt, a field that an auditor verifies *identity* with is top-level; a
+field that a dashboard *correlates or visualizes* with is runtime.
+
+### D6. Gates (per ADR-0024)
+
+The new structure ships with its enforcement in the same release:
+
+- The cross-SDK byte-identity / signature vectors gain a v0.5.0 case carrying a
+  populated `issuer.runtime`, pinning identical canonicalization and signatures
+  across the Go, TS, and Python SDKs.
+- The schema-conformance suite validates v0.5.0 examples (with and without
+  `runtime`) against the v0.5.0 schema.
+- The daemon bounds the runtime fields it writes: `agent_id` keeps its existing
+  length + character validation (it is interpolated into chain IDs);
+  `agent_type` gets the same `maxIdentityFieldLen` cap the other proxy-supplied
+  identity fields have. Schema openness governs *consumers*; the daemon still
+  validates what it *produces*.
+
+## Consequences
+
+### Easier
+
+- Runtime/observability metadata — including the OTel/trace fields in #762 —
+  lands without a protocol-version or context bump from here on.
+- Sub-agent receipts are distinguishable in the store and dashboard via
+  `issuer.runtime.agent_id`, and the issuer maps cleanly onto OTel GenAI
+  conventions (`gen_ai.agent.id`, `gen_ai.agent.name`).
+- The expensive parts of schema evolution (closed identity model, immutable
+  released versions) are preserved where they matter and relaxed only in the one
+  region designed to grow.
+
+### More difficult / costs
+
+- One-time, large change: spec v0.5.0 + context v2 + the signed `@context` array
+  bump rippling through all three SDKs and the cross-SDK vectors.
+- Two ways to express "this came from a sub-agent" now exist in the ecosystem
+  for a while: the nested v0.5.0 form and the (never-released) flat PR-#761 form.
+  Mitigated by reworking #761 before it merges.
+- `runtime` openness means a buggy or hostile emitter can attach arbitrary keys
+  inside `runtime` that pass schema validation. They are signed (tamper-evident)
+  and bounded by the 1 MiB frame cap, but consumers MUST treat unknown `runtime`
+  keys as untrusted metadata, not as identity.
+
+## Out of scope for this ADR
+
+- The OTel trace-export work that consumes `runtime` (#762). This ADR makes it
+  cheap; it does not implement it.
+- A general extension mechanism for non-issuer parts of the receipt
+  (`credentialSubject`, etc.). If those accrete open metadata later, they can
+  follow this pattern; this ADR does not pre-commit them.
+- `parent_agent_id` / deeper agent nesting. Not expressible today (sub-agents
+  cannot spawn sub-agents in the current Claude Code toolset); revisit if that
+  changes.
+
+## Spawned follow-up work (not in this ADR's diff)
+
+- Implement v0.5.0 across spec, context v2, the three SDKs, the daemon, and the
+  cross-SDK vectors (reworks #761).
+- Publish `spec/v0.5.0/` and `spec/context/v2/` per ADR-0021 D2/D4 tagging.
+- Consume `issuer.runtime` in the OTel exporter (#762).

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -17,6 +17,7 @@ type claudeCodeFrame struct {
 	ToolInput     json.RawMessage `json:"tool_input"`
 	ToolResponse  json.RawMessage `json:"tool_response"`
 	AgentID       string          `json:"agent_id"`
+	AgentType     string          `json:"agent_type"`
 }
 
 // readClaudeCode parses a Claude Code PostToolUse or PreToolUse stdin frame
@@ -58,6 +59,7 @@ func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string,
 		Decision:      decision,
 		CorrelationID: f.ToolUseID,
 		AgentID:       f.AgentID,
+		AgentType:     f.AgentType,
 	}
 	// Only set Input/Output when non-empty; the emitter rejects non-nil empty
 	// slices and the daemon expects nil to mean "no payload".

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -147,6 +147,10 @@ type Event struct {
 	// populate delegation.parent_chain_id on the first receipt of a new agent.
 	// Optional; omitted from the frame when empty (root agent).
 	AgentID string
+
+	// AgentType is the runtime-reported agent type label (Claude Code:
+	// agent_type, e.g. "general-purpose"). Optional; omitted when empty.
+	AgentType string
 }
 
 // Option configures an Emitter at construction.
@@ -308,6 +312,7 @@ type frame struct {
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 	CorrelationID  string          `json:"correlation_id,omitempty"`
 	AgentID        string          `json:"agent_id,omitempty"`
+	AgentType      string          `json:"agent_type,omitempty"`
 }
 
 type frameTool struct {
@@ -433,6 +438,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		IdempotencyKey: ev.IdempotencyKey,
 		CorrelationID:  ev.CorrelationID,
 		AgentID:        ev.AgentID,
+		AgentType:      ev.AgentType,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/receipt/live_emit_version_test.go
+++ b/sdk/go/receipt/live_emit_version_test.go
@@ -9,7 +9,7 @@ import "testing"
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const liveEmitVersion = "0.4.0"
+const liveEmitVersion = "0.5.0"
 
 // TestCreateStampsCrossSDKVersion asserts that Create() stamps the
 // cross-SDK-agreed literal version string. This pins the SDK's Version

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 // Protocol constants (unexported to prevent mutation).
 var (
-	protocolContext        = []string{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"}
+	protocolContext        = []string{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v2"}
 	protocolCredentialType = []string{"VerifiableCredential", "AgentReceipt"}
 )
 
@@ -16,7 +16,7 @@ func Context() []string { return append([]string{}, protocolContext...) }
 // CredentialType returns a copy of the credential type array.
 func CredentialType() []string { return append([]string{}, protocolCredentialType...) }
 
-const Version = "0.4.0"
+const Version = "0.5.0"
 
 // RiskLevel classifies the security risk of an action.
 type RiskLevel string
@@ -69,6 +69,21 @@ type Issuer struct {
 	Operator  *Operator `json:"operator,omitempty"`
 	Model     string    `json:"model,omitempty"`
 	SessionID string    `json:"session_id,omitempty"`
+	Runtime   *Runtime  `json:"runtime,omitempty"`
+}
+
+// Runtime is the open container for runtime/observability metadata the issuing
+// runtime attaches to an action (ADR-0026). It is intentionally extensible: the
+// fields below are documented members, but the JSON-LD context types it @json
+// and the schema does not close it, so additional runtime keys (e.g. future
+// trace-context identifiers) may be added without a protocol-version bump.
+// Absent for the root agent.
+type Runtime struct {
+	// AgentID identifies the sub-agent that issued the receipt. Absent for the
+	// root agent.
+	AgentID string `json:"agent_id,omitempty"`
+	// AgentType is the runtime-reported agent type label (e.g. "general-purpose").
+	AgentType string `json:"agent_type,omitempty"`
 }
 
 // Principal identifies the human or organisation that authorised the action.

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -109,18 +109,22 @@ func (r Runtime) MarshalJSON() ([]byte, error) {
 	if r.AgentID != "" {
 		b, err := json.Marshal(r.AgentID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal runtime.agent_id: %w", err)
 		}
 		m["agent_id"] = b
 	}
 	if r.AgentType != "" {
 		b, err := json.Marshal(r.AgentType)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal runtime.agent_type: %w", err)
 		}
 		m["agent_type"] = b
 	}
-	return json.Marshal(m)
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal runtime: %w", err)
+	}
+	return b, nil
 }
 
 // UnmarshalJSON reads the typed members into AgentID / AgentType and keeps any
@@ -128,7 +132,7 @@ func (r Runtime) MarshalJSON() ([]byte, error) {
 func (r *Runtime) UnmarshalJSON(data []byte) error {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
-		return err
+		return fmt.Errorf("unmarshal runtime: %w", err)
 	}
 	*r = Runtime{}
 	if v, ok := m["agent_id"]; ok {

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -2,7 +2,10 @@
 // verifying Action Receipts — W3C Verifiable Credentials for AI agent actions.
 package receipt
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Protocol constants (unexported to prevent mutation).
 var (
@@ -78,12 +81,72 @@ type Issuer struct {
 // and the schema does not close it, so additional runtime keys (e.g. future
 // trace-context identifiers) may be added without a protocol-version bump.
 // Absent for the root agent.
+//
+// Unlike the rest of the receipt struct (whose unknown fields are dropped on a
+// round-trip — see HashRawReceipt), Runtime PRESERVES unknown keys via Extra so
+// the Go, TS, and Python SDKs all keep runtime open at the typed layer. A key
+// added by a newer SDK therefore survives an older Go SDK's HashReceipt/Sign
+// round-trip and stays byte-identical across languages.
 type Runtime struct {
 	// AgentID identifies the sub-agent that issued the receipt. Absent for the
 	// root agent.
-	AgentID string `json:"agent_id,omitempty"`
+	AgentID string
 	// AgentType is the runtime-reported agent type label (e.g. "general-purpose").
-	AgentType string `json:"agent_type,omitempty"`
+	AgentType string
+	// Extra holds runtime keys this SDK version does not model as typed fields,
+	// preserved verbatim so they survive a round-trip and hash identically.
+	Extra map[string]json.RawMessage
+}
+
+// MarshalJSON emits agent_id / agent_type (when non-empty) alongside every Extra
+// key, so unknown runtime members round-trip. Key ordering is irrelevant:
+// Canonicalize re-sorts per RFC 8785.
+func (r Runtime) MarshalJSON() ([]byte, error) {
+	m := make(map[string]json.RawMessage, len(r.Extra)+2)
+	for k, v := range r.Extra {
+		m[k] = v
+	}
+	if r.AgentID != "" {
+		b, err := json.Marshal(r.AgentID)
+		if err != nil {
+			return nil, err
+		}
+		m["agent_id"] = b
+	}
+	if r.AgentType != "" {
+		b, err := json.Marshal(r.AgentType)
+		if err != nil {
+			return nil, err
+		}
+		m["agent_type"] = b
+	}
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON reads the typed members into AgentID / AgentType and keeps any
+// remaining keys in Extra.
+func (r *Runtime) UnmarshalJSON(data []byte) error {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	*r = Runtime{}
+	if v, ok := m["agent_id"]; ok {
+		if err := json.Unmarshal(v, &r.AgentID); err != nil {
+			return fmt.Errorf("runtime.agent_id: %w", err)
+		}
+		delete(m, "agent_id")
+	}
+	if v, ok := m["agent_type"]; ok {
+		if err := json.Unmarshal(v, &r.AgentType); err != nil {
+			return fmt.Errorf("runtime.agent_type: %w", err)
+		}
+		delete(m, "agent_type")
+	}
+	if len(m) > 0 {
+		r.Extra = m
+	}
+	return nil
 }
 
 // Principal identifies the human or organisation that authorised the action.

--- a/sdk/py/src/agent_receipts/__init__.py
+++ b/sdk/py/src/agent_receipts/__init__.py
@@ -76,6 +76,7 @@ from agent_receipts.receipt.types import (
     PeerCredential,
     Principal,
     Proof,
+    Runtime,
     StateChange,
     UnsignedAgentReceipt,
 )
@@ -142,6 +143,7 @@ __all__ = [
     "PeerCredential",
     "Principal",
     "Proof",
+    "Runtime",
     "StateChange",
     "UnsignedAgentReceipt",
     # Backwards compat aliases (deprecated)

--- a/sdk/py/src/agent_receipts/receipt/__init__.py
+++ b/sdk/py/src/agent_receipts/receipt/__init__.py
@@ -32,6 +32,7 @@ from agent_receipts.receipt.types import (
     Outcome,
     Principal,
     Proof,
+    Runtime,
     StateChange,
     UnsignedAgentReceipt,
 )
@@ -55,6 +56,7 @@ __all__ = [
     "Outcome",
     "Principal",
     "Proof",
+    "Runtime",
     "StateChange",
     "UnsignedActionReceipt",
     "UnsignedAgentReceipt",

--- a/sdk/py/src/agent_receipts/receipt/types.py
+++ b/sdk/py/src/agent_receipts/receipt/types.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 CONTEXT: list[str] = [
     "https://www.w3.org/ns/credentials/v2",
-    "https://agentreceipts.ai/context/v1",
+    "https://agentreceipts.ai/context/v2",
 ]
 
 CREDENTIAL_TYPE: list[str] = [
@@ -24,7 +24,7 @@ CREDENTIAL_TYPE: list[str] = [
     "AgentReceipt",
 ]
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 
 RiskLevel = Literal["low", "medium", "high", "critical"]
 
@@ -38,6 +38,23 @@ class Operator(BaseModel):
     name: str
 
 
+class Runtime(BaseModel):
+    """Open container for runtime/observability metadata the issuing runtime
+    attaches to an action (ADR-0026).
+
+    Intentionally extensible: ``agent_id`` and ``agent_type`` are documented
+    members, but the JSON-LD context types this ``@json`` and the schema does
+    not close it, so additional runtime keys (e.g. future trace-context
+    identifiers) may be added without a protocol-version bump. ``extra="allow"``
+    preserves unknown keys on round-trip. Absent for the root agent.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    agent_id: str | None = None
+    agent_type: str | None = None
+
+
 class Issuer(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -47,6 +64,7 @@ class Issuer(BaseModel):
     operator: Operator | None = None
     model: str | None = None
     session_id: str | None = None
+    runtime: Runtime | None = None
 
 
 class Principal(BaseModel):

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -29,7 +29,7 @@ from agent_receipts.receipt.types import (
     Principal,
 )
 
-LIVE_EMIT_VERSION = "0.4.0"
+LIVE_EMIT_VERSION = "0.5.0"
 
 
 class TestCreateReceiptCrossSDKVersion:

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -23,7 +23,7 @@ class TestConstants:
         assert CONTEXT[0] == "https://www.w3.org/ns/credentials/v2"
 
     def test_context_includes_agent_receipts_uri(self) -> None:
-        assert CONTEXT[1] == "https://agentreceipts.ai/context/v1"
+        assert CONTEXT[1] == "https://agentreceipts.ai/context/v2"
 
     def test_credential_type_has_two_entries(self) -> None:
         assert len(CREDENTIAL_TYPE) == 2
@@ -35,7 +35,7 @@ class TestConstants:
         assert "AgentReceipt" in CREDENTIAL_TYPE
 
     def test_version(self) -> None:
-        assert VERSION == "0.4.0"
+        assert VERSION == "0.5.0"
 
 
 class TestAgentReceipt:

--- a/sdk/py/tests/test_v050_vectors.py
+++ b/sdk/py/tests/test_v050_vectors.py
@@ -1,0 +1,66 @@
+"""Cross-SDK v0.5.0 vectors (issuer.runtime open sub-object, ADR-0026).
+
+Asserts that the Python SDK reproduces the pinned ``expectedReceiptHash`` for a
+receipt whose issuer carries ``runtime.agent_id`` / ``runtime.agent_type`` and
+for a root-agent receipt that omits ``runtime``. Vectors live at
+``cross-sdk-tests/v050_vectors.json``.
+
+If a hash diverges, the Python SDK has a wire-format incompatibility with Go and
+TS on the new issuer.runtime sub-object — almost always a Pydantic
+serialization / alias / omit-when-None issue.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_receipts.receipt.hash import hash_receipt
+from agent_receipts.receipt.signing import verify_receipt
+from agent_receipts.receipt.types import AgentReceipt
+
+VECTORS = (
+    Path(__file__).parent.parent.parent.parent / "cross-sdk-tests" / "v050_vectors.json"
+)
+
+
+def _load_vectors() -> dict:
+    with open(VECTORS, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestV050Vectors:
+    """Byte-identical reproduction + runtime round-trip for v0.5.0 vectors."""
+
+    def test_runtime_receipt_hash_matches(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["runtimeReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]
+
+    def test_runtime_receipt_signature_verifies(self) -> None:
+        vectors = _load_vectors()
+        public_key = vectors["keys"]["publicKey"]
+        section = vectors["runtimeReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert verify_receipt(receipt, public_key) is True
+
+    def test_runtime_members_round_trip(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["runtimeReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert receipt.issuer.runtime is not None
+        assert receipt.issuer.runtime.agent_id == "a3e49db54342a92d4"
+        assert receipt.issuer.runtime.agent_type == "general-purpose"
+
+    def test_root_agent_receipt_hash_matches(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["rootAgentReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]
+
+    def test_root_agent_receipt_omits_runtime(self) -> None:
+        vectors = _load_vectors()
+        section = vectors["rootAgentReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert receipt.issuer.runtime is None

--- a/sdk/py/tests/test_v050_vectors.py
+++ b/sdk/py/tests/test_v050_vectors.py
@@ -53,6 +53,20 @@ class TestV050Vectors:
         assert receipt.issuer.runtime.agent_id == "a3e49db54342a92d4"
         assert receipt.issuer.runtime.agent_type == "general-purpose"
 
+    def test_extended_runtime_preserves_unknown_key(self) -> None:
+        # Open-container gate: a runtime key the SDK does not model (trace_id)
+        # must survive model round-trip and still hash to the pinned digest
+        # (ADR-0026). extra="allow" on Runtime keeps it; model_dump re-emits it.
+        vectors = _load_vectors()
+        section = vectors["extendedRuntimeReceipt"]
+        receipt = AgentReceipt.model_validate(section["receipt"])
+        assert receipt.issuer.runtime is not None
+        assert (
+            getattr(receipt.issuer.runtime, "trace_id", None)
+            == "4bf92f3577b34da6a3ce929d0e0e4736"
+        )
+        assert hash_receipt(receipt) == section["expectedReceiptHash"]
+
     def test_root_agent_receipt_hash_matches(self) -> None:
         vectors = _load_vectors()
         section = vectors["rootAgentReceipt"]

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.11.1"
+version = "0.12.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/src/receipt/cross-language.test.ts
+++ b/sdk/ts/src/receipt/cross-language.test.ts
@@ -444,3 +444,63 @@ describe("cross-language: v0.4.0 vectors", () => {
 		);
 	});
 });
+
+interface V050ReceiptSection {
+	receipt: AgentReceipt;
+	expectedReceiptHash: string;
+	expectedValid: boolean;
+}
+
+interface V050Vectors {
+	version: string;
+	keys: { publicKey: string; privateKey: string };
+	runtimeReceipt: V050ReceiptSection;
+	rootAgentReceipt: V050ReceiptSection;
+}
+
+function loadV050Vectors(): V050Vectors {
+	const path = resolve(
+		currentDir,
+		"../../../../cross-sdk-tests/v050_vectors.json",
+	);
+	return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+// Cross-SDK reproduction of the v0.5.0 vectors pinned in
+// cross-sdk-tests/v050_vectors.json (issuer.runtime open sub-object, ADR-0026).
+// The TS SDK MUST hash both the runtime-bearing and root-agent receipts to the
+// same digests as Go and Python, proving the nested runtime object canonicalises
+// identically.
+describe("cross-language: v0.5.0 vectors", () => {
+	it("runtime receipt hash matches pin", () => {
+		const v = loadV050Vectors();
+		expect(hashReceipt(v.runtimeReceipt.receipt)).toBe(
+			v.runtimeReceipt.expectedReceiptHash,
+		);
+	});
+
+	it("runtime receipt verifies with shared key", () => {
+		const v = loadV050Vectors();
+		expect(verifyReceipt(v.runtimeReceipt.receipt, v.keys.publicKey)).toBe(
+			true,
+		);
+	});
+
+	it("runtime members round-trip", () => {
+		const v = loadV050Vectors();
+		expect(v.runtimeReceipt.receipt.issuer.runtime?.agent_id).toBe(
+			"a3e49db54342a92d4",
+		);
+		expect(v.runtimeReceipt.receipt.issuer.runtime?.agent_type).toBe(
+			"general-purpose",
+		);
+	});
+
+	it("root-agent receipt hash matches pin and omits runtime", () => {
+		const v = loadV050Vectors();
+		expect(hashReceipt(v.rootAgentReceipt.receipt)).toBe(
+			v.rootAgentReceipt.expectedReceiptHash,
+		);
+		expect(v.rootAgentReceipt.receipt.issuer.runtime).toBeUndefined();
+	});
+});

--- a/sdk/ts/src/receipt/cross-language.test.ts
+++ b/sdk/ts/src/receipt/cross-language.test.ts
@@ -455,6 +455,7 @@ interface V050Vectors {
 	version: string;
 	keys: { publicKey: string; privateKey: string };
 	runtimeReceipt: V050ReceiptSection;
+	extendedRuntimeReceipt: V050ReceiptSection;
 	rootAgentReceipt: V050ReceiptSection;
 }
 
@@ -493,6 +494,19 @@ describe("cross-language: v0.5.0 vectors", () => {
 		);
 		expect(v.runtimeReceipt.receipt.issuer.runtime?.agent_type).toBe(
 			"general-purpose",
+		);
+	});
+
+	it("extended runtime preserves unknown key and hash matches", () => {
+		// Open-container gate: a runtime key the SDK does not model (trace_id)
+		// must survive and hash to the pinned digest (ADR-0026). The Runtime
+		// index signature keeps it; canonicalize re-emits it.
+		const v = loadV050Vectors();
+		expect(v.extendedRuntimeReceipt.receipt.issuer.runtime?.trace_id).toBe(
+			"4bf92f3577b34da6a3ce929d0e0e4736",
+		);
+		expect(hashReceipt(v.extendedRuntimeReceipt.receipt)).toBe(
+			v.extendedRuntimeReceipt.expectedReceiptHash,
 		);
 	});
 

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -9,7 +9,7 @@ import { VERSION } from "./types.js";
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const LIVE_EMIT_VERSION = "0.4.0";
+const LIVE_EMIT_VERSION = "0.5.0";
 
 describe("createReceipt cross-SDK version invariant", () => {
 	it("stamps the cross-SDK literal version on freshly-emitted receipts", () => {

--- a/sdk/ts/src/receipt/schema.ts
+++ b/sdk/ts/src/receipt/schema.ts
@@ -26,6 +26,16 @@ const operatorSchema = z
 	})
 	.passthrough();
 
+// Open runtime/observability metadata container (ADR-0026). Known members are
+// declared for documentation; `.passthrough()` keeps it extensible so future
+// runtime keys validate without a schema change.
+const runtimeSchema = z
+	.object({
+		agent_id: z.string().optional(),
+		agent_type: z.string().optional(),
+	})
+	.passthrough();
+
 const issuerSchema = z
 	.object({
 		id: z.string(),
@@ -34,6 +44,7 @@ const issuerSchema = z
 		operator: operatorSchema.optional(),
 		model: z.string().optional(),
 		session_id: z.string().optional(),
+		runtime: runtimeSchema.optional(),
 	})
 	.passthrough();
 

--- a/sdk/ts/src/receipt/types.test.ts
+++ b/sdk/ts/src/receipt/types.test.ts
@@ -31,7 +31,7 @@ describe("receipt schema constants", () => {
 	it("has the correct context URIs", () => {
 		expect(CONTEXT).toEqual([
 			"https://www.w3.org/ns/credentials/v2",
-			"https://agentreceipts.ai/context/v1",
+			"https://agentreceipts.ai/context/v2",
 		]);
 	});
 
@@ -39,8 +39,8 @@ describe("receipt schema constants", () => {
 		expect(CREDENTIAL_TYPE).toEqual(["VerifiableCredential", "AgentReceipt"]);
 	});
 
-	it("has version 0.4.0", () => {
-		expect(VERSION).toBe("0.4.0");
+	it("has version 0.5.0", () => {
+		expect(VERSION).toBe("0.5.0");
 	});
 });
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -10,7 +10,7 @@ import type { DisclosureEnvelope } from "./disclosure.js";
 
 export const CONTEXT = [
 	"https://www.w3.org/ns/credentials/v2",
-	"https://agentreceipts.ai/context/v1",
+	"https://agentreceipts.ai/context/v2",
 ] as const;
 
 export const CREDENTIAL_TYPE = [
@@ -18,7 +18,7 @@ export const CREDENTIAL_TYPE = [
 	"AgentReceipt",
 ] as const;
 
-export const VERSION = "0.4.0";
+export const VERSION = "0.5.0";
 
 // --- Risk levels ---
 
@@ -35,6 +35,22 @@ export interface Operator {
 	name: string;
 }
 
+/**
+ * Open container for runtime/observability metadata the issuing runtime
+ * attaches to an action (ADR-0026). Intentionally extensible: the members
+ * below are documented, but the JSON-LD context types it `@json` and the schema
+ * does not close it, so additional runtime keys (e.g. future trace-context
+ * identifiers) may be added without a protocol-version bump. Absent for the
+ * root agent.
+ */
+export interface Runtime {
+	/** Identifier of the sub-agent that issued the receipt. Absent for the root agent. */
+	agent_id?: string;
+	/** Runtime-reported agent type label (e.g. "general-purpose"). */
+	agent_type?: string;
+	[key: string]: unknown;
+}
+
 export interface Issuer {
 	id: string;
 	type?: string;
@@ -42,6 +58,7 @@ export interface Issuer {
 	operator?: Operator;
 	model?: string;
 	session_id?: string;
+	runtime?: Runtime;
 }
 
 // --- Principal ---

--- a/site/src/content/docs/sdk-go/api-reference.mdx
+++ b/site/src/content/docs/sdk-go/api-reference.mdx
@@ -153,6 +153,16 @@ type Issuer struct {
     Operator  *Operator `json:"operator,omitempty"`
     Model     string    `json:"model,omitempty"`
     SessionID string    `json:"session_id,omitempty"`
+    Runtime   *Runtime  `json:"runtime,omitempty"` // open metadata container (v0.5.0, ADR-0026)
+}
+
+// Runtime is the open container for runtime/observability metadata. The typed
+// members are documented; unknown keys are preserved via Extra so the field
+// stays open across SDKs.
+type Runtime struct {
+    AgentID   string                     // runtime.agent_id — the sub-agent that issued the receipt
+    AgentType string                     // runtime.agent_type — e.g. "general-purpose"
+    Extra     map[string]json.RawMessage // any additional runtime keys, preserved verbatim
 }
 ```
 

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -249,6 +249,14 @@ class Issuer(BaseModel):
     operator: Operator | None = None
     model: str | None = None
     session_id: str | None = None
+    runtime: Runtime | None = None  # open metadata container (v0.5.0, ADR-0026)
+
+class Runtime(BaseModel):
+    # Open container for runtime/observability metadata. extra="allow" keeps it
+    # extensible, so unknown runtime keys survive round-trips.
+    model_config = ConfigDict(extra="allow")
+    agent_id: str | None = None    # the sub-agent that issued the receipt
+    agent_type: str | None = None  # e.g. "general-purpose"
 
 class Operator(BaseModel):
     id: str
@@ -355,7 +363,7 @@ OutcomeStatus = Literal["success", "failure", "pending"]
 
 CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
-RECEIPT_VERSION: str        # "0.4.0" (receipt schema)
+RECEIPT_VERSION: str        # "0.5.0" (receipt schema)
 VERSION: str                # current package version
 ```
 

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -361,7 +361,7 @@ class Proof(BaseModel):
 RiskLevel = Literal["low", "medium", "high", "critical"]
 OutcomeStatus = Literal["success", "failure", "pending"]
 
-CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
+CONTEXT: list[str]          # ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v2"]
 CREDENTIAL_TYPE: list[str]  # ["VerifiableCredential", "AgentReceipt"]
 RECEIPT_VERSION: str        # "0.5.0" (receipt schema)
 VERSION: str                # current package version

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -139,6 +139,15 @@ interface Issuer {
   operator?: Operator;
   model?: string;
   session_id?: string;
+  runtime?: Runtime; // open metadata container (v0.5.0, ADR-0026)
+}
+
+// Open container for runtime/observability metadata. The index signature keeps
+// it extensible, so unknown runtime keys survive round-trips.
+interface Runtime {
+  agent_id?: string;   // the sub-agent that issued the receipt
+  agent_type?: string; // e.g. "general-purpose"
+  [key: string]: unknown;
 }
 
 interface Operator {
@@ -256,7 +265,7 @@ type OutcomeStatus = "success" | "failure" | "pending"
 
 const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
 const CREDENTIAL_TYPE: readonly ["VerifiableCredential", "AgentReceipt"]
-const RECEIPT_VERSION: "0.4.0"  // receipt schema
+const RECEIPT_VERSION: "0.5.0"  // receipt schema
 const VERSION: "0.9.0"          // package version
 ```
 

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -263,7 +263,7 @@ interface Proof {
 type RiskLevel = "low" | "medium" | "high" | "critical"
 type OutcomeStatus = "success" | "failure" | "pending"
 
-const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v1"]
+const CONTEXT: readonly ["https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v2"]
 const CREDENTIAL_TYPE: readonly ["VerifiableCredential", "AgentReceipt"]
 const RECEIPT_VERSION: "0.5.0"  // receipt schema
 const VERSION: "0.9.0"          // package version

--- a/site/src/content/docs/specification/agent-receipt-schema.mdx
+++ b/site/src/content/docs/specification/agent-receipt-schema.mdx
@@ -46,11 +46,11 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://agentreceipts.ai/context/v1"
+    "https://agentreceipts.ai/context/v2"
   ],
   "id": "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
   "type": ["VerifiableCredential", "AgentReceipt"],
-  "version": "0.3.0",
+  "version": "0.5.0",
 
   "issuer": {
     "id": "did:agent:claude-cowork-instance-abc123",
@@ -61,7 +61,11 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
       "name": "Anthropic"
     },
     "model": "claude-sonnet-4-6",
-    "session_id": "session_xyz789"
+    "session_id": "session_xyz789",
+    "runtime": {
+      "agent_id": "a3e49db54342a92d4",
+      "agent_type": "general-purpose"
+    }
   },
 
   "issuanceDate": "2026-03-31T14:30:00Z",
@@ -140,7 +144,7 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `@context` | Yes | JSON-LD context. Must include the W3C VC v2 and Agent Receipt context URIs in order. |
 | `id` | Yes | Globally unique identifier. Must be `urn:receipt:<uuid>`. |
 | `type` | Yes | Must be `["VerifiableCredential", "AgentReceipt"]`. |
-| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, or `"0.4.0"`. Verifiers MUST accept all five. |
+| `version` | Yes | Protocol version. Must be `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, `"0.4.0"`, or `"0.5.0"`. Verifiers MUST accept all six. Versions `0.1.0`–`0.4.0` reference Agent Receipts context v1; `0.5.0` references v2. |
 | `issuer` | Yes | The agent or platform that issued the receipt. |
 | `issuanceDate` | Yes | ISO 8601 datetime when the receipt was issued. May differ from `action.timestamp`. |
 | `credentialSubject` | Yes | The receipt payload. |
@@ -157,6 +161,9 @@ An Agent Receipt is a W3C Verifiable Credential with type `AgentReceipt`. This p
 | `operator.name` | Conditional | Human-readable operator name. Required when `operator` is present. |
 | `model` | No | Model identifier (e.g. `claude-sonnet-4-6`). |
 | `session_id` | No | Opaque session identifier. |
+| `runtime` | No | Open container for runtime/observability metadata (added in v0.5.0, ADR-0026). Absent for the root agent. Unlike the other issuer fields it is extensible: it carries the members below plus any additional keys a runtime supplies, typed `@json` in the context so JSON-LD treats it as an opaque literal. |
+| `runtime.agent_id` | No | Identifier of the sub-agent that issued the receipt. |
+| `runtime.agent_type` | No | Runtime-reported agent type label (e.g. `general-purpose`). |
 
 ## Credential subject
 

--- a/site/src/content/docs/specification/how-it-works.mdx
+++ b/site/src/content/docs/specification/how-it-works.mdx
@@ -98,7 +98,7 @@ sequenceDiagram
   participant D as agent-receipts-daemon
   participant DB as receipts.db
 
-  E->>D: emitter frame (v, ts_emit, tool, session_id, channel, decision, input?, output?, error?) [Unix socket]
+  E->>D: emitter frame (v, ts_emit, tool, session_id, agent_id?, agent_type?, channel, decision, input?, output?, error?) [Unix socket]
   Note over D: daemon builds receipt fields from frame
   Note over D: capture peer_credential (platform, pid, uid?, gid?, exe_path? — POSIX/best-effort)
   Note over D: RFC 8785 canonicalize<br/>hash input → action.parameters_hash<br/>(optional) encrypt input → action.parameters_disclosure (HPKE envelope)<br/>hash output → outcome.response_hash<br/>(plaintext not stored)

--- a/site/src/content/docs/specification/overview.mdx
+++ b/site/src/content/docs/specification/overview.mdx
@@ -5,14 +5,14 @@ description: Design principles and core concepts of the Agent Receipt Protocol.
 
 import { Aside, Badge } from "@astrojs/starlight/components";
 
-<Badge text="v0.4.0" variant="note" /> <Badge text="Draft" variant="caution" />
+<Badge text="v0.5.0" variant="note" /> <Badge text="Draft" variant="caution" />
 
 The Agent Receipt Protocol defines a standard format for cryptographically signed records of AI agent actions. This page covers the design principles and core concepts. For the full specification, see the [spec source on GitHub](https://github.com/agent-receipts/ar/tree/main/spec).
 
-<Aside type="note" title="What's new in v0.4.0">
-- `credentialSubject.action.idempotency_key` — optional stable identifier for the logical operation an action represents (e.g. a request ID). When an agent retries a tool call, the SDK or MCP proxy stamps the same key on every receipt for that operation, so verifiers can tell a legitimate retry from a duplicated emission. The MCP proxy populates it automatically from the wrapped JSON-RPC request `id`.
-- Verifier rule (spec §7.3.6): two or more receipts in a chain sharing a non-empty `idempotency_key` are surfaced as a **warning**, never a verification failure — retries are legitimate.
-- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, or `"0.4.0"`. Verifiers MUST accept all five; new receipts SHOULD use `"0.4.0"`. See the [full changelog](https://github.com/agent-receipts/ar/blob/main/spec/CHANGELOG.md).
+<Aside type="note" title="What's new in v0.5.0">
+- `issuer.runtime` — optional **open** container for runtime/observability metadata the issuing runtime attaches to an action. Initial members are `runtime.agent_id` (the sub-agent that issued the receipt) and `runtime.agent_type` (e.g. `"general-purpose"`); the root agent omits `runtime` entirely. Unlike the other issuer fields it is intentionally extensible — typed `@json` in the JSON-LD context and not `additionalProperties: false` in the schema — so future runtime keys (e.g. trace-context identifiers) need no protocol-version bump. See [ADR-0026](https://github.com/agent-receipts/ar/blob/main/docs/adr/0026-issuer-runtime-open-metadata.md).
+- JSON-LD **context v2** (`https://agentreceipts.ai/context/v2`) adds the `runtime` term. Receipts at `0.5.0` reference context v2; `0.1.0`–`0.4.0` keep context v1 permanently.
+- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, `"0.4.0"`, or `"0.5.0"`. Verifiers MUST accept all six; new receipts SHOULD use `"0.5.0"`. See the [full changelog](https://github.com/agent-receipts/ar/blob/main/spec/CHANGELOG.md).
 </Aside>
 
 ## Design principles

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-09
+
+### Added
+- `issuer.runtime` — optional open container for runtime/observability metadata the issuing runtime attaches to an action. Initially defined members: `runtime.agent_id` (identifier of the sub-agent that issued the receipt) and `runtime.agent_type` (runtime-reported agent type label, e.g. `"general-purpose"`). Absent for the root agent. Unlike every other issuer field, `runtime` is **not** `additionalProperties: false` in the schema and is typed `@json` in the JSON-LD context, so it is an opaque JSON literal that may carry additional keys. New runtime members (e.g. forthcoming W3C Trace Context / OpenTelemetry identifiers) MAY be added without a protocol-version or context-version bump. See spec §4.3.1 and ADR-0026.
+- JSON-LD **context v2** (`https://agentreceipts.ai/context/v2`) — adds the `runtime` term (`@type: @json`). Identical to v1 otherwise. Receipts at `0.5.0` reference context v2 in their `@context` array; v1 remains permanent for earlier receipts (ADR-0021 D3).
+
+### Changed
+- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, `"0.4.0"`, or `"0.5.0"`. Verifiers MUST accept all six. All new receipts SHOULD use `"0.5.0"`.
+
+### Upgrade notes
+
+**Issuers:** No action required to remain protocol-valid. Receipts emitted through a daemon that knows a sub-agent's identity will carry `issuer.runtime.agent_id` / `agent_type`; the root agent omits `runtime` entirely. Upgrade to `"version": "0.5.0"` (and context v2) when emitting new receipts.
+
+**Verifiers:** No breaking changes. Receipts at `0.1.0`–`0.4.0` validate unchanged against their pinned context v1. Treat unknown keys inside `issuer.runtime` as untrusted, signed-but-unvalidated metadata — never as identity.
+
 ## [0.4.0] - 2026-05-23
 
 ### Added

--- a/spec/context/v2/context.jsonld
+++ b/spec/context/v2/context.jsonld
@@ -1,0 +1,311 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "ar": "https://agentreceipts.ai/vocab#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "AgentReceipt": "ar:AgentReceipt",
+    "AIActionReceipt": "ar:AgentReceipt",
+    "AIAgent": "ar:AIAgent",
+    "HumanPrincipal": "ar:HumanPrincipal",
+    "OrganizationPrincipal": "ar:OrganizationPrincipal",
+
+    "version": {
+      "@id": "ar:version",
+      "@type": "xsd:string"
+    },
+
+    "issuanceDate": {
+      "@id": "ar:issuanceDate",
+      "@type": "xsd:dateTime"
+    },
+
+    "name": "https://schema.org/name",
+    "operator": {
+      "@id": "ar:operator"
+    },
+    "model": {
+      "@id": "ar:model",
+      "@type": "xsd:string"
+    },
+    "session_id": {
+      "@id": "ar:session_id",
+      "@type": "xsd:string"
+    },
+    "runtime": {
+      "@id": "ar:runtime",
+      "@type": "@json"
+    },
+
+    "principal": {
+      "@id": "ar:principal"
+    },
+
+    "action": {
+      "@id": "ar:action",
+      "@context": {
+        "@protected": true,
+        "id": {
+          "@id": "ar:action_id",
+          "@type": "xsd:string"
+        },
+        "type": {
+          "@id": "ar:action_type",
+          "@type": "xsd:string"
+        },
+        "risk_level": {
+          "@id": "ar:risk_level",
+          "@type": "xsd:string"
+        },
+        "target": {
+          "@id": "ar:target",
+          "@context": {
+            "@protected": true,
+            "system": {
+              "@id": "ar:target_system",
+              "@type": "xsd:string"
+            },
+            "resource": {
+              "@id": "ar:target_resource",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "parameters_hash": {
+          "@id": "ar:parameters_hash",
+          "@type": "xsd:string"
+        },
+        "parameters_disclosure": {
+          "@id": "ar:parameters_disclosure",
+          "@type": "@json"
+        },
+        "peer_credential": {
+          "@id": "ar:peer_credential",
+          "@context": {
+            "@protected": true,
+            "platform": {
+              "@id": "ar:peer_platform",
+              "@type": "xsd:string"
+            },
+            "pid": {
+              "@id": "ar:peer_pid",
+              "@type": "xsd:integer"
+            },
+            "uid": {
+              "@id": "ar:peer_uid",
+              "@type": "xsd:integer"
+            },
+            "gid": {
+              "@id": "ar:peer_gid",
+              "@type": "xsd:integer"
+            },
+            "exe_path": {
+              "@id": "ar:peer_exe_path",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "emitter_metadata": {
+          "@id": "ar:emitter_metadata",
+          "@context": {
+            "@protected": true,
+            "drop_count": {
+              "@id": "ar:emitter_drop_count",
+              "@type": "xsd:integer"
+            }
+          }
+        },
+        "timestamp": {
+          "@id": "ar:action_timestamp",
+          "@type": "xsd:dateTime"
+        },
+        "trusted_timestamp": {
+          "@id": "ar:trusted_timestamp",
+          "@type": "xsd:string"
+        },
+        "idempotency_key": {
+          "@id": "ar:idempotency_key",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "intent": {
+      "@id": "ar:intent",
+      "@context": {
+        "@protected": true,
+        "conversation_hash": {
+          "@id": "ar:conversation_hash",
+          "@type": "xsd:string"
+        },
+        "prompt_preview": {
+          "@id": "ar:prompt_preview",
+          "@type": "xsd:string"
+        },
+        "prompt_preview_truncated": {
+          "@id": "ar:prompt_preview_truncated",
+          "@type": "xsd:boolean"
+        },
+        "reasoning_hash": {
+          "@id": "ar:reasoning_hash",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "outcome": {
+      "@id": "ar:outcome",
+      "@context": {
+        "@protected": true,
+        "status": {
+          "@id": "ar:status",
+          "@type": "xsd:string"
+        },
+        "error": {
+          "@id": "ar:error",
+          "@type": "xsd:string"
+        },
+        "reversible": {
+          "@id": "ar:reversible",
+          "@type": "xsd:boolean"
+        },
+        "reversal_method": {
+          "@id": "ar:reversal_method",
+          "@type": "xsd:string"
+        },
+        "reversal_window_seconds": {
+          "@id": "ar:reversal_window_seconds",
+          "@type": "xsd:integer"
+        },
+        "reversal_of": {
+          "@id": "ar:reversal_of",
+          "@type": "@id"
+        },
+        "state_change": {
+          "@id": "ar:state_change",
+          "@context": {
+            "@protected": true,
+            "before_hash": {
+              "@id": "ar:before_hash",
+              "@type": "xsd:string"
+            },
+            "after_hash": {
+              "@id": "ar:after_hash",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "response_hash": {
+          "@id": "ar:response_hash",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "authorization": {
+      "@id": "ar:authorization",
+      "@context": {
+        "@protected": true,
+        "scopes": {
+          "@id": "ar:scopes",
+          "@container": "@set",
+          "@type": "xsd:string"
+        },
+        "granted_at": {
+          "@id": "ar:granted_at",
+          "@type": "xsd:dateTime"
+        },
+        "expires_at": {
+          "@id": "ar:expires_at",
+          "@type": "xsd:dateTime"
+        },
+        "grant_ref": {
+          "@id": "ar:grant_ref",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "delegation": {
+      "@id": "ar:delegation",
+      "@context": {
+        "@protected": true,
+        "parent_chain_id": {
+          "@id": "ar:parent_chain_id",
+          "@type": "xsd:string"
+        },
+        "parent_receipt_id": {
+          "@id": "ar:parent_receipt_id",
+          "@type": "@id"
+        },
+        "delegator": {
+          "@id": "ar:delegator"
+        }
+      }
+    },
+
+    "chain": {
+      "@id": "ar:chain",
+      "@context": {
+        "@protected": true,
+        "sequence": {
+          "@id": "ar:sequence",
+          "@type": "xsd:integer"
+        },
+        "previous_receipt_hash": {
+          "@id": "ar:previous_receipt_hash",
+          "@type": "xsd:string"
+        },
+        "chain_id": {
+          "@id": "ar:chain_id",
+          "@type": "xsd:string"
+        },
+        "terminal": {
+          "@id": "ar:terminal",
+          "@type": "xsd:boolean"
+        },
+        "status": {
+          "@id": "ar:chain_status",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "keyRotation": {
+      "@id": "ar:keyRotation",
+      "@context": {
+        "@protected": true,
+        "event_type": {
+          "@id": "ar:rotation_event_type",
+          "@type": "xsd:string"
+        },
+        "new_public_key": {
+          "@id": "ar:new_public_key",
+          "@type": "xsd:string"
+        },
+        "old_key_fingerprint": {
+          "@id": "ar:old_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "new_key_fingerprint": {
+          "@id": "ar:new_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "old_algorithm": {
+          "@id": "ar:old_algorithm",
+          "@type": "xsd:string"
+        },
+        "new_algorithm": {
+          "@id": "ar:new_algorithm",
+          "@type": "xsd:string"
+        },
+        "signed_with": {
+          "@id": "ar:rotation_signed_with",
+          "@type": "xsd:string"
+        }
+      }
+    }
+  }
+}

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -55,6 +55,35 @@
     "proof": { "$ref": "#/$defs/proof" }
   },
 
+  "allOf": [
+    {
+      "title": "Context is pinned to the protocol version",
+      "description": "Versions 0.1.0–0.4.0 MUST reference Agent Receipts context v1; 0.5.0 (which adds issuer.runtime) MUST reference v2. This couples the two so a receipt cannot declare a version whose context does not define its fields.",
+      "if": {
+        "properties": { "version": { "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0"] } }
+      },
+      "then": {
+        "properties": {
+          "@context": {
+            "prefixItems": [{}, { "const": "https://agentreceipts.ai/context/v1" }]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "version": { "const": "0.5.0" } }
+      },
+      "then": {
+        "properties": {
+          "@context": {
+            "prefixItems": [{}, { "const": "https://agentreceipts.ai/context/v2" }]
+          }
+        }
+      }
+    }
+  ],
+
   "$defs": {
     "sha256Hash": {
       "type": "string",

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentreceipts.ai/schema/v0.1/agent-receipt.schema.json",
   "title": "Agent Receipt",
-  "description": "A cryptographically signed record of a single action taken by an AI agent on behalf of a human principal. Validates receipts conforming to the Agent Receipt Protocol v0.1 through v0.3 — the protocol `version` enum on each receipt selects the applicable version; see CHANGELOG.md for what each version adds.",
+  "description": "A cryptographically signed record of a single action taken by an AI agent on behalf of a human principal. Validates receipts conforming to the Agent Receipt Protocol v0.1 through v0.5 — the protocol `version` enum on each receipt selects the applicable version; see CHANGELOG.md for what each version adds.",
   "type": "object",
   "required": [
     "@context",
@@ -20,11 +20,11 @@
       "type": "array",
       "prefixItems": [
         { "const": "https://www.w3.org/ns/credentials/v2" },
-        { "const": "https://agentreceipts.ai/context/v1" }
+        { "enum": ["https://agentreceipts.ai/context/v1", "https://agentreceipts.ai/context/v2"] }
       ],
       "minItems": 2,
       "items": { "type": "string" },
-      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Agent Receipts context URIs in order. Additional context URIs MAY follow."
+      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Agent Receipts context URIs in order. The Agent Receipts context is v1 for receipts at versions 0.1.0–0.4.0 and v2 (which adds issuer.runtime) for 0.5.0+; both remain permanent. Additional context URIs MAY follow."
     },
     "id": {
       "type": "string",
@@ -42,8 +42,8 @@
       "description": "MUST be [\"VerifiableCredential\", \"AgentReceipt\"]."
     },
     "version": {
-      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0"],
-      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", \"0.3.0\", or \"0.4.0\". Verifiers MUST accept all five."
+      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0", "0.5.0"],
+      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", \"0.3.0\", \"0.4.0\", or \"0.5.0\". Verifiers MUST accept all six."
     },
     "issuer": { "$ref": "#/$defs/issuer" },
     "issuanceDate": {
@@ -101,6 +101,20 @@
         "session_id": {
           "type": "string",
           "description": "Opaque session identifier."
+        },
+        "runtime": {
+          "type": "object",
+          "description": "Open container for runtime/observability metadata the issuing runtime attaches to the action (ADR-0026). Absent for the root agent. Intentionally NOT additionalProperties:false and typed @json in the JSON-LD context: it carries the members below plus any additional keys a runtime supplies, and new members may be added without a protocol-version bump. Consumers MUST treat unknown keys as untrusted metadata, never as identity.",
+          "properties": {
+            "agent_id": {
+              "type": "string",
+              "description": "Identifier of the sub-agent that issued the receipt. Absent for the root agent."
+            },
+            "agent_type": {
+              "type": "string",
+              "description": "Runtime-reported agent type label (e.g. \"general-purpose\"). Absent for the root agent."
+            }
+          }
         }
       }
     },

--- a/spec/v0.5.0/spec.md
+++ b/spec/v0.5.0/spec.md
@@ -60,7 +60,7 @@ A cryptographically signed record of a single action taken by an AI agent on beh
 
 An ordered sequence of Agent Receipts linked by hash references. Each receipt contains the hash of the previous receipt in the chain, creating a tamper-evident log. The first receipt in a chain has a `null` previous hash.
 
-> **Note:** In v0.1.0, receipt chains are strictly linear — each receipt has exactly one predecessor. Concurrent action streams (e.g., parallel tool calls, sub-agent fan-out) cannot be represented within a single chain. See §9.8 for discussion of this limitation.
+> **Note:** In this version, receipt chains are strictly linear — each receipt has exactly one predecessor. Concurrent action streams (e.g., parallel tool calls, sub-agent fan-out) cannot be represented within a single chain. See §9.8 for discussion of this limitation.
 
 ### 3.3 Action Taxonomy
 
@@ -293,7 +293,7 @@ All five `proof` fields are required even in the minimal form.
 
 #### 4.3.2.1 Intent field guidance (non-normative)
 
-The `intent` fields link an action to the context that triggered it. Because agent frameworks differ in how they structure conversations and reasoning, the following guidance is non-normative for v0.1.0. Capitalized keywords (e.g., "SHOULD") in this subsection are used for consistency with the rest of the document but are informational, not normative.
+The `intent` fields link an action to the context that triggered it. Because agent frameworks differ in how they structure conversations and reasoning, the following guidance is non-normative in this version. Capitalized keywords (e.g., "SHOULD") in this subsection are used for consistency with the rest of the document but are informational, not normative.
 
 **`conversation_hash`** should be computed over the complete message history — including system prompts, user messages, assistant messages, and tool results — in the conversation thread that preceded this action, serialized as an RFC 8785 canonical JSON array of message objects. Implementations that truncate or filter the conversation context should document their truncation policy. If no conversation context exists (e.g., a scheduled autonomous action), this field should be omitted.
 
@@ -570,7 +570,7 @@ To verify a single Agent Receipt:
 
 A receipt that passes steps 1–4 is individually valid. Steps 5–6 provide chain and delegation context but require additional receipts to verify fully.
 
-> **Note:** This algorithm depends on DID resolution (step 2), which is not fully specified in v0.1.0. Implementations MUST document their DID resolution strategy. See §9.6.
+> **Note:** This algorithm depends on DID resolution (step 2), which is not fully specified in this version. Implementations MUST document their DID resolution strategy. See §9.6.
 
 ---
 
@@ -629,6 +629,6 @@ A receipt that passes steps 1–4 is individually valid. Steps 5–6 provide cha
 
 7. **Revocation is append-only.** Reversal is recorded by issuing a new receipt, not by mutating the original. The chain is always append-only.
 
-8. **Key lifecycle is out of scope for v0.1.** Agent key generation, secure storage, rotation, and revocation are not specified by this version of the protocol. Implementers SHOULD treat key management as a critical security concern: a compromised agent key allows production of validly-signed but fraudulent receipts that are indistinguishable from legitimate ones. MolTrust (listed in §8) or a dedicated key management specification may address this in future. At minimum, implementations SHOULD document their key generation and storage practices.
+8. **Key lifecycle is out of scope for this version.** Agent key generation, secure storage, rotation, and revocation are not specified by this version of the protocol. Implementers SHOULD treat key management as a critical security concern: a compromised agent key allows production of validly-signed but fraudulent receipts that are indistinguishable from legitimate ones. MolTrust (listed in §8) or a dedicated key management specification may address this in future. At minimum, implementations SHOULD document their key generation and storage practices.
 
 9. **base64url for `proofValue`.** The `proofValue` field uses multibase `u`-prefixed base64url (no padding) rather than the W3C Data Integrity default of base58btc (`z`). base64url avoids the need for a base58 library, is natively supported in all target runtimes, and is slightly more compact. This is an intentional deviation from the W3C default.

--- a/spec/v0.5.0/spec.md
+++ b/spec/v0.5.0/spec.md
@@ -1,0 +1,634 @@
+# Agent Receipt Protocol — Specification v0.5.0
+
+> **Status:** Draft
+> **Version:** 0.5.0
+> **Date:** 2026-06-09
+> **License:** MIT
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+---
+
+## 1. Problem Statement
+
+AI agents are increasingly acting on behalf of humans — sending emails, modifying documents, making purchases, booking travel, managing files. No open standard exists for recording what an agent did, why it did it, whether it succeeded, and whether it can be undone.
+
+The current state:
+
+- 93% of open-source AI agent projects use unscoped API keys with no audit trail (Grantex, March 2026)
+- Only 13% include any form of action logging, and where it exists, it is opt-in and not tied to authorization
+- No project produces an audit trail linking a specific action to a specific agent, user authorization, and set of scopes
+- The EU AI Act mandates traceability for high-risk AI systems, but no standard format exists for agent action records
+
+### What exists and what doesn't
+
+| Layer | Existing standards | Gap |
+|---|---|---|
+| Agent identity | W3C DIDs, AgentStamp, MolTrust, Grantex | No adoption by major platforms |
+| Action authorization | OAuth 2.0, Grantex (IETF draft) | No cross-platform standard for agent-specific scopes |
+| Content provenance | C2PA Content Credentials | Designed for media assets, not agent actions |
+| Action logging | Vendor-specific (LangSmith, Arize) | No standard format — everyone rolls their own |
+| **Action receipts** | **Nothing** | **This specification** |
+
+---
+
+## 2. Design Principles
+
+1. **Privacy-preserving by default.** Parameters are hashed, not stored in plaintext. The human principal controls what is disclosed. Sensitive data never appears in receipts — only hashes and user-controlled previews.
+
+2. **Built on existing standards.** W3C Verifiable Credentials Data Model 2.0 for structure. Ed25519 for signing. SHA-256 for hashing. RFC 3161 for trusted timestamps. No novel cryptographic primitives.
+
+3. **Hash-chained for integrity.** Each receipt includes the hash of the previous receipt, forming a tamper-evident chain. Breaking the chain is detectable.
+
+4. **Agent-agnostic.** The spec does not assume MCP, OpenAI function calling, or any specific agent framework. Any agent that can produce JSON and sign it can emit receipts.
+
+5. **Human-readable and machine-verifiable.** Receipts can be displayed as a timeline to end users and cryptographically verified by auditors and compliance tools.
+
+6. **Reversibility-aware.** Every receipt declares whether the action can be undone, and if so, how. This enables downstream tooling to offer "undo" capabilities.
+
+7. **Minimal by default, extensible by design.** The core schema is small. Domain-specific extensions (financial actions, healthcare, etc.) can be layered on via additional `@context` URIs.
+
+---
+
+## 3. Core Concepts
+
+### 3.1 Agent Receipt
+
+A cryptographically signed record of a single action taken by an AI agent on behalf of a human principal. Modeled as a W3C Verifiable Credential with type `AgentReceipt`.
+
+### 3.2 Receipt Chain
+
+An ordered sequence of Agent Receipts linked by hash references. Each receipt contains the hash of the previous receipt in the chain, creating a tamper-evident log. The first receipt in a chain has a `null` previous hash.
+
+> **Note:** In v0.1.0, receipt chains are strictly linear — each receipt has exactly one predecessor. Concurrent action streams (e.g., parallel tool calls, sub-agent fan-out) cannot be represented within a single chain. See §9.8 for discussion of this limitation.
+
+### 3.3 Action Taxonomy
+
+A standardized vocabulary of action types, organized by domain and risk level. The taxonomy enables cross-agent comparison and risk classification.
+
+### 3.4 Principal
+
+The human (or organization) on whose behalf the agent acted. Identified by a DID or URI. The principal is the entity who authorized the action, not the entity that built or operates the agent.
+
+### 3.5 Issuer
+
+The agent (or agent platform) that performed the action and produced the receipt. The issuer signs the receipt with its private key.
+
+---
+
+## 4. Schema
+
+### 4.1 Agent Receipt (full schema)
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v2"
+  ],
+  "id": "urn:receipt:550e8400-e29b-41d4-a716-446655440000",
+  "type": ["VerifiableCredential", "AgentReceipt"],
+  "version": "0.5.0",
+
+  "issuer": {
+    "id": "did:agent:claude-cowork-instance-abc123",
+    "type": "AIAgent",
+    "name": "Claude Cowork",
+    "operator": {
+      "id": "did:org:anthropic",
+      "name": "Anthropic"
+    },
+    "model": "claude-sonnet-4-6",
+    "session_id": "session_xyz789",
+    "runtime": {
+      "agent_id": "a3e49db54342a92d4",
+      "agent_type": "general-purpose"
+    }
+  },
+
+  "issuanceDate": "2026-03-31T14:30:00Z",
+
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:otto-abc",
+      "type": "HumanPrincipal"
+    },
+
+    "action": {
+      "id": "act_7f3a1b2c-d4e5-46f7-a8b9-c0d1e2f3a4b5",
+      "type": "communication.email.send",
+      "risk_level": "high",
+      "target": {
+        "system": "mail.google.com",
+        "resource": "email:compose"
+      },
+      "parameters_hash": "sha256:a3f1c2d4e5b6a7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1d6",
+      "timestamp": "2026-03-31T14:30:00Z",
+      "trusted_timestamp": null
+    },
+
+    "intent": {
+      "conversation_hash": "sha256:b4e2d1f3a5c6b7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1e7",
+      "prompt_preview": "Send the Q3 report to the team",
+      "prompt_preview_truncated": true,
+      "reasoning_hash": "sha256:c5f3e2d4a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2f8"
+    },
+
+    "outcome": {
+      "status": "success",
+      "error": null,
+      "reversible": true,
+      "reversal_method": "gmail:undo_send",
+      "reversal_window_seconds": 30,
+      "state_change": {
+        "before_hash": "sha256:d604f3e5a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3a9",
+        "after_hash": "sha256:e7a504f6a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4ba"
+      }
+    },
+
+    "authorization": {
+      "scopes": ["email:send", "drive:read"],
+      "granted_at": "2026-03-31T14:00:00Z",
+      "expires_at": "2026-03-31T15:00:00Z",
+      "grant_ref": null
+    },
+
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_session_xyz789"
+    }
+  },
+
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-03-31T14:30:01Z",
+    "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
+  }
+}
+```
+
+### 4.2 Minimal Receipt (required fields only)
+
+For lightweight or high-frequency actions, a minimal receipt containing only required fields:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v2"
+  ],
+  "id": "urn:receipt:660e8400-e29b-41d4-a716-446655440001",
+  "type": ["VerifiableCredential", "AgentReceipt"],
+  "version": "0.5.0",
+  "issuer": { "id": "did:agent:claude-cowork-instance-abc123" },
+  "issuanceDate": "2026-03-31T14:31:00Z",
+  "credentialSubject": {
+    "principal": { "id": "did:user:otto-abc" },
+    "action": {
+      "id": "act_8a4b2c3d-e5f6-47a8-b9c0-d1e2f3a4b5c6",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-03-31T14:31:00Z"
+    },
+    "outcome": { "status": "success" },
+    "chain": {
+      "sequence": 2,
+      "previous_receipt_hash": "sha256:f806a507a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5cb",
+      "chain_id": "chain_session_xyz789"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-03-31T14:31:01Z",
+    "verificationMethod": "did:agent:claude-cowork-instance-abc123#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "ul_wFLgGWlzFaYt2ckT4wZfoeRa7ZqL0tt3y10dgr7FdsVMivs5tc9ZrUYBJ_FKEE4aFApeAzPH6jp57irtgDCw"
+  }
+}
+```
+
+All five `proof` fields are required even in the minimal form.
+
+### 4.3 Field Reference
+
+#### Top-level fields
+
+| Field | Required | Description |
+|---|---|---|
+| `@context` | Yes | JSON-LD context. MUST include the W3C VC v2 and Agent Receipts context URIs in the order shown. Receipts at this version use `https://agentreceipts.ai/context/v2`. |
+| `id` | Yes | Globally unique receipt identifier. MUST be a `urn:receipt:<uuid>`. |
+| `type` | Yes | MUST be `["VerifiableCredential", "AgentReceipt"]`. |
+| `version` | Yes | Spec version this receipt conforms to. MUST be `"0.5.0"` for this version. |
+| `issuer` | Yes | The agent or platform that issued the receipt. See §4.3.1. |
+| `issuanceDate` | Yes | ISO 8601 datetime when the receipt was issued. This is the *receipt* timestamp (when the issuer created and signed the credential), which MAY differ from `action.timestamp` (when the action itself was executed). In real-time emitters these will be near-identical; in batched or retroactive scenarios they may diverge significantly. Uses the VC Data Model 1.x field name; see ADR-0009 for the rationale. The VC 2.0 name `validFrom` is **not** used. |
+| `credentialSubject` | Yes | The receipt payload. See §4.3.2. |
+| `proof` | Yes | Cryptographic proof. See §4.3.3. |
+
+#### 4.3.1 `issuer`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | Yes | DID or URI identifying the agent instance. |
+| `type` | No | SHOULD be `"AIAgent"`. |
+| `name` | No | Human-readable agent name. |
+| `operator.id` | Yes* | DID or URI of the entity operating the agent. *Required when `operator` is present. |
+| `operator.name` | Yes* | Human-readable operator name. *Required when `operator` is present. |
+| `model` | No | Model identifier (e.g. `claude-sonnet-4-6`). |
+| `session_id` | No | Opaque session identifier. |
+| `runtime` | No | Open container for runtime/observability metadata the issuing runtime attaches to the action. Absent for the root agent. Unlike the other issuer fields, `runtime` is intentionally extensible: it carries the members defined below plus any additional keys a runtime supplies, and is treated as an opaque JSON literal by JSON-LD processors (`@type: @json` in the context). New members MAY be added without a protocol-version bump. See ADR-0026. |
+| `runtime.agent_id` | No | Identifier of the sub-agent that issued the receipt. Absent for the root agent. |
+| `runtime.agent_type` | No | Runtime-reported agent type label (e.g. `general-purpose`). Absent for the root agent. |
+
+#### 4.3.2 `credentialSubject`
+
+| Field | Required | Description |
+|---|---|---|
+| `principal` | Yes | The human or org on whose behalf the action was taken. |
+| `principal.id` | Yes | DID or URI identifying the principal. |
+| `principal.type` | No | SHOULD be `"HumanPrincipal"` or `"OrganizationPrincipal"`. |
+| `action` | Yes | Details of the action taken. |
+| `action.id` | Yes | Unique action identifier. Format: `act_<uuid>`. |
+| `action.type` | Yes | Action type from the taxonomy (§5). |
+| `action.risk_level` | Yes | One of: `low`, `medium`, `high`, `critical`. |
+| `action.target.system` | No | The system or service acted upon. |
+| `action.target.resource` | No | The specific resource within the system. |
+| `action.parameters_hash` | No | `sha256:`-prefixed hash of the action parameters (RFC 8785 canonical JSON). A verifier can independently canonicalize any disclosed parameters and recompute this hash; however, this version of the spec does not define per-action-type parameter schemas, so verifiers cannot reliably determine whether the disclosed parameters are complete or expected for the action type, and mismatches may be ambiguous. See §9.9. |
+| `action.timestamp` | Yes | ISO 8601 datetime when the action was executed. |
+| `action.trusted_timestamp` | No | Base64-encoded RFC 3161 `TimeStampToken` (DER encoding, then base64). The TSA MUST timestamp the same canonical JSON (proof field removed) used for signing. If no trusted timestamp is available, this field MAY be omitted or set explicitly to `null`. See §7.7. |
+| `action.idempotency_key` | No | Stable identifier for the logical operation this action represents (e.g. a request ID). When an agent retries a tool call, the SDK or MCP proxy SHOULD stamp the same `idempotency_key` on every receipt emitted for that operation. Verifiers surface duplicate values across a chain as a warning, not a failure — retries are legitimate. MUST be a non-empty string when present; MUST NOT be `null`. See §7.3.6 and ADR-0019 §S5. |
+| `intent` | No | Context about the agent's intent at time of action. |
+| `intent.conversation_hash` | No | `sha256:` prefixed hash of the conversation context. |
+| `intent.prompt_preview` | No | Plain-text preview of the prompt that triggered the action (may be truncated). |
+| `intent.prompt_preview_truncated` | No | `true` if `prompt_preview` was truncated. |
+| `intent.reasoning_hash` | No | `sha256:` prefixed hash of the agent's reasoning trace. |
+| `outcome` | Yes | The result of the action. |
+| `outcome.status` | Yes | One of: `success`, `failure`, `pending`. |
+| `outcome.error` | No | Error message if `status` is `failure`. |
+| `outcome.reversible` | No | `true` if the action can be undone. |
+| `outcome.reversal_method` | No | Machine-readable reversal method identifier (e.g. `gmail:undo_send`). |
+| `outcome.reversal_window_seconds` | No | Seconds within which reversal is possible. |
+| `outcome.reversal_of` | No | `urn:receipt:<uuid>` referencing the `id` of the original receipt this receipt reverses. Present only on reversal receipts (see §7.4). |
+| `outcome.state_change.before_hash` | Yes* | `sha256:` prefixed hash of relevant state before the action. *Required when `outcome.state_change` is present. |
+| `outcome.state_change.after_hash` | Yes* | `sha256:` prefixed hash of relevant state after the action. *Required when `outcome.state_change` is present. |
+| `outcome.response_hash` | No | SHA-256 hash of the RFC 8785 canonical JSON of the server's response, computed **after** secret redaction. Ordering: redact → hash → populate `outcome` → sign. When present and the response body is available, verifiers MUST recompute and compare; a mismatch is a verification failure. When the response body is absent, verifiers MUST continue and note "response hash present, body not supplied". Absence of this field is not a verification failure — it means the issuer did not commit to the response. |
+| `authorization` | No | Authorization context under which the action was taken. |
+| `authorization.scopes` | Yes* | List of authorization scopes active at time of action. *Required when `authorization` is present. |
+| `authorization.granted_at` | Yes* | ISO 8601 datetime when authorization was granted. *Required when `authorization` is present. |
+| `authorization.expires_at` | No | ISO 8601 datetime when authorization expires. |
+| `authorization.grant_ref` | No | Reference to the authorization grant (e.g. a Grantex grant token). |
+| `delegation` | No | Present when this chain was spawned by delegation from another agent. See §7.6. |
+| `delegation.parent_chain_id` | Yes* | `chain_id` of the delegating agent's chain. *Required when `delegation` is present. |
+| `delegation.parent_receipt_id` | Yes* | `id` of the receipt in the parent chain where delegation occurred. *Required when `delegation` is present. |
+| `delegation.delegator` | Yes* | Identifies the delegating agent. *Required when `delegation` is present. |
+| `delegation.delegator.id` | Yes* | DID or URI of the delegating agent (the parent chain's issuer). *Required when `delegation` is present. |
+| `chain` | Yes | Hash-chain linkage fields. |
+| `chain.chain_id` | Yes | Opaque identifier grouping receipts into a logical chain (e.g. per session). All receipts within a single chain MUST share the same value; verifiers MUST reject input that mixes receipts from different chains. See §7.3.4. |
+| `chain.sequence` | Yes | Monotonically increasing integer position within the chain. Starts at `1`. |
+| `chain.previous_receipt_hash` | Yes | `sha256:` prefixed hash of the previous receipt's canonical form. MUST be `null` for the first receipt in a chain (`sequence: 1`). The field MUST always be present; `null` is not the same as omitting it. |
+| `chain.terminal` | No | When present, MUST be `true`. Asserts that no further receipts will be appended to this chain. Explicit `false` is schema-invalid; absence is the only valid way to express "no claim". Verifiers that observe any receipt following a terminal receipt in the verified input sequence MUST fail with a "receipt after terminal" error regardless of caller parameters. See §7.3.2. |
+| `chain.status` | No | When present, MUST be one of `"complete"` or `"interrupted"`. Issuer-asserted reason the chain ended. `"complete"` means the issuer ran to normal end-of-session; `"interrupted"` means a best-effort terminal receipt was emitted on signal or known abort path. Only meaningful alongside `chain.terminal: true` — a non-terminal receipt with `chain.status` is schema-invalid. Absence on a terminal receipt is equivalent to `"complete"` for backwards compatibility. The verifier-derived classification `"unknown"` (chains with no terminal at all) is never written on the wire. See §7.3.3. |
+
+#### 4.3.2.1 Intent field guidance (non-normative)
+
+The `intent` fields link an action to the context that triggered it. Because agent frameworks differ in how they structure conversations and reasoning, the following guidance is non-normative for v0.1.0. Capitalized keywords (e.g., "SHOULD") in this subsection are used for consistency with the rest of the document but are informational, not normative.
+
+**`conversation_hash`** should be computed over the complete message history — including system prompts, user messages, assistant messages, and tool results — in the conversation thread that preceded this action, serialized as an RFC 8785 canonical JSON array of message objects. Implementations that truncate or filter the conversation context should document their truncation policy. If no conversation context exists (e.g., a scheduled autonomous action), this field should be omitted.
+
+**`reasoning_hash`** should be computed over the agent's reasoning trace (e.g., chain-of-thought, planning steps, or extended thinking blocks) that led to this specific action. The content and format of reasoning traces vary across agent frameworks; implementations should document what content is included. If the agent framework does not expose a reasoning trace, this field should be omitted rather than hashed as empty.
+
+> **Note:** Cross-agent intent comparison requires implementations to document their hashing inputs. Future versions may promote specific content boundaries to normative requirements.
+
+#### 4.3.3 `proof`
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | Yes | MUST be `"Ed25519Signature2020"`. |
+| `created` | Yes | ISO 8601 datetime when the proof was created. |
+| `verificationMethod` | Yes | DID URL of the signing key (e.g. `did:agent:...#key-1`). |
+| `proofPurpose` | Yes | MUST be `"assertionMethod"`. |
+| `proofValue` | Yes | Multibase-encoded (`u`-prefixed base64url, no padding) Ed25519 signature over the canonical receipt (proof field excluded). |
+
+### 4.4 JSON Schema
+
+A machine-readable JSON Schema (draft 2020-12) for validating Agent Receipts is provided at:
+
+→ [`schema/agent-receipt.schema.json`](../schema/agent-receipt.schema.json)
+
+The schema encodes all required/optional field constraints, enum values, hash format patterns, and ID formats defined in §4.3. Implementations SHOULD validate receipts against this schema before signing or persisting.
+
+---
+
+## 5. Action Taxonomy
+
+Hierarchical action types, organized by domain. Risk levels are defaults — implementations may override based on context.
+
+A canonical machine-readable taxonomy is defined in [`spec/taxonomy/action-types.json`](../spec/taxonomy/action-types.json). Implementations SHOULD treat the JSON taxonomy as authoritative for type names and default risk levels. The tables below are illustrative; if discrepancies arise, the JSON file is the source of truth. Future versions of the taxonomy MAY include parameter schemas for each action type to support deterministic `parameters_hash` verification (see §9.9).
+
+### 5.1 Filesystem
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `filesystem.file.create` | Create a file | low |
+| `filesystem.file.read` | Read a file | low |
+| `filesystem.file.modify` | Modify a file | medium |
+| `filesystem.file.delete` | Delete a file | high |
+| `filesystem.file.move` | Move or rename a file | medium |
+| `filesystem.directory.create` | Create a directory | low |
+| `filesystem.directory.delete` | Delete a directory | high |
+
+### 5.2 System
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `system.application.launch` | Launch an application | low |
+| `system.application.control` | Control an application via UI automation | medium |
+| `system.settings.modify` | Modify system or app settings | high |
+| `system.command.execute` | Execute a shell command | high |
+| `system.browser.navigate` | Navigate to a URL | low |
+| `system.browser.form_submit` | Submit a web form | medium |
+| `system.browser.authenticate` | Log into a service | high |
+
+### 5.3 Communication
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `communication.email.send` | Send an email | high |
+| `communication.email.draft` | Create a draft email | medium |
+| `communication.email.read` | Read email content | low |
+| `communication.email.delete` | Delete an email | high |
+| `communication.message.send` | Send a chat message (Slack, Teams, etc.) | high |
+| `communication.calendar.create` | Create a calendar event | medium |
+| `communication.calendar.modify` | Modify a calendar event | medium |
+| `communication.calendar.delete` | Delete a calendar event | high |
+
+### 5.4 Documents
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `document.file.create` | Create a new document | low |
+| `document.file.modify` | Modify document content | medium |
+| `document.file.delete` | Delete a document | high |
+| `document.file.share` | Share a document with others | high |
+| `document.spreadsheet.modify_cell` | Modify spreadsheet cell values | medium |
+| `document.spreadsheet.modify_formula` | Modify spreadsheet formulas | high |
+| `document.spreadsheet.modify_structure` | Add/remove sheets, rows, columns | medium |
+| `document.presentation.modify_slide` | Modify presentation slide content | medium |
+
+### 5.5 Financial
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `financial.payment.initiate` | Initiate a payment or purchase | critical |
+| `financial.payment.authorize` | Authorize a pending payment | critical |
+| `financial.subscription.create` | Create a subscription | critical |
+| `financial.subscription.cancel` | Cancel a subscription | high |
+| `financial.booking.create` | Book travel, accommodation, etc. | high |
+| `financial.booking.cancel` | Cancel a booking | high |
+
+### 5.6 Data
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `data.api.read` | Read data from an external API | low |
+| `data.api.write` | Write data to an external API | medium |
+| `data.api.delete` | Delete data via an external API | high |
+| `data.database.query` | Query a database | low |
+| `data.database.modify` | Modify database records | high |
+
+### 5.7 Unknown
+
+| Action type | Description | Default risk |
+|---|---|---|
+| `unknown` | Action that does not map to any known type | medium |
+
+Any action that cannot be classified via the taxonomy falls back to `unknown` with a default risk level of `medium`. When `action.type` is `unknown`, `action.target` MUST be present and `action.target.system` MUST contain the original tool name or method identifier to preserve traceability for later classification. Implementations SHOULD track the frequency of `unknown`-typed receipts and surface unclassified action patterns for taxonomy extension.
+
+### 5.8 Custom Action Types
+
+Implementations MAY define action types beyond those listed above. Custom action types MUST use a reverse-domain prefix to avoid collisions with the standard taxonomy (e.g. `com.acme.crm.lead.create`, `io.example.ml.model.deploy`). Custom types MUST declare a default risk level. The `unknown` fallback still applies for any action that cannot be classified.
+
+---
+
+## 6. Risk Levels
+
+Four levels, used for filtering, alerting, and authorization policy:
+
+| Level | Description | Examples |
+|---|---|---|
+| `low` | Read-only or easily reversible | Read a file, navigate to a URL, create a draft |
+| `medium` | Modifies state but reversible or low-impact | Edit a document, move a file, modify settings |
+| `high` | Significant state change, may be hard to reverse | Send an email, delete a file, share a document |
+| `critical` | Financial commitment or irreversible action | Make a purchase, authorize a payment, delete an account |
+
+Risk levels are assigned by action type as defaults. Implementations MAY escalate but MUST NOT downgrade risk levels based on runtime context. For example, a `filesystem.file.delete` on a system backup SHOULD be escalated to `critical` even though the default is `high`. The no-downgrade rule ensures that risk levels serve as a reliable floor for compliance and audit tooling — a consumer of receipts can trust that any receipt marked `high` represents at least a `high`-risk action by the taxonomy's definition.
+
+> **Note:** The `unknown` action type carries a default risk of `medium`. High volumes of `unknown` receipts reduce the effectiveness of risk-based filtering and alerting. Where possible, implementations SHOULD define custom action types (§5.8) rather than relying on the `unknown` fallback.
+
+---
+
+## 7. Receipt Chain Verification
+
+### 7.1 Canonical form
+
+For hashing and signing, receipts MUST be serialized using the JSON Canonicalization Scheme (RFC 8785) with the `proof` field removed before hashing. This canonicalization step is aligned with the use of RFC 8785 in the W3C Verifiable Credentials Data Integrity specification; however, the overall signing procedure defined in this document (see §7.2 and §10) is intentionally simplified and is not a full implementation of the W3C Data Integrity algorithm.
+
+#### 7.1.1 Null and optional field handling
+
+Implementations MUST apply the following normalisation before serializing to RFC 8785:
+
+- **Required-nullable fields** — fields listed in the schema `required` array whose type permits `null` MUST be emitted with their value, including the explicit JSON `null` literal when the value is null. The only current required-nullable field is `credentialSubject.chain.previous_receipt_hash` (null for the first receipt in a chain, a hash string for all subsequent receipts).
+- **Optional fields** — fields not listed in `required` MUST NOT be emitted when their value is null or absent. An SDK that receives `null` on an optional field MUST normalise it to absent before canonicalising. The form `"error":null` is not a valid canonical representation.
+
+This rule ensures all three SDKs produce byte-identical canonical output for the same logical receipt regardless of whether an optional field is set to `null` or simply omitted by the caller. Cross-SDK test vectors in `cross-sdk-tests/canonicalization_vectors.json` pin the expected behaviour and are intended to enforce this invariant once integrated into each SDK's CI (tracked in #82, #86, #118).
+
+### 7.2 Signing
+
+The issuer MUST sign the canonical receipt (proof field excluded) with its Ed25519 private key. The signature MUST be encoded as a multibase string (`u`-prefixed base64url, no padding) and placed in `proof.proofValue`.
+
+### 7.3 Chain integrity verification
+
+To verify a receipt chain:
+
+1. Retrieve all receipts for the chain, ordered by `chain.sequence`. Let _n_ be the number of receipts.
+2. For each receipt _R(i)_ (0-based index):
+   a. Verify the `proof` signature against the issuer's public key at `proof.verificationMethod`. (Note: resolving the public key from the `verificationMethod` DID URL requires a DID resolution mechanism, which is not specified by this version of the protocol. See §9.6.)
+   b. Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of _R(i)_ with the `proof` field removed.
+   c. If _i < n - 1_, confirm _R(i+1)_'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.
+3. For each receipt _R(i)_ where _i > 0_, confirm `chain.sequence` equals _R(i-1)_'s `chain.sequence` + 1.
+4. Confirm _R(0)_'s `chain.previous_receipt_hash` is `null`.
+
+#### 7.3.1 Chain truncation detection
+
+Chain verification as defined in steps 1–4 does **not** detect tail truncation: dropping the last N receipts from a chain still produces `Valid: true`, because no in-chain field commits to the chain's total length or final state. This is a deliberate design floor — a receipt can only commit to values its issuer already knows at signing time.
+
+Three mitigations are available:
+
+1. **Out-of-band witness (`ExpectedLength` / `ExpectedFinalHash`).** Callers who maintain an external record of chain state (audit log, transparency log, signed checkpoint) MAY supply `ExpectedLength` and/or `ExpectedFinalHash` to `VerifyChain`. Verification fails when the observed chain does not match. When unsupplied, the verifier preserves current behaviour — `Valid: true` for a tail-truncated chain is intentional and documented.
+
+2. **In-band terminal marker (`chain.terminal` + `chain.status` + `RequireTerminal`).** When the final receipt in a chain bears `chain.terminal: true`, no receipt referencing it via `previous_receipt_hash` is permitted — this check runs unconditionally (§7.3.2). The terminal receipt MAY also carry `chain.status` (§7.3.3) to distinguish normal `"complete"` termination from best-effort `"interrupted"` termination on signal. Callers MAY additionally supply `RequireTerminal`; verification then fails if the final observed receipt is not explicitly terminal. If the terminal receipt itself was dropped, `RequireTerminal` fires, but `chain.terminal` alone cannot detect this case — the verifier classifies the chain's termination status as `"unknown"` (§7.3.3) regardless of `RequireTerminal`.
+
+3. **Floor.** Tail truncation of an open (non-terminal) chain without any external witness **cannot** be detected by any mechanism defined in this specification. Operators whose compliance requirements demand detection of such truncation MUST maintain an out-of-band chain record and supply `ExpectedFinalHash`.
+
+#### 7.3.2 Receipt-after-terminal integrity check (automatic)
+
+If any receipt R(i) in the verified input has `chain.terminal: true`, and a subsequent receipt R(i+1) exists at position i+1 in the input, verification MUST fail immediately with a clear "receipt after terminal" error. This check is unconditional — no caller parameter can suppress it. It does not depend on R(i+1)'s `previous_receipt_hash` field; the presence of any receipt after a terminal predecessor in the verified sequence is sufficient to trigger the failure. This is the verifier's enforcement mechanism against an issuer who marks a chain closed and then extends it, or an attacker who appends a receipt to a chain its issuer marked terminal.
+
+If any step fails, the chain is broken at that point. Receipts before the break may still be individually valid; receipts after are suspect.
+
+> **Note:** This algorithm assumes a linear chain where each receipt has exactly one predecessor. It does not cover concurrent or branching topologies (e.g., fan-out tool calls producing multiple receipts with the same predecessor). See §9.8.
+
+#### 7.3.3 Chain termination status
+
+A chain ends in one of three states; the verifier's `ChainVerification` result MUST surface which:
+
+1. **`"complete"`** — the chain has a final receipt with `chain.terminal: true` and either `chain.status: "complete"` or no `chain.status` field. The issuer reached normal end-of-session and emitted a terminator deliberately.
+
+2. **`"interrupted"`** — the chain has a final receipt with `chain.terminal: true` and `chain.status: "interrupted"`. The issuer (or the signing process on its behalf at shutdown — typically the daemon, since signing is daemon-side per ADR-0010) emitted a best-effort terminator before crashing or being killed. The chain is closed but the closure was not part of normal operation. Auditors SHOULD treat the chain as complete for integrity purposes but flag the imperfect termination for operational review.
+
+3. **`"unknown"`** — the chain has no terminal receipt. The verifier cannot distinguish a chain whose issuer crashed mid-session (no terminator written) from a chain whose terminator was truncated off the end (which `ExpectedLength` / `ExpectedFinalHash` per §7.3.1 may detect). This classification is the verifier's signal that completeness cannot be determined from the chain alone.
+
+The verifier classifies in this exact order: presence of `chain.terminal: true` and the value of `chain.status` on the final receipt determine `"complete"` or `"interrupted"`; absence of any terminal receipt yields `"unknown"`. The classification is independent of `RequireTerminal` — `RequireTerminal` controls whether `unknown` is a verification failure, but the classification is reported regardless.
+
+Issuers MUST NOT write `chain.status: "unknown"` to the wire; it is a verifier-derived value. Implementations encountering `"unknown"` in a receipt's `chain.status` field MUST reject the receipt as schema-invalid.
+
+#### 7.3.4 Chain identifier binding (automatic)
+
+All receipts within a chain MUST share the same `chain.chain_id` (per §7.5, a chain is the authoritative log of a single issuer; the `chain_id` is the opaque identifier that groups its receipts). Verifiers MUST reject input in which any receipt R(i) has a `chain.chain_id` different from that of R(0), failing immediately with a clear "chain_id mismatch" error that identifies the offending index and both `chain_id` values. This check is unconditional — no caller parameter can suppress it, and it runs independently of `previous_receipt_hash` linkage so that an attacker who splices in a forged hash link cannot mix receipts from two distinct chains under a single verification call. Verifiers MUST NOT attempt to "stitch" or partition cross-chain input; the only correct response is rejection.
+
+This check parallels §7.3.2: both enforce single-chain integrity invariants that no caller parameter can disable. Verifying receipts from multiple chains requires multiple calls to the chain verifier, one per chain.
+
+#### 7.3.5 Sequence number contiguity and store trust
+
+Verification step 3 (above) mandates strict contiguity: each receipt's `chain.sequence` MUST equal its predecessor's + 1. Any gap (e.g. receipts at sequence 1, 3, 5 missing sequence 2 and 4) is a hard verification failure, not a warning. Verifiers MUST mark the chain invalid and identify the offending index. This applies even when signatures and hash linkage on the surviving receipts are otherwise valid — a partial chain with gaps cannot be silently accepted.
+
+**Store trust model.** Chain verification proves the integrity of the receipts the verifier is *given*; it cannot, on its own, prove that the verifier was given every receipt the issuer wrote. If an attacker can both delete receipts from the store AND re-sign every downstream receipt with an updated `previous_receipt_hash` (which requires the agent's signing key), they can erase mid-chain history undetectably from chain verification alone. The receipt store is therefore a trusted component for completeness claims.
+
+Operators who require detection of store-level tampering SHOULD layer at least one of the following on top of chain verification:
+
+- **Append-only storage backend** — S3 Object Lock, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.
+- **External chain-state witnesses** — `ExpectedLength` and/or `ExpectedFinalHash` (per §7.3.1) supplied from an out-of-band record the attacker cannot also rewrite (separate audit log, transparency log, signed checkpoint).
+- **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.
+
+These are operational controls outside the protocol; the verifier cannot synthesize them and the spec does not mandate any specific backend. They are listed here so that compliance reviewers can match the protocol's verification contract to their operational threat model.
+
+#### 7.3.6 Idempotency key and retry deduplication
+
+When an agent retries a tool call (e.g. on timeout), the wrapping proxy or SDK may emit more than one `tool_call` receipt for the same logical operation. Without a shared identifier, an auditor cannot distinguish a legitimate retry from a duplicated emission. `action.idempotency_key` (§4.3.2) carries a stable identifier for the logical operation so that all receipts arising from one operation share a value. The SDK and MCP proxy SHOULD populate it automatically where a stable source exists (e.g. the MCP proxy derives it from the wrapped JSON-RPC request `id`).
+
+Duplicate `idempotency_key` values are **not** a verification failure. Retries are a normal, legitimate occurrence and the protocol does not attempt to suppress duplicate receipts. Verifiers MUST treat two or more receipts sharing a non-empty `idempotency_key` as a **warning** surfaced alongside the verification result, leaving `valid` unchanged. The warning lets auditors review whether the duplicates represent expected retries or unexpected double-counting. Receipts that omit `idempotency_key` never contribute to duplicate warnings.
+
+### 7.4 Reversal receipts
+
+Receipts are immutable once issued. To record that an action was reversed, issue a new receipt appended to the same chain with:
+
+- The same `action.type` as the original receipt
+- `outcome.status`: `"success"` if the reversal succeeded, `"failure"` if it did not
+- `outcome.reversal_of` set to the `id` of the original receipt
+
+The chain is always append-only; the original receipt is never mutated or removed.
+
+### 7.5 Chain issuer model
+
+A receipt chain MUST have a single issuer. All receipts within a chain MUST have the same `issuer.id`. Delegated agents MUST create a new chain and link it to the parent chain via the `delegation` field (see §4.3.2). This ensures that each chain is an authoritative log from a single agent, and cross-agent workflows are represented as linked chains rather than mixed-issuer sequences.
+
+### 7.6 Delegation verification
+
+When a receipt chain includes a `delegation` field (see §4.3.2):
+
+1. Resolve `delegation.parent_chain_id` and retrieve the parent chain.
+2. Locate the receipt with `id` matching `delegation.parent_receipt_id` in the parent chain.
+3. Confirm `delegation.delegator.id` matches the `issuer.id` of the parent chain's receipts.
+4. Confirm the `principal` in the delegated chain matches the `principal` in the parent chain (the human on whose behalf actions are taken does not change across delegation).
+
+If any step fails, the delegation link is unverifiable. The delegated chain's receipts are still individually valid but cannot be traced back to the parent chain.
+
+### 7.7 Trusted timestamp verification
+
+When `action.trusted_timestamp` is present and non-null:
+
+1. Base64-decode the value to obtain the DER-encoded RFC 3161 `TimeStampToken`.
+2. Verify the TSA's signature on the `TimeStampToken` against the TSA's certificate.
+3. Extract the `MessageImprint` hash from the `TimeStampToken`.
+4. Confirm the `MessageImprint` hash matches the SHA-256 digest of the receipt's canonical form (proof field removed) — the same digest used for signing (§7.2).
+5. Confirm the TSA timestamp falls within a reasonable window of `action.timestamp` (implementation-defined tolerance).
+
+Trusted timestamps are OPTIONAL. When present, they provide independent evidence of when the receipt was created, which cannot be backdated by the issuer.
+
+### 7.8 End-to-end receipt verification
+
+To verify a single Agent Receipt:
+
+1. **Schema validation.** Validate the receipt against the JSON Schema (§4.4). If validation fails, verification fails with `MALFORMED_RECEIPT`.
+2. **DID resolution.** Resolve the DID URL in `proof.verificationMethod` to obtain the issuer's public key. The resolution mechanism depends on the DID method used (see §9.6). If the DID cannot be resolved, verification fails with `UNRESOLVABLE_DID`.
+3. **Signature verification.** Compute the RFC 8785 canonical serialization (UTF-8 bytes) of the receipt with the `proof` field removed. Verify the Ed25519 signature in `proof.proofValue` (decoded from multibase `u`-prefixed base64url) directly over these canonical bytes using the resolved public key. If verification fails, the receipt is `INVALID_SIGNATURE`.
+4. **Timestamp validation.** If `action.trusted_timestamp` is present, verify it per §7.7. If the trusted timestamp is invalid, the receipt is `INVALID_TIMESTAMP`. If no trusted timestamp is present, the receipt relies on `issuanceDate` and `action.timestamp` which are issuer-asserted and not independently verifiable.
+5. **Chain context.** If verifying as part of a chain, perform chain integrity checks per §7.3. If verifying a standalone receipt, chain fields indicate the issuer-asserted position in a chain. A verifier MAY perform local consistency checks (e.g., that `sequence` is a positive integer and `previous_receipt_hash` is well-formed), but the receipt's actual chain position cannot be confirmed without at least the preceding receipt.
+6. **Delegation context.** If the receipt includes a `delegation` field, verify per §7.6.
+
+A receipt that passes steps 1–4 is individually valid. Steps 5–6 provide chain and delegation context but require additional receipts to verify fully.
+
+> **Note:** This algorithm depends on DID resolution (step 2), which is not fully specified in v0.1.0. Implementations MUST document their DID resolution strategy. See §9.6.
+
+---
+
+## 8. Relationship to Existing Work
+
+| Project | Relationship |
+|---|---|
+| **C2PA / Content Credentials** | Inspiration for the approach (signed provenance manifests, hash-chained). The Agent Receipt Protocol extends the concept from media assets to agent actions. Could potentially be formalized as a C2PA extension. |
+| **W3C Verifiable Credentials** | Agent Receipts are W3C VCs. The VC Data Model 2.0 is used as the envelope format. |
+| **Grantex** | Complementary. Grantex handles authorization (should this agent be allowed to act?). The Agent Receipt Protocol handles receipts (what did this agent do?). An Agent Receipt may reference a Grantex grant token in `authorization.grant_ref`. |
+| **AgentStamp** | Overlapping in audit trail and agent identity. AgentStamp's hash-chained audit is similar but narrower (trust verification events only). |
+| **MolTrust** | Complementary. Agent registry and reputation. Could serve as the identity layer issuing the agent DIDs referenced in receipts. |
+| **W3C DIDs** | Agent and principal identities are expressed as DIDs. No specific DID method is required. |
+
+---
+
+## 9. Open Questions
+
+1. ~~**Multi-agent delegation.**~~ **Resolved.** See `delegation` field in §4.3.2 and verification in §7.6.
+
+2. **Reversal receipt schema.** The field for linking a reversal receipt back to the original receipt (`reversal_of`) needs to be defined and placed within `credentialSubject` or as a top-level field.
+
+3. **Privacy granularity.** How much control does the principal have over what appears in receipts? Action types reveal what was done even without parameters. Needs a user consent model.
+
+4. **Offline / batched receipts.** If the agent cannot sign in real-time (e.g., high-frequency or offline scenarios), can receipts be batched and signed later? This weakens chain integrity guarantees and needs explicit handling.
+
+5. ~~**Multiple issuers per chain.**~~ **Resolved.** A chain MUST have a single issuer (§7.5). Multi-agent scenarios use separate chains linked via `delegation` (§7.6).
+
+6. **DID method requirements and key lifecycle.** The spec requires a DID for the issuer but does not mandate a DID method. Should conformance require resolvable DIDs, or are opaque identifiers acceptable for early implementations? Additionally, the spec does not address agent key lifecycle: how Ed25519 key pairs are generated, where private keys are stored, how keys are rotated (and how rotation interacts with chain verification), or how compromised keys are revoked. The `did:agent:` identifier used in examples has no defined resolution mechanism — a verifier cannot resolve it to a public key without out-of-band knowledge. A companion specification (e.g., MolTrust for agent registry and reputation) may address key management, but the boundary between this spec and any such companion is undefined.
+
+7. **Sequence gaps.** If a receipt is created but never persisted (e.g., crash during write), the chain will have a gap in `chain.sequence`. The verification algorithm (§7.3) treats this as a chain break. Whether verifiers should distinguish "gap" from "tamper" is undefined.
+
+8. **Concurrent action streams.** The chain model is strictly linear: each receipt references exactly one predecessor via `chain.previous_receipt_hash`, and `chain.sequence` is monotonically increasing. Modern agent patterns — fan-out tool calls, sub-agent hierarchies, orchestrator/worker topologies — produce concurrent action streams that cannot be represented as a single linear chain. Possible approaches include: (a) allowing `chain.previous_receipt_hash` to be an array for DAG-structured chains, (b) defining explicit fork/join receipt types, or (c) requiring separate chains per concurrent branch with a linking mechanism. The delegation model (§7.5) partially addresses multi-agent scenarios but does not cover intra-agent concurrency (e.g., an agent dispatching multiple tool calls in parallel within a single session).
+
+9. **Per-action-type parameter schemas.** The `parameters_hash` field enables privacy-preserving proof of action parameters. Given disclosed parameters as a JSON value, a verifier can independently reconstruct the RFC 8785 canonical form and recompute `parameters_hash`. What is missing without parameter schemas per taxonomy entry is the ability to validate the disclosed parameters against an expected structure for that `action.type` and to standardize parameter layouts across implementations. Defining per-action-type parameter schemas would provide this validation and interoperability. This is deferred to a future version.
+
+10. **Intent field content boundaries.** The `conversation_hash` and `reasoning_hash` fields lack normative definitions of what content should be hashed. Cross-agent interoperability requires either normative content boundaries or a mechanism for implementations to declare their hashing inputs. See §4.3.2.1 for non-normative guidance.
+
+11. **Verification error taxonomy.** The end-to-end verification algorithm (§7.8) references verification error conditions (`MALFORMED_RECEIPT`, `UNRESOLVABLE_DID`, `INVALID_SIGNATURE`, `INVALID_TIMESTAMP`) but does not define a formal error taxonomy. A future version should define machine-readable codes covering both malformed receipts and verification results to enable consistent error reporting across implementations.
+
+---
+
+## 10. Design Decisions
+
+1. **W3C VC envelope.** Receipts conform to the VC Data Model 2.0 JSON shape. No VC library dependency is required — receipts MAY be constructed with plain JSON serialization. The VC envelope is used for interoperability with existing VC tooling, not as a binding requirement on implementations. The top-level `version` field is a protocol extension not defined by the VC Data Model; VC tooling that validates strictly against the VC schema SHOULD ignore unrecognized top-level fields.
+
+2. **Ed25519 signing.** Single proof type for this version. The `proof.type` value `Ed25519Signature2020` is borrowed from the W3C Data Integrity family for ecosystem recognition, but the signing input is intentionally simplified: the signer MUST compute the Ed25519 signature over the RFC 8785 canonical JSON of the receipt with the `proof` field removed. This differs from the full W3C Data Integrity signing algorithm (which constructs a separate verification hash from document and proof options). Implementations that need full Data Integrity compatibility SHOULD use the complete algorithm and note this in their conformance documentation. Multi-proof-type support (e.g., X.509 for C2PA alignment) is deferred.
+
+3. **Trusted timestamps.** Local timestamps are the minimum requirement. RFC 3161 TSA tokens are OPTIONAL but RECOMMENDED for compliance-grade deployments. When present, the TSA timestamps the same canonical JSON used for signing, providing independent non-repudiation of receipt creation time. See §7.7 for verification.
+
+4. **Chain scope.** Chains group receipts by a logical unit (typically a session or conversation). The definition of chain boundaries is left to implementations.
+
+5. **Storage agnostic.** The spec defines the receipt format and chain verification algorithm. It does not prescribe a storage backend.
+
+6. **Receipts as a separate log.** Receipts are stored in a separate log, not attached to action outputs. Attachment (C2PA-style embedding) is deferred.
+
+7. **Revocation is append-only.** Reversal is recorded by issuing a new receipt, not by mutating the original. The chain is always append-only.
+
+8. **Key lifecycle is out of scope for v0.1.** Agent key generation, secure storage, rotation, and revocation are not specified by this version of the protocol. Implementers SHOULD treat key management as a critical security concern: a compromised agent key allows production of validly-signed but fraudulent receipts that are indistinguishable from legitimate ones. MolTrust (listed in §8) or a dedicated key management specification may address this in future. At minimum, implementations SHOULD document their key generation and storage practices.
+
+9. **base64url for `proofValue`.** The `proofValue` field uses multibase `u`-prefixed base64url (no padding) rather than the W3C Data Integrity default of base58btc (`z`). base64url avoids the need for a base58 library, is natively supported in all target runtimes, and is slightly more compact. This is an intentional deviation from the W3C default.


### PR DESCRIPTION
## Summary

Claude Code sends `agent_id` (and `agent_type`) in its PostToolUse hook payload for sub-agents, and the hook → emitter → daemon pipeline already forwarded `agent_id` for chain routing — but the daemon **dropped it from the signed receipt issuer**, so sub-agent receipts were indistinguishable from root-agent receipts in the store and dashboard.

Rather than add each runtime field top-level — every such addition is a breaking change under the issuer's `additionalProperties: false` content model, and a context bump under the `@protected` JSON-LD context — this introduces a single **open `issuer.runtime` sub-object**. It holds `agent_id`, `agent_type`, and future runtime/observability metadata (e.g. forthcoming W3C Trace Context / OpenTelemetry identifiers, see #762). `runtime` is typed `@json` in the context and is **not** `additionalProperties: false` in the schema, so new members need no protocol-version bump.

Design recorded in **ADR-0026**. This mints protocol **v0.5.0** and JSON-LD **context v2**, per ADR-0021 (released versions are immutable; a new term is a context bump). v0.4.0 and earlier receipts are unchanged and validate against their pinned context v1.

## Changes

**Spec**
- `docs/adr/0026-issuer-runtime-open-metadata.md` — the design + rationale (`runtime` as `@json` open sub-object; why 0.5.0 + context v2).
- `spec/v0.5.0/spec.md` — new immutable version file; `issuer.runtime` in the §3.5 example and §4.3.1 table. Fixes stale `version` boilerplate carried since v0.4.0.
- `spec/context/v2/context.jsonld` — v1 plus the `runtime` `@json` term.
- `spec/schema/agent-receipt.schema.json` — open `runtime` object on issuer; `0.5.0` added to the version enum; `@context[1]` accepts v1 **or** v2; refreshed description.
- `spec/CHANGELOG.md` — `[0.5.0]` entry.

**SDKs (Go, TS, Python)**
- `Issuer.runtime` sub-type (`Runtime` struct / interface / model); `VERSION` → 0.5.0; context → v2.
- Daemon `issuerFromFrame` nests `agent_id`/`agent_type` into `issuer.runtime` and **validates `agent_type` length** — it was the only proxy-supplied identity field missing the `maxIdentityFieldLen` cap (surfaced in review).
- Emitter/hook wire frames keep flat `agent_id`/`agent_type` (transport only); only the signed receipt issuer nests them.
- TS Zod `issuerSchema` and the Python model carry the new shape (closing the earlier schema/interface drift).

**Cross-SDK vectors**
- `cross-sdk-tests/v050_vectors.json` — a runtime-bearing receipt and a root receipt (no runtime). Go/TS/Python runners assert byte-identical hash + signature and round-trip `issuer.runtime`.
- Historical v0.2/0.3/0.4 generators pinned to context v1 so the `protocolContext` bump can't rewrite them.

## Test plan

- [x] Go: `sdk/go`, `daemon`, `hook` — pass; `go vet` clean
- [x] Cross-SDK integration (`-tags integration`): schema validation of v0.5.0 examples + all vector reproduction — pass
- [x] TS: 430 tests + `tsc` typecheck + biome — pass
- [x] Python: 457 tests + ruff + pyright — pass
- [x] Byte-identical `expectedReceiptHash` reproduced by all three SDKs for a `runtime`-bearing receipt

## Follow-ups

- #762 (OTLP trace export) consumes `issuer.runtime` and now lands without a further protocol bump.
- Publishing `spec/v0.5.0/` and `spec/context/v2/` via the ADR-0021 tag-driven site build.