### PR TITLE
chore(daemon): rename Homebrew formula agent-receipts-daemon → obsigna-daemon

### DIFF
--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -108,11 +108,11 @@ release:
   disable: true
 
 brews:
-  - name: agent-receipts-daemon
+  - name: obsigna-daemon
     # `auto` skips the formula bump PR when the release version contains a
     # pre-release suffix (e.g. v0.8.0-alpha.1). The Homebrew tap stays
     # locked to the latest stable daemon until a non-pre-release tag is cut,
-    # so `brew install agent-receipts/tap/agent-receipts-daemon` keeps giving
+    # so `brew install agent-receipts/tap/obsigna-daemon` keeps giving
     # users a stable build during alpha/beta soak periods.
     skip_upload: auto
     repository:
@@ -173,7 +173,7 @@ brews:
           If you reference the old binary name in any install script, systemd unit,
           launchd plist, or `brew services` wrapper, update it to obsigna-daemon and
           restart the service after upgrading:
-            brew services restart agent-receipts/tap/agent-receipts-daemon
+            brew services restart agent-receipts/tap/obsigna-daemon
 
           agent-receipts-hook is now a separate formula. If you previously installed
           it via this formula, run:
@@ -183,7 +183,7 @@ brews:
             obsigna-daemon --init
 
           Then start the daemon:
-            brew services start agent-receipts/tap/agent-receipts-daemon
+            brew services start agent-receipts/tap/obsigna-daemon
 
           Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
                              (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)
@@ -202,7 +202,7 @@ brews:
         EOS
       end
 
-      conflicts_with "agent-receipts-daemon-alpha", because: "both install the same binaries"
+      conflicts_with "obsigna-daemon-alpha", because: "both install the same binaries"
 
       livecheck do
         url "https://github.com/agent-receipts/obsigna"
@@ -211,10 +211,10 @@ brews:
       end
 
   # Alpha-track formula — updated on every release (stable and pre-release).
-  # `brew install agent-receipts/tap/agent-receipts-daemon-alpha` always gives
+  # `brew install agent-receipts/tap/obsigna-daemon-alpha` always gives
   # the latest cut; conflicts with the stable formula since both install the
   # same binaries.
-  - name: agent-receipts-daemon-alpha
+  - name: obsigna-daemon-alpha
     repository:
       owner: agent-receipts
       name: homebrew-tap
@@ -242,7 +242,7 @@ brews:
       system "#{bin}/obsigna", "--help"
       system "#{bin}/agent-receipts", "--help"
     custom_block: |
-      conflicts_with "agent-receipts-daemon", because: "both install the same binaries"
+      conflicts_with "obsigna-daemon", because: "both install the same binaries"
 
       def post_install
         (var/"log/agent-receipts").mkpath
@@ -258,19 +258,19 @@ brews:
       def caveats
         <<~EOS
           This is the alpha/beta track — it tracks every release including pre-releases.
-          For stable-only installs use: brew install agent-receipts/tap/agent-receipts-daemon
+          For stable-only installs use: brew install agent-receipts/tap/obsigna-daemon
 
           The daemon binary is now obsigna-daemon (was agent-receipts-daemon).
           If you reference the old binary name in any install script, systemd unit,
           launchd plist, or `brew services` wrapper, update it to obsigna-daemon and
           restart the service after upgrading:
-            brew services restart agent-receipts/tap/agent-receipts-daemon-alpha
+            brew services restart agent-receipts/tap/obsigna-daemon-alpha
 
           Before starting the service for the first time, generate your signing key:
             obsigna-daemon --init
 
           Then start the daemon:
-            brew services start agent-receipts/tap/agent-receipts-daemon-alpha
+            brew services start agent-receipts/tap/obsigna-daemon-alpha
 
           Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
                              (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-All notable changes to `agent-receipts-daemon` are documented in this file.
+All notable changes to `obsigna-daemon` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.23.0] - 2026-06-12
+
+### Changed
+
+- **Homebrew formula renamed `agent-receipts-daemon` → `obsigna-daemon`** (and `agent-receipts-daemon-alpha` → `obsigna-daemon-alpha`) — the final step of the Obsigna rebrand. The installed binary has been `obsigna-daemon` since 0.22.0 (ADR-0031); now the formula itself carries the brand: `brew install agent-receipts/tap/obsigna-daemon`. Existing installs migrate transparently — the tap's `tap_migrations.json` maps the old formula names to the new ones, so `brew update && brew upgrade` moves users with no manual step. The formula's `conflicts_with` (stable ↔ alpha) is updated accordingly. The `obsigna-daemon` binary, the `brew services` integration, data paths (`~/.local/share/agent-receipts/`), the `agentreceipts` OS user, `AGENTRECEIPTS_*` env vars, and `did:agent-receipts-daemon:` issuer strings are all unchanged.
 
 ## [0.22.0] - 2026-06-12
 

--- a/daemon/cmd/obsigna/entrypoint_guard_test.go
+++ b/daemon/cmd/obsigna/entrypoint_guard_test.go
@@ -94,6 +94,60 @@ func TestObsignaIsPrimaryEntrypoint(t *testing.T) {
 	}
 }
 
+// brewFormulaNames returns the formula `name:` of every entry under the
+// goreleaser `brews:` list. The name is the list-item's own key (`  - name:`),
+// which sits two spaces in; the nested `name: homebrew-tap` under `repository:`
+// is deeper-indented and is deliberately not captured.
+func brewFormulaNames(yaml string) []string {
+	topKey := regexp.MustCompile(`^[a-z]`)
+	nameRe := regexp.MustCompile(`^  - name:\s*(\S+)`)
+
+	inBrews := false
+	var names []string
+	for _, line := range strings.Split(yaml, "\n") {
+		if topKey.MatchString(line) {
+			inBrews = strings.HasPrefix(line, "brews:")
+			continue
+		}
+		if !inBrews {
+			continue
+		}
+		if m := nameRe.FindStringSubmatch(line); m != nil {
+			names = append(names, m[1])
+		}
+	}
+	return names
+}
+
+// TestBrewFormulaeUseObsignaName is the anti-regression gate for the Homebrew
+// formula rename (agent-receipts-daemon -> obsigna-daemon). The installed binary
+// has been obsigna-daemon since ADR-0031; this guards the final step where the
+// formula itself carries the Obsigna brand. The tap's tap_migrations.json moves
+// existing installs off the legacy names, so reintroducing them here would fork
+// users back onto an unmigrated formula.
+func TestBrewFormulaeUseObsignaName(t *testing.T) {
+	yaml := readFile(t, "../../.goreleaser.yaml")
+	names := brewFormulaNames(yaml)
+	if len(names) == 0 {
+		t.Fatal("no formula names found under goreleaser brews:")
+	}
+
+	want := map[string]bool{"obsigna-daemon": false, "obsigna-daemon-alpha": false}
+	for _, name := range names {
+		if strings.HasPrefix(name, "agent-receipts-daemon") {
+			t.Errorf("brew formula %q uses the legacy name; the daemon formula must be obsigna-daemon(-alpha)", name)
+		}
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("expected a brew formula named %q, but it is missing", name)
+		}
+	}
+}
+
 // TestShimDoesNotReimplementSurface keeps cmd/agent-receipts a thin forwarder: it
 // must carry the shim marker and must NOT import the subcommand packages (which
 // would mean it had grown its own command surface again).

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -30,7 +30,7 @@ die()  { printf '\nerror: %s\n' "$*" >&2; exit 1; }
 main() {
   # Linux only
   [ "$(uname -s)" = "Linux" ] || \
-    die "Linux only. For macOS: brew install agent-receipts/tap/agent-receipts-daemon"
+    die "Linux only. For macOS: brew install agent-receipts/tap/obsigna-daemon"
 
   # Require systemd
   command -v systemctl >/dev/null 2>&1 || \

--- a/site/src/content/docs/blog/daemon-process-separation.mdx
+++ b/site/src/content/docs/blog/daemon-process-separation.mdx
@@ -79,8 +79,8 @@ That's the cost of an audit boundary that means something. In-process signing is
 Homebrew handles most of it:
 
 ```sh
-brew install agent-receipts/tap/agent-receipts-daemon
-brew services start agent-receipts-daemon
+brew install agent-receipts/tap/obsigna-daemon
+brew services start obsigna-daemon
 ```
 
 ---

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -18,7 +18,7 @@ Agent Receipts signs receipts in a separate `agent-receipts-daemon` process rath
 **macOS (Homebrew):**
 
 ```bash
-brew install agent-receipts/tap/agent-receipts-daemon
+brew install agent-receipts/tap/obsigna-daemon
 ```
 
 Homebrew installs both the `agent-receipts-daemon` and `agent-receipts` (verify) binaries.

--- a/site/src/content/docs/sdk-py/installation.mdx
+++ b/site/src/content/docs/sdk-py/installation.mdx
@@ -28,7 +28,7 @@ supported yet:
 
 ```bash
 # macOS (Homebrew)
-brew install agent-receipts/tap/agent-receipts-daemon
+brew install agent-receipts/tap/obsigna-daemon
 
 # Linux / from source (requires Go 1.26.1+) — builds the daemon and the agent-receipts CLI
 go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest


### PR DESCRIPTION
## What

Renames the Homebrew daemon formula `agent-receipts-daemon` → `obsigna-daemon` (and `agent-receipts-daemon-alpha` → `obsigna-daemon-alpha`) — the final leg of the Obsigna rebrand. The CLI, the `obsigna-daemon` binary, and the py/ts SDKs are already on the brand; the formula was the last legacy name.

- `daemon/.goreleaser.yaml`: rename both `brews:` `name:` fields, swap the cross `conflicts_with` lines (stable ↔ alpha), and update the `brew install` / `brew services` references inside the caveats. Repository (`homebrew-tap`), binary installs, `service`, and `post_install` are unchanged (already `obsigna-daemon`).
- `daemon/cmd/obsigna/entrypoint_guard_test.go`: new `TestBrewFormulaeUseObsignaName` parses the goreleaser `brews:` block and fails if a legacy `agent-receipts-daemon` formula name reappears.
- `daemon/install.sh` macOS hint + site docs (sdk-py, getting-started, blog): `brew install`/`brew services` → `obsigna-daemon`.
- `daemon/CHANGELOG.md`: 0.23.0 entry documenting the rename and the auto-migration.

## Why

Brand consistency. The installed binary has been `obsigna-daemon` since 0.22.0 (ADR-0031), but `brew install agent-receipts/tap/agent-receipts-daemon` still exposed the legacy name. Existing installs migrate transparently via the tap's `tap_migrations.json` (separate PR in `agent-receipts/homebrew-tap`), so `brew update && brew upgrade` moves users with no manual step.

## Migration / release notes

- **Requires a companion PR in `agent-receipts/homebrew-tap`**: add `tap_migrations.json` mapping the old formula names to `agent-receipts/tap/obsigna-daemon{,-alpha}`, and remove the stale `Formula/agent-receipts-daemon*.rb` (goreleaser creates `Formula/obsigna-daemon*.rb` on the next release).
- Must ship on a **stable** tag — the stable formula only publishes on a non-prerelease tag. Targeting `daemon/v0.23.0`.

## Out of scope (noted, not touched)

- Service-unit / launchd identities (`agent-receipts-daemon.service`, `ai.agentreceipts.daemon`) — a separate, breaking-without-auto-migration change.
- Pre-existing doc staleness: `go install …/cmd/agent-receipts-daemon@latest` references the old cmd path (now `cmd/obsigna-daemon`) in a couple of site docs — part of the binary-rename axis, left for a follow-up.

## Checklist

- [x] Tests pass for changed components (`go test ./cmd/obsigna/...`, `go vet`)
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [x] `legacy_name_guard/check.py` clean
- [ ] Cross-language tests — N/A (no receipt format / signing / hashing change)