### PR TITLE
docs: add ADR-0030 CLI command taxonomy

### DIFF
--- a/docs/adr/0030-cli-command-taxonomy.md
+++ b/docs/adr/0030-cli-command-taxonomy.md
@@ -1,0 +1,82 @@
+# ADR-0030: CLI Command Taxonomy
+
+## Status
+
+Accepted (2026-06-12).
+
+## Context
+
+The implementation layer is being rebranded `agent-receipts` → `obsigna`, and the
+separate binaries (receipt CLI, daemon, collector, mcp-proxy) are consolidating under a
+single `obsigna` entrypoint. The command surface becomes a stability contract the moment
+it ships — the same class of commitment as the `/context/v1` spec URLs, which are
+cryptographically load-bearing in issued receipts.
+
+The existing surface is flat: `agent-receipts verify`, `agent-receipts show`. That string
+appears in SDK docs, quick-starts, and user CI. Any taxonomy we pick has to (a) scale to
+the five noun-groups we actually have, and (b) make the rename a name-only swap on the hot
+path rather than a restructuring that breaks every pipeline.
+
+## Decision
+
+**Canonical form is grouped noun-verb: `obsigna <noun> <verb>`.**
+
+Noun groups and leaves:
+
+```
+obsigna receipt verify <file|->     # alias: obsigna verify
+obsigna receipt show <id>           # alias: obsigna show
+obsigna receipt list
+
+obsigna daemon run                  # foreground primitive
+obsigna daemon status
+
+obsigna collector run
+obsigna collector status
+
+obsigna keys generate
+obsigna keys pubkey
+obsigna keys rotate                 # ADR-0015 surface
+
+obsigna mcp run                     # the mcp-proxy
+```
+
+**Flat aliases are a closed two-member set: `{verify, show}`**, mapping to
+`obsigna receipt verify` / `obsigna receipt show`.
+
+**Invariant (the bound against alias sprawl):** a flat alias may exist *only* if it
+corresponds to a pre-existing `agent-receipts` verb. The migration is the sole
+justification for a flat alias, so the set is closed the day we ship and cannot grow. New
+functionality only ever receives a grouped command — never a flat one.
+
+**Leaf defaults:**
+- `daemon run` (and `collector run`) are foreground primitives. Lifecycle —
+  start/stop/daemonize, and execution under the dedicated non-agent OS user where the
+  trust boundary lives — is owned by the service manager (`brew services`, systemd), not
+  reimplemented in the binary.
+- `mcp`, not `proxy`, as the noun — it names what is proxied; "proxy" is generic.
+
+Aliases are shown in `--help`, documented as "shortcut for `obsigna receipt verify`", so
+the canonical form stays unambiguous without hurting discoverability.
+
+## Consequences
+
+- The `agent-receipts` deprecation shim is a verbatim passthrough
+  (`agent-receipts "$@"` → `obsigna "$@"`) for the two flat verbs. Flat→flat is preserved
+  for exactly the verbs that live in everyone's scripts; the hot path migrates by name
+  only.
+- Unblocks the one-shot formula move+rename: a single `tap_migrations.json` entry can
+  move and rename together, with no incoherent intermediate (a tap named `obsigna`
+  shipping a binary named `agent-receipts`).
+- The top-level noun groups, the leaf verbs, and the two flat aliases are now a frozen
+  compatibility surface. Changing any of them later is itself a user-visible migration.
+- This decision is agnostic to binary packaging — `obsigna daemon run` may be compiled-in
+  or transparently exec `obsigna-daemon`; the verb contract and the formula consumer never
+  see the difference.
+
+## Non-goals
+
+- Monolith vs. dispatcher packaging — deferred to a later ADR.
+- Per-command flag/option design.
+- Service-manager integration specifics beyond establishing `run` as the foreground
+  primitive.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0027](0027-opensandbox-execd-channel.md) | opensandbox_execd Emission Channel | Proposed |
 | [ADR-0028](0028-reversibility-taxonomy-and-cascade-model.md) | Reversibility Taxonomy and Cascade Model | Accepted |
 | [ADR-0029](0029-attribution-primary-product-model.md) | Attribution-Primary Product Model | Accepted |
+| [ADR-0030](0030-cli-command-taxonomy.md) | CLI Command Taxonomy | Accepted |
 
 ## References
 


### PR DESCRIPTION
## Summary

Adds **ADR-0030: CLI Command Taxonomy**, recording the decision to consolidate the separate `agent-receipts` binaries under a single `obsigna` entrypoint with a grouped noun-verb command surface (`obsigna <noun> <verb>`), plus a closed two-member flat-alias set (`{verify, show}`) to keep the rebrand a name-only swap on the hot path.

## Changes

- `docs/adr/0030-cli-command-taxonomy.md` — the ADR (Context / Decision / Consequences / Non-goals), following the `0000-template.md` house style.
- `docs/adr/README.md` — index row for ADR-0030.

## Notes

- Numbered **0030** (the source draft said 0025, which is already taken by the Emit Failure Contract ADR); header matches the filename prefix per the README convention.
- `keys rotate` cross-references **ADR-0015** (Key Rotation, BYOK Abstraction, and External Anchoring).
- Docs-only change; no code paths touched.