### PR TITLE
feat(daemon): rename receipt CLI agent-receipts → obsigna (ADR-0030)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ __pycache__/
 /collector/collector
 /daemon/bin/
 /daemon/agent-receipts-daemon
+/daemon/obsigna
+/daemon/agent-receipts
 /daemon/bin/

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -28,6 +28,26 @@ builds:
     ldflags:
       - -s -w -X main.version=v{{.Version}}
 
+  # The receipt CLI, renamed agent-receipts -> obsigna (ADR-0030). This is the
+  # primary CLI; the agent-receipts entry below is a thin deprecation shim that
+  # forwards to it.
+  - id: obsigna
+    main: ./cmd/obsigna
+    binary: obsigna
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+  # Deprecation shim: keeps `agent-receipts <cmd>` working by forwarding to
+  # obsigna with a one-line stderr notice. Ships alongside obsigna so existing
+  # scripts/CI keep running through the rename.
   - id: agent-receipts
     main: ./cmd/agent-receipts
     binary: agent-receipts
@@ -45,6 +65,7 @@ builds:
 archives:
   - ids:
       - agent-receipts-daemon
+      - obsigna
       - agent-receipts
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats: [tar.gz]
@@ -94,9 +115,11 @@ brews:
     commit_msg_template: "chore(daemon): bump to v{{ .Version }}"
     install: |
       bin.install "agent-receipts-daemon"
+      bin.install "obsigna"
       bin.install "agent-receipts"
     test: |
       system "#{bin}/agent-receipts-daemon", "--version"
+      system "#{bin}/obsigna", "--help"
       system "#{bin}/agent-receipts", "--help"
     # `brew outdated` and `brew livecheck` use this to detect new releases.
     # The `ar` repo ships multiple taggable components, so we can't use
@@ -181,9 +204,11 @@ brews:
     commit_msg_template: "chore(daemon): bump alpha to v{{ .Version }}"
     install: |
       bin.install "agent-receipts-daemon"
+      bin.install "obsigna"
       bin.install "agent-receipts"
     test: |
       system "#{bin}/agent-receipts-daemon", "--version"
+      system "#{bin}/obsigna", "--help"
       system "#{bin}/agent-receipts", "--help"
     custom_block: |
       conflicts_with "agent-receipts-daemon", because: "both install the same binaries"

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0-alpha.1] - 2026-06-12
+
+### Added
+
+- **`obsigna` CLI** (ADR-0030) — the receipt CLI is renamed `agent-receipts` → `obsigna` with a grouped noun-verb surface: `obsigna receipt {verify,show,list,verify-event}`, `obsigna keys {generate,pubkey,rotate}`, and `obsigna doctor`. Flat aliases `obsigna verify` / `obsigna show` are preserved as a closed set for the verbs that live in existing scripts. `keys generate` and `keys rotate` mirror `agent-receipts-daemon --init` / `--rotate`; `keys pubkey` prints the SPKI public key. A golden surface test freezes the command tree so any drift from ADR-0030 fails CI. The daemon, collector, and mcp-proxy binaries are unchanged (out of scope for this rename).
+
+### Changed
+
+- **`agent-receipts` is now a deprecation shim** — it keeps every historical subcommand working (`verify`, `show`, `list`, `verify-event`, `doctor`) by printing a one-line deprecation notice to **stderr** (never stdout, so piped output stays byte-clean) and forwarding to the equivalent `obsigna` command, exiting with the forwarded status. The Homebrew formula now installs `obsigna` alongside `agent-receipts-daemon` and the shim.
+
 ## [0.20.0-alpha.1] - 2026-06-12
 
 ### Added

--- a/daemon/cmd/agent-receipts-daemon/main.go
+++ b/daemon/cmd/agent-receipts-daemon/main.go
@@ -191,8 +191,8 @@ func resolveConfig(args []string, getenv func(string) string, errOut io.Writer) 
 		DBPath:               daemon.DefaultDBPath(),
 		KeyPath:              daemon.DefaultKeyPath(),
 		ChainID:              time.Now().UTC().Format("2006-01-02"),
-		IssuerID:             "did:agent-receipts-daemon:local",
-		VerificationMethodID: "did:agent-receipts-daemon:local#k1",
+		IssuerID:             daemon.DefaultIssuerID,
+		VerificationMethodID: daemon.DefaultVerificationMethodID,
 		ShutdownDeadline:     200 * time.Millisecond,
 	}
 

--- a/daemon/cmd/agent-receipts/main.go
+++ b/daemon/cmd/agent-receipts/main.go
@@ -1,52 +1,134 @@
-// Command agent-receipts is the daemon's read-side companion CLI. Logic lives
-// in internal/verifycli and internal/listcli so subcommands can be tested
-// without shelling out to the binary.
+// Command agent-receipts is the deprecation shim for the renamed `obsigna` CLI
+// (ADR-0030). It preserves every subcommand the historical agent-receipts CLI
+// exposed — verify, show, list, verify-event, doctor — by translating each into
+// the equivalent obsigna command and exec-forwarding to the obsigna binary, so
+// there is a single source of truth for behaviour. It prints a one-line
+// deprecation notice to STDERR (never stdout, so piped output stays byte-clean)
+// and exits with the forwarded command's status.
+//
+// This file must remain a thin shim: it deliberately does not re-implement the
+// command surface. The entrypoint-guard test in cmd/obsigna asserts that, so
+// `agent-receipts` can never be reintroduced as a primary CLI.
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
-
-	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
-	"github.com/agent-receipts/ar/daemon/internal/listcli"
-	"github.com/agent-receipts/ar/daemon/internal/showcli"
-	"github.com/agent-receipts/ar/daemon/internal/verifycli"
-	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
+	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
-const usage = `Usage: agent-receipts <command> [flags]
+// deprecationShimMarker identifies this entrypoint as the agent-receipts → obsigna
+// deprecation shim. The anti-regression guard test (cmd/obsigna) greps for it to
+// prove cmd/agent-receipts is only ever the shim.
+const deprecationShimMarker = "agent-receipts-deprecation-shim"
 
-Commands:
-  list          List recent receipts from the store.
-  show          Print the full fields of a single receipt by sequence number.
-  verify        Verify a stored chain's signatures and hash links.
-  verify-event  Verify one historical receipt's end-to-end pipeline provenance.
-  doctor        Diagnose pipeline health end-to-end (emitter → socket → daemon → DB → verify).
+// obsignaBinary is the name of the binary the shim forwards to. Releases target
+// darwin and linux only, so no platform-specific extension is needed.
+const obsignaBinary = "obsigna"
 
-Run 'agent-receipts <command> -h' for command-specific flags.
-`
+// legacyMap translates each historical agent-receipts subcommand to its obsigna
+// equivalent. The flat verbs verify/show map 1:1 to the obsigna flat aliases;
+// list/verify-event move under the `receipt` noun; doctor stays top-level.
+var legacyMap = map[string][]string{
+	"verify":       {"verify"},
+	"show":         {"show"},
+	"list":         {"receipt", "list"},
+	"verify-event": {"receipt", "verify-event"},
+	"doctor":       {"doctor"},
+}
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprint(os.Stderr, usage)
-		os.Exit(verifycli.ExitUsageError)
+	args := os.Args[1:]
+	target, ok := translate(args)
+	if !ok {
+		fmt.Fprintf(os.Stderr,
+			"agent-receipts: unknown command %q — agent-receipts is deprecated; run 'obsigna --help' for the current commands\n",
+			args[0])
+		os.Exit(2)
 	}
-	switch os.Args[1] {
-	case "list":
-		os.Exit(listcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
-	case "show":
-		os.Exit(showcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
-	case "verify":
-		os.Exit(verifycli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
-	case "verify-event":
-		os.Exit(verifyeventcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
-	case "doctor":
-		os.Exit(doctorcli.Run(os.Args[2:], os.Stdout, os.Stderr, os.Getenv))
+	printDeprecationNotice(os.Stderr, target)
+	os.Exit(execObsigna(target, os.Stdin, os.Stdout, os.Stderr))
+}
+
+// translate maps the shim's args to the obsigna args to forward. ok is false for
+// an unknown subcommand (so the caller can report it); for no args and for the
+// help flags it returns ok=true with the obsigna form (no args / --help).
+func translate(args []string) (target []string, ok bool) {
+	if len(args) == 0 {
+		// Forward with no args: obsigna prints its usage and exits non-zero,
+		// matching the historical bare-invocation behaviour.
+		return nil, true
+	}
+	switch args[0] {
 	case "-h", "--help", "help":
-		fmt.Fprint(os.Stdout, usage)
-		os.Exit(verifycli.ExitOK)
-	default:
-		fmt.Fprintf(os.Stderr, "agent-receipts: unknown command %q\n\n%s", os.Args[1], usage)
-		os.Exit(verifycli.ExitUsageError)
+		return []string{"--help"}, true
 	}
+	mapped, found := legacyMap[args[0]]
+	if !found {
+		return nil, false
+	}
+	return append(append([]string{}, mapped...), args[1:]...), true
+}
+
+// printDeprecationNotice writes the single-line notice to stderr. It is the only
+// thing the shim ever writes itself; the forwarded obsigna process owns stdout
+// and the rest of stderr.
+func printDeprecationNotice(w io.Writer, target []string) {
+	newForm := obsignaBinary
+	if len(target) > 0 {
+		newForm = obsignaBinary + " " + strings.Join(target, " ")
+	}
+	fmt.Fprintf(w, "agent-receipts is deprecated; use '%s'. Forwarding…\n", newForm)
+}
+
+// execObsigna runs the obsigna binary with target and forwards stdio, returning
+// its exit code.
+func execObsigna(target []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	bin, err := resolveObsigna()
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts: %v\n", err)
+		return 1
+	}
+	cmd := exec.Command(bin, target...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		fmt.Fprintf(stderr, "agent-receipts: failed to run obsigna: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// resolveObsigna locates the obsigna binary. It prefers a binary installed
+// alongside this shim (the Homebrew/goreleaser layout installs both into the
+// same bin dir), falling back to $PATH. Resolving beside the shim avoids picking
+// up an unrelated obsigna earlier on PATH.
+func resolveObsigna() (string, error) {
+	if self, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(self), obsignaBinary)
+		if isExecutableFile(candidate) {
+			return candidate, nil
+		}
+	}
+	if p, err := exec.LookPath(obsignaBinary); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf("cannot locate the '%s' binary (expected next to this binary or on $PATH)", obsignaBinary)
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
 }

--- a/daemon/cmd/agent-receipts/shim_test.go
+++ b/daemon/cmd/agent-receipts/shim_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTranslate(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		want   []string
+		wantOK bool
+	}{
+		{"verify maps 1:1", []string{"verify", "--db", "x"}, []string{"verify", "--db", "x"}, true},
+		{"show maps 1:1", []string{"show", "--seq", "3"}, []string{"show", "--seq", "3"}, true},
+		{"list moves under receipt", []string{"list", "--json"}, []string{"receipt", "list", "--json"}, true},
+		{"verify-event moves under receipt", []string{"verify-event", "--seq", "2"}, []string{"receipt", "verify-event", "--seq", "2"}, true},
+		{"doctor stays top-level", []string{"doctor"}, []string{"doctor"}, true},
+		{"help flag", []string{"--help"}, []string{"--help"}, true},
+		{"-h flag", []string{"-h"}, []string{"--help"}, true},
+		{"help verb", []string{"help"}, []string{"--help"}, true},
+		{"no args forwards bare", nil, nil, true},
+		{"unknown is rejected", []string{"frobnicate"}, nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := translate(c.args)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if ok && !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("target = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// legacyCommands is the closed set the shim must keep working. Keep it in sync
+// with the historical agent-receipts surface; the golden surface test owns the
+// obsigna side.
+func TestEveryLegacyCommandIsMapped(t *testing.T) {
+	for _, cmd := range []string{"verify", "show", "list", "verify-event", "doctor"} {
+		if _, ok := legacyMap[cmd]; !ok {
+			t.Errorf("legacy command %q is no longer mapped by the shim", cmd)
+		}
+	}
+}
+
+// TestForwardingIntegration builds the shim and obsigna into one directory (the
+// installed layout) and checks the shim forwards correctly: the deprecation
+// notice appears once on STDERR and never on STDOUT, stdout is byte-identical to
+// running obsigna directly, and the exit code is propagated.
+func TestForwardingIntegration(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "agent-receipts")
+	obsigna := filepath.Join(dir, "obsigna")
+	goBuild(t, shim, "github.com/agent-receipts/ar/daemon/cmd/agent-receipts")
+	goBuild(t, obsigna, "github.com/agent-receipts/ar/daemon/cmd/obsigna")
+
+	absentDB := filepath.Join(dir, "absent.db")
+
+	// `agent-receipts list` -> `obsigna receipt list`. Pointed at a missing DB
+	// both error to stderr with exit 2 and empty stdout.
+	shimOut, shimErr, shimCode := runBin(t, shim, "list", "--db", absentDB)
+	obsOut, obsErr, obsCode := runBin(t, obsigna, "receipt", "list", "--db", absentDB)
+
+	if shimCode != obsCode {
+		t.Errorf("exit code: shim=%d obsigna=%d", shimCode, obsCode)
+	}
+	if shimOut != obsOut {
+		t.Errorf("stdout differs:\n shim=%q\n obsigna=%q", shimOut, obsOut)
+	}
+	const notice = "agent-receipts is deprecated"
+	if !strings.Contains(shimErr, notice) {
+		t.Errorf("deprecation notice missing from stderr: %q", shimErr)
+	}
+	if strings.Contains(shimOut, notice) {
+		t.Errorf("deprecation notice leaked into stdout: %q", shimOut)
+	}
+	if strings.Count(shimErr, notice) != 1 {
+		t.Errorf("deprecation notice printed %d times, want exactly 1", strings.Count(shimErr, notice))
+	}
+	// The shim's stderr is the notice followed by obsigna's own stderr.
+	if !strings.HasSuffix(shimErr, obsErr) {
+		t.Errorf("shim stderr should end with obsigna's stderr.\n shim=%q\n obsigna=%q", shimErr, obsErr)
+	}
+}
+
+func goBuild(t *testing.T, out, pkg string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build %s: %v\n%s", pkg, err, combined)
+	}
+}
+
+func runBin(t *testing.T, bin string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	code = 0
+	if err != nil {
+		var ee *exec.ExitError
+		if !asExit(err, &ee) {
+			t.Fatalf("run %s %v: %v", bin, args, err)
+		}
+		code = ee.ExitCode()
+	}
+	return out.String(), errOut.String(), code
+}
+
+func asExit(err error, target **exec.ExitError) bool {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*target = ee
+		return true
+	}
+	return false
+}

--- a/daemon/cmd/obsigna/dispatch_test.go
+++ b/daemon/cmd/obsigna/dispatch_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// noEnv is an injected environment that returns nothing, so dispatch tests don't
+// pick up the host's AGENTRECEIPTS_* configuration.
+func noEnv(string) string { return "" }
+
+// runCapture invokes the dispatcher with captured stdout/stderr.
+func runCapture(args []string) (code int, stdout, stderr string) {
+	var out, errOut bytes.Buffer
+	code = run(args, &out, &errOut, noEnv)
+	return code, out.String(), errOut.String()
+}
+
+// TestAliasMatchesGrouped is the acceptance check that `obsigna verify …` and
+// `obsigna receipt verify …` are the same command: pointed at the same
+// (nonexistent) store they must produce byte-identical output and the same exit
+// code. Same for show. This proves the alias is a true shortcut, not a
+// re-implementation that could drift.
+func TestAliasMatchesGrouped(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "absent.db")
+	cases := []struct {
+		alias   []string
+		grouped []string
+	}{
+		{[]string{"verify", "--db", db}, []string{"receipt", "verify", "--db", db}},
+		{[]string{"show", "--db", db, "--seq", "1"}, []string{"receipt", "show", "--db", db, "--seq", "1"}},
+	}
+	for _, c := range cases {
+		ac, ao, ae := runCapture(c.alias)
+		gc, go_, ge := runCapture(c.grouped)
+		if ac != gc {
+			t.Errorf("%v exit=%d, %v exit=%d; want equal", c.alias, ac, c.grouped, gc)
+		}
+		if ao != go_ {
+			t.Errorf("%v stdout=%q, %v stdout=%q; want equal", c.alias, ao, c.grouped, go_)
+		}
+		if ae != ge {
+			t.Errorf("%v stderr=%q, %v stderr=%q; want equal", c.alias, ae, c.grouped, ge)
+		}
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	code, _, stderr := runCapture([]string{"frobnicate"})
+	if code != exitUsageError {
+		t.Errorf("unknown command exit = %d, want %d", code, exitUsageError)
+	}
+	if !strings.Contains(stderr, "unknown command") {
+		t.Errorf("stderr = %q, want it to report the unknown command", stderr)
+	}
+}
+
+func TestUnknownSubcommand(t *testing.T) {
+	code, _, stderr := runCapture([]string{"receipt", "frobnicate"})
+	if code != exitUsageError {
+		t.Errorf("unknown subcommand exit = %d, want %d", code, exitUsageError)
+	}
+	if !strings.Contains(stderr, "unknown subcommand") {
+		t.Errorf("stderr = %q, want it to report the unknown subcommand", stderr)
+	}
+}
+
+func TestBareNounPrintsGroupHelp(t *testing.T) {
+	code, _, stderr := runCapture([]string{"keys"})
+	if code != exitUsageError {
+		t.Errorf("bare noun exit = %d, want %d", code, exitUsageError)
+	}
+	if !strings.Contains(stderr, "Usage: obsigna keys <subcommand>") {
+		t.Errorf("stderr = %q, want group usage", stderr)
+	}
+}
+
+func TestTopLevelHelp(t *testing.T) {
+	code, stdout, _ := runCapture([]string{"--help"})
+	if code != exitOK {
+		t.Errorf("--help exit = %d, want %d", code, exitOK)
+	}
+	for _, want := range []string{"obsigna receipt verify", "obsigna keys rotate", "obsigna doctor", "shortcut for 'obsigna receipt verify'"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("--help missing %q\n%s", want, stdout)
+		}
+	}
+}

--- a/daemon/cmd/obsigna/entrypoint_guard_test.go
+++ b/daemon/cmd/obsigna/entrypoint_guard_test.go
@@ -14,38 +14,50 @@ type goreleaserBuild struct {
 
 // parseGoreleaserBuilds extracts (id, main, binary) for each build by scanning
 // the YAML lines. A tiny hand parser avoids pulling a YAML dependency into the
-// daemon module just for a guard test; the goreleaser build entries use a fixed
-// two-space/four-space indentation this relies on.
+// daemon module just for a guard test. A new build begins at each `  - ` list
+// marker inside the `builds:` section; id/main/binary are captured in ANY order
+// within a build (the first may sit on the dash line), so reformatting that
+// reorders fields cannot silently misassign them.
 func parseGoreleaserBuilds(t *testing.T, yaml string) []goreleaserBuild {
 	t.Helper()
-	idRe := regexp.MustCompile(`^\s*- id:\s*(\S+)`)
-	mainRe := regexp.MustCompile(`^\s+main:\s*(\S+)`)
-	binRe := regexp.MustCompile(`^\s+binary:\s*(\S+)`)
+	topKey := regexp.MustCompile(`^[a-z]`)
+	// "  - key: value" — a build list item with its first key on the dash line.
+	itemRe := regexp.MustCompile(`^  - (\w[\w-]*):\s*(\S+)`)
+	// "    key: value" — any subsequent key inside the current build.
+	keyRe := regexp.MustCompile(`^\s+(\w[\w-]*):\s*(\S+)`)
+
+	set := func(b *goreleaserBuild, key, val string) {
+		switch key {
+		case "id":
+			b.id = val
+		case "main":
+			b.main = val
+		case "binary":
+			b.binary = val
+		}
+	}
 
 	inBuilds := false
 	var builds []goreleaserBuild
 	for _, line := range strings.Split(yaml, "\n") {
-		// The builds: section ends at the next top-level (column 0) key.
-		if regexp.MustCompile(`^[a-z]`).MatchString(line) {
-			inBuilds = line == "builds:"
+		// Any column-0 key ends the builds: section.
+		if topKey.MatchString(line) {
+			inBuilds = strings.HasPrefix(line, "builds:")
 			continue
 		}
 		if !inBuilds {
 			continue
 		}
-		if m := idRe.FindStringSubmatch(line); m != nil {
-			builds = append(builds, goreleaserBuild{id: m[1]})
+		if m := itemRe.FindStringSubmatch(line); m != nil {
+			builds = append(builds, goreleaserBuild{})
+			set(&builds[len(builds)-1], m[1], m[2])
 			continue
 		}
 		if len(builds) == 0 {
 			continue
 		}
-		cur := &builds[len(builds)-1]
-		if m := mainRe.FindStringSubmatch(line); m != nil {
-			cur.main = m[1]
-		}
-		if m := binRe.FindStringSubmatch(line); m != nil {
-			cur.binary = m[1]
+		if m := keyRe.FindStringSubmatch(line); m != nil {
+			set(&builds[len(builds)-1], m[1], m[2])
 		}
 	}
 	return builds

--- a/daemon/cmd/obsigna/entrypoint_guard_test.go
+++ b/daemon/cmd/obsigna/entrypoint_guard_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// goreleaserBuild is one entry under the goreleaser `builds:` list.
+type goreleaserBuild struct {
+	id, main, binary string
+}
+
+// parseGoreleaserBuilds extracts (id, main, binary) for each build by scanning
+// the YAML lines. A tiny hand parser avoids pulling a YAML dependency into the
+// daemon module just for a guard test; the goreleaser build entries use a fixed
+// two-space/four-space indentation this relies on.
+func parseGoreleaserBuilds(t *testing.T, yaml string) []goreleaserBuild {
+	t.Helper()
+	idRe := regexp.MustCompile(`^\s*- id:\s*(\S+)`)
+	mainRe := regexp.MustCompile(`^\s+main:\s*(\S+)`)
+	binRe := regexp.MustCompile(`^\s+binary:\s*(\S+)`)
+
+	inBuilds := false
+	var builds []goreleaserBuild
+	for _, line := range strings.Split(yaml, "\n") {
+		// The builds: section ends at the next top-level (column 0) key.
+		if regexp.MustCompile(`^[a-z]`).MatchString(line) {
+			inBuilds = line == "builds:"
+			continue
+		}
+		if !inBuilds {
+			continue
+		}
+		if m := idRe.FindStringSubmatch(line); m != nil {
+			builds = append(builds, goreleaserBuild{id: m[1]})
+			continue
+		}
+		if len(builds) == 0 {
+			continue
+		}
+		cur := &builds[len(builds)-1]
+		if m := mainRe.FindStringSubmatch(line); m != nil {
+			cur.main = m[1]
+		}
+		if m := binRe.FindStringSubmatch(line); m != nil {
+			cur.binary = m[1]
+		}
+	}
+	return builds
+}
+
+// TestObsignaIsPrimaryEntrypoint is the anti-regression gate: the primary receipt
+// CLI must build from ./cmd/obsigna as the `obsigna` binary, and `agent-receipts`
+// may appear ONLY as the deprecation shim. If someone reintroduces agent-receipts
+// as a primary entrypoint (e.g. points the obsigna source at an agent-receipts
+// binary, or gives the shim the real command surface) this fails.
+func TestObsignaIsPrimaryEntrypoint(t *testing.T) {
+	yaml := readFile(t, "../../.goreleaser.yaml")
+	builds := parseGoreleaserBuilds(t, yaml)
+
+	var primary *goreleaserBuild
+	for i := range builds {
+		if builds[i].main == "./cmd/obsigna" {
+			primary = &builds[i]
+		}
+		// No build may ship the obsigna source under the agent-receipts name.
+		if builds[i].main == "./cmd/obsigna" && builds[i].binary == "agent-receipts" {
+			t.Errorf("build %q ships ./cmd/obsigna as binary agent-receipts; the primary CLI must be 'obsigna'", builds[i].id)
+		}
+		// Anything named agent-receipts must be the shim package.
+		if builds[i].binary == "agent-receipts" && builds[i].main != "./cmd/agent-receipts" {
+			t.Errorf("build %q ships binary agent-receipts from %q; only ./cmd/agent-receipts (the shim) may", builds[i].id, builds[i].main)
+		}
+	}
+	if primary == nil {
+		t.Fatal("no goreleaser build builds ./cmd/obsigna — the primary CLI is missing")
+	}
+	if primary.binary != "obsigna" {
+		t.Errorf("primary CLI binary = %q, want \"obsigna\"", primary.binary)
+	}
+}
+
+// TestShimDoesNotReimplementSurface keeps cmd/agent-receipts a thin forwarder: it
+// must carry the shim marker and must NOT import the subcommand packages (which
+// would mean it had grown its own command surface again).
+func TestShimDoesNotReimplementSurface(t *testing.T) {
+	src := readFile(t, "../agent-receipts/main.go")
+	if !strings.Contains(src, "agent-receipts-deprecation-shim") {
+		t.Error("cmd/agent-receipts is missing the deprecation-shim marker; it must remain a forwarding shim")
+	}
+	for _, pkg := range []string{
+		"internal/verifycli", "internal/showcli", "internal/listcli",
+		"internal/verifyeventcli", "internal/doctorcli", "internal/keyscli",
+	} {
+		if strings.Contains(src, pkg) {
+			t.Errorf("cmd/agent-receipts imports %q — the shim must forward to obsigna, not re-implement the surface", pkg)
+		}
+	}
+}
+
+// TestObsignaRegistersSurface is the converse: obsigna is the real CLI, so it must
+// wire the subcommand packages.
+func TestObsignaRegistersSurface(t *testing.T) {
+	src := readFile(t, "registry.go")
+	for _, pkg := range []string{"internal/verifycli", "internal/keyscli", "internal/doctorcli"} {
+		if !strings.Contains(src, pkg) {
+			t.Errorf("cmd/obsigna registry does not wire %q; obsigna must be the primary CLI", pkg)
+		}
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/daemon/cmd/obsigna/main.go
+++ b/daemon/cmd/obsigna/main.go
@@ -1,0 +1,156 @@
+// Command obsigna is the Agent Receipts read-side CLI. It is the renamed
+// successor to `agent-receipts` (ADR-0030): the canonical surface is grouped
+// noun-verb (`obsigna receipt verify`, `obsigna keys rotate`), with a closed set
+// of flat aliases {verify, show} preserved for the verbs that live in existing
+// scripts.
+//
+// Subcommand logic lives in internal/{verifycli,showcli,listcli,verifyeventcli,
+// doctorcli,keyscli} so each verb is testable without shelling out to the
+// binary; this file is only the dispatcher and the help surface, both driven by
+// the declarative tree in registry.go.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+const (
+	exitOK         = 0
+	exitUsageError = 2
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, os.Getenv))
+}
+
+// run dispatches a single invocation. It is split from main so tests can drive
+// it with captured I/O and an injected environment.
+func run(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	t := commandTree()
+
+	if len(args) == 0 {
+		fmt.Fprint(stderr, t.usage())
+		return exitUsageError
+	}
+
+	cmd, rest := args[0], args[1:]
+	switch cmd {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, t.usage())
+		return exitOK
+	}
+
+	if g, ok := t.groups[cmd]; ok {
+		return t.dispatchGroup(cmd, g, rest, stdout, stderr, getenv)
+	}
+	if lf, ok := t.topLeaves[cmd]; ok {
+		return lf.run(rest, stdout, stderr, getenv)
+	}
+	if a, ok := t.aliases[cmd]; ok {
+		return t.groups[a.group].leaves[a.verb].run(rest, stdout, stderr, getenv)
+	}
+
+	fmt.Fprintf(stderr, "obsigna: unknown command %q\n\n%s", cmd, t.usage())
+	return exitUsageError
+}
+
+// dispatchGroup routes `obsigna <noun> <verb> [flags]`. A bare noun or `<noun>
+// -h` prints the group's help; an unknown verb is a usage error.
+func (t tree) dispatchGroup(name string, g group, args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, t.groupUsage(name, g))
+		return exitUsageError
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, t.groupUsage(name, g))
+		return exitOK
+	}
+	verb := args[0]
+	lf, ok := g.leaves[verb]
+	if !ok {
+		fmt.Fprintf(stderr, "obsigna %s: unknown subcommand %q\n\n%s", name, verb, t.groupUsage(name, g))
+		return exitUsageError
+	}
+	return lf.run(args[1:], stdout, stderr, getenv)
+}
+
+// usage renders the top-level help: every group's verbs, the top-level
+// diagnostics, and the flat aliases — all read from the tree so help and
+// dispatch never drift.
+func (t tree) usage() string {
+	w := newUsageWriter()
+	fmt.Fprintln(w.buf, "obsigna — cryptographically signed audit trails for AI agent actions")
+	fmt.Fprintln(w.buf)
+	fmt.Fprintln(w.buf, "Usage:")
+	fmt.Fprintln(w.buf, "  obsigna <command> [flags]")
+
+	for _, gname := range t.groupOrder {
+		g := t.groups[gname]
+		fmt.Fprintf(w.buf, "\n%s:\n", g.heading)
+		w.start()
+		for _, v := range g.order {
+			fmt.Fprintf(w.tab, "  obsigna %s %s\t%s\n", gname, v, g.leaves[v].summary)
+		}
+		w.flush()
+	}
+
+	fmt.Fprintf(w.buf, "\nDiagnostics:\n")
+	w.start()
+	for _, name := range t.topOrder {
+		fmt.Fprintf(w.tab, "  obsigna %s\t%s\n", name, t.topLeaves[name].summary)
+	}
+	w.flush()
+
+	fmt.Fprintf(w.buf, "\nAliases:\n")
+	w.start()
+	for _, name := range t.aliasOrder {
+		a := t.aliases[name]
+		fmt.Fprintf(w.tab, "  obsigna %s\tshortcut for 'obsigna %s %s'\n", name, a.group, a.verb)
+	}
+	w.flush()
+
+	fmt.Fprintln(w.buf, "\nRun 'obsigna <command> -h' for command-specific flags.")
+	return w.buf.String()
+}
+
+// usageWriter accumulates help text into a single buffer while letting each
+// aligned section use its own tabwriter (column widths are per-section, so verbs
+// in `receipt` don't pad against the longer `verify-event` summaries elsewhere).
+type usageWriter struct {
+	buf *strings.Builder
+	tab *tabwriter.Writer
+}
+
+func newUsageWriter() *usageWriter {
+	return &usageWriter{buf: &strings.Builder{}}
+}
+
+// start opens a fresh tab-aligned section writing into the shared buffer.
+func (u *usageWriter) start() {
+	u.tab = tabwriter.NewWriter(u.buf, 0, 0, 2, ' ', 0)
+}
+
+// flush writes the current section's aligned rows into the buffer.
+func (u *usageWriter) flush() {
+	_ = u.tab.Flush()
+	u.tab = nil
+}
+
+// groupUsage renders the help for a single noun group, e.g. `obsigna receipt -h`.
+func (t tree) groupUsage(name string, g group) string {
+	w := newUsageWriter()
+	fmt.Fprintf(w.buf, "Usage: obsigna %s <subcommand> [flags]\n\n", name)
+	fmt.Fprintf(w.buf, "Subcommands:\n")
+	w.start()
+	for _, v := range g.order {
+		fmt.Fprintf(w.tab, "  %s\t%s\n", v, g.leaves[v].summary)
+	}
+	w.flush()
+	fmt.Fprintf(w.buf, "\nRun 'obsigna %s <subcommand> -h' for subcommand-specific flags.\n", name)
+	return w.buf.String()
+}

--- a/daemon/cmd/obsigna/registry.go
+++ b/daemon/cmd/obsigna/registry.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"io"
+
+	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
+	"github.com/agent-receipts/ar/daemon/internal/keyscli"
+	"github.com/agent-receipts/ar/daemon/internal/listcli"
+	"github.com/agent-receipts/ar/daemon/internal/showcli"
+	"github.com/agent-receipts/ar/daemon/internal/verifycli"
+	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
+)
+
+// runFunc is the shape every subcommand implementation shares (verifycli.Run,
+// keyscli.RunRotate, …): parse args, write to stdout/stderr, return an exit
+// code. envLookup is injected so subcommands stay unit-testable.
+type runFunc func(args []string, stdout, stderr io.Writer, envLookup func(string) string) int
+
+// leaf is a single executable verb.
+type leaf struct {
+	summary string
+	run     runFunc
+}
+
+// group is a noun with a set of verbs under it (e.g. `receipt`, `keys`). order
+// fixes the help/listing order; leaves holds the verbs.
+type group struct {
+	heading string // section title in top-level help
+	order   []string
+	leaves  map[string]leaf
+}
+
+// aliasTarget is the grouped command a flat alias forwards to.
+type aliasTarget struct {
+	group string
+	verb  string
+}
+
+// commandTree is the single source of truth for the obsigna command surface.
+// Both the dispatcher and the golden surface test read it, so any drift from the
+// ADR-0030 contract (the receipt + keys subtrees, the two carried-over
+// diagnostics, and the closed alias set) fails CI rather than shipping silently.
+//
+// ADR-0030 freezes the canonical grouped form; `verify-event` and `doctor` are
+// carried over from the legacy `agent-receipts` CLI so the deprecation shim can
+// preserve every current subcommand. Reserved nouns (daemon, collector, mcp) are
+// intentionally absent — they are out of scope until the consolidation ADR.
+func commandTree() tree {
+	return tree{
+		groupOrder: []string{"receipt", "keys"},
+		groups: map[string]group{
+			"receipt": {
+				heading: "Receipt commands",
+				order:   []string{"verify", "show", "list", "verify-event"},
+				leaves: map[string]leaf{
+					"verify":       {"Verify a stored chain's signatures and hash links.", verifycli.Run},
+					"show":         {"Print the full fields of a single receipt by sequence number.", showcli.Run},
+					"list":         {"List recent receipts from the store.", listcli.Run},
+					"verify-event": {"Verify one historical receipt's end-to-end pipeline provenance.", verifyeventcli.Run},
+				},
+			},
+			"keys": {
+				heading: "Key commands",
+				order:   []string{"generate", "pubkey", "rotate"},
+				leaves: map[string]leaf{
+					"generate": {"Generate a new Ed25519 signing key pair.", keyscli.RunGenerate},
+					"pubkey":   {"Print the SPKI public key for the signing key.", keyscli.RunPubkey},
+					"rotate":   {"Rotate the signing key (ADR-0015).", keyscli.RunRotate},
+				},
+			},
+		},
+		topOrder: []string{"doctor"},
+		topLeaves: map[string]leaf{
+			"doctor": {"Diagnose pipeline health end-to-end (emitter → socket → daemon → DB → verify).", doctorcli.Run},
+		},
+		// The flat aliases are a closed two-member set {verify, show} — the only
+		// migration shortcuts ADR-0030 permits. New functionality never gets a
+		// flat alias; the golden test enforces the membership.
+		aliasOrder: []string{"verify", "show"},
+		aliases: map[string]aliasTarget{
+			"verify": {"receipt", "verify"},
+			"show":   {"receipt", "show"},
+		},
+	}
+}
+
+// tree is the resolved command surface.
+type tree struct {
+	groupOrder []string
+	groups     map[string]group
+	topOrder   []string
+	topLeaves  map[string]leaf
+	aliasOrder []string
+	aliases    map[string]aliasTarget
+}

--- a/daemon/cmd/obsigna/surface_test.go
+++ b/daemon/cmd/obsigna/surface_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestGoldenSurface pins the obsigna command surface to the frozen ADR-0030
+// contract (the receipt + keys subtrees, the two carried-over diagnostics, and
+// the closed flat-alias set). Any added, removed, or renamed noun/verb/alias
+// changes this snapshot and fails CI — the frozen surface is a stability
+// commitment of the same class as the /context/v1 spec URLs, so a drift must be
+// a deliberate, reviewed migration, never an accident.
+//
+// If you are intentionally changing the surface: update ADR-0030 and the
+// expectations below in the same change, and confirm the flat-alias invariant
+// still holds (a flat alias may exist only for a verb that the legacy
+// agent-receipts CLI already exposed).
+func TestGoldenSurface(t *testing.T) {
+	tr := commandTree()
+
+	wantGroups := map[string][]string{
+		"receipt": {"verify", "show", "list", "verify-event"},
+		"keys":    {"generate", "pubkey", "rotate"},
+	}
+	wantTopLeaves := []string{"doctor"}
+	wantAliases := map[string]aliasTarget{
+		"verify": {"receipt", "verify"},
+		"show":   {"receipt", "show"},
+	}
+
+	// Groups: exact membership, and each group's verb set.
+	if got := keys(tr.groups); !equalSet(got, mapKeys(wantGroups)) {
+		t.Errorf("group set = %v, want %v", got, mapKeys(wantGroups))
+	}
+	if !equalSet(tr.groupOrder, mapKeys(wantGroups)) {
+		t.Errorf("groupOrder = %v, want a permutation of %v", tr.groupOrder, mapKeys(wantGroups))
+	}
+	for name, wantVerbs := range wantGroups {
+		g, ok := tr.groups[name]
+		if !ok {
+			t.Errorf("missing group %q", name)
+			continue
+		}
+		if got := keys(g.leaves); !equalSet(got, wantVerbs) {
+			t.Errorf("group %q verbs = %v, want %v", name, got, wantVerbs)
+		}
+		// order must list exactly the leaves, so help never omits or invents a verb.
+		if !equalSet(g.order, keys(g.leaves)) {
+			t.Errorf("group %q order = %v, want a permutation of its leaves %v", name, g.order, keys(g.leaves))
+		}
+		for _, v := range g.order {
+			if g.leaves[v].run == nil {
+				t.Errorf("group %q verb %q has nil run func", name, v)
+			}
+		}
+	}
+
+	// Top-level leaves (carried-over diagnostics).
+	if got := keys(tr.topLeaves); !equalSet(got, wantTopLeaves) {
+		t.Errorf("topLeaves = %v, want %v", got, wantTopLeaves)
+	}
+	if !equalSet(tr.topOrder, wantTopLeaves) {
+		t.Errorf("topOrder = %v, want %v", tr.topOrder, wantTopLeaves)
+	}
+
+	// Aliases: exact membership and targets.
+	if got := keys(tr.aliases); !equalSet(got, mapKeys(wantAliases)) {
+		t.Errorf("alias set = %v, want %v", got, mapKeys(wantAliases))
+	}
+	if !equalSet(tr.aliasOrder, mapKeys(wantAliases)) {
+		t.Errorf("aliasOrder = %v, want a permutation of %v", tr.aliasOrder, mapKeys(wantAliases))
+	}
+	for name, want := range wantAliases {
+		got, ok := tr.aliases[name]
+		if !ok {
+			t.Errorf("missing alias %q", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("alias %q -> %+v, want %+v", name, got, want)
+		}
+	}
+}
+
+// TestFlatAliasInvariant enforces ADR-0030's bound against alias sprawl: the flat
+// aliases are the closed set {verify, show}, and each must resolve to a real verb
+// in its group.
+func TestFlatAliasInvariant(t *testing.T) {
+	tr := commandTree()
+	allowed := map[string]bool{"verify": true, "show": true}
+
+	for name, target := range tr.aliases {
+		if !allowed[name] {
+			t.Errorf("flat alias %q is not in the closed set {verify, show}", name)
+		}
+		g, ok := tr.groups[target.group]
+		if !ok {
+			t.Errorf("alias %q targets unknown group %q", name, target.group)
+			continue
+		}
+		if _, ok := g.leaves[target.verb]; !ok {
+			t.Errorf("alias %q targets unknown verb %q in group %q", name, target.verb, target.group)
+		}
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func mapKeys[V any](m map[string]V) []string { return keys(m) }
+
+func equalSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/daemon/cmd/obsigna/surface_test.go
+++ b/daemon/cmd/obsigna/surface_test.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
+	"github.com/agent-receipts/ar/daemon/internal/keyscli"
+	"github.com/agent-receipts/ar/daemon/internal/listcli"
+	"github.com/agent-receipts/ar/daemon/internal/showcli"
+	"github.com/agent-receipts/ar/daemon/internal/verifycli"
+	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
 )
 
 // TestGoldenSurface pins the obsigna command surface to the frozen ADR-0030
@@ -81,6 +89,46 @@ func TestGoldenSurface(t *testing.T) {
 			t.Errorf("alias %q -> %+v, want %+v", name, got, want)
 		}
 	}
+}
+
+// TestLeafWiring asserts each leaf is wired to the CORRECT implementation, not
+// merely to some non-nil function. Without this, a registry mix-up that points
+// two verbs at the same Run (e.g. both `verify` and `show` → showcli.Run) would
+// pass TestGoldenSurface and TestAliasMatchesGrouped while silently running the
+// wrong command — so the "frozen surface" guarantee would cover verb names but
+// not behaviour.
+func TestLeafWiring(t *testing.T) {
+	tr := commandTree()
+
+	wantGroupRun := map[string]map[string]runFunc{
+		"receipt": {
+			"verify":       verifycli.Run,
+			"show":         showcli.Run,
+			"list":         listcli.Run,
+			"verify-event": verifyeventcli.Run,
+		},
+		"keys": {
+			"generate": keyscli.RunGenerate,
+			"pubkey":   keyscli.RunPubkey,
+			"rotate":   keyscli.RunRotate,
+		},
+	}
+	for gname, verbs := range wantGroupRun {
+		for v, want := range verbs {
+			if got := tr.groups[gname].leaves[v].run; !sameFunc(got, want) {
+				t.Errorf("group %q verb %q is wired to the wrong function", gname, v)
+			}
+		}
+	}
+	if !sameFunc(tr.topLeaves["doctor"].run, doctorcli.Run) {
+		t.Error("doctor is wired to the wrong function")
+	}
+}
+
+// sameFunc reports whether two func values point at the same code. Go funcs are
+// not comparable with ==, so compare their code pointers via reflect.
+func sameFunc(a, b runFunc) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }
 
 // TestFlatAliasInvariant enforces ADR-0030's bound against alias sprawl: the flat

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -187,6 +187,18 @@ func DefaultPublicKeyPath(keyPath string) string {
 	return keyPath + ".pub"
 }
 
+// DefaultIssuerID and DefaultVerificationMethodID are the identity defaults a
+// local daemon signs under when no issuer/verification-method is configured.
+// They are exported so any tool that builds a Config for the same local install
+// — the daemon's own config resolution and `obsigna keys rotate` — shares one
+// source of truth: the issuer DID and verification method are embedded in every
+// signed receipt, so two callers defaulting them differently would fork chain
+// identity for the same operator.
+const (
+	DefaultIssuerID             = "did:agent-receipts-daemon:local"
+	DefaultVerificationMethodID = DefaultIssuerID + "#k1"
+)
+
 // DefaultForensicKeyPath returns the default forensic private-key path,
 // co-located with the signing key and receipt store. Empty when the XDG data
 // home cannot be resolved, matching the other Default*Path helpers.

--- a/daemon/internal/keyscli/keyscli.go
+++ b/daemon/internal/keyscli/keyscli.go
@@ -33,17 +33,6 @@ const (
 	ExitUsageError = 2
 )
 
-// These mirror the daemon's own resolveConfig defaults (see
-// cmd/agent-receipts-daemon/main.go). They MUST match so a rotation performed
-// via `obsigna keys rotate` records the same issuer / verification method as one
-// the daemon would write — the issuer DID is part of the signed receipt, so a
-// divergent default here would fork chain identity. The literal daemon name is
-// intentional and not rebranded with the binary.
-const (
-	defaultIssuerID             = "did:agent-receipts-daemon:local"
-	defaultVerificationMethodID = "did:agent-receipts-daemon:local#k1"
-)
-
 // pubkeyVerificationMethod is a placeholder fed to keysource.NewFile so Init's
 // "verification method required" guard passes. `keys pubkey` only derives the
 // public half of the key and never signs, so the value is never embedded in a
@@ -56,11 +45,12 @@ const pubkeyVerificationMethod = "did:obsigna:pubkey"
 // --init`.
 func RunGenerate(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
 	getenv = orOsGetenv(getenv)
-	base, err := baseConfig(getenv)
-	if err != nil {
-		fmt.Fprintf(stderr, "obsigna keys generate: %v\n", err)
-		return ExitUsageError
-	}
+	// The config error is deferred until after flag parsing so `--help` still
+	// works when the config file is malformed or AGENTRECEIPTS_CONFIG names a
+	// missing file — help must not depend on a readable config. On error base is
+	// the zero Config; the flag defaults are then empty, which is harmless
+	// because cfgErr short-circuits before they are used.
+	base, cfgErr := baseConfig(getenv)
 
 	fs := flag.NewFlagSet("keys generate", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -68,6 +58,10 @@ func RunGenerate(args []string, stdout, stderr io.Writer, getenv func(string) st
 	pubPath := fs.String("public-key", base.PublicKeyPath, "Public key output path as PEM, mode 0644 (default: <key>.pub) (env: AGENTRECEIPTS_PUBLIC_KEY)")
 	if code, done := parse(fs, args, stderr, "keys generate"); done {
 		return code
+	}
+	if cfgErr != nil {
+		fmt.Fprintf(stderr, "obsigna keys generate: %v\n", cfgErr)
+		return ExitUsageError
 	}
 	if *keyPath == "" {
 		fmt.Fprintln(stderr, "obsigna keys generate: --key is required (no AGENTRECEIPTS_KEY and no home directory)")
@@ -93,17 +87,19 @@ func RunGenerate(args []string, stdout, stderr io.Writer, getenv func(string) st
 // a previously published .pub file.
 func RunPubkey(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
 	getenv = orOsGetenv(getenv)
-	base, err := baseConfig(getenv)
-	if err != nil {
-		fmt.Fprintf(stderr, "obsigna keys pubkey: %v\n", err)
-		return ExitUsageError
-	}
+	// Config error deferred past parse so `--help` works regardless of config
+	// validity (see RunGenerate).
+	base, cfgErr := baseConfig(getenv)
 
 	fs := flag.NewFlagSet("keys pubkey", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	keyPath := fs.String("key", base.KeyPath, "Ed25519 PEM private key path to derive the public key from (env: AGENTRECEIPTS_KEY)")
 	if code, done := parse(fs, args, stderr, "keys pubkey"); done {
 		return code
+	}
+	if cfgErr != nil {
+		fmt.Fprintf(stderr, "obsigna keys pubkey: %v\n", cfgErr)
+		return ExitUsageError
 	}
 	if *keyPath == "" {
 		fmt.Fprintln(stderr, "obsigna keys pubkey: --key is required (no AGENTRECEIPTS_KEY and no home directory)")
@@ -132,11 +128,9 @@ func RunPubkey(args []string, stdout, stderr io.Writer, getenv func(string) stri
 // stopped first (daemon.RotateKey refuses while the socket is reachable).
 func RunRotate(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
 	getenv = orOsGetenv(getenv)
-	base, err := baseConfig(getenv)
-	if err != nil {
-		fmt.Fprintf(stderr, "obsigna keys rotate: %v\n", err)
-		return ExitUsageError
-	}
+	// Config error deferred past parse so `--help` works regardless of config
+	// validity (see RunGenerate).
+	base, cfgErr := baseConfig(getenv)
 
 	fs := flag.NewFlagSet("keys rotate", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -150,6 +144,10 @@ func RunRotate(args []string, stdout, stderr io.Writer, getenv func(string) stri
 	socketPath := fs.String("socket", base.SocketPath, "Daemon socket path; rotation is refused if a daemon is reachable here (env: AGENTRECEIPTS_SOCKET)")
 	if code, done := parse(fs, args, stderr, "keys rotate"); done {
 		return code
+	}
+	if cfgErr != nil {
+		fmt.Fprintf(stderr, "obsigna keys rotate: %v\n", cfgErr)
+		return ExitUsageError
 	}
 
 	cfg := daemon.Config{
@@ -230,8 +228,8 @@ func baseConfig(getenv func(string) string) (daemon.Config, error) {
 		DBPath:               daemon.DefaultDBPath(),
 		SocketPath:           daemon.DefaultSocketPath(),
 		ChainID:              time.Now().UTC().Format("2006-01-02"),
-		IssuerID:             defaultIssuerID,
-		VerificationMethodID: defaultVerificationMethodID,
+		IssuerID:             daemon.DefaultIssuerID,
+		VerificationMethodID: daemon.DefaultVerificationMethodID,
 	}
 
 	fc, err := loadConfigFile(getenv)

--- a/daemon/internal/keyscli/keyscli.go
+++ b/daemon/internal/keyscli/keyscli.go
@@ -1,0 +1,318 @@
+// Package keyscli implements the `obsigna keys` subcommands — generate, pubkey,
+// and rotate — that manage the daemon's Ed25519 signing key from the read-side
+// CLI. The heavy lifting lives in the daemon package (daemon.GenerateKey,
+// daemon.RotateKey) and internal/keysource; this package only resolves the
+// key-relevant configuration (defaults < config file < env < flags, mirroring
+// the daemon's own precedence for the fields these verbs touch) and renders the
+// CLI surface. Keeping it here, away from cmd/obsigna/main.go, lets tests drive
+// each verb directly with captured I/O and an injected environment.
+//
+// The verbs are the obsigna home for what `agent-receipts-daemon --init` and
+// `--rotate` do today; the daemon binary keeps those flags untouched (ADR-0030,
+// ADR-0015).
+package keyscli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/daemon/internal/keysource"
+)
+
+// Exit codes are part of the CLI contract — keep them stable and aligned with
+// the other subcommand packages (verifycli, listcli): 0 ok, 2 usage error. 1 is
+// an operational failure (key already exists, store unreadable, rotation
+// refused because a daemon is live, …).
+const (
+	ExitOK         = 0
+	ExitError      = 1
+	ExitUsageError = 2
+)
+
+// These mirror the daemon's own resolveConfig defaults (see
+// cmd/agent-receipts-daemon/main.go). They MUST match so a rotation performed
+// via `obsigna keys rotate` records the same issuer / verification method as one
+// the daemon would write — the issuer DID is part of the signed receipt, so a
+// divergent default here would fork chain identity. The literal daemon name is
+// intentional and not rebranded with the binary.
+const (
+	defaultIssuerID             = "did:agent-receipts-daemon:local"
+	defaultVerificationMethodID = "did:agent-receipts-daemon:local#k1"
+)
+
+// pubkeyVerificationMethod is a placeholder fed to keysource.NewFile so Init's
+// "verification method required" guard passes. `keys pubkey` only derives the
+// public half of the key and never signs, so the value is never embedded in a
+// receipt — it exists solely to reuse keysource's TOCTOU-safe, permission-checked
+// key loader instead of re-parsing PKCS#8 by hand.
+const pubkeyVerificationMethod = "did:obsigna:pubkey"
+
+// RunGenerate implements `obsigna keys generate`: create a fresh Ed25519 signing
+// key pair, refusing to overwrite existing files. Mirrors `agent-receipts-daemon
+// --init`.
+func RunGenerate(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	getenv = orOsGetenv(getenv)
+	base, err := baseConfig(getenv)
+	if err != nil {
+		fmt.Fprintf(stderr, "obsigna keys generate: %v\n", err)
+		return ExitUsageError
+	}
+
+	fs := flag.NewFlagSet("keys generate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	keyPath := fs.String("key", base.KeyPath, "Ed25519 PEM private key output path, mode 0600 (env: AGENTRECEIPTS_KEY)")
+	pubPath := fs.String("public-key", base.PublicKeyPath, "Public key output path as PEM, mode 0644 (default: <key>.pub) (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	if code, done := parse(fs, args, stderr, "keys generate"); done {
+		return code
+	}
+	if *keyPath == "" {
+		fmt.Fprintln(stderr, "obsigna keys generate: --key is required (no AGENTRECEIPTS_KEY and no home directory)")
+		return ExitUsageError
+	}
+
+	pub := *pubPath
+	if pub == "" {
+		pub = daemon.DefaultPublicKeyPath(*keyPath)
+	}
+	if err := daemon.GenerateKey(*keyPath, pub); err != nil {
+		fmt.Fprintf(stderr, "obsigna keys generate: %v\n", err)
+		return ExitError
+	}
+	fmt.Fprintf(stdout, "generated signing key: %s\n", *keyPath)
+	fmt.Fprintf(stdout, "public key: %s\n", pub)
+	return ExitOK
+}
+
+// RunPubkey implements `obsigna keys pubkey`: print the SPKI public key derived
+// from the signing key at --key. New verb (no legacy equivalent) — useful for
+// distributing the verifier key without exposing the private half or relying on
+// a previously published .pub file.
+func RunPubkey(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	getenv = orOsGetenv(getenv)
+	base, err := baseConfig(getenv)
+	if err != nil {
+		fmt.Fprintf(stderr, "obsigna keys pubkey: %v\n", err)
+		return ExitUsageError
+	}
+
+	fs := flag.NewFlagSet("keys pubkey", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	keyPath := fs.String("key", base.KeyPath, "Ed25519 PEM private key path to derive the public key from (env: AGENTRECEIPTS_KEY)")
+	if code, done := parse(fs, args, stderr, "keys pubkey"); done {
+		return code
+	}
+	if *keyPath == "" {
+		fmt.Fprintln(stderr, "obsigna keys pubkey: --key is required (no AGENTRECEIPTS_KEY and no home directory)")
+		return ExitUsageError
+	}
+
+	ks := keysource.NewFile(*keyPath, pubkeyVerificationMethod)
+	if err := ks.Init(); err != nil {
+		fmt.Fprintf(stderr, "obsigna keys pubkey: %v\n", err)
+		return ExitError
+	}
+	defer func() { _ = ks.Teardown() }()
+	pemStr, err := ks.PublicKey()
+	if err != nil {
+		fmt.Fprintf(stderr, "obsigna keys pubkey: %v\n", err)
+		return ExitError
+	}
+	// PublicKey() returns a PEM block already terminated by a newline.
+	fmt.Fprint(stdout, pemStr)
+	return ExitOK
+}
+
+// RunRotate implements `obsigna keys rotate`: append a key_rotated receipt
+// signed by the current key, archive the current public key, and swap in a new
+// key (ADR-0015). Mirrors `agent-receipts-daemon --rotate`; the daemon must be
+// stopped first (daemon.RotateKey refuses while the socket is reachable).
+func RunRotate(args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	getenv = orOsGetenv(getenv)
+	base, err := baseConfig(getenv)
+	if err != nil {
+		fmt.Fprintf(stderr, "obsigna keys rotate: %v\n", err)
+		return ExitUsageError
+	}
+
+	fs := flag.NewFlagSet("keys rotate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	keyPath := fs.String("key", base.KeyPath, "Ed25519 PEM private key path (env: AGENTRECEIPTS_KEY)")
+	pubPath := fs.String("public-key", base.PublicKeyPath, "Published public-key path (default: <key>.pub) (env: AGENTRECEIPTS_PUBLIC_KEY)")
+	dbPath := fs.String("db", base.DBPath, "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
+	chainID := fs.String("chain-id", base.ChainID, "Chain id to write the rotation under (env: AGENTRECEIPTS_CHAIN_ID)")
+	issuerID := fs.String("issuer-id", base.IssuerID, "Receipt issuer.id (env: AGENTRECEIPTS_ISSUER_ID)")
+	vmID := fs.String("verification-method", base.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
+	anchorLog := fs.String("anchor-log", base.AnchorLogPath, "Append-only external-witness log for the rotation event, ADR-0015 (env: AGENTRECEIPTS_ANCHOR_LOG)")
+	socketPath := fs.String("socket", base.SocketPath, "Daemon socket path; rotation is refused if a daemon is reachable here (env: AGENTRECEIPTS_SOCKET)")
+	if code, done := parse(fs, args, stderr, "keys rotate"); done {
+		return code
+	}
+
+	cfg := daemon.Config{
+		KeyPath:              *keyPath,
+		PublicKeyPath:        *pubPath,
+		DBPath:               *dbPath,
+		ChainID:              *chainID,
+		IssuerID:             *issuerID,
+		VerificationMethodID: *vmID,
+		AnchorLogPath:        *anchorLog,
+		SocketPath:           *socketPath,
+	}
+	summary, err := daemon.RotateKey(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "obsigna keys rotate: %v\n", err)
+		return ExitError
+	}
+
+	pubKeyPath := cfg.PublicKeyPath
+	if pubKeyPath == "" {
+		pubKeyPath = daemon.DefaultPublicKeyPath(cfg.KeyPath)
+	}
+	fmt.Fprintf(stdout, "rotated signing key on chain %s (seq %d)\n", summary.ChainID, summary.Sequence)
+	fmt.Fprintf(stdout, "  key_rotated receipt: %s\n", summary.ReceiptID)
+	fmt.Fprintf(stdout, "  outgoing key:        %s\n", summary.OldFingerprint)
+	fmt.Fprintf(stdout, "  incoming key:        %s\n", summary.NewFingerprint)
+	fmt.Fprintf(stdout, "  archived public key: %s\n", summary.ArchivedPublicKey)
+	if summary.AnchoredTo != "" {
+		fmt.Fprintf(stdout, "  anchored to:         %s\n", summary.AnchoredTo)
+	} else {
+		fmt.Fprintf(stdout, "  anchored to:         (none — set --anchor-log for post-compromise integrity)\n")
+	}
+	fmt.Fprintf(stdout, "\nRestart the daemon to sign with the new key. `obsigna verify`\n")
+	fmt.Fprintf(stdout, "checks the rotated chain when pointed at the published key %s —\n", pubKeyPath)
+	fmt.Fprintf(stdout, "it resolves the archived genesis key and traverses the rotation automatically.\n")
+	return ExitOK
+}
+
+// parse runs fs.Parse and maps its outcome to a CLI result. The bool return is
+// true when the caller should stop (help printed, or a parse error); false when
+// parsing succeeded and the caller should continue. A trailing positional
+// argument is rejected — these verbs take only flags.
+func parse(fs *flag.FlagSet, args []string, stderr io.Writer, name string) (int, bool) {
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return ExitOK, true
+		}
+		return ExitUsageError, true
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "obsigna %s: unexpected positional argument(s): %v\n", name, fs.Args())
+		return ExitUsageError, true
+	}
+	return ExitOK, false
+}
+
+func orOsGetenv(getenv func(string) string) func(string) string {
+	if getenv == nil {
+		return os.Getenv
+	}
+	return getenv
+}
+
+// baseConfig assembles the key-relevant configuration from defaults, then the
+// TOML config file (default path or AGENTRECEIPTS_CONFIG), then AGENTRECEIPTS_*
+// environment variables — the same low-to-high precedence the daemon applies,
+// restricted to the fields these verbs use. Callers register flags with these
+// values as defaults so an explicit flag still wins (the top precedence layer).
+//
+// Unlike the daemon, keyscli does not accept a --config flag; it honours the
+// default config path and AGENTRECEIPTS_CONFIG so a standard install's
+// daemon.toml is respected, which is what avoids `keys rotate` silently
+// targeting the wrong store. A --config flag can follow once the daemon's
+// two-pass config scanner is shared.
+func baseConfig(getenv func(string) string) (daemon.Config, error) {
+	cfg := daemon.Config{
+		KeyPath:              daemon.DefaultKeyPath(),
+		DBPath:               daemon.DefaultDBPath(),
+		SocketPath:           daemon.DefaultSocketPath(),
+		ChainID:              time.Now().UTC().Format("2006-01-02"),
+		IssuerID:             defaultIssuerID,
+		VerificationMethodID: defaultVerificationMethodID,
+	}
+
+	fc, err := loadConfigFile(getenv)
+	if err != nil {
+		return daemon.Config{}, err
+	}
+	applyFileConfig(&cfg, fc)
+	applyEnv(&cfg, getenv)
+	return cfg, nil
+}
+
+// loadConfigFile resolves the TOML config path (AGENTRECEIPTS_CONFIG, else the
+// default path) and loads it. An explicit AGENTRECEIPTS_CONFIG naming a missing
+// file is an error; a missing file at the default path is tolerated (nil, nil).
+func loadConfigFile(getenv func(string) string) (*daemon.FileConfig, error) {
+	path := getenv("AGENTRECEIPTS_CONFIG")
+	required := path != ""
+	if path == "" {
+		path = daemon.DefaultConfigPath()
+		if path == "" {
+			return nil, nil
+		}
+	}
+	return daemon.LoadConfigFile(path, required)
+}
+
+// applyFileConfig overlays the key-relevant fields of a FileConfig onto cfg.
+// Only keys present in the file (non-nil pointers) are applied, so an absent key
+// leaves the default/env value untouched. No-op when fc is nil.
+func applyFileConfig(cfg *daemon.Config, fc *daemon.FileConfig) {
+	if fc == nil {
+		return
+	}
+	if fc.Key != nil {
+		cfg.KeyPath = *fc.Key
+	}
+	if fc.PublicKey != nil {
+		cfg.PublicKeyPath = *fc.PublicKey
+	}
+	if fc.DB != nil {
+		cfg.DBPath = *fc.DB
+	}
+	if fc.ChainID != nil {
+		cfg.ChainID = *fc.ChainID
+	}
+	if fc.IssuerID != nil {
+		cfg.IssuerID = *fc.IssuerID
+	}
+	if fc.VerificationMethod != nil {
+		cfg.VerificationMethodID = *fc.VerificationMethod
+	}
+	if fc.Socket != nil {
+		cfg.SocketPath = *fc.Socket
+	}
+}
+
+// applyEnv overlays AGENTRECEIPTS_* variables onto cfg. An unset (empty)
+// variable leaves the existing value in place.
+func applyEnv(cfg *daemon.Config, getenv func(string) string) {
+	if v := getenv("AGENTRECEIPTS_KEY"); v != "" {
+		cfg.KeyPath = v
+	}
+	if v := getenv("AGENTRECEIPTS_PUBLIC_KEY"); v != "" {
+		cfg.PublicKeyPath = v
+	}
+	if v := getenv("AGENTRECEIPTS_DB"); v != "" {
+		cfg.DBPath = v
+	}
+	if v := getenv("AGENTRECEIPTS_CHAIN_ID"); v != "" {
+		cfg.ChainID = v
+	}
+	if v := getenv("AGENTRECEIPTS_ISSUER_ID"); v != "" {
+		cfg.IssuerID = v
+	}
+	if v := getenv("AGENTRECEIPTS_VERIFICATION_METHOD"); v != "" {
+		cfg.VerificationMethodID = v
+	}
+	if v := getenv("AGENTRECEIPTS_SOCKET"); v != "" {
+		cfg.SocketPath = v
+	}
+	if v := getenv("AGENTRECEIPTS_ANCHOR_LOG"); v != "" {
+		cfg.AnchorLogPath = v
+	}
+}

--- a/daemon/internal/keyscli/keyscli.go
+++ b/daemon/internal/keyscli/keyscli.go
@@ -149,6 +149,18 @@ func RunRotate(args []string, stdout, stderr io.Writer, getenv func(string) stri
 		fmt.Fprintf(stderr, "obsigna keys rotate: %v\n", cfgErr)
 		return ExitUsageError
 	}
+	// Validate the inputs that can be empty (no flag/env and no resolvable home)
+	// here, as a usage error, rather than letting daemon.RotateKey report them as
+	// operational errors — this keeps the package's exit-code contract consistent
+	// with generate/pubkey (missing required path => ExitUsageError, not ExitError).
+	if *keyPath == "" {
+		fmt.Fprintln(stderr, "obsigna keys rotate: --key is required (no AGENTRECEIPTS_KEY and no home directory)")
+		return ExitUsageError
+	}
+	if *dbPath == "" {
+		fmt.Fprintln(stderr, "obsigna keys rotate: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		return ExitUsageError
+	}
 
 	cfg := daemon.Config{
 		KeyPath:              *keyPath,

--- a/daemon/internal/keyscli/keyscli_test.go
+++ b/daemon/internal/keyscli/keyscli_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/store"
 )
 
 // isolate points the per-user default paths (config, key, db, socket) at a fresh
@@ -119,6 +122,66 @@ func TestRunRotate(t *testing.T) {
 	}
 	if strings.Contains(got, "agent-receipts verify") {
 		t.Fatalf("rotate stdout still references the deprecated `agent-receipts verify`: %q", got)
+	}
+
+	// The rotation receipt must carry the SAME issuer the daemon defaults to, so
+	// a chain rotated via `obsigna keys rotate` and one rotated via the daemon
+	// share one identity. This guards against keyscli drifting from
+	// daemon.DefaultIssuerID.
+	st, err := store.OpenReadOnly(filepath.Join(dir, "receipts.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	chain, err := st.GetChain("test-chain")
+	if err != nil {
+		t.Fatalf("get chain: %v", err)
+	}
+	if len(chain) == 0 {
+		t.Fatal("rotation wrote no receipt to the chain")
+	}
+	if iss := chain[0].Issuer.ID; iss != daemon.DefaultIssuerID {
+		t.Errorf("rotation receipt issuer = %q, want daemon default %q", iss, daemon.DefaultIssuerID)
+	}
+}
+
+func TestHelpWorksWithBrokenConfig(t *testing.T) {
+	dir := isolate(t)
+	// Point AGENTRECEIPTS_CONFIG at a file that does not exist — baseConfig will
+	// error, but --help must still succeed for every verb.
+	t.Setenv("AGENTRECEIPTS_CONFIG", filepath.Join(dir, "missing.toml"))
+
+	verbs := map[string]func([]string, io.Writer, io.Writer, func(string) string) int{
+		"generate": RunGenerate,
+		"pubkey":   RunPubkey,
+		"rotate":   RunRotate,
+	}
+	for name, run := range verbs {
+		t.Run(name+"/help-ok", func(t *testing.T) {
+			if code := run([]string{"--help"}, io.Discard, io.Discard, nil); code != ExitOK {
+				t.Errorf("%s --help exit = %d, want %d (broken config must not block help)", name, code, ExitOK)
+			}
+		})
+		t.Run(name+"/exec-reports-config-error", func(t *testing.T) {
+			var errOut bytes.Buffer
+			if code := run(nil, io.Discard, &errOut, nil); code != ExitUsageError {
+				t.Errorf("%s exec exit = %d, want %d (config error surfaced on execute)", name, code, ExitUsageError)
+			}
+		})
+	}
+}
+
+func TestBaseConfigUsesDaemonIdentityDefaults(t *testing.T) {
+	isolate(t)
+	base, err := baseConfig(func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("baseConfig: %v", err)
+	}
+	if base.IssuerID != daemon.DefaultIssuerID {
+		t.Errorf("default issuer = %q, want %q", base.IssuerID, daemon.DefaultIssuerID)
+	}
+	if base.VerificationMethodID != daemon.DefaultVerificationMethodID {
+		t.Errorf("default verification method = %q, want %q", base.VerificationMethodID, daemon.DefaultVerificationMethodID)
 	}
 }
 

--- a/daemon/internal/keyscli/keyscli_test.go
+++ b/daemon/internal/keyscli/keyscli_test.go
@@ -20,11 +20,14 @@ func isolate(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dir)
-	// Clear any inherited overrides so each test starts from the defaults it
-	// sets explicitly.
+	// Clear every AGENTRECEIPTS_* variable keyscli reads so each test starts from
+	// the defaults it sets explicitly — a host value (especially ANCHOR_LOG, which
+	// would write to an unintended path, or ISSUER_ID, which would fail the
+	// identity-default assertions) must not leak in.
 	for _, k := range []string{
 		"AGENTRECEIPTS_CONFIG", "AGENTRECEIPTS_KEY", "AGENTRECEIPTS_PUBLIC_KEY",
 		"AGENTRECEIPTS_DB", "AGENTRECEIPTS_CHAIN_ID", "AGENTRECEIPTS_SOCKET",
+		"AGENTRECEIPTS_ISSUER_ID", "AGENTRECEIPTS_VERIFICATION_METHOD", "AGENTRECEIPTS_ANCHOR_LOG",
 	} {
 		t.Setenv(k, "")
 	}
@@ -142,6 +145,23 @@ func TestRunRotate(t *testing.T) {
 	}
 	if iss := chain[0].Issuer.ID; iss != daemon.DefaultIssuerID {
 		t.Errorf("rotation receipt issuer = %q, want daemon default %q", iss, daemon.DefaultIssuerID)
+	}
+}
+
+func TestRotateMissingRequiredPathsAreUsageErrors(t *testing.T) {
+	dir := isolate(t)
+	db := filepath.Join(dir, "receipts.db")
+	cases := map[string][]string{
+		"empty key": {"--key", "", "--db", db},
+		"empty db":  {"--key", filepath.Join(dir, "signing.key"), "--db", ""},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			var errOut bytes.Buffer
+			if code := RunRotate(args, io.Discard, &errOut, nil); code != ExitUsageError {
+				t.Errorf("rotate with %s exit = %d, want %d (usage error, not operational)", name, code, ExitUsageError)
+			}
+		})
 	}
 }
 

--- a/daemon/internal/keyscli/keyscli_test.go
+++ b/daemon/internal/keyscli/keyscli_test.go
@@ -1,0 +1,154 @@
+package keyscli
+
+import (
+	"bytes"
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// isolate points the per-user default paths (config, key, db, socket) at a fresh
+// temp dir so a test never reads or writes the host's real signing key or
+// daemon.toml. Returns the temp dir.
+func isolate(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	// Clear any inherited overrides so each test starts from the defaults it
+	// sets explicitly.
+	for _, k := range []string{
+		"AGENTRECEIPTS_CONFIG", "AGENTRECEIPTS_KEY", "AGENTRECEIPTS_PUBLIC_KEY",
+		"AGENTRECEIPTS_DB", "AGENTRECEIPTS_CHAIN_ID", "AGENTRECEIPTS_SOCKET",
+	} {
+		t.Setenv(k, "")
+	}
+	return dir
+}
+
+func TestRunGenerateThenPubkey(t *testing.T) {
+	dir := isolate(t)
+	keyPath := filepath.Join(dir, "signing.key")
+	pubPath := keyPath + ".pub"
+	t.Setenv("AGENTRECEIPTS_KEY", keyPath)
+
+	var out, errOut bytes.Buffer
+	if code := RunGenerate(nil, &out, &errOut, nil); code != ExitOK {
+		t.Fatalf("generate exit = %d, want %d (stderr=%s)", code, ExitOK, errOut.String())
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("private key not written: %v", err)
+	}
+	if _, err := os.Stat(pubPath); err != nil {
+		t.Fatalf("public key not written: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "generated signing key: "+keyPath) ||
+		!strings.Contains(got, "public key: "+pubPath) {
+		t.Fatalf("generate stdout = %q, want it to name both paths", got)
+	}
+
+	// pubkey must reproduce the published key. Compare DER bytes so a benign
+	// PEM whitespace difference doesn't fail the test.
+	var pout, perr bytes.Buffer
+	if code := RunPubkey(nil, &pout, &perr, nil); code != ExitOK {
+		t.Fatalf("pubkey exit = %d, want %d (stderr=%s)", code, ExitOK, perr.String())
+	}
+	derived, _ := pem.Decode(pout.Bytes())
+	if derived == nil || derived.Type != "PUBLIC KEY" {
+		t.Fatalf("pubkey stdout is not a PUBLIC KEY PEM block: %q", pout.String())
+	}
+	published, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatalf("read published pub: %v", err)
+	}
+	pubBlock, _ := pem.Decode(published)
+	if pubBlock == nil || !bytes.Equal(pubBlock.Bytes, derived.Bytes) {
+		t.Fatalf("pubkey output does not match the published .pub key")
+	}
+}
+
+func TestRunGenerateRefusesOverwrite(t *testing.T) {
+	dir := isolate(t)
+	t.Setenv("AGENTRECEIPTS_KEY", filepath.Join(dir, "signing.key"))
+
+	if code := RunGenerate(nil, io.Discard, io.Discard, nil); code != ExitOK {
+		t.Fatalf("first generate exit = %d, want %d", code, ExitOK)
+	}
+	var errOut bytes.Buffer
+	if code := RunGenerate(nil, io.Discard, &errOut, nil); code != ExitError {
+		t.Fatalf("second generate exit = %d, want %d (refuse overwrite)", code, ExitError)
+	}
+}
+
+func TestRunPubkeyMissingKey(t *testing.T) {
+	dir := isolate(t)
+	t.Setenv("AGENTRECEIPTS_KEY", filepath.Join(dir, "absent.key"))
+
+	var errOut bytes.Buffer
+	if code := RunPubkey(nil, io.Discard, &errOut, nil); code != ExitError {
+		t.Fatalf("pubkey on missing key exit = %d, want %d", code, ExitError)
+	}
+}
+
+func TestRunRotate(t *testing.T) {
+	dir := isolate(t)
+	t.Setenv("AGENTRECEIPTS_KEY", filepath.Join(dir, "signing.key"))
+	t.Setenv("AGENTRECEIPTS_DB", filepath.Join(dir, "receipts.db"))
+	t.Setenv("AGENTRECEIPTS_CHAIN_ID", "test-chain")
+	// Point the running-daemon guard at a socket that does not exist.
+	t.Setenv("AGENTRECEIPTS_SOCKET", filepath.Join(dir, "absent.sock"))
+
+	if code := RunGenerate(nil, io.Discard, io.Discard, nil); code != ExitOK {
+		t.Fatalf("generate exit = %d, want %d", code, ExitOK)
+	}
+
+	var out, errOut bytes.Buffer
+	if code := RunRotate(nil, &out, &errOut, nil); code != ExitOK {
+		t.Fatalf("rotate exit = %d, want %d (stderr=%s)", code, ExitOK, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "rotated signing key on chain test-chain") {
+		t.Fatalf("rotate stdout = %q, want chain summary", got)
+	}
+	// The post-rotation hint must reference the new canonical command, never
+	// the deprecated binary name.
+	if !strings.Contains(got, "obsigna verify") {
+		t.Fatalf("rotate stdout = %q, want it to mention `obsigna verify`", got)
+	}
+	if strings.Contains(got, "agent-receipts verify") {
+		t.Fatalf("rotate stdout still references the deprecated `agent-receipts verify`: %q", got)
+	}
+}
+
+// TestConfigPrecedence checks the defaults < file < env ordering keyscli relies
+// on: a key path set only in the TOML config file is honoured, and an env var
+// overrides the file.
+func TestConfigPrecedence(t *testing.T) {
+	dir := isolate(t)
+	fileKey := filepath.Join(dir, "from-file.key")
+	cfgPath := filepath.Join(dir, "daemon.toml")
+	if err := os.WriteFile(cfgPath, []byte("key = \""+fileKey+"\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("AGENTRECEIPTS_CONFIG", cfgPath)
+
+	// No AGENTRECEIPTS_KEY: the file value wins over the default.
+	if code := RunGenerate(nil, io.Discard, io.Discard, nil); code != ExitOK {
+		t.Fatalf("generate (file key) exit = %d, want %d", code, ExitOK)
+	}
+	if _, err := os.Stat(fileKey); err != nil {
+		t.Fatalf("config-file key path not used: %v", err)
+	}
+
+	// Env overrides the file.
+	envKey := filepath.Join(dir, "from-env.key")
+	t.Setenv("AGENTRECEIPTS_KEY", envKey)
+	if code := RunGenerate(nil, io.Discard, io.Discard, nil); code != ExitOK {
+		t.Fatalf("generate (env key) exit = %d, want %d", code, ExitOK)
+	}
+	if _, err := os.Stat(envKey); err != nil {
+		t.Fatalf("env key path did not override the config file: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Renames the receipt CLI `agent-receipts` → **`obsigna`** with the frozen ADR-0030 grouped noun-verb surface, and keeps `agent-receipts` working as a deprecation shim. This is the **upstream** rename that flips **Gate 0** of the Homebrew formula migration. The daemon, collector, and mcp-proxy binaries are **out of scope and untouched**.

### obsigna surface (frozen by the golden test)

```
obsigna receipt verify <file|->   # alias: obsigna verify
obsigna receipt show <id>         # alias: obsigna show
obsigna receipt list
obsigna receipt verify-event      # carried over from the legacy CLI
obsigna keys generate
obsigna keys pubkey               # new — prints the SPKI public key
obsigna keys rotate
obsigna doctor                    # carried over from the legacy CLI
```

Flat aliases are the **closed set `{verify, show}`**. Reserved nouns `daemon`/`collector`/`mcp` are intentionally absent (deferred to the consolidation ADR).

## How

- **`cmd/obsigna`** — registry-driven dispatcher (single source of truth for dispatch + help); top-level and per-noun `--help`.
- **`internal/keyscli`** — `generate`/`pubkey`/`rotate`, reusing exported `daemon` helpers (`GenerateKey`, `RotateKey`, config-file/env/flag resolution with the daemon's own precedence). `generate`/`rotate` mirror `agent-receipts-daemon --init`/`--rotate`; `pubkey` is new.
- **`cmd/agent-receipts`** — now a thin **exec-passthrough shim**: translates every legacy subcommand (`verify`, `show`, `list`, `verify-event`, `doctor`) to its obsigna form, prints a **one-line deprecation notice to stderr only** (stdout stays byte-clean), and propagates the exit code.
- **Golden surface test** freezes the command tree against ADR-0030 drift; an **anti-regression guard** asserts `agent-receipts` can only ever be the shim (the primary CLI build must be `obsigna`).
- **goreleaser** (CLI-only edits): rename the CLI build to `obsigna`, add the shim build, ship `obsigna` in the archive and Homebrew install/test. The `agent-receipts-daemon` build and the daemon-specific formula bits (service, caveats, name) are untouched.

## Decisions recorded (for the downstream formula prompt)

- **FORMULA_TARGET**: the `agent-receipts-daemon` Homebrew formula installs the daemon **and bundles this CLI** (single `brews:` block). So **this release is the Gate-0 artifact** — it ships the `obsigna` binary + checksums for darwin arm64/amd64 and linux arm64/amd64. The formula/tap **name** rename remains downstream.
- **verify-event + doctor**: carried over as obsigna leaves (`obsigna receipt verify-event`, `obsigna doctor`) — a deliberate **superset** of ADR-0030's listed receipt+keys surface, so the shim preserves every current subcommand. ADR-0030 itself is **not** edited; worth an ADR reconciliation follow-up.

## Verification

- `go vet ./...`, `go build ./cmd/...`, `go test -race -tags=integration ./...` all green (one pre-existing failure, `TestPeerCredFromSDKSubprocesses/ts`, is environmental — needs `pnpm -C sdk/ts build`; passes once the TS dist is built, which CI does).
- All three binaries cross-compile for the four release platforms (`CGO_ENABLED=0 GOWORK=off`).
- Manual smoke: `keys generate`→`pubkey` is byte-identical to the published `.pub`; `keys rotate` writes a `key_rotated` receipt; alias `obsigna verify` ≡ `obsigna receipt verify`; the shim's notice appears once on stderr with clean stdout.

## Release handoff

This PR lands the code only. After merge, push the tag **`daemon/v0.21.0-alpha.1`** (default; adjust as desired) to trigger the goreleaser/tap pipeline. CHANGELOG entry for `0.21.0-alpha.1` is included.

## Follow-ups

- Internal subcommand packages still print `agent-receipts <cmd>:` error prefixes; rebranding them to `obsigna` is a broader, test-touching cleanup left out to keep this scope tight.
- `obsigna keys` reads the default config path + `AGENTRECEIPTS_CONFIG` but not a `--config` flag yet (the daemon's two-pass config scanner could be shared).