### PR TITLE
docs(sdk-go): add v0.17.0 graduation changelog entry

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-11
+
+Graduates `0.17.0-alpha.1` after the alpha pass. No source changes since the alpha; see the `0.17.0-alpha.1` entry below for the full surface (`issuer.runtime` open metadata sub-object, `agent_type` forwarding).
+
 ## [0.17.0-alpha.1] - 2026-06-09
 
 ### Added


### PR DESCRIPTION
Graduate `sdk/go v0.17.0-alpha.1` to stable.

## Changes

- `sdk/go/CHANGELOG.md`: add `[0.17.0]` graduation entry (changelog-only; no source changes since the alpha)

## What's in v0.17.0

- **`issuer.runtime` open metadata sub-object** (#761, ADR-0026) — `receipt.Issuer` gains `Runtime *Runtime`, an open container preserving unknown keys via `Extra map[string]json.RawMessage`. Receipts emitting `runtime` use protocol version `0.5.0` / JSON-LD context v2.
- **`agent_type` forwarding** — emitter `Event`/frame gains `agent_type` alongside the existing `agent_id`.

## After merge

Push tag `sdk/go/v0.17.0` pointing to the alpha commit (`307f13a`), then open the daemon/hook graduation PR pinning this stable release.