### PR TITLE
fix: update repository URLs after rename ar → obsigna

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/agent-receipts/ar"
-Repository = "https://github.com/agent-receipts/ar"
-Issues = "https://github.com/agent-receipts/ar/issues"
+Homepage = "https://github.com/agent-receipts/obsigna"
+Repository = "https://github.com/agent-receipts/obsigna"
+Issues = "https://github.com/agent-receipts/obsigna/issues"
 Spec = "https://github.com/agent-receipts/spec"
 
 [project.optional-dependencies]

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -6,7 +6,7 @@
 	"author": "Otto Jongerius",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/agent-receipts/ar.git",
+		"url": "git+https://github.com/agent-receipts/obsigna.git",
 		"directory": "sdk/ts"
 	},
 	"type": "module",


### PR DESCRIPTION
Fixes npm provenance E422 and PyPI metadata after the repository rename.

- `sdk/ts/package.json`: `repository.url` → `git+https://github.com/agent-receipts/obsigna.git`  
  (npm provenance validates this against the GitHub Actions OIDC claim)
- `sdk/py/pyproject.toml`: Homepage/Repository/Issues → `obsigna`

Go module paths (`github.com/agent-receipts/ar/...`) are unchanged — canonical import paths, not repository URLs.