### PR TITLE
feat: populate action.target.resource from Claude Code hook tool input

### DIFF
--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -118,6 +118,13 @@ type EmitterFrame struct {
 	Model         string          `json:"model,omitempty"`
 	Usage         json.RawMessage `json:"usage,omitempty"`
 	CaptureMethod string          `json:"capture_method,omitempty"`
+	// TargetSystem and TargetResource together identify the resource the action
+	// operates on. The daemon maps them into action.target.{system,resource}.
+	// For filesystem tools (Read, Write, Edit, MultiEdit) on the claude-code
+	// channel, TargetSystem is "filesystem" and TargetResource is the file path.
+	// Both are optional; omitted when the tool has no addressable resource.
+	TargetSystem   string `json:"target_system,omitempty"`
+	TargetResource string `json:"target_resource,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -689,6 +696,12 @@ func (p *Pipeline) buildAndSign(
 		Timestamp:      now,
 		PeerCredential: peerCred,
 		IdempotencyKey: f.IdempotencyKey,
+	}
+	if f.TargetSystem != "" || f.TargetResource != "" {
+		action.Target = &receipt.ActionTarget{
+			System:   f.TargetSystem,
+			Resource: f.TargetResource,
+		}
 	}
 	if hasJSONPayload(f.Input) {
 		hash, err := canonicalSHA256(f.Input)

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -34,6 +34,11 @@ const multibaseBase64URL = "u"
 // messages legible.
 const maxIdentityFieldLen = 256
 
+// maxTargetResourceLen caps the byte length of TargetResource. File paths can
+// reach 4096 bytes on Linux (PATH_MAX), so a separate, wider cap is used
+// rather than the identity-field limit.
+const maxTargetResourceLen = 4096
+
 // SupportedFrameVersion is the only emitter-frame schema this daemon accepts.
 // Bumping it requires a migration plan and a daemon-side translator for the
 // old version; until that exists, accepting unknown versions would silently
@@ -529,6 +534,19 @@ func validateFrame(f *EmitterFrame) error {
 	if len(f.CaptureMethod) > maxIdentityFieldLen {
 		return fmt.Errorf("capture_method exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.CaptureMethod))
 	}
+	if len(f.TargetSystem) > maxIdentityFieldLen {
+		return fmt.Errorf("target_system exceeds %d bytes (got %d)", maxIdentityFieldLen, len(f.TargetSystem))
+	}
+	if len(f.TargetResource) > maxTargetResourceLen {
+		return fmt.Errorf("target_resource exceeds %d bytes (got %d)", maxTargetResourceLen, len(f.TargetResource))
+	}
+	// target_system and target_resource must both be set or both absent.
+	// A half-populated target would produce ActionTarget{System:""} or
+	// ActionTarget{Resource:""} in the signed receipt because ActionTarget.System
+	// carries no omitempty tag.
+	if (f.TargetSystem != "") != (f.TargetResource != "") {
+		return fmt.Errorf("target_system and target_resource must both be set or both absent")
+	}
 	// Input and Output are accepted as any valid JSON value (object, array,
 	// primitive, or null). json.Unmarshal into EmitterFrame already validated
 	// JSON syntax, so anything reaching this point is well-formed. The hash
@@ -697,7 +715,7 @@ func (p *Pipeline) buildAndSign(
 		PeerCredential: peerCred,
 		IdempotencyKey: f.IdempotencyKey,
 	}
-	if f.TargetSystem != "" || f.TargetResource != "" {
+	if f.TargetSystem != "" && f.TargetResource != "" {
 		action.Target = &receipt.ActionTarget{
 			System:   f.TargetSystem,
 			Resource: f.TargetResource,

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -2136,3 +2136,67 @@ func TestProcess_NoTargetLeavesActionTargetNil(t *testing.T) {
 		t.Errorf("action.target = %+v; want nil", *target)
 	}
 }
+
+// TestValidateFrame_RejectsOversizeTargetSystem verifies that validateFrame rejects
+// a target_system value exceeding maxIdentityFieldLen bytes.
+func TestValidateFrame_RejectsOversizeTargetSystem(t *testing.T) {
+	f := &EmitterFrame{
+		Version:        "1",
+		TsEmit:         "2026-06-12T00:00:00Z",
+		SessionID:      "s",
+		Channel:        "claude-code",
+		Tool:           EmitterTool{Name: "Read"},
+		Decision:       "allowed",
+		TargetSystem:   strings.Repeat("x", maxIdentityFieldLen+1),
+		TargetResource: "/etc/hosts",
+	}
+	if err := validateFrame(f); err == nil {
+		t.Error("validateFrame accepted an oversize target_system; want rejection")
+	}
+}
+
+// TestValidateFrame_RejectsOversizeTargetResource verifies that validateFrame rejects
+// a target_resource value exceeding maxTargetResourceLen bytes.
+func TestValidateFrame_RejectsOversizeTargetResource(t *testing.T) {
+	f := &EmitterFrame{
+		Version:        "1",
+		TsEmit:         "2026-06-12T00:00:00Z",
+		SessionID:      "s",
+		Channel:        "claude-code",
+		Tool:           EmitterTool{Name: "Read"},
+		Decision:       "allowed",
+		TargetSystem:   "filesystem",
+		TargetResource: strings.Repeat("x", maxTargetResourceLen+1),
+	}
+	if err := validateFrame(f); err == nil {
+		t.Error("validateFrame accepted an oversize target_resource; want rejection")
+	}
+}
+
+// TestValidateFrame_RejectsHalfPopulatedTarget verifies that validateFrame rejects
+// frames where only one of target_system/target_resource is set.
+func TestValidateFrame_RejectsHalfPopulatedTarget(t *testing.T) {
+	base := EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-06-12T00:00:00Z",
+		SessionID: "s",
+		Channel:   "claude-code",
+		Tool:      EmitterTool{Name: "Read"},
+		Decision:  "allowed",
+	}
+
+	t.Run("system without resource", func(t *testing.T) {
+		f := base
+		f.TargetSystem = "filesystem"
+		if err := validateFrame(&f); err == nil {
+			t.Error("validateFrame accepted target_system without target_resource; want rejection")
+		}
+	})
+	t.Run("resource without system", func(t *testing.T) {
+		f := base
+		f.TargetResource = "/etc/hosts"
+		if err := validateFrame(&f); err == nil {
+			t.Error("validateFrame accepted target_resource without target_system; want rejection")
+		}
+	})
+}

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -2067,3 +2067,72 @@ func TestEmitTerminator_TerminatesAgentChains(t *testing.T) {
 		}
 	}
 }
+
+// TestProcess_TargetResourcePopulatesActionTarget verifies that TargetSystem and
+// TargetResource in the emitter frame flow through into action.target on the
+// signed receipt.
+func TestProcess_TargetResourcePopulatesActionTarget(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:        "1",
+		TsEmit:         "2026-05-03T00:00:00Z",
+		SessionID:      "sess-target",
+		Channel:        "claude-code",
+		Tool:           EmitterTool{Name: "Read"},
+		Decision:       "allowed",
+		TargetSystem:   "filesystem",
+		TargetResource: "/home/user/project/main.go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts; want 1", len(receipts))
+	}
+	target := receipts[0].CredentialSubject.Action.Target
+	if target == nil {
+		t.Fatal("action.target is nil; want populated")
+	}
+	if target.System != "filesystem" {
+		t.Errorf("action.target.system = %q; want filesystem", target.System)
+	}
+	if target.Resource != "/home/user/project/main.go" {
+		t.Errorf("action.target.resource = %q; want /home/user/project/main.go", target.Resource)
+	}
+}
+
+// TestProcess_NoTargetLeavesActionTargetNil verifies that a frame with no
+// TargetSystem/TargetResource leaves action.target nil.
+func TestProcess_NoTargetLeavesActionTargetNil(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	if err := p.Process(sampleFrame(t)); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts; want 1", len(receipts))
+	}
+	if target := receipts[0].CredentialSubject.Action.Target; target != nil {
+		t.Errorf("action.target = %+v; want nil", *target)
+	}
+}

--- a/daemon/internal/pipeline/parity_test.go
+++ b/daemon/internal/pipeline/parity_test.go
@@ -35,6 +35,8 @@ func TestEmitterFrameParityKnownFields(t *testing.T) {
 		"operator_name",
 		"output",
 		"session_id",
+		"target_resource",
+		"target_system",
 		"tool",
 		"ts_emit",
 		"usage",

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -146,7 +146,12 @@ func extractFileTarget(toolName string, input json.RawMessage) (system, resource
 	var inp struct {
 		FilePath string `json:"file_path"`
 	}
-	if err := json.Unmarshal(input, &inp); err != nil || inp.FilePath == "" {
+	if err := json.Unmarshal(input, &inp); err != nil {
+		// Malformed JSON is not a schema-drift signal — don't warn.
+		return "", "", ""
+	}
+	filePath := strings.TrimSpace(inp.FilePath)
+	if filePath == "" {
 		if fileTools[toolName] {
 			return "", "", fmt.Sprintf(
 				"agent-receipts-hook: %s input has no file_path; action.target.resource will be empty",
@@ -155,5 +160,5 @@ func extractFileTarget(toolName string, input json.RawMessage) (system, resource
 		}
 		return "", "", ""
 	}
-	return "filesystem", inp.FilePath, ""
+	return "filesystem", filePath, ""
 }

--- a/hook/cmd/agent-receipts-hook/claude_code.go
+++ b/hook/cmd/agent-receipts-hook/claude_code.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/agent-receipts/ar/sdk/go/emitter"
 )
@@ -68,6 +69,11 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 	// slices and the daemon expects nil to mean "no payload".
 	if len(f.ToolInput) > 0 {
 		ev.Input = f.ToolInput
+		if sys, res, warn := extractFileTarget(f.ToolName, f.ToolInput); res != "" {
+			ev.Target = emitter.Target{System: sys, Resource: res}
+		} else if warn != "" {
+			fmt.Fprintln(os.Stderr, warn)
+		}
 	}
 	if len(f.ToolResponse) > 0 {
 		ev.Output = f.ToolResponse
@@ -96,4 +102,58 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 	}
 
 	return ev, f.SessionID, nil
+}
+
+// fileTools is the set of tools known to always operate on a named file and
+// expected to carry file_path in their input. An absent file_path for any tool
+// in this set is returned as a warning string so the caller can surface the
+// schema drift without failing the hook.
+var fileTools = map[string]bool{
+	"Read": true, "Write": true, "Edit": true, "MultiEdit": true,
+}
+
+// skipTools is the set of non-filesystem tools excluded from file_path
+// extraction. Everything outside this set (and not MCP-namespaced) is
+// attempted opportunistically, so new filesystem tools are auto-captured
+// without requiring an explicit listing.
+var skipTools = map[string]bool{
+	"Bash": true, "Agent": true, "WebFetch": true, "WebSearch": true,
+}
+
+// extractFileTarget attempts to extract a file path from a tool's input JSON.
+//
+// Skip rules (in order):
+//  1. MCP-namespaced tools (prefix "mcp__") — dynamic schema, not ours to predict.
+//  2. Tools in skipTools — known non-filesystem tools.
+//
+// For all other tools, file_path is attempted. On success: returns
+// ("filesystem", path, ""). When file_path is absent for a tool in fileTools
+// (the known-important set), returns a non-empty warning so the caller can
+// log the degradation — these tools should always have file_path, so absence
+// means Claude Code's payload schema may have changed. For any other tool
+// without file_path: returns ("", "", "") silently, since the tool may simply
+// not touch files.
+func extractFileTarget(toolName string, input json.RawMessage) (system, resource, warning string) {
+	if strings.HasPrefix(toolName, "mcp__") {
+		return "", "", ""
+	}
+	if skipTools[toolName] {
+		return "", "", ""
+	}
+	if len(input) == 0 {
+		return "", "", ""
+	}
+	var inp struct {
+		FilePath string `json:"file_path"`
+	}
+	if err := json.Unmarshal(input, &inp); err != nil || inp.FilePath == "" {
+		if fileTools[toolName] {
+			return "", "", fmt.Sprintf(
+				"agent-receipts-hook: %s input has no file_path; action.target.resource will be empty",
+				toolName,
+			)
+		}
+		return "", "", ""
+	}
+	return "filesystem", inp.FilePath, ""
 }

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -369,6 +369,210 @@ func TestReadClaudeCode_PreToolUseAcceptedByEmitter(t *testing.T) {
 	checkEventAcceptedByEmitter(t, ev)
 }
 
+// --- extractFileTarget unit tests ---
+
+func TestExtractFileTarget(t *testing.T) {
+	cases := []struct {
+		name        string
+		toolName    string
+		input       string
+		wantSys     string
+		wantRes     string
+		wantWarning bool // true = non-empty warning expected
+	}{
+		// Known file tools — file_path present.
+		{
+			name:     "Read with file_path",
+			toolName: "Read",
+			input:    `{"file_path":"/etc/hosts"}`,
+			wantSys:  "filesystem",
+			wantRes:  "/etc/hosts",
+		},
+		{
+			name:     "Write with file_path",
+			toolName: "Write",
+			input:    `{"file_path":"src/main.go","content":"package main"}`,
+			wantSys:  "filesystem",
+			wantRes:  "src/main.go",
+		},
+		{
+			name:     "Edit with file_path",
+			toolName: "Edit",
+			input:    `{"file_path":"a.go","old_string":"x","new_string":"y"}`,
+			wantSys:  "filesystem",
+			wantRes:  "a.go",
+		},
+		{
+			name:     "MultiEdit with file_path",
+			toolName: "MultiEdit",
+			input:    `{"file_path":"b.go","edits":[]}`,
+			wantSys:  "filesystem",
+			wantRes:  "b.go",
+		},
+		// Known file tools — file_path absent (schema drift): must warn.
+		{
+			name:        "Read without file_path triggers warning",
+			toolName:    "Read",
+			input:       `{"offset":0}`,
+			wantWarning: true,
+		},
+		{
+			name:        "Write without file_path triggers warning",
+			toolName:    "Write",
+			input:       `{"content":"x"}`,
+			wantWarning: true,
+		},
+		// Skip-listed tools — never attempt extraction.
+		{
+			name:     "Bash is skipped",
+			toolName: "Bash",
+			input:    `{"command":"ls"}`,
+		},
+		{
+			name:     "Agent is skipped",
+			toolName: "Agent",
+			input:    `{"prompt":"do stuff"}`,
+		},
+		{
+			name:     "WebFetch is skipped",
+			toolName: "WebFetch",
+			input:    `{"url":"https://example.com"}`,
+		},
+		{
+			name:     "WebSearch is skipped",
+			toolName: "WebSearch",
+			input:    `{"query":"golang"}`,
+		},
+		// MCP tools — always skipped regardless of input.
+		{
+			name:     "MCP tool with file_path is skipped",
+			toolName: "mcp__github-audited__list_issues",
+			input:    `{"file_path":"/sneaky"}`,
+		},
+		// Unknown tools — opportunistic extraction, no warning on miss.
+		{
+			name:     "unknown tool with file_path is auto-captured",
+			toolName: "Move",
+			input:    `{"file_path":"old.go","destination":"new.go"}`,
+			wantSys:  "filesystem",
+			wantRes:  "old.go",
+		},
+		{
+			name:     "unknown tool without file_path: silent, no warning",
+			toolName: "Grep",
+			input:    `{"pattern":"func","path":"."}`,
+		},
+		// Edge cases.
+		{
+			name:     "empty input returns empty",
+			toolName: "Read",
+			input:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sys, res, warn := extractFileTarget(tc.toolName, json.RawMessage(tc.input))
+			if sys != tc.wantSys {
+				t.Errorf("system = %q; want %q", sys, tc.wantSys)
+			}
+			if res != tc.wantRes {
+				t.Errorf("resource = %q; want %q", res, tc.wantRes)
+			}
+			if tc.wantWarning && warn == "" {
+				t.Error("warning = \"\"; want non-empty warning")
+			}
+			if !tc.wantWarning && warn != "" {
+				t.Errorf("warning = %q; want empty", warn)
+			}
+		})
+	}
+}
+
+// TestExtractFileTarget_WarningNamesTheTool checks that the warning message
+// includes the tool name so operators can triage the degradation.
+func TestExtractFileTarget_WarningNamesTheTool(t *testing.T) {
+	_, _, warn := extractFileTarget("Read", json.RawMessage(`{"offset":0}`))
+	if warn == "" {
+		t.Fatal("expected warning; got empty")
+	}
+	if !strings.Contains(warn, "Read") {
+		t.Errorf("warning %q does not contain tool name %q", warn, "Read")
+	}
+}
+
+// TestReadClaudeCode_Target verifies that readClaudeCode populates ev.Target
+// for filesystem tools, auto-captures unknown tools with file_path, and leaves
+// target empty for skip-listed and MCP tools.
+func TestReadClaudeCode_Target(t *testing.T) {
+	cases := []struct {
+		name    string
+		stdin   string
+		wantSys string
+		wantRes string
+	}{
+		{
+			name: "Read populates target",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Read",` +
+				`"tool_input":{"file_path":"/etc/hosts"},"tool_response":{"content":"127.0.0.1"}}`,
+			wantSys: "filesystem",
+			wantRes: "/etc/hosts",
+		},
+		{
+			name: "Write populates target",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Write",` +
+				`"tool_input":{"file_path":"out.go","content":"package main"}}`,
+			wantSys: "filesystem",
+			wantRes: "out.go",
+		},
+		{
+			name: "Edit populates target",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Edit",` +
+				`"tool_input":{"file_path":"x.go","old_string":"a","new_string":"b"}}`,
+			wantSys: "filesystem",
+			wantRes: "x.go",
+		},
+		{
+			name: "MultiEdit populates target",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"MultiEdit",` +
+				`"tool_input":{"file_path":"z.go","edits":[]}}`,
+			wantSys: "filesystem",
+			wantRes: "z.go",
+		},
+		{
+			name: "unknown tool with file_path is auto-captured",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Move",` +
+				`"tool_input":{"file_path":"old.go","destination":"new.go"}}`,
+			wantSys: "filesystem",
+			wantRes: "old.go",
+		},
+		{
+			name: "Bash leaves target empty",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Bash",` +
+				`"tool_input":{"command":"echo hi"},"tool_response":{"output":"hi"}}`,
+		},
+		{
+			name: "MCP tool leaves target empty",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s",` +
+				`"tool_name":"mcp__github-audited__list_issues","tool_input":{"owner":"foo"}}`,
+		},
+	}
+	noEnv := func(string) string { return "" }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, _, err := readClaudeCode([]byte(tc.stdin), noEnv)
+			if err != nil {
+				t.Fatalf("readClaudeCode: %v", err)
+			}
+			if ev.Target.System != tc.wantSys {
+				t.Errorf("Target.System = %q; want %q", ev.Target.System, tc.wantSys)
+			}
+			if ev.Target.Resource != tc.wantRes {
+				t.Errorf("Target.Resource = %q; want %q", ev.Target.Resource, tc.wantRes)
+			}
+		})
+	}
+}
+
 // --- resolveVersion unit tests ---
 
 // TestResolveVersion_PrefersLDFlagInjection pins the precedence the

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -500,6 +500,43 @@ func TestExtractFileTarget_WarningNamesTheTool(t *testing.T) {
 	}
 }
 
+// TestExtractFileTarget_WhitespaceFilePath checks that a file_path containing
+// only whitespace is treated as absent (trimmed to empty), not as a valid path.
+// Known file tools must still warn; unknown tools must be silent.
+func TestExtractFileTarget_WhitespaceFilePath(t *testing.T) {
+	t.Run("fileTools warns on whitespace-only path", func(t *testing.T) {
+		sys, res, warn := extractFileTarget("Read", json.RawMessage(`{"file_path":"   "}`))
+		if sys != "" || res != "" {
+			t.Errorf("system=%q resource=%q; want both empty for whitespace path", sys, res)
+		}
+		if warn == "" {
+			t.Error("expected warning for whitespace-only path on Read; got empty")
+		}
+	})
+	t.Run("unknown tool is silent on whitespace-only path", func(t *testing.T) {
+		sys, res, warn := extractFileTarget("Move", json.RawMessage(`{"file_path":"\t"}`))
+		if sys != "" || res != "" {
+			t.Errorf("system=%q resource=%q; want both empty for whitespace path", sys, res)
+		}
+		if warn != "" {
+			t.Errorf("unexpected warning for unknown tool with whitespace path: %q", warn)
+		}
+	})
+}
+
+// TestExtractFileTarget_MalformedJSON verifies that malformed JSON input is
+// treated as a silent miss (no warning, no resource). Malformed JSON is not
+// a schema-drift signal — it should not trigger the fileTools warning.
+func TestExtractFileTarget_MalformedJSON(t *testing.T) {
+	sys, res, warn := extractFileTarget("Read", json.RawMessage(`{bad json`))
+	if sys != "" || res != "" {
+		t.Errorf("system=%q resource=%q; want both empty for malformed JSON", sys, res)
+	}
+	if warn != "" {
+		t.Errorf("warning = %q; want empty (malformed JSON is not a schema-drift signal)", warn)
+	}
+}
+
 // TestReadClaudeCode_Target verifies that readClaudeCode populates ev.Target
 // for filesystem tools, auto-captures unknown tools with file_path, and leaves
 // target empty for skip-listed and MCP tools.

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -108,6 +108,14 @@ type Tool struct {
 	Name   string
 }
 
+// Target identifies the system and resource the action operates on.
+// System names a resource domain (e.g. "filesystem"); Resource is the
+// path or identifier within that domain (e.g. a file path).
+type Target struct {
+	System   string
+	Resource string
+}
+
 // Event is one tool invocation forwarded to the daemon. Input and Output
 // are raw JSON bytes; the daemon canonicalises them (RFC 8785) and writes
 // only the SHA-256 digest to the receipt. Either may be nil to indicate
@@ -170,6 +178,11 @@ type Event struct {
 	// derived receipts are distinguishable from other ingesters. Optional;
 	// omitted when empty.
 	CaptureMethod string
+
+	// Target identifies the resource the action operates on (e.g. a file path
+	// for filesystem tools). Optional; omitted from the frame when System and
+	// Resource are both empty.
+	Target Target
 }
 
 // Option configures an Emitter at construction.
@@ -335,6 +348,8 @@ type frame struct {
 	Model          string          `json:"model,omitempty"`
 	Usage          json.RawMessage `json:"usage,omitempty"`
 	CaptureMethod  string          `json:"capture_method,omitempty"`
+	TargetSystem   string          `json:"target_system,omitempty"`
+	TargetResource string          `json:"target_resource,omitempty"`
 }
 
 type frameTool struct {
@@ -477,6 +492,8 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		Model:          ev.Model,
 		Usage:          ev.Usage,
 		CaptureMethod:  ev.CaptureMethod,
+		TargetSystem:   ev.Target.System,
+		TargetResource: ev.Target.Resource,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -64,6 +64,11 @@ const MaxFrameSize = 1 << 20
 // before the write rather than as silent daemon-side rejections.
 const MaxIdentityFieldLen = 256
 
+// MaxTargetResourceLen is the maximum byte length of Target.Resource. File
+// paths can reach 4096 bytes on Linux (PATH_MAX), so a wider cap is used
+// rather than MaxIdentityFieldLen. The daemon enforces the same limit.
+const MaxTargetResourceLen = 4096
+
 // SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
 // The wire format is versioned; bumping it requires a daemon-side
 // translator, so a single supported value is the only safe contract.
@@ -459,6 +464,14 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	if (ev.Target.System != "") != (ev.Target.Resource != "") {
 		e.dropCount.Add(pendingDrops)
 		return fmt.Errorf("emitter: Target.System and Target.Resource must both be set or both empty")
+	}
+	if len(ev.Target.System) > MaxIdentityFieldLen {
+		e.dropCount.Add(pendingDrops)
+		return fmt.Errorf("emitter: target_system exceeds %d bytes (got %d)", MaxIdentityFieldLen, len(ev.Target.System))
+	}
+	if len(ev.Target.Resource) > MaxTargetResourceLen {
+		e.dropCount.Add(pendingDrops)
+		return fmt.Errorf("emitter: target_resource exceeds %d bytes (got %d)", MaxTargetResourceLen, len(ev.Target.Resource))
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -451,6 +451,15 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		e.dropCount.Add(pendingDrops)
 		return fmt.Errorf("emitter: operator_name requires operator_id")
 	}
+	// Target.System and Target.Resource must both be set or both empty.
+	// A half-populated Target produces ActionTarget{System:""} or
+	// ActionTarget{Resource:""} in the signed receipt — the daemon enforces
+	// the same rule in validateFrame; catching it here surfaces a clear error
+	// at the call site before the write.
+	if (ev.Target.System != "") != (ev.Target.Resource != "") {
+		e.dropCount.Add(pendingDrops)
+		return fmt.Errorf("emitter: Target.System and Target.Resource must both be set or both empty")
+	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
 	for _, f := range [9]struct{ name, val string }{

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -577,6 +577,44 @@ func TestEmit_RejectsHalfPopulatedTarget(t *testing.T) {
 	})
 }
 
+// TestEmit_RejectsOversizeTargetFields mirrors the daemon's per-field length
+// caps client-side: an oversized Target.System or Target.Resource must be
+// caught at Emit rather than silently dropped after a daemon-side rejection.
+func TestEmit_RejectsOversizeTargetFields(t *testing.T) {
+	em, err := emitter.NewDaemon(
+		emitter.WithSocketPath("/nonexistent/events.sock"),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	ctx := context.Background()
+	base := emitter.Event{Channel: "claude-code", Tool: emitter.Tool{Name: "Read"}, Decision: "allowed"}
+
+	t.Run("oversize target_system", func(t *testing.T) {
+		ev := base
+		ev.Target = emitter.Target{
+			System:   strings.Repeat("x", emitter.MaxIdentityFieldLen+1),
+			Resource: "/etc/hosts",
+		}
+		if err := em.Emit(ctx, ev); err == nil {
+			t.Error("Emit returned nil for oversize target_system; want error")
+		}
+	})
+	t.Run("oversize target_resource", func(t *testing.T) {
+		ev := base
+		ev.Target = emitter.Target{
+			System:   "filesystem",
+			Resource: strings.Repeat("x", emitter.MaxTargetResourceLen+1),
+		}
+		if err := em.Emit(ctx, ev); err == nil {
+			t.Error("Emit returned nil for oversize target_resource; want error")
+		}
+	})
+}
+
 // TestEmit_WithSessionIDOverride pins the OQ4 host-id forwarding path:
 // when WithSessionID supplies a non-empty value, every receipt carries
 // that exact id rather than a freshly generated UUID. Mirrors the

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -544,6 +544,39 @@ func TestEmit_ValidatesEvent(t *testing.T) {
 	}
 }
 
+// TestEmit_RejectsHalfPopulatedTarget pins the XOR validation: Target.System
+// and Target.Resource must both be set or both empty. A half-populated Target
+// produces a malformed ActionTarget in the receipt; the emitter catches it
+// before the write so it is a caller error, not a transport failure.
+func TestEmit_RejectsHalfPopulatedTarget(t *testing.T) {
+	em, err := emitter.NewDaemon(
+		emitter.WithSocketPath("/nonexistent/events.sock"),
+		emitter.WithLogger(silentLogger),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer em.Close()
+
+	ctx := context.Background()
+	base := emitter.Event{Channel: "claude-code", Tool: emitter.Tool{Name: "Read"}, Decision: "allowed"}
+
+	t.Run("system without resource", func(t *testing.T) {
+		ev := base
+		ev.Target = emitter.Target{System: "filesystem"}
+		if err := em.Emit(ctx, ev); err == nil {
+			t.Error("Emit returned nil for system-only target; want error")
+		}
+	})
+	t.Run("resource without system", func(t *testing.T) {
+		ev := base
+		ev.Target = emitter.Target{Resource: "/etc/hosts"}
+		if err := em.Emit(ctx, ev); err == nil {
+			t.Error("Emit returned nil for resource-only target; want error")
+		}
+	})
+}
+
 // TestEmit_WithSessionIDOverride pins the OQ4 host-id forwarding path:
 // when WithSessionID supplies a non-empty value, every receipt carries
 // that exact id rather than a freshly generated UUID. Mirrors the

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"strings"
 	"time"
 
 	"github.com/agent-receipts/ar/daemon"

--- a/sdk/go/emitter/parity_test.go
+++ b/sdk/go/emitter/parity_test.go
@@ -33,6 +33,8 @@ func TestFrameParityKnownFields(t *testing.T) {
 		"operator_name",
 		"output",
 		"session_id",
+		"target_resource",
+		"target_system",
 		"tool",
 		"ts_emit",
 		"usage",


### PR DESCRIPTION
## What

Adds `action.target.{system,resource}` population to the Claude Code hook pipeline so the dashboard's session attribution view (ADR-0029 §4) has file identity data to build state-dependency edges and blast-radius annotations.

Three-layer change:
- `sdk/go/emitter`: new `Target` struct + field on `Event`; `target_system`/`target_resource` wire fields on the `frame` struct
- `daemon/internal/pipeline`: `TargetSystem`/`TargetResource` on `EmitterFrame`; `buildAndSign` maps them to `action.target` on the signed receipt
- `hook/cmd/agent-receipts-hook`: `extractFileTarget` populates `Target` from `file_path` in tool input JSON

## Why

`action.target.resource` was the only missing piece for the dashboard attribution query. Without it, `identity_receipts` is always 0 and state-dependency edges are empty for all real sessions.

## Extraction heuristic

Rather than a named-tool allowlist (fragile, silent on schema drift), the hook uses an opportunistic approach:

- **MCP tools** (`mcp__` prefix): always skipped — dynamic schema
- **Known non-filesystem tools** (`Bash`, `Agent`, `WebFetch`, `WebSearch`): skipped
- **Everything else**: `file_path` extraction attempted automatically — new filesystem tools are captured without an explicit listing
- **Known-important set** (`Read`, `Write`, `Edit`, `MultiEdit`): if `file_path` is absent, a warning is written to stderr so Claude Code payload schema drift is visible without failing the hook

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [ ] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [ ] AGENTS.md updated (if project structure changed)
- [ ] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)

No crypto changes. The new fields are parsed from emitter-supplied input (already untrusted) and flow into `action.target`, which is signature-protected by the existing receipt signing path. No new trust boundaries introduced.