### PR TITLE
chore(release): prep hook v0.16.0-alpha.1 and daemon v0.19.0-alpha.1

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0-alpha.1] - 2026-06-11
+
+### Added
+
+- **`--rotate` offline key rotation** ([#778](https://github.com/agent-receipts/obsigna/pull/778), ADR-0015 Phase A) — new `--rotate` flag generates a fresh Ed25519 key pair, emits a `key_rotated` receipt (action type `agent.key.rotate`) signed by the current key, archives the old public key as `signing.key.pub.rotated-<fp>`, and atomically swaps in the new key. The daemon must be stopped first; a live-socket check aborts rotation if the daemon is reachable. Pass `--anchor-log` to write the rotation event to an append-only external witness log before committing. `--verify` and `--doctor` traverse rotation chains and surface `IncompleteSession` when a `system.pty.open` receipt has no matching close.
+- **Transcript-derived model and token usage** ([#779](https://github.com/agent-receipts/obsigna/pull/779), ADR-0026) — `issuerFromFrame` now maps the hook-forwarded `model`, `usage` (verbatim JSON), and `capture_method` fields into `issuer.runtime` on all receipts, including root-chain receipts when observability fields are present.
+- **`IncompleteSession` advisory** ([#780](https://github.com/agent-receipts/obsigna/pull/780), ADR-0027) — `--verify` prints `Advisory: incomplete session: PTY open/close imbalance` and `--doctor` surfaces the same advisory when a `system.pty.open` receipt has no corresponding `system.pty.close` in the chain. Advisory-only; does not affect `Valid`.
+
+### Dependencies
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.18.0-alpha.1` (provides `receipt.Runtime` typed fields, `KeyRotation` type, and `ChainVerification.IncompleteSession`).
+
 ## [0.18.0] - 2026-06-11
 
 Graduates `0.18.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.17.0` (the alpha pinned `v0.17.0-alpha.1`). See the `0.18.0-alpha.1` entry below for the full surface (`issuer.runtime` sub-object, `agent_type` forwarding).

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.17.0
+	github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.17.0 h1:BEeBwF0Opn/AERZUJ3+pxT1nWDSs/qxjw/FjOmKqXEY=
-github.com/agent-receipts/ar/sdk/go v0.17.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1 h1:sbpOk/DEOF+S/bnv/RfyqtIMdq+3i/RDndM1VJunl/M=
+github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0-alpha.1] - 2026-06-11
+
+### Added
+
+- **Transcript-derived model and token usage** ([#779](https://github.com/agent-receipts/obsigna/pull/779), ADR-0026) — `lookupTranscriptUsage` streams the Claude Code session transcript JSONL and joins on `tool_use_id` to resolve the model name and token counts for each tool call. Best-effort: a missing entry or read error is logged to stderr but never fails the hook. The resolved `model`, `usage` (verbatim JSON), and `capture_method: "transcript"` are forwarded in the emitter frame; the daemon stamps them into `issuer.runtime` on the receipt.
+
+### Dependencies
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.18.0-alpha.1` (provides the `receipt.Runtime` typed fields).
+
 ## [0.15.0] - 2026-06-11
 
 Graduates `0.15.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.17.0` (the alpha pinned `v0.17.0-alpha.1`). See the `0.15.0-alpha.1` entry below for the full surface (`agent_type` forwarding).

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.17.0
+require github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.17.0 h1:BEeBwF0Opn/AERZUJ3+pxT1nWDSs/qxjw/FjOmKqXEY=
-github.com/agent-receipts/ar/sdk/go v0.17.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1 h1:sbpOk/DEOF+S/bnv/RfyqtIMdq+3i/RDndM1VJunl/M=
+github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Summary

- **hook v0.16.0-alpha.1**: CHANGELOG entry for transcript-derived model/token usage (#779); bump `sdk/go` to `v0.18.0-alpha.1`
- **daemon v0.19.0-alpha.1**: CHANGELOG entry for `--rotate` offline key rotation (#778), transcript enrichment (#779), and `IncompleteSession` advisory (#780); bump `sdk/go` to `v0.18.0-alpha.1`
- `go.sum` files updated via `go mod tidy`

## Test plan

- [ ] CI passes for hook and daemon
- [ ] After merge: push `hook/v0.16.0-alpha.1` and `daemon/v0.19.0-alpha.1` tags