### PR TITLE
docs(sdk-go): finalize v0.16.0 changelog for graduation

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-09
+
+Graduates `0.16.0-alpha.1` after the alpha pass. No source changes since the alpha; see the `0.16.0-alpha.1` entry below for the full surface (subagent-chain delegation, issuer/event `agent_id`, and `correlation_id`).
+
 ## [0.16.0-alpha.1] - 2026-06-08
 
 ### Added


### PR DESCRIPTION
Stage A of the alpha→stable graduation (6 components). Promotes `sdk/go` first because daemon and hook pin it.

## Change
- `sdk/go/CHANGELOG.md`: rename `[0.16.0-alpha.1] - 2026-06-08` → `[0.16.0] - 2026-06-09`.

No code change — `sdk/go` is byte-identical to the `v0.16.0-alpha.1` tag (only goreleaser/changelog commits touched the tree since). This PR just finalizes the changelog heading so the stable tag can be cut.

## Next
After merge: push tag `sdk/go/v0.16.0`. Then Stage B bumps daemon/hook `go.mod` to the published `v0.16.0` and graduates the remaining five components (sdk-ts 0.12.0, sdk-py 0.12.0, mcp-proxy 0.14.0, daemon 0.17.0, hook 0.14.0).