### PR TITLE
chore(release): graduate alphas to stable (sdk-ts 0.12.0, sdk-py 0.12.0, mcp-proxy 0.14.0, daemon 0.17.0, hook 0.14.0)

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-09
+
+Graduates `0.17.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.16.0` (the alpha pinned `v0.16.0-alpha.1`). See the `0.17.0-alpha.1` entry below for the full surface (subagent chain delegation, correlation ID).
+
 ## [0.17.0-alpha.1] - 2026-06-08
 
 ### Added

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.16.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1 h1:JaapHEBRHxvPLb1/7wx4Ryc8IVU/loIysZfJowMv9dM=
-github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.16.0 h1:/wC/YIHXF8ExG1i+x8ZB502AQel+5HlT51zxX8ZK9xo=
+github.com/agent-receipts/ar/sdk/go v0.16.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-09
+
+Graduates `0.14.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.16.0` (the alpha pinned `v0.16.0-alpha.1`). See the `0.14.0-alpha.1` entry below for the full surface (`agent_id` and `correlation_id` forwarding).
+
 ## [0.14.0-alpha.1] - 2026-06-08
 
 ### Added

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.16.0
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1 h1:JaapHEBRHxvPLb1/7wx4Ryc8IVU/loIysZfJowMv9dM=
-github.com/agent-receipts/ar/sdk/go v0.16.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.16.0 h1:/wC/YIHXF8ExG1i+x8ZB502AQel+5HlT51zxX8ZK9xo=
+github.com/agent-receipts/ar/sdk/go v0.16.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-09
+
+Graduates `0.14.0-alpha.1` after the alpha pass. No source changes since the alpha; see the `0.14.0-alpha.1` entry below for the full surface (`correlation_id` and `agent_id` forwarding, delegation receipts).
+
 ## [0.14.0-alpha.1] - 2026-06-09
 
 ### Added

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-09
+
+Graduates `0.12.0a1` after the alpha pass. No source changes since the alpha; see the `0.12.0a1` entry below for the full surface (`Delegation` dataclass and `correlation_id`).
+
 ## [0.12.0a1] - 2026-06-08
 
 ### Added

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-receipts"
-version = "0.12.0a1"
+version = "0.12.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-receipts"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-09
+
+Graduates `0.12.0-alpha.1` after the alpha pass. No source changes since the alpha; see the `0.12.0-alpha.1` entry below for the full surface (`Delegation` type and `correlation_id`).
+
 ## [0.12.0-alpha.1] - 2026-06-08
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agnt-rcpt/sdk-ts",
-	"version": "0.12.0-alpha.1",
+	"version": "0.12.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Stage B of the alpha→stable graduation. `sdk/go v0.16.0` already shipped in Stage A (#763); this graduates the remaining five components. Tags are pushed one at a time after merge (Stage C).

## Changes

| Component | Change |
|-----------|--------|
| **sdk-ts** | `package.json` `0.12.0-alpha.1` → `0.12.0` |
| **sdk-py** | `pyproject.toml` `0.12.0a1` → `0.12.0`; `uv.lock` self-version refreshed (was a stale `0.11.1` left over from the alpha bump #758 — papercut fix) |
| **daemon** | `go.mod` sdk/go `v0.16.0-alpha.1` → `v0.16.0`, `go.sum` tidied |
| **hook** | `go.mod` sdk/go `v0.16.0-alpha.1` → `v0.16.0`, `go.sum` tidied |
| **mcp-proxy** | changelog only — stays on sdk/go `v0.15.0` (deliberate, no scope creep) |

All six changelogs use the repo's **keep-alpha + stable graduation-entry** convention (sdk/go 0.11.0, sdk/ts 0.9.0). **hook** is brought into line — it previously dropped its alpha entries. Each stable entry states there were no source changes since the alpha; daemon/hook entries note the only change is pinning the now-stable `sdk/go v0.16.0`.

## Verification (local, via go.work)
- daemon: `go vet` / `go build` / `go test ./...` — pass
- hook: `go vet` / `go build` / `go test ./...` — pass
- mcp-proxy: `go build` / `go test ./...` — pass
- sdk-py: `uv run pytest` — **452 passed, 7 skipped**
- sdk-ts: `pnpm test` — **426 passed (25 files)**
- No receipt-format changes, so cross-SDK compatibility is unaffected (cross-sdk-tests is vector-generation only).