### PR TITLE
chore(release): graduate daemon v0.18.0 and hook v0.15.0

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-11
+
+Graduates `0.18.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.17.0` (the alpha pinned `v0.17.0-alpha.1`). See the `0.18.0-alpha.1` entry below for the full surface (`issuer.runtime` sub-object, `agent_type` forwarding).
+
 ## [0.18.0-alpha.1] - 2026-06-09
 
 ### Added

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.17.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1 h1:4R1Bnhf3KQ5/jDz/yDyljTO4XgLUtqemGtEoAvmhdms=
-github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.17.0 h1:BEeBwF0Opn/AERZUJ3+pxT1nWDSs/qxjw/FjOmKqXEY=
+github.com/agent-receipts/ar/sdk/go v0.17.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-11
+
+Graduates `0.15.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.17.0` (the alpha pinned `v0.17.0-alpha.1`). See the `0.15.0-alpha.1` entry below for the full surface (`agent_type` forwarding).
+
 ## [0.15.0-alpha.1] - 2026-06-09
 
 ### Added

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.17.0
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1 h1:4R1Bnhf3KQ5/jDz/yDyljTO4XgLUtqemGtEoAvmhdms=
-github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.17.0 h1:BEeBwF0Opn/AERZUJ3+pxT1nWDSs/qxjw/FjOmKqXEY=
+github.com/agent-receipts/ar/sdk/go v0.17.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Graduate the current alpha releases to stable now that `sdk/go v0.17.0` has shipped (#776).

## Changes

- `daemon/CHANGELOG.md`: add `[0.18.0]` graduation entry
- `daemon/go.mod` + `go.sum`: pin `sdk/go v0.17.0` (was `v0.17.0-alpha.1`)
- `hook/CHANGELOG.md`: add `[0.15.0]` graduation entry
- `hook/go.mod` + `go.sum`: pin `sdk/go v0.17.0` (was `v0.17.0-alpha.1`)

No source changes in either module since their respective alphas.

## What's in these releases

**daemon v0.18.0** — `issuer.runtime` sub-object on emitted receipts (#761, ADR-0026); `agent_type` forwarded from hook payloads and nested under `issuer.runtime`.

**hook v0.15.0** — `agent_type` parsed from Claude Code PostToolUse payload and forwarded to the daemon.

## After merge

Push tags one at a time:
```
git push origin <alpha-sha>:refs/tags/daemon/v0.18.0
git push origin <alpha-sha>:refs/tags/hook/v0.15.0
```