### PR TITLE
chore(release): prep hook v0.17.0-alpha.1 and daemon v0.20.0-alpha.1

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0-alpha.1] - 2026-06-12
+
+### Added
+
+- **`action.target.{system,resource}` on signed receipts** ([#784](https://github.com/agent-receipts/ar/pull/784), ADR-0029) — `validateFrame` enforces XOR consistency (both fields set or both absent), caps `target_system` at 256 bytes and `target_resource` at 4096 bytes (Linux PATH_MAX). `buildAndSign` maps validated frame target fields into `action.target` on the signed receipt. Enables dashboard session attribution to build state-dependency edges and blast-radius annotations.
+
+### Dependencies
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.19.0-alpha.1`.
+
 ## [0.19.0-alpha.1] - 2026-06-11
 
 ### Added

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1 h1:sbpOk/DEOF+S/bnv/RfyqtIMdq+3i/RDndM1VJunl/M=
-github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1 h1:8bf6sLLq+ST5A4wZzgTC2dI9CpbTC02fw3Av+yWgggM=
+github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0-alpha.1] - 2026-06-12
+
+### Added
+
+- **`action.target.resource` population from tool input** ([#784](https://github.com/agent-receipts/ar/pull/784), ADR-0029) — `extractFileTarget` parses `file_path` from Claude Code tool input and forwards `target_system: "filesystem"` + `target_resource: "<path>"` in the emitter frame. Opportunistic heuristic: skip-listed tools (`Bash`, `Agent`, `WebFetch`, `WebSearch`) and MCP-namespaced tools are ignored; all other tools are attempted so new filesystem tools are auto-captured. Known file tools (`Read`, `Write`, `Edit`, `MultiEdit`) emit a stderr warning when `file_path` is absent (schema-drift signal). Whitespace-only paths are treated as absent; malformed JSON is silently skipped.
+
+### Dependencies
+
+- Pin `github.com/agent-receipts/ar/sdk/go` to `v0.19.0-alpha.1` (provides `emitter.Target`, `MaxTargetResourceLen`, and client-side XOR + length validation).
+
 ## [0.16.0-alpha.1] - 2026-06-11
 
 ### Added

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1 h1:sbpOk/DEOF+S/bnv/RfyqtIMdq+3i/RDndM1VJunl/M=
-github.com/agent-receipts/ar/sdk/go v0.18.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1 h1:8bf6sLLq+ST5A4wZzgTC2dI9CpbTC02fw3Av+yWgggM=
+github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Changelog entries and go.mod bumps for the hook and daemon alphas following sdk/go v0.19.0-alpha.1.

## hook v0.17.0-alpha.1

- `action.target.resource` population from Claude Code tool input (PR #784, ADR-0029)

## daemon v0.20.0-alpha.1

- `action.target.{system,resource}` mapping + validateFrame XOR/length checks (PR #784, ADR-0029)

## Dependencies

Both modules pinned to `sdk/go v0.19.0-alpha.1` (tagged, published).

## What comes next

After merge: push `hook/v0.17.0-alpha.1` and `daemon/v0.20.0-alpha.1` tags → CI builds and publishes binaries.