### PR TITLE
chore(release): prep sdk-ts 0.13.0 (obsigna stable)

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Otto Jongerius" }]
 keywords = ["ai", "agent", "audit", "receipts", "verifiable-credentials"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-12
+
+Graduates `0.13.0-alpha.1` after the alpha pass. The `@obsigna/sdk-ts` rename ships with this stable release (no source changes since the alpha); see the `0.13.0-alpha.1` entry below for the `KeyRotation` surface.
+
 ### Changed
 
 - **Package renamed to `@obsigna/sdk-ts`** (was `@agnt-rcpt/sdk-ts`). The import

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.13.0-alpha.1",
+	"version": "0.13.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Graduates `0.13.0-alpha.1` to stable. Surface since `0.12.0`: `@obsigna/sdk-ts` rename and `KeyRotation` chain-verifier traversal (`0.13.0-alpha.1`).

- `sdk-ts`: `0.13.0-alpha.1` → `0.13.0` (`package.json`)
- CHANGELOG: move `[Unreleased]` rename note into the `[0.13.0]` graduation entry
- `sdk-py`: fix PyPI classifier `4 - Beta` → `5 - Production/Stable` (missed in #796, flagged by Copilot)

Tag `sdk-ts/v0.13.0` pushed separately after merge.