### PR TITLE
chore(release): prep daemon/hook v0.5.0 alpha on sdk/go v0.17.0-alpha.1

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0-alpha.1] - 2026-06-09
+
+### Added
+
+- **`issuer.runtime` on emitted receipts** ([#761](https://github.com/agent-receipts/ar/pull/761), ADR-0026) — `issuerFromFrame` now nests the frame's `agent_id` / `agent_type` under `issuer.runtime` (gated on `agent_id`, matching chain routing, so root-chain receipts stay runtime-free). `agent_type` is validated for length like the other proxy-supplied identity fields. Receipts are emitted at protocol version `0.5.0` / JSON-LD context v2.
+
+### Changed
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.17.0-alpha.1` (provides the `receipt.Runtime` type). The daemon does not compile against `sdk/go v0.16.0`, which predates `Runtime`.
+
 ## [0.17.0] - 2026-06-09
 
 Graduates `0.17.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.16.0` (the alpha pinned `v0.16.0-alpha.1`). See the `0.17.0-alpha.1` entry below for the full surface (subagent chain delegation, correlation ID).

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.16.0
+	github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.16.0 h1:/wC/YIHXF8ExG1i+x8ZB502AQel+5HlT51zxX8ZK9xo=
-github.com/agent-receipts/ar/sdk/go v0.16.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1 h1:4R1Bnhf3KQ5/jDz/yDyljTO4XgLUtqemGtEoAvmhdms=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.1] - 2026-06-09
+
+### Added
+
+- **`agent_type` forwarding** ([#761](https://github.com/agent-receipts/ar/pull/761), ADR-0026) — the Claude Code hook now parses `agent_type` from the PostToolUse payload and forwards it to the emitter alongside the existing `agent_id`. The daemon nests both under `issuer.runtime`.
+
+### Changed
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.17.0-alpha.1` (carries the `agent_type` emitter field).
+
 ## [0.14.0] - 2026-06-09
 
 Graduates `0.14.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.16.0` (the alpha pinned `v0.16.0-alpha.1`). See the `0.14.0-alpha.1` entry below for the full surface (`agent_id` and `correlation_id` forwarding).

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.16.0
+require github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.16.0 h1:/wC/YIHXF8ExG1i+x8ZB502AQel+5HlT51zxX8ZK9xo=
-github.com/agent-receipts/ar/sdk/go v0.16.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1 h1:4R1Bnhf3KQ5/jDz/yDyljTO4XgLUtqemGtEoAvmhdms=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,12 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.17.0-alpha.1] - 2026-06-09
+
+### Added
+
+- **`issuer.runtime` open metadata sub-object** ([#761](https://github.com/agent-receipts/ar/pull/761), ADR-0026) — `receipt.Issuer` gains `Runtime *Runtime`, an open container for runtime/observability metadata (initial members `agent_id` / `agent_type`). Unlike the rest of the receipt struct, `Runtime` preserves unknown keys via an `Extra map[string]json.RawMessage` with custom (un)marshalling, so a key added by a newer SDK survives an older SDK's `HashReceipt`/`Sign` round-trip and stays byte-identical across Go/TS/Python. Receipts emitting `runtime` use protocol version `0.5.0` and JSON-LD context v2. The emitter `Event`/frame gains `agent_type` alongside the existing `agent_id`.
+
 ## [0.16.0] - 2026-06-09
 
 Graduates `0.16.0-alpha.1` after the alpha pass. No source changes since the alpha; see the `0.16.0-alpha.1` entry below for the full surface (subagent-chain delegation, issuer/event `agent_id`, and `correlation_id`).


### PR DESCRIPTION
## Summary

Prep for the **v0.5.0 (`issuer.runtime`) alpha** on the emitter path. Bumps **daemon** and **hook** to require the just-published `github.com/agent-receipts/ar/sdk/go` **`v0.17.0-alpha.1`** (which carries `receipt.Runtime`, ADR-0026).

This bump is **required, not cosmetic**: the binary release builds use `GOWORK: off`, so they resolve `sdk/go` from `go.mod` rather than the workspace. The daemon's merged code constructs `receipt.Runtime{…}`, which does **not** exist in the previous pin `sdk/go v0.16.0` — so a daemon release at v0.16.0 would fail to compile. Bumping to `v0.17.0-alpha.1` fixes that.

## Changes
- **daemon** — `go.mod` → `sdk/go v0.17.0-alpha.1`; CHANGELOG `[0.18.0-alpha.1]` (nests `agent_id`/`agent_type` under `issuer.runtime`; validates `agent_type` length).
- **hook** — `go.mod` → `sdk/go v0.17.0-alpha.1`; CHANGELOG `[0.15.0-alpha.1]` (`agent_type` forwarding).
- **sdk/go** — retroactive CHANGELOG `[0.17.0-alpha.1]` for the already-tagged `Runtime` open-container release.

`go.work` untouched; only the `sdk/go` require line + its `go.sum` hashes changed.

## Verification
- ✅ daemon: `GOWORK=off go build ./... && go test ./internal/pipeline/` — green against the **published** `sdk/go v0.17.0-alpha.1`
- ✅ hook: `GOWORK=off go build ./... && go test ./...` — green
- (This is the exact release condition; at `v0.16.0` it would not compile.)

## Release tags (after merge — one at a time)
```
daemon/v0.18.0-alpha.1
hook/v0.15.0-alpha.1
```
Already done as part of this alpha: `spec-v0.5.0` (published), `sdk/go/v0.17.0-alpha.1` (published), context v2 (live from the #761 merge deploy). `mcp-proxy` intentionally excluded — it emits via the daemon and never sets `agent_id`, so it carries no runtime. `sdk-ts` / `sdk-py` deferred (consumer libs, not needed for the emitter alpha).

## Context
Follows #761 (the v0.5.0 / `issuer.runtime` feature). See ADR-0026.