### PR TITLE
Enrich receipts with transcript-derived model + token usage

### DIFF
--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -82,11 +82,11 @@ const actionTypeChainInterrupted = "agent_receipts.chain_interrupted"
 // events_dropped receipt with this count before the live receipt so the gap
 // is visible in the chain.
 type EmitterFrame struct {
-	Version        string          `json:"v"`
-	TsEmit         string          `json:"ts_emit"`
-	SessionID      string          `json:"session_id"`
-	Channel        string          `json:"channel"`
-	Tool           EmitterTool     `json:"tool"`
+	Version   string      `json:"v"`
+	TsEmit    string      `json:"ts_emit"`
+	SessionID string      `json:"session_id"`
+	Channel   string      `json:"channel"`
+	Tool      EmitterTool `json:"tool"`
 	// ActionType, when set, is the taxonomic action type the emitter has already
 	// resolved (e.g. "filesystem.file.delete"). The daemon uses it verbatim as
 	// action.type and resolves risk_level from it via the taxonomy. When empty,
@@ -110,6 +110,14 @@ type EmitterFrame struct {
 	CorrelationID  string          `json:"correlation_id,omitempty"`
 	AgentID        string          `json:"agent_id,omitempty"`
 	AgentType      string          `json:"agent_type,omitempty"`
+	// Model, Usage, and CaptureMethod carry runtime/observability metadata the
+	// emitter derived for this call (Claude Code: from the session transcript).
+	// The daemon maps them into issuer.runtime.{model,usage,capture_method}
+	// (ADR-0026 open container). Usage is forwarded verbatim — the runtime's own
+	// token-usage object, never recomputed. All optional.
+	Model         string          `json:"model,omitempty"`
+	Usage         json.RawMessage `json:"usage,omitempty"`
+	CaptureMethod string          `json:"capture_method,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -508,6 +516,12 @@ func validateFrame(f *EmitterFrame) error {
 	if len(f.AgentType) > maxIdentityFieldLen {
 		return fmt.Errorf("agent_type exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.AgentType))
 	}
+	if len(f.Model) > maxIdentityFieldLen {
+		return fmt.Errorf("model exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.Model))
+	}
+	if len(f.CaptureMethod) > maxIdentityFieldLen {
+		return fmt.Errorf("capture_method exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.CaptureMethod))
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash
@@ -752,14 +766,27 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 	if f.OperatorID != "" {
 		op = &receipt.Operator{ID: f.OperatorID, Name: f.OperatorName}
 	}
-	// Gate runtime on AgentID alone, matching getOrCreateAgentState's routing
-	// key: a frame routes to a per-agent chain iff agent_id is non-empty, so
-	// only those receipts carry issuer.runtime. A stray agent_type without an
-	// agent_id belongs to the root chain and must stay runtime-free ("absent
-	// for the root agent").
+	// issuer.runtime is the ADR-0026 open container for runtime/observability
+	// metadata. agent_id/agent_type identify a sub-agent (and gate chain
+	// routing); model/usage/capture_method are observability fields the emitter
+	// derived for the call (e.g. from the session transcript) and, unlike the
+	// agent identity, apply to root-chain receipts too. So runtime is emitted
+	// whenever ANY of these are present — a root receipt now carries it when it
+	// has transcript-derived model/usage even though it has no agent_id.
+	// Forward usage verbatim, but only a real JSON payload — a literal null or
+	// empty must not be stored as the runtime's reported usage.
+	hasUsage := hasJSONPayload(f.Usage)
 	var runtime *receipt.Runtime
-	if f.AgentID != "" {
-		runtime = &receipt.Runtime{AgentID: f.AgentID, AgentType: f.AgentType}
+	if f.AgentID != "" || f.Model != "" || f.CaptureMethod != "" || hasUsage {
+		runtime = &receipt.Runtime{
+			AgentID:       f.AgentID,
+			AgentType:     f.AgentType,
+			Model:         f.Model,
+			CaptureMethod: f.CaptureMethod,
+		}
+		if hasUsage {
+			runtime.Usage = f.Usage
+		}
 	}
 	return receipt.Issuer{
 		ID:        daemonID,

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1658,6 +1658,71 @@ func agentFrame(t *testing.T, agentID string) socket.Frame {
 	return socket.Frame{Payload: body}
 }
 
+// TestProcess_RuntimeModelUsageOnRootReceipt verifies that the transcript-
+// derived model/usage/capture_method fields on a frame are stamped onto
+// issuer.runtime — even on a ROOT receipt with no agent_id, which historically
+// carried no runtime. Usage is forwarded verbatim, and the receipt round-trips
+// through HashReceipt so a dropped runtime key would fail the hash.
+func TestProcess_RuntimeModelUsageOnRootReceipt(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	usage := json.RawMessage(`{"input_tokens":1954,"output_tokens":392,"cache_read_input_tokens":0,"cache_creation_input_tokens":16762}`)
+	body, err := json.Marshal(EmitterFrame{
+		Version:       "1",
+		TsEmit:        "2026-05-03T00:00:00Z",
+		SessionID:     "sess-abc",
+		Channel:       "claude-code",
+		Tool:          EmitterTool{Name: "Bash"},
+		Decision:      "allowed",
+		Model:         "claude-opus-4-8",
+		Usage:         usage,
+		CaptureMethod: "transcript",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	rt := receipts[0].Issuer.Runtime
+	if rt == nil {
+		t.Fatal("issuer.runtime is nil; want model/usage/capture_method on a root receipt")
+	}
+	if rt.AgentID != "" {
+		t.Errorf("runtime.agent_id = %q; want empty on a root receipt", rt.AgentID)
+	}
+	if rt.Model != "claude-opus-4-8" {
+		t.Errorf("runtime.model = %q; want claude-opus-4-8", rt.Model)
+	}
+	if rt.CaptureMethod != "transcript" {
+		t.Errorf("runtime.capture_method = %q; want transcript", rt.CaptureMethod)
+	}
+	var got map[string]int
+	if err := json.Unmarshal(rt.Usage, &got); err != nil {
+		t.Fatalf("runtime.usage is not an object: %v (%s)", err, rt.Usage)
+	}
+	if got["input_tokens"] != 1954 || got["output_tokens"] != 392 || got["cache_creation_input_tokens"] != 16762 {
+		t.Errorf("runtime.usage = %v; want the verbatim token object", got)
+	}
+
+	// The signed receipt must re-hash to a stable value through the typed
+	// Runtime struct (the open-container round-trip invariant from ADR-0026).
+	if _, err := receipt.HashReceipt(receipts[0]); err != nil {
+		t.Fatalf("HashReceipt on a runtime-bearing receipt: %v", err)
+	}
+}
+
 // TestProcess_AgentIDRoutesToSeparateChain verifies that frames with a non-empty
 // agent_id land on a per-agent chain distinct from the root chain.
 func TestProcess_AgentIDRoutesToSeparateChain(t *testing.T) {

--- a/daemon/internal/pipeline/parity_test.go
+++ b/daemon/internal/pipeline/parity_test.go
@@ -20,6 +20,7 @@ func TestEmitterFrameParityKnownFields(t *testing.T) {
 		"action_type", // EmitterFrame-only: taxonomic action type resolved by emitter
 		"agent_id",
 		"agent_type",
+		"capture_method",
 		"channel",
 		"correlation_id",
 		"decision",
@@ -29,12 +30,14 @@ func TestEmitterFrameParityKnownFields(t *testing.T) {
 		"input",
 		"issuer_model",
 		"issuer_name",
+		"model",
 		"operator_id",
 		"operator_name",
 		"output",
 		"session_id",
 		"tool",
 		"ts_emit",
+		"usage",
 		"v",
 	}
 

--- a/hook/.gitignore
+++ b/hook/.gitignore
@@ -1,3 +1,5 @@
-agent-receipts-hook
+# Built binary at the module root. Anchored with a leading slash so it does not
+# also match the cmd/agent-receipts-hook/ source directory.
+/agent-receipts-hook
 dist/
 LICENSE

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
@@ -10,14 +12,15 @@ import (
 // claudeCodeFrame is the JSON envelope Claude Code sends on stdin for
 // PostToolUse and PreToolUse hooks.
 type claudeCodeFrame struct {
-	HookEventName string          `json:"hook_event_name"`
-	SessionID     string          `json:"session_id"`
-	ToolUseID     string          `json:"tool_use_id"`
-	ToolName      string          `json:"tool_name"`
-	ToolInput     json.RawMessage `json:"tool_input"`
-	ToolResponse  json.RawMessage `json:"tool_response"`
-	AgentID       string          `json:"agent_id"`
-	AgentType     string          `json:"agent_type"`
+	HookEventName  string          `json:"hook_event_name"`
+	SessionID      string          `json:"session_id"`
+	ToolUseID      string          `json:"tool_use_id"`
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input"`
+	ToolResponse   json.RawMessage `json:"tool_response"`
+	AgentID        string          `json:"agent_id"`
+	AgentType      string          `json:"agent_type"`
+	TranscriptPath string          `json:"transcript_path"`
 }
 
 // readClaudeCode parses a Claude Code PostToolUse or PreToolUse stdin frame
@@ -28,7 +31,7 @@ type claudeCodeFrame struct {
 //
 // The returned sessionID is the host-supplied session identifier from the
 // frame; it is the empty string when absent.
-func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string, error) {
+func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, string, error) {
 	if len(stdin) == 0 {
 		return emitter.Event{}, "", errors.New("empty stdin")
 	}
@@ -68,6 +71,28 @@ func readClaudeCode(stdin []byte, _ func(string) string) (emitter.Event, string,
 	}
 	if len(f.ToolResponse) > 0 {
 		ev.Output = f.ToolResponse
+	}
+
+	// Enrich with the model and token usage for this tool call, read from the
+	// session transcript (works with OTEL disabled — no proxy involved). This is
+	// strictly best-effort: a missing transcript, an unmatched id, or a turn with
+	// no usage object simply leaves the fields unset. Enrichment never fails the
+	// hook, so lookup errors are swallowed rather than surfaced.
+	if f.ToolUseID != "" {
+		path := resolveTranscriptPath(f.TranscriptPath, f.SessionID, env)
+		model, usage, found, lookupErr := lookupTranscriptUsage(path, f.ToolUseID)
+		switch {
+		case lookupErr != nil:
+			// Enrichment is best-effort and must never fail the hook, but a
+			// genuine read error (unreadable or corrupt transcript) is worth a
+			// non-fatal note so it is not silently indistinguishable from a
+			// tool_use_id that is simply absent. We do not exit non-zero.
+			fmt.Fprintf(os.Stderr, "agent-receipts-hook: transcript enrichment skipped: %v\n", lookupErr)
+		case found:
+			ev.Model = model
+			ev.Usage = usage
+			ev.CaptureMethod = "transcript"
+		}
 	}
 
 	return ev, f.SessionID, nil

--- a/hook/cmd/agent-receipts-hook/claude_transcript.go
+++ b/hook/cmd/agent-receipts-hook/claude_transcript.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// transcriptEntry is the minimal projection of one Claude Code transcript JSONL
+// line we need to resolve a tool call's model and token usage. Only assistant
+// message lines carry message.model and message.usage; user (tool_result),
+// queue-operation, attachment, and similar lines leave them empty and are
+// skipped. See the investigation notes in this package's tests for the full
+// on-disk shape.
+type transcriptEntry struct {
+	Type    string `json:"type"`
+	Message struct {
+		Model string `json:"model"`
+		// Usage is the runtime's token-usage object, kept as a raw message so it
+		// is forwarded into the receipt verbatim — never recomputed.
+		Usage json.RawMessage `json:"usage"`
+		// Content is an array of blocks on assistant turns (and a plain string on
+		// some user turns), so it is decoded lazily only when it looks like an
+		// array.
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// transcriptBlock is one entry of an assistant turn's message.content array.
+// A tool_use block carries the id the PostToolUse hook later echoes back as
+// tool_use_id, which is the join key into the turn's model + usage.
+type transcriptBlock struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// lookupTranscriptUsage scans the transcript JSONL at path for the assistant
+// turn that emitted toolUseID and returns that turn's model and token usage.
+//
+// The join is: PostToolUse tool_use_id == tool_use.id on an assistant turn,
+// whose message.model and message.usage describe the model run that produced
+// the call. Returns:
+//
+//   - found == false when no assistant turn emitted the id (id not in
+//     transcript). err is nil in this case — a missing id is an expected,
+//     non-fatal condition for a best-effort enrichment.
+//   - found == true, usage == nil when the turn is located but has no usage
+//     object (model is still returned).
+//   - a non-nil err only for I/O failures opening or reading the file.
+//
+// The file may be large, so it is streamed line by line rather than read whole.
+// Each line is cheaply pre-filtered with a substring check on toolUseID before
+// the JSON decode, so only the handful of lines that mention the id (the
+// assistant turn and its tool_result echo) are ever parsed.
+func lookupTranscriptUsage(path, toolUseID string) (model string, usage json.RawMessage, found bool, err error) {
+	if path == "" || toolUseID == "" {
+		return "", nil, false, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", nil, false, err
+	}
+	defer f.Close()
+
+	needle := []byte(toolUseID)
+	r := bufio.NewReader(f)
+	for {
+		line, readErr := r.ReadBytes('\n')
+		if len(line) > 0 && bytes.Contains(line, needle) {
+			m, u, ok := matchToolUse(line, toolUseID)
+			if ok {
+				return m, u, true, nil
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return "", nil, false, nil
+			}
+			return "", nil, false, readErr
+		}
+	}
+}
+
+// matchToolUse reports whether line is an assistant turn that emitted
+// toolUseID, returning the turn's model and usage when it is. A malformed line
+// is treated as a non-match rather than an error: the transcript is an external
+// artifact and one bad line must not abort a best-effort lookup.
+func matchToolUse(line []byte, toolUseID string) (model string, usage json.RawMessage, ok bool) {
+	var entry transcriptEntry
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", nil, false
+	}
+	if entry.Type != "assistant" || !looksLikeJSONArray(entry.Message.Content) {
+		return "", nil, false
+	}
+	var blocks []transcriptBlock
+	if err := json.Unmarshal(entry.Message.Content, &blocks); err != nil {
+		return "", nil, false
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_use" && b.ID == toolUseID {
+			// usage is left nil when the turn carries no usage object, which the
+			// caller surfaces as the "found but missing usage" case.
+			return entry.Message.Model, entry.Message.Usage, true
+		}
+	}
+	return "", nil, false
+}
+
+// looksLikeJSONArray reports whether raw's first non-whitespace byte is '[', so
+// string-valued content (some user turns) is skipped without a failed decode.
+func looksLikeJSONArray(raw json.RawMessage) bool {
+	for _, c := range raw {
+		switch c {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// resolveTranscriptPath returns the transcript JSONL path for a frame. The
+// hook payload's transcript_path is authoritative; when absent it falls back to
+// the conventional ~/.claude/projects/*/<session_id>.jsonl layout, returning
+// "" when neither resolves (enrichment is then skipped). The glob is keyed on
+// the globally-unique session id, so the project-directory mangling Claude Code
+// applies to the cwd does not need to be reproduced.
+func resolveTranscriptPath(transcriptPath, sessionID string, env func(string) string) string {
+	if transcriptPath != "" {
+		return transcriptPath
+	}
+	if sessionID == "" {
+		return ""
+	}
+	home := env("HOME")
+	if home == "" {
+		return ""
+	}
+	matches, err := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", sessionID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}

--- a/hook/cmd/agent-receipts-hook/claude_transcript_test.go
+++ b/hook/cmd/agent-receipts-hook/claude_transcript_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// twoModelTranscript is a redacted, real-shaped Claude Code transcript fixture.
+// It contains two assistant turns that used DIFFERENT models, each emitting one
+// tool_use block, followed by their tool_result echoes. A third assistant turn
+// emits a tool_use with NO usage object (the missing-usage case), and there are
+// non-assistant lines (queue-operation, attachment, user text) interleaved to
+// exercise the line filtering.
+const twoModelTranscript = `{"type":"queue-operation","message":null}
+{"type":"user","message":{"role":"user","content":"do the thing"}}
+{"type":"assistant","message":{"model":"claude-opus-4-8","role":"assistant","content":[{"type":"thinking","thinking":"hmm"}],"usage":{"input_tokens":10,"output_tokens":2}}}
+{"type":"assistant","message":{"model":"claude-opus-4-8","role":"assistant","content":[{"type":"tool_use","id":"toolu_AAA","name":"Bash","input":{"command":"ls"}}],"usage":{"input_tokens":1954,"output_tokens":392,"cache_read_input_tokens":0,"cache_creation_input_tokens":16762}}}
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_AAA","type":"tool_result","content":"a\nb\n","is_error":false}]}}
+{"type":"attachment","message":null}
+{"type":"assistant","message":{"model":"claude-haiku-4-5-20251001","role":"assistant","content":[{"type":"tool_use","id":"toolu_BBB","name":"Read","input":{"file_path":"x"}}],"usage":{"input_tokens":77,"output_tokens":12,"cache_read_input_tokens":16762,"cache_creation_input_tokens":0}}}
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_BBB","type":"tool_result","content":"contents","is_error":false}]}}
+{"type":"assistant","message":{"model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"tool_use","id":"toolu_CCC","name":"Grep","input":{"pattern":"x"}}]}}
+`
+
+func writeTranscript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// usageField pulls one integer field out of a raw usage object so tests can
+// assert the usage attached to a tool call without pinning the whole blob.
+func usageField(t *testing.T, usage json.RawMessage, key string) (float64, bool) {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(usage, &m); err != nil {
+		t.Fatalf("usage is not a JSON object: %v (%s)", err, usage)
+	}
+	raw, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+	var v float64
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("usage[%q] is not a number: %v", key, err)
+	}
+	return v, true
+}
+
+// TestLookupTranscriptUsage_DifferentModelsPerToolCall is the core join test:
+// two tool calls in the same transcript resolve to their own assistant turn's
+// model and usage, even though those turns used different models.
+func TestLookupTranscriptUsage_DifferentModelsPerToolCall(t *testing.T) {
+	path := writeTranscript(t, twoModelTranscript)
+
+	cases := []struct {
+		toolUseID string
+		wantModel string
+		wantIn    float64
+		wantOut   float64
+		wantRead  float64
+	}{
+		{"toolu_AAA", "claude-opus-4-8", 1954, 392, 0},
+		{"toolu_BBB", "claude-haiku-4-5-20251001", 77, 12, 16762},
+	}
+	for _, tc := range cases {
+		t.Run(tc.toolUseID, func(t *testing.T) {
+			model, usage, found, err := lookupTranscriptUsage(path, tc.toolUseID)
+			if err != nil {
+				t.Fatalf("lookupTranscriptUsage: %v", err)
+			}
+			if !found {
+				t.Fatalf("id %q not found; want found", tc.toolUseID)
+			}
+			if model != tc.wantModel {
+				t.Errorf("model = %q; want %q", model, tc.wantModel)
+			}
+			if got, ok := usageField(t, usage, "input_tokens"); !ok || got != tc.wantIn {
+				t.Errorf("usage.input_tokens = %v (ok=%v); want %v", got, ok, tc.wantIn)
+			}
+			if got, ok := usageField(t, usage, "output_tokens"); !ok || got != tc.wantOut {
+				t.Errorf("usage.output_tokens = %v (ok=%v); want %v", got, ok, tc.wantOut)
+			}
+			if got, ok := usageField(t, usage, "cache_read_input_tokens"); !ok || got != tc.wantRead {
+				t.Errorf("usage.cache_read_input_tokens = %v (ok=%v); want %v", got, ok, tc.wantRead)
+			}
+		})
+	}
+}
+
+// TestLookupTranscriptUsage_NotFound covers an id that no assistant turn
+// emitted: found is false and err is nil (a missing id is non-fatal).
+func TestLookupTranscriptUsage_NotFound(t *testing.T) {
+	path := writeTranscript(t, twoModelTranscript)
+	model, usage, found, err := lookupTranscriptUsage(path, "toolu_MISSING")
+	if err != nil {
+		t.Fatalf("lookupTranscriptUsage: %v", err)
+	}
+	if found {
+		t.Errorf("found = true; want false for an absent id")
+	}
+	if model != "" || usage != nil {
+		t.Errorf("model=%q usage=%s; want empty for an absent id", model, usage)
+	}
+}
+
+// TestLookupTranscriptUsage_MissingUsage covers an assistant turn that emitted
+// the id but carried no usage object: the model resolves, usage is nil, and
+// found is true so the caller can still attach model + capture_method.
+func TestLookupTranscriptUsage_MissingUsage(t *testing.T) {
+	path := writeTranscript(t, twoModelTranscript)
+	model, usage, found, err := lookupTranscriptUsage(path, "toolu_CCC")
+	if err != nil {
+		t.Fatalf("lookupTranscriptUsage: %v", err)
+	}
+	if !found {
+		t.Fatalf("found = false; want true (turn exists, only usage is absent)")
+	}
+	if model != "claude-sonnet-4-6" {
+		t.Errorf("model = %q; want claude-sonnet-4-6", model)
+	}
+	if usage != nil {
+		t.Errorf("usage = %s; want nil when the turn has no usage object", usage)
+	}
+}
+
+// TestLookupTranscriptUsage_MissingFile returns the I/O error so the caller can
+// distinguish a read failure from an absent id.
+func TestLookupTranscriptUsage_MissingFile(t *testing.T) {
+	_, _, found, err := lookupTranscriptUsage(filepath.Join(t.TempDir(), "nope.jsonl"), "toolu_AAA")
+	if err == nil {
+		t.Fatal("expected an error opening a missing transcript")
+	}
+	if found {
+		t.Error("found = true on a missing file; want false")
+	}
+}
+
+// TestLookupTranscriptUsage_EmptyArgs short-circuits without touching the disk.
+func TestLookupTranscriptUsage_EmptyArgs(t *testing.T) {
+	if _, _, found, err := lookupTranscriptUsage("", "toolu_AAA"); err != nil || found {
+		t.Errorf("empty path: found=%v err=%v; want false,nil", found, err)
+	}
+	path := writeTranscript(t, twoModelTranscript)
+	if _, _, found, err := lookupTranscriptUsage(path, ""); err != nil || found {
+		t.Errorf("empty id: found=%v err=%v; want false,nil", found, err)
+	}
+}
+
+// TestReadClaudeCode_EnrichesFromTranscript verifies the wiring: a PostToolUse
+// frame whose tool_use_id matches a transcript turn yields an emitter.Event
+// carrying that turn's model, the verbatim usage object, and capture_method.
+func TestReadClaudeCode_EnrichesFromTranscript(t *testing.T) {
+	path := writeTranscript(t, twoModelTranscript)
+	frame := map[string]any{
+		"hook_event_name": "PostToolUse",
+		"session_id":      "sess-xyz",
+		"tool_use_id":     "toolu_BBB",
+		"tool_name":       "Read",
+		"tool_input":      map[string]string{"file_path": "x"},
+		"tool_response":   map[string]string{"content": "contents"},
+		"transcript_path": path,
+	}
+	stdin, _ := json.Marshal(frame)
+
+	ev, _, err := readClaudeCode(stdin, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+	if ev.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("ev.Model = %q; want claude-haiku-4-5-20251001", ev.Model)
+	}
+	if ev.CaptureMethod != "transcript" {
+		t.Errorf("ev.CaptureMethod = %q; want transcript", ev.CaptureMethod)
+	}
+	if got, ok := usageField(t, ev.Usage, "output_tokens"); !ok || got != 12 {
+		t.Errorf("ev.Usage.output_tokens = %v (ok=%v); want 12", got, ok)
+	}
+}
+
+// TestReadClaudeCode_NoTranscriptLeavesFieldsUnset confirms enrichment is
+// best-effort: with no transcript_path and no resolvable fallback, the model,
+// usage, and capture_method fields stay empty and no error is raised.
+func TestReadClaudeCode_NoTranscriptLeavesFieldsUnset(t *testing.T) {
+	stdin := []byte(`{
+		"hook_event_name": "PostToolUse",
+		"session_id": "sess-none",
+		"tool_use_id": "toolu_AAA",
+		"tool_name": "Bash",
+		"tool_input": {"command":"ls"}
+	}`)
+	// HOME points at an empty dir so the glob fallback resolves nothing.
+	env := func(k string) string {
+		if k == "HOME" {
+			return t.TempDir()
+		}
+		return ""
+	}
+	ev, _, err := readClaudeCode(stdin, env)
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+	if ev.Model != "" || ev.Usage != nil || ev.CaptureMethod != "" {
+		t.Errorf("enrichment fields set without a transcript: model=%q usage=%s capture=%q",
+			ev.Model, ev.Usage, ev.CaptureMethod)
+	}
+}

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -151,6 +151,25 @@ type Event struct {
 	// AgentType is the runtime-reported agent type label (Claude Code:
 	// agent_type, e.g. "general-purpose"). Optional; omitted when empty.
 	AgentType string
+
+	// Model is the model the runtime observed producing this tool call (Claude
+	// Code: derived from the session transcript). The daemon stamps it onto
+	// issuer.runtime.model — observability metadata distinct from IssuerModel,
+	// which populates the identity-bearing issuer.model. Optional; omitted when
+	// empty.
+	Model string
+
+	// Usage is the token-usage object exactly as the runtime reported it
+	// (input/output/cache tokens), forwarded verbatim to issuer.runtime.usage.
+	// Must be valid JSON or nil; a non-nil empty slice is rejected at Emit.
+	// Optional; omitted when nil.
+	Usage json.RawMessage
+
+	// CaptureMethod records how Model/Usage were captured (Claude Code:
+	// "transcript"), stamped onto issuer.runtime.capture_method so transcript-
+	// derived receipts are distinguishable from other ingesters. Optional;
+	// omitted when empty.
+	CaptureMethod string
 }
 
 // Option configures an Emitter at construction.
@@ -313,6 +332,9 @@ type frame struct {
 	CorrelationID  string          `json:"correlation_id,omitempty"`
 	AgentID        string          `json:"agent_id,omitempty"`
 	AgentType      string          `json:"agent_type,omitempty"`
+	Model          string          `json:"model,omitempty"`
+	Usage          json.RawMessage `json:"usage,omitempty"`
+	CaptureMethod  string          `json:"capture_method,omitempty"`
 }
 
 type frameTool struct {
@@ -354,8 +376,11 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	if ev.Output != nil && len(ev.Output) == 0 {
 		return fmt.Errorf("emitter: Output is a non-nil empty slice; pass nil to indicate no payload")
 	}
-	if len(ev.Input)+len(ev.Output) > MaxFrameSize {
-		return fmt.Errorf("emitter: combined Input+Output payload exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
+	if ev.Usage != nil && len(ev.Usage) == 0 {
+		return fmt.Errorf("emitter: Usage is a non-nil empty slice; pass nil to indicate no usage")
+	}
+	if len(ev.Input)+len(ev.Output)+len(ev.Usage) > MaxFrameSize {
+		return fmt.Errorf("emitter: combined Input+Output+Usage payload exceeds MaxFrameSize (%d bytes)", MaxFrameSize)
 	}
 	// json.Valid only checks lexical syntax — `1e400` parses as a token but
 	// overflows float64, so the daemon's RFC 8785 canonicalisation (which
@@ -370,6 +395,14 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	if len(ev.Output) > 0 {
 		if err := json.Unmarshal(ev.Output, new(interface{})); err != nil {
 			return fmt.Errorf("emitter: Output is not valid or representable JSON: %w", err)
+		}
+	}
+	// Usage is forwarded verbatim into the receipt; gate it on the same
+	// representable-JSON check as Input/Output so a malformed token object
+	// fails fast at the caller rather than on the daemon's canonicalisation.
+	if len(ev.Usage) > 0 {
+		if err := json.Unmarshal(ev.Usage, new(interface{})); err != nil {
+			return fmt.Errorf("emitter: Usage is not valid or representable JSON: %w", err)
 		}
 	}
 
@@ -405,7 +438,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	for _, f := range [7]struct{ name, val string }{
+	for _, f := range [9]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
@@ -413,6 +446,8 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		{"idempotency_key", ev.IdempotencyKey},
 		{"correlation_id", ev.CorrelationID},
 		{"agent_id", ev.AgentID},
+		{"model", ev.Model},
+		{"capture_method", ev.CaptureMethod},
 	} {
 		if len(f.val) > MaxIdentityFieldLen {
 			e.dropCount.Add(pendingDrops)
@@ -439,6 +474,9 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		CorrelationID:  ev.CorrelationID,
 		AgentID:        ev.AgentID,
 		AgentType:      ev.AgentType,
+		Model:          ev.Model,
+		Usage:          ev.Usage,
+		CaptureMethod:  ev.CaptureMethod,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/emitter/parity_test.go
+++ b/sdk/go/emitter/parity_test.go
@@ -18,6 +18,7 @@ func TestFrameParityKnownFields(t *testing.T) {
 	expected := []string{
 		"agent_id",
 		"agent_type",
+		"capture_method",
 		"channel",
 		"correlation_id",
 		"decision",
@@ -27,12 +28,14 @@ func TestFrameParityKnownFields(t *testing.T) {
 		"input",
 		"issuer_model",
 		"issuer_name",
+		"model",
 		"operator_id",
 		"operator_name",
 		"output",
 		"session_id",
 		"tool",
 		"ts_emit",
+		"usage",
 		"v",
 	}
 

--- a/sdk/go/receipt/runtime_test.go
+++ b/sdk/go/receipt/runtime_test.go
@@ -1,0 +1,81 @@
+package receipt
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestRuntimeRoundTrip_ModelUsageCaptureMethod locks the JSON shape of the
+// observability members added to the open issuer.runtime container: model,
+// usage (verbatim), and capture_method survive a marshal → unmarshal round-trip
+// alongside agent_id/agent_type and any unknown keys preserved via Extra.
+func TestRuntimeRoundTrip_ModelUsageCaptureMethod(t *testing.T) {
+	usage := json.RawMessage(`{"input_tokens":1954,"output_tokens":392,"cache_read_input_tokens":0}`)
+	in := Runtime{
+		AgentID:       "agent-abc",
+		AgentType:     "general-purpose",
+		Model:         "claude-opus-4-8",
+		Usage:         usage,
+		CaptureMethod: "transcript",
+		Extra:         map[string]json.RawMessage{"trace_id": json.RawMessage(`"abc123"`)},
+	}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Confirm the wire keys are the snake_case names the schema documents.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	for _, k := range []string{"agent_id", "agent_type", "model", "usage", "capture_method", "trace_id"} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("marshalled runtime missing key %q (got %s)", k, b)
+		}
+	}
+
+	var out Runtime
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Model != in.Model {
+		t.Errorf("model = %q; want %q", out.Model, in.Model)
+	}
+	if out.CaptureMethod != in.CaptureMethod {
+		t.Errorf("capture_method = %q; want %q", out.CaptureMethod, in.CaptureMethod)
+	}
+	if string(out.Usage) == "" {
+		t.Fatal("usage was dropped on round-trip")
+	}
+	var um map[string]int
+	if err := json.Unmarshal(out.Usage, &um); err != nil {
+		t.Fatalf("round-tripped usage not an object: %v", err)
+	}
+	if um["input_tokens"] != 1954 || um["output_tokens"] != 392 {
+		t.Errorf("usage = %v; want the verbatim token counts", um)
+	}
+	if got, ok := out.Extra["trace_id"]; !ok || string(got) != `"abc123"` {
+		t.Errorf("unknown runtime key trace_id not preserved: %q (ok=%v)", got, ok)
+	}
+}
+
+// TestRuntimeMarshal_OmitsEmptyObservabilityFields confirms a runtime carrying
+// only agent identity emits no model/usage/capture_method keys, so existing
+// sub-agent receipts are byte-for-byte unchanged by this addition.
+func TestRuntimeMarshal_OmitsEmptyObservabilityFields(t *testing.T) {
+	b, err := json.Marshal(Runtime{AgentID: "agent-x", AgentType: "explorer"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"model", "usage", "capture_method"} {
+		if _, ok := raw[k]; ok {
+			t.Errorf("empty %q should be omitted; got %s", k, b)
+		}
+	}
+}

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -93,6 +93,21 @@ type Runtime struct {
 	AgentID string
 	// AgentType is the runtime-reported agent type label (e.g. "general-purpose").
 	AgentType string
+	// Model is the model the runtime observed producing this action (e.g. a
+	// transcript-derived "claude-opus-4-8"). It is observability-oriented
+	// (ADR-0026 D5) and distinct from the identity-bearing top-level
+	// issuer.model: runtime.model records what an auditor can *correlate* the
+	// call with, not what they verify identity against. Absent when unknown.
+	Model string
+	// Usage is the token-usage object exactly as the agent runtime reported it
+	// (input/output/cache tokens). It is stored verbatim and never recomputed,
+	// so field names and shape track the runtime's own report across versions.
+	// Absent when unknown.
+	Usage json.RawMessage
+	// CaptureMethod records how Model/Usage were captured (e.g. "transcript"),
+	// so transcript-derived receipts can be distinguished from receipts enriched
+	// by other ingesters (OTLP, daemon). Absent when unknown.
+	CaptureMethod string
 	// Extra holds runtime keys this SDK version does not model as typed fields,
 	// preserved verbatim so they survive a round-trip and hash identically.
 	Extra map[string]json.RawMessage
@@ -102,7 +117,10 @@ type Runtime struct {
 // key, so unknown runtime members round-trip. Key ordering is irrelevant:
 // Canonicalize re-sorts per RFC 8785.
 func (r Runtime) MarshalJSON() ([]byte, error) {
-	m := make(map[string]json.RawMessage, len(r.Extra)+2)
+	// +5 reserves space for every typed member emitted below (agent_id,
+	// agent_type, model, usage, capture_method) so a fully-populated runtime
+	// does not reallocate the map.
+	m := make(map[string]json.RawMessage, len(r.Extra)+5)
 	for k, v := range r.Extra {
 		m[k] = v
 	}
@@ -119,6 +137,26 @@ func (r Runtime) MarshalJSON() ([]byte, error) {
 			return nil, fmt.Errorf("marshal runtime.agent_type: %w", err)
 		}
 		m["agent_type"] = b
+	}
+	if r.Model != "" {
+		b, err := json.Marshal(r.Model)
+		if err != nil {
+			return nil, fmt.Errorf("marshal runtime.model: %w", err)
+		}
+		m["model"] = b
+	}
+	if len(r.Usage) > 0 {
+		// Stored verbatim — the runtime's own token-usage object, never
+		// recomputed. Canonicalize re-serialises it deterministically at hash
+		// time, so the byte form here need not be pre-canonicalised.
+		m["usage"] = r.Usage
+	}
+	if r.CaptureMethod != "" {
+		b, err := json.Marshal(r.CaptureMethod)
+		if err != nil {
+			return nil, fmt.Errorf("marshal runtime.capture_method: %w", err)
+		}
+		m["capture_method"] = b
 	}
 	b, err := json.Marshal(m)
 	if err != nil {
@@ -146,6 +184,24 @@ func (r *Runtime) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("runtime.agent_type: %w", err)
 		}
 		delete(m, "agent_type")
+	}
+	if v, ok := m["model"]; ok {
+		if err := json.Unmarshal(v, &r.Model); err != nil {
+			return fmt.Errorf("runtime.model: %w", err)
+		}
+		delete(m, "model")
+	}
+	if v, ok := m["usage"]; ok {
+		// Keep the verbatim bytes so the token-usage object round-trips and
+		// hashes identically — it is the runtime's report, not ours to reshape.
+		r.Usage = v
+		delete(m, "usage")
+	}
+	if v, ok := m["capture_method"]; ok {
+		if err := json.Unmarshal(v, &r.CaptureMethod); err != nil {
+			return fmt.Errorf("runtime.capture_method: %w", err)
+		}
+		delete(m, "capture_method")
 	}
 	if len(m) > 0 {
 		r.Extra = m

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -80,7 +80,11 @@ type Issuer struct {
 // fields below are documented members, but the JSON-LD context types it @json
 // and the schema does not close it, so additional runtime keys (e.g. future
 // trace-context identifiers) may be added without a protocol-version bump.
-// Absent for the root agent.
+//
+// Runtime is present whenever any member is set. The agent-identity members
+// (AgentID/AgentType) appear only on sub-agent receipts, but the observability
+// members (Model/Usage/CaptureMethod) also appear on root-agent receipts — so
+// consumers MUST NOT assume Issuer.Runtime is nil on a root-chain receipt.
 //
 // Unlike the rest of the receipt struct (whose unknown fields are dropped on a
 // round-trip — see HashRawReceipt), Runtime PRESERVES unknown keys via Extra so


### PR DESCRIPTION
## What

Enrich each Agent Receipt with the **model** that produced a tool call and its **real token usage**, derived from the Claude Code session transcript. Works with **OTEL disabled** and **no proxy** — the data comes straight from the transcript JSONL the PostToolUse hook already has a pointer to.

## The join

`PostToolUse tool_use_id` == `tool_use.id` on an assistant transcript turn → that turn's `message.model` + `message.usage`. Verified against a real transcript: every `tool_result.tool_use_id` resolves to an assistant turn and its model/usage.

## How it flows

```
hook (transcript lookup) → emitter.Event → wire frame → daemon pipeline → issuer.runtime on the signed receipt
```

The transcript can only be read in the hook (it has `transcript_path`), but the receipt is built in the daemon, so the new data is threaded hook → emitter → daemon → receipt. Everything is **additive**.

### Changes

- **Transcript lookup** (`hook/cmd/agent-receipts-hook/claude_transcript.go`): `lookupTranscriptUsage` streams the JSONL with a `bufio.Reader`, pre-filters lines by the `tool_use_id` substring before decoding (so only the handful of lines mentioning the id are parsed), and returns `{model, usage}`. Distinguishes **not-found** (`found=false`), **missing-usage** (`found=true`, `usage=nil`, model still returned), and I/O errors. Path resolves from the frame's `transcript_path` with a `~/.claude/projects/*/<session>.jsonl` fallback.
- **Wiring** (`claude_code.go`): adds `transcript_path` to the frame; enrichment in `readClaudeCode` is strictly best-effort and never fails the hook (sets `Model`, `Usage`, `CaptureMethod="transcript"`).
- **Transport** (`sdk/go/emitter`, `daemon/internal/pipeline`): `Event` / wire `frame` / `EmitterFrame` carry `model`, `usage` (verbatim), `capture_method`, validated like the other forwarded fields. Both frame-parity tests updated.
- **Receipt schema** (`sdk/go/receipt/types.go`): the ADR-0026 open `issuer.runtime` container gains typed `Model` / `Usage` (raw, **never recomputed**) / `CaptureMethod`, round-tripping alongside the existing `Extra` mechanism. The daemon now stamps `issuer.runtime` on **root** receipts too when these observability fields are present (previously sub-agent-only). No `spec/` edit, no protocol-version bump, no signing change — runtime is the container designed for exactly this (ADR-0026 D2/D5).

### `capture_method`

Set to `"transcript"` so transcript-derived receipts can later be distinguished from other ingesters (OTLP, daemon).

## Tests

- **Hook**: fixture with two assistant turns using **different models** (`claude-opus-4-8` / `claude-haiku-4-5-20251001`), asserting the correct model + usage attaches per `tool_use_id`; plus **not-found**, **missing-usage**, missing-file, empty-args, and the full `readClaudeCode` enrich / leave-unset wiring.
- **Daemon**: a root frame's model/usage/capture_method land in `issuer.runtime`; the receipt re-hashes cleanly (open-container round-trip invariant).
- **Receipt**: `Runtime` round-trip for the new members + `omitempty` so existing sub-agent receipts are byte-unchanged.

All suites pass locally: Go (sdk/go, daemon, hook, mcp-proxy), TS (432), Py (459) — confirming cross-SDK is unaffected (no existing receipt fields, wire fields, or signing changed).

## Papercut

Anchored `hook/.gitignore`'s `agent-receipts-hook` binary pattern with a leading slash — the bare form also ignored the `cmd/agent-receipts-hook/` **source directory**.

## Follow-ups (not in this PR)

- Cross-SDK byte-identity vectors pinning a populated `issuer.runtime` with model/usage across the Go/TS/Py SDKs.
- Documenting the new `runtime` members in the JSON Schema's `runtime` object (documentation-only per ADR-0026 D2).