### PR TITLE
chore(release): prep sdk-py 0.13.0a2 (first obsigna release)

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,12 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.13.0a2] - 2026-06-12
+
+First release under the **`obsigna`** distribution name (no functional change
+over `0.13.0a1`; the bump exists because the `sdk-py-v0.13.0a1` tag was already
+consumed by the final `agent-receipts` release).
+
 ### Changed
 
 - **Package renamed to `obsigna`** (was `agent-receipts`), and the import module

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.13.0a1"
+version = "0.13.0a2"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "obsigna"
-version = "0.13.0a1"
+version = "0.13.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bumps the Python SDK to **`obsigna 0.13.0a2`** so the first PyPI release under the renamed `obsigna` project can ship via the `sdk-py-v*` tag pipeline.

**Why a2, not a1:** the `sdk-py-v0.13.0a1` tag already exists and points at the pre-rename commit (#782); its CI run already published the final `agent-receipts 0.13.0a1` on 2026-06-11. That tag is consumed, so the renamed project takes the next alpha. No functional change over a1 — only the rename (already merged in #792).

## Changes
- `sdk/py/pyproject.toml`: `0.13.0a1` → `0.13.0a2`
- `sdk/py/uv.lock`: regenerated
- `sdk/py/CHANGELOG.md`: `[0.13.0a2]` section

## After merge
Tag `sdk-py-v0.13.0a2` on the merge commit → `release-sdk-py.yml` builds, publishes `obsigna 0.13.0a2` to PyPI via the configured trusted publisher (OIDC), and runs the post-publish gates. PyPI `obsigna` currently has only the `0.0.0` reservation, so this is a clean first real release.

Verified locally: builds to `obsigna-0.13.0a2` (wheel + sdist), 464 tests pass, ruff clean.