### PR TITLE
chore(release): prep sdk-py 0.13.0 (obsigna stable)

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-12
+
+Graduates `0.13.0a2` after the alpha pass. No source changes since the alpha; see the `0.13.0a2` and `0.13.0a1` entries below for the full surface (`obsigna` rename, `KeyRotation` dataclass and chain-verifier traversal).
+
 ## [0.13.0a2] - 2026-06-12
 
 First release under the **`obsigna`** distribution name (no functional change

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.13.0a2"
+version = "0.13.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Otto Jongerius" }]
 keywords = ["ai", "agent", "audit", "receipts", "verifiable-credentials"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "obsigna"
-version = "0.13.0a2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Graduates `0.13.0a2` to stable. No source changes — alpha pass is done.

## What's in 0.13.0

- **`obsigna` rename** (0.13.0a2) — first stable release under the new distribution name; `agent-receipts` shim published for backwards compat
- **`KeyRotation` dataclass + chain-verifier traversal** (0.13.0a1, #778) — ADR-0015 Phase A

## Changes in this PR

- `pyproject.toml`: `0.13.0a2` → `0.13.0`, classifier `Alpha` → `Beta`
- `CHANGELOG.md`: graduation entry added
- `uv.lock`: version updated

## Release steps after merge

Push the tag to trigger CI + PyPI publish:

```sh
git tag sdk-py-v0.13.0
git push origin sdk-py-v0.13.0
```