### PR TITLE
fix(daemon): doctor auto-detects the daemon's active chain

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`obsigna doctor` auto-detects the daemon's active chain** — with no `--chain-id`/`AGENTRECEIPTS_CHAIN_ID`, doctor now resolves the chain to inspect from the store's most recently written root chain (via `store.LatestRootChainID`) instead of assuming today's UTC date. The old default produced a spurious `chain head` warn and a `round-trip` **fail** ("did not land … the daemon may not be the sole writer") whenever the daemon's chain id was not literally today's UTC date — i.e. a configured `chain_id`, a daemon running across a UTC-midnight rollover, or a rolled `-N` suffix. The synthetic event was traversing the pipeline correctly all along; doctor was just polling the wrong chain. The bare UTC date remains the fallback only for an empty store.
+
+### Changed
+
+- **Doctor output and error messages now say `obsigna doctor`** (not `agent-receipts doctor`), matching the renamed CLI.
+
 ## [0.23.0] - 2026-06-12
 
 ### Changed

--- a/daemon/internal/doctorcli/doctor.go
+++ b/daemon/internal/doctorcli/doctor.go
@@ -117,7 +117,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	socketPath := fs.String("socket", envOr("AGENTRECEIPTS_SOCKET", daemon.DefaultSocketPath()), "Unix-domain socket path the daemon listens on (env: AGENTRECEIPTS_SOCKET)")
 	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
-	chainID := fs.String("chain-id", envOr("AGENTRECEIPTS_CHAIN_ID", time.Now().UTC().Format("2006-01-02")), "Chain id to inspect (env: AGENTRECEIPTS_CHAIN_ID)")
+	chainID := fs.String("chain-id", "", "Chain id to inspect; when unset, doctor auto-detects the daemon's active root chain from the store and falls back to today's UTC date if the store is empty (env: AGENTRECEIPTS_CHAIN_ID)")
 	asJSON := fs.Bool("json", false, "Emit structured JSON instead of human-readable lines")
 	noRoundtrip := fs.Bool("no-roundtrip", false, "Skip the synthetic round-trip check (no event is written to the chain)")
 	warnAsError := fs.Bool("warn-as-error", false, "Exit non-zero when any check warns, not only on failures")
@@ -129,15 +129,28 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitUsageError
 	}
 	if fs.NArg() > 0 {
-		fmt.Fprintf(stderr, "agent-receipts doctor: unexpected positional argument(s): %v\n", fs.Args())
+		fmt.Fprintf(stderr, "obsigna doctor: unexpected positional argument(s): %v\n", fs.Args())
 		return ExitUsageError
+	}
+
+	// Resolve the chain id to inspect. An explicit flag wins, then the env var,
+	// then the daemon's active root chain discovered from the store. The bare
+	// UTC date is only a last-resort fallback for an empty store: the daemon
+	// pins its chain id at startup (config or per-OS default) and rolls a "-N"
+	// suffix across restarts, so today's date rarely names the live chain.
+	resolvedChainID := *chainID
+	if resolvedChainID == "" {
+		resolvedChainID = envLookup("AGENTRECEIPTS_CHAIN_ID")
+	}
+	if resolvedChainID == "" {
+		resolvedChainID = resolveChainID(*dbPath)
 	}
 
 	cfg := config{
 		socketPath: *socketPath,
 		dbPath:     *dbPath,
 		pubKeyPath: *pubKeyPath,
-		chainID:    *chainID,
+		chainID:    resolvedChainID,
 	}
 
 	results := runChecks(cfg, envLookup, *noRoundtrip, *roundtripTimeout)
@@ -148,7 +161,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(report); err != nil {
-			fmt.Fprintf(stderr, "agent-receipts doctor: encode JSON: %v\n", err)
+			fmt.Fprintf(stderr, "obsigna doctor: encode JSON: %v\n", err)
 			return ExitUsageError
 		}
 	} else {
@@ -609,6 +622,40 @@ func pollForRoundtrip(dbPath, chainID, sessionID string, timeout time.Duration) 
 	}
 }
 
+// resolveChainID picks the chain id doctor inspects when the operator did not
+// name one explicitly: the daemon's active root chain if the store has one,
+// otherwise today's UTC date. The date fallback only matters for a brand-new,
+// empty store — once any receipt exists, detectActiveRootChain names the live
+// chain the daemon is actually appending to (see daemon advanceChainID).
+func resolveChainID(dbPath string) string {
+	if cid := detectActiveRootChain(dbPath); cid != "" {
+		return cid
+	}
+	return time.Now().UTC().Format("2006-01-02")
+}
+
+// detectActiveRootChain returns the chain id of the most recently written root
+// receipt — the chain the daemon is actively appending to — or "" when the
+// store is empty/unreadable. The store excludes agent sub-chains and orders by
+// write recency (see store.LatestRootChainID); doctor's chain-head and
+// round-trip checks must target that root chain. Read-only access keeps doctor
+// safe to run against a live daemon (the sole writer).
+func detectActiveRootChain(dbPath string) string {
+	if dbPath == "" {
+		return ""
+	}
+	s, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		return ""
+	}
+	defer s.Close()
+	chainID, found, err := s.LatestRootChainID()
+	if err != nil || !found {
+		return ""
+	}
+	return chainID
+}
+
 // publicKeyFingerprint parses an Ed25519 SPKI public key from a PEM file and
 // returns a short "sha256:<hex>" fingerprint over the DER bytes. It rejects
 // non-Ed25519 keys: Ed25519 is the only signing algorithm the protocol
@@ -639,7 +686,7 @@ func publicKeyFingerprint(path string) (string, error) {
 
 // writeHuman renders the report as one line per check plus a summary line.
 func writeHuman(w io.Writer, results []Result, warnAsError bool) {
-	fmt.Fprintln(w, "agent-receipts doctor — pipeline health")
+	fmt.Fprintln(w, "obsigna doctor — pipeline health")
 	fmt.Fprintln(w)
 	var ok, warn, fail int
 	for _, r := range results {

--- a/daemon/internal/doctorcli/doctor_test.go
+++ b/daemon/internal/doctorcli/doctor_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
@@ -526,4 +527,109 @@ func TestRunNoRoundtripFlag(t *testing.T) {
 		}
 	}
 	t.Error("round-trip check missing from report")
+}
+
+// seedChain appends count signed receipts on chainID to the store at dbPath,
+// signed with privPEM. Unlike fixtureChain it does not create the public-key
+// file and can be called repeatedly to build a multi-chain store.
+func seedChain(t *testing.T, dbPath, privPEM, chainID string, count int) {
+	t.Helper()
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	var prevHash *string
+	for i := 1; i <= count; i++ {
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action:    receipt.Action{Type: "filesystem.file.read", RiskLevel: receipt.RiskLow},
+			Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:     receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: chainID},
+		})
+		signed, err := receipt.Sign(unsigned, privPEM, "did:test#k1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := receipt.HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+}
+
+func TestDetectActiveRootChain(t *testing.T) {
+	t.Run("empty store returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "receipts.db")
+		s, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = s.Close()
+		if got := detectActiveRootChain(dbPath); got != "" {
+			t.Fatalf("got %q, want empty for an empty store", got)
+		}
+	})
+
+	t.Run("unreadable store returns empty", func(t *testing.T) {
+		if got := detectActiveRootChain(filepath.Join(t.TempDir(), "nope.db")); got != "" {
+			t.Fatalf("got %q, want empty for a missing store", got)
+		}
+	})
+
+	t.Run("picks newest root chain", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "receipts.db")
+		privPEM, _ := genKeyPEM(t)
+		seedChain(t, dbPath, privPEM, "2026-06-03", 3)
+		seedChain(t, dbPath, privPEM, "2026-06-03-8", 2) // inserted last → newest
+		if got := detectActiveRootChain(dbPath); got != "2026-06-03-8" {
+			t.Fatalf("got %q, want the most recently appended root chain", got)
+		}
+	})
+
+	t.Run("skips agent sub-chains", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "receipts.db")
+		privPEM, _ := genKeyPEM(t)
+		seedChain(t, dbPath, privPEM, "2026-06-03-8", 2)
+		// An agent sub-chain receipt is newer (inserted last) but must be
+		// skipped: doctor's round-trip lands on the root chain, not here.
+		seedChain(t, dbPath, privPEM, "2026-06-03-8/agent/abc123", 1)
+		if got := detectActiveRootChain(dbPath); got != "2026-06-03-8" {
+			t.Fatalf("got %q, want the root chain (agent sub-chain must be skipped)", got)
+		}
+	})
+}
+
+func TestResolveChainID(t *testing.T) {
+	t.Run("detected chain wins over date fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "receipts.db")
+		privPEM, _ := genKeyPEM(t)
+		seedChain(t, dbPath, privPEM, "2026-06-03-8", 1)
+		if got := resolveChainID(dbPath); got != "2026-06-03-8" {
+			t.Fatalf("got %q, want the detected active chain", got)
+		}
+	})
+
+	t.Run("empty store falls back to UTC date", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "receipts.db")
+		s, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = s.Close()
+		got := resolveChainID(dbPath)
+		if _, err := time.Parse("2006-01-02", got); err != nil {
+			t.Fatalf("got %q, want a YYYY-MM-DD date fallback: %v", got, err)
+		}
+	})
 }

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+### Added
+
+- **`Store.LatestRootChainID()`** — returns the chain id of the most recently written root receipt (the chain the daemon is currently appending to), or `found=false` for an empty store. Recency is by `rowid` (write order), not timestamp, so it is correct even when many receipts share the same RFC3339 second. Agent sub-chains (`…/agent/…`) are excluded. Used by `obsigna doctor` to target the live chain instead of guessing today's date.
+
 ## [0.19.0-alpha.1] - 2026-06-12
 
 ### Added

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -428,6 +428,27 @@ func (s *Store) DistinctChainIDs() ([]string, error) {
 	return chains, nil
 }
 
+// LatestRootChainID returns the chain id of the most recently written root
+// receipt — the chain the daemon is currently appending to. Recency is measured
+// by rowid (insertion order), not timestamp: a busy daemon writes many receipts
+// within the same RFC3339 second, so a timestamp ordering would tiebreak on
+// sequence and could surface an older chain's high-sequence receipt. Agent
+// sub-chains (ids containing "/agent/") are excluded so the result is the root
+// chain operators and diagnostics target. found is false when the store holds
+// no root receipts.
+func (s *Store) LatestRootChainID() (chainID string, found bool, err error) {
+	row := s.db.QueryRow(
+		"SELECT chain_id FROM receipts WHERE chain_id NOT LIKE '%/agent/%' ORDER BY rowid DESC LIMIT 1",
+	)
+	if scanErr := row.Scan(&chainID); scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("latest root chain id: %w", scanErr)
+	}
+	return chainID, true, nil
+}
+
 // GetChainTail returns the highest-sequence receipt's sequence and hash for
 // chainID. found is false (with zero values for the other fields and err nil)
 // when the chain is empty. The daemon uses this on startup to resume the

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -250,6 +250,73 @@ func TestDistinctChainIDs_Empty(t *testing.T) {
 	}
 }
 
+func TestLatestRootChainID_Empty(t *testing.T) {
+	s := setupStore(t)
+	chainID, found, err := s.LatestRootChainID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found || chainID != "" {
+		t.Errorf("got (%q, %v), want (\"\", false) for an empty store", chainID, found)
+	}
+}
+
+func TestLatestRootChainID_MostRecentlyWritten(t *testing.T) {
+	s := setupStore(t)
+	kp := mustKeyPair(t)
+
+	// Insert "2026-06-03" first (more receipts → higher max sequence), then
+	// "2026-06-03-8". Recency is by write order (rowid), so the second chain
+	// wins even though the first holds a higher-sequence receipt — guarding
+	// against a timestamp/sequence tiebreak surfacing the older chain.
+	insert := func(chainID string, count int) {
+		var prevHash *string
+		for i := 1; i <= count; i++ {
+			r := makeSignedReceipt(t, kp, i, chainID, prevHash)
+			h := mustHashReceipt(t, r)
+			if err := s.Insert(r, h); err != nil {
+				t.Fatal(err)
+			}
+			prevHash = &h
+		}
+	}
+	insert("2026-06-03", 3)
+	insert("2026-06-03-8", 2)
+
+	chainID, found, err := s.LatestRootChainID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || chainID != "2026-06-03-8" {
+		t.Errorf("got (%q, %v), want (\"2026-06-03-8\", true)", chainID, found)
+	}
+}
+
+func TestLatestRootChainID_ExcludesAgentSubchains(t *testing.T) {
+	s := setupStore(t)
+	kp := mustKeyPair(t)
+
+	r := makeSignedReceipt(t, kp, 1, "2026-06-03-8", nil)
+	h := mustHashReceipt(t, r)
+	if err := s.Insert(r, h); err != nil {
+		t.Fatal(err)
+	}
+	// Agent sub-chain receipt written last: newer by rowid, but must be excluded.
+	ar := makeSignedReceipt(t, kp, 1, "2026-06-03-8/agent/abc123", nil)
+	ah := mustHashReceipt(t, ar)
+	if err := s.Insert(ar, ah); err != nil {
+		t.Fatal(err)
+	}
+
+	chainID, found, err := s.LatestRootChainID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || chainID != "2026-06-03-8" {
+		t.Errorf("got (%q, %v), want the root chain excluding agent sub-chains", chainID, found)
+	}
+}
+
 func TestGetChainTail_Empty(t *testing.T) {
 	s := setupStore(t)
 	seq, hash, found, err := s.GetChainTail("chain-1")


### PR DESCRIPTION
## Problem

`obsigna doctor` run with no `--chain-id` defaulted the chain it inspects to **today's UTC date**:

```go
chainID := fs.String("chain-id", envOr("AGENTRECEIPTS_CHAIN_ID", time.Now().UTC().Format("2006-01-02")), ...)
```

But the daemon does not name its chain after today's date. Its chain id is pinned at startup — from `daemon.toml`'s `chain_id`, the per-OS default, or `AGENTRECEIPTS_CHAIN_ID` — and rolls a `-N` suffix across restarts (`advanceChainID`) when the prior chain is sealed. So on a healthy machine where receipts are actively flowing into, say, `2026-06-03-8`, doctor queried `2026-06-12` and reported:

```
[warn] chain head    chain "2026-06-12" has no receipts yet; nothing to verify
[fail] round-trip    synthetic event was accepted by the daemon but did not land in …/receipts.db
                     within 3s; the daemon may not be the sole writer of this DB
```

The synthetic event **was** traversing the full pipeline and landing correctly — in the live chain. doctor was polling the wrong chain, and the "may not be the sole writer" reason is a misdiagnosis. This also bites any daemon left running across a UTC-midnight rollover.

## Fix

When the operator does not name a chain explicitly (flag, then env), resolve it from the store's **most recently written root chain** instead of the wall clock. The bare UTC date remains only as the fallback for an empty store.

- New `store.LatestRootChainID()` — `SELECT chain_id … WHERE chain_id NOT LIKE '%/agent/%' ORDER BY rowid DESC LIMIT 1`. Recency is by `rowid` (write order), **not** timestamp: a busy daemon writes many receipts within the same RFC3339 second, and `QueryReceipts`' `timestamp DESC, sequence DESC` tiebreak could otherwise surface an older chain's high-sequence receipt over a newer chain's low-sequence one. Agent sub-chains are excluded because the round-trip event and the daemon's primary pipeline write to the root chain.
- `doctor` gains `resolveChainID` / `detectActiveRootChain` (read-only store access — safe against the live daemon as sole writer).

## Drive-by

Doctor's header and error strings now read `obsigna doctor` instead of `agent-receipts doctor`, matching the renamed CLI. (The `agent-receipts-doctor.roundtrip` tool name / `doctor.agent-receipts-doctor.roundtrip` action type are protocol-bound taxonomy constants and were left untouched.)

## Verification

Against a live daemon, no-arg `doctor` now auto-detects the active chain and passes:

```
obsigna doctor — pipeline health
[ok  ] round-trip   synthetic event traversed the full pipeline and landed at seq 340 with a fresh peer credential (pid=80794, uid=501)
doctor: PASS (7 ok, 1 warn, 0 fail)
```

(The remaining warn is the expected "head is not a clean terminator" for a live, open chain.)

## Tests

- `store`: `LatestRootChainID` — empty store, most-recently-written wins over higher-sequence older chain, agent sub-chains excluded.
- `doctorcli`: `detectActiveRootChain` (empty / unreadable / newest root / skips agent sub-chain) and `resolveChainID` (detected wins, empty → date fallback).
- `go test ./...` passes for both `sdk/go` and `daemon`; `go vet` clean.