### PR TITLE
chore(mcp-proxy): stamp CHANGELOG 0.15.0-alpha.1

### DIFF
--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -11,6 +11,8 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.15.0-alpha.1] - 2026-06-13
+
 ### Changed
 
 - **Binary renamed `mcp-proxy` → `obsigna-mcp` (ADR-0033).** The proxy is now its own


### PR DESCRIPTION
Stamps the mcp-proxy CHANGELOG `[Unreleased]` entries (binary topology / ADR-0033, Gate A/B) as `[0.15.0-alpha.1] - 2026-06-13`, keeping an empty `[Unreleased]` per Keep-a-Changelog. Release-prep for cutting the `mcp-proxy/v0.15.0-alpha.1` tag off main. No source changes.