### PR TITLE
feat(collector): binary topology — minimal obsigna-collector, obsigna collector run (ADR-0035)

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -26,16 +26,79 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          # Pin to the patch recorded in collector/go.mod (ADR-0035) so CI stops
+          # floating to the latest 1.26.x — a moving toolchain would defeat the
+          # reproducible-build attestation Gate B asserts.
+          go-version-file: collector/go.mod
 
       - name: Vet
         run: go vet ./...
 
       - name: Build
-        run: go build ./cmd/collector
+        # -trimpath mirrors the release build (collector/.goreleaser.yaml): CI
+        # must exercise the same flags the attestation depends on (ADR-0035).
+        # ./cmd/... covers both the obsigna-collector binary and the collector shim.
+        run: go build -trimpath ./cmd/...
 
       # -race because the in-memory and SQLite stores carry concurrency
       # invariants exercised by TestInMemoryStore_ConcurrentInserts and
       # TestSQLiteStore_ConcurrentInserts.
       - name: Test
         run: go test -race ./... -v
+
+  # Gate A (ADR-0035): obsigna-collector stays a dumb append-only sink — its
+  # import graph must never reach the daemon library (the signer, ADR-0010) or
+  # any operator read-side (*cli) package. Persistence (sdk/go/store, a SQLite
+  # driver) is the hub's legitimate job and is allowed, which is why this is a
+  # denylist rather than the allowlist obsigna-mcp uses. The rule lives in a Go
+  # test next to the code (cmd/obsigna-collector/import_guard_test.go) so it is
+  # enforced locally too; this job just runs it.
+  import-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: collector/go.mod
+      - name: Assert obsigna-collector stays a dumb sink
+        working-directory: collector
+        run: go test -run '^TestImportGraphExcludesSignerAndOperatorSurface$' ./cmd/obsigna-collector -v
+
+  # Gate B (ADR-0035): reproducible build. Build obsigna-collector twice from two
+  # working-directory paths of different lengths and assert byte-identical
+  # sha256. This is what proves -trimpath actually took: without it the absolute
+  # build path is baked into the binary and the two hashes diverge. The release
+  # workflow extends this to an independent rebuild that must match the published
+  # artifact (release-collector.yml), which is the auditor-facing attestation.
+  reproducible-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: collector/go.mod
+      - name: Build from two different paths, assert identical sha256
+        run: |
+          set -euo pipefail
+          # Export the tracked tree (no .git, no untracked worktrees) into two
+          # parent dirs whose paths differ in length, then build the collector in
+          # each via the shared reproducible-build script (same determinism flags
+          # the release attestation uses). The workspace (go.work) is exported
+          # too, so both builds resolve the in-tree sdk/go identically; the only
+          # difference between them is the absolute build path.
+          a=/tmp/p1
+          b=/tmp/path-two-longer-than-one
+          mkdir -p "$a/repo" "$b/repo"
+          git archive --format=tar HEAD | tar -x -C "$a/repo"
+          git archive --format=tar HEAD | tar -x -C "$b/repo"
+          "$a/repo/collector/scripts/reproducible-build.sh" "$a/repo/collector" /tmp/collector-a
+          "$b/repo/collector/scripts/reproducible-build.sh" "$b/repo/collector" /tmp/collector-b
+          h1="$(sha256sum /tmp/collector-a | awk '{print $1}')"
+          h2="$(sha256sum /tmp/collector-b | awk '{print $1}')"
+          echo "path-a sha256=$h1"
+          echo "path-b sha256=$h2"
+          if [ "$h1" != "$h2" ]; then
+            echo "::error::obsigna-collector is not reproducible across build paths ($h1 vs $h2); -trimpath is not taking effect."
+            exit 1
+          fi
+          echo "ok: byte-identical obsigna-collector from two different build paths ($h1)"

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -155,6 +155,6 @@ jobs:
           marker="<!-- obsigna-collector-attestation -->"
           notes="$(gh release view "${GITHUB_REF_NAME}" --json body -q .body)"
           if ! printf '%s' "$notes" | grep -qF "$marker"; then
-            printf '%s\n\n%s\n**Reproducible build (ADR-0035):** linux/amd64 `obsigna-collector` sha256 `%s` — independently rebuilt from source and matched byte-for-byte. Rebuild with `GOTOOLCHAIN=%s GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=v%s" ./cmd/obsigna-collector`.\n' \
+            printf '%s\n\n%s\n**Reproducible build (ADR-0035):** linux/amd64 `obsigna-collector` sha256 `%s` — independently rebuilt from source and matched byte-for-byte. Rebuild from a clean checkout with `cd collector && GOTOOLCHAIN=%s GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=v%s" ./cmd/obsigna-collector`.\n' \
               "$notes" "$marker" "$released_hash" "$toolchain" "$VERSION" | gh release edit "${GITHUB_REF_NAME}" --notes-file -
           fi

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -23,7 +23,10 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          # Pin to collector/go.mod's toolchain (ADR-0035): the release build must
+          # use the exact compiler the reproducible-attestation gate rebuilds
+          # with, not a floating latest 1.26.x.
+          go-version-file: collector/go.mod
 
       # GoReleaser can't parse the prefixed tag `collector/vX.Y.Z` as semver.
       # Create a local lightweight `vX.Y.Z` tag at the same commit so
@@ -83,3 +86,75 @@ jobs:
             collector/dist/*.tar.gz \
             collector/dist/checksums.txt \
             --clobber
+
+  # Gate B (release side, ADR-0035): the attestation claim is that auditors can
+  # independently rebuild obsigna-collector and match a published hash. Prove it
+  # on every release — independently rebuild the binary with the same
+  # deterministic flags GoReleaser used, assert its sha256 equals the binary
+  # inside the just-released archive, then publish that hash (a .sha256 asset + a
+  # notes line) as the collector's known-good attestation value. A mismatch means
+  # the build is not reproducible, so we refuse to publish a hash and fail the
+  # release.
+  reproducible-attest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: collector/go.mod
+      - name: Rebuild obsigna-collector and match the released artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#collector/v}"   # e.g. 0.13.0-alpha.1 (no leading v)
+          asset="collector_${VERSION}_linux_amd64.tar.gz"
+
+          # 1) Hash obsigna-collector as shipped, from the archive uploaded by the
+          #    release job above.
+          mkdir -p released
+          gh release download "${GITHUB_REF_NAME}" --pattern "$asset" --dir released
+          tar -xzf "released/${asset}" -C released
+          released_hash="$(sha256sum released/obsigna-collector | awk '{print $1}')"
+
+          # 2) Independent clean rebuild via the shared reproducible-build script
+          #    (the same one Gate B uses), so the release rebuild and the PR gate
+          #    can't drift. GOWORK=off resolves the published sdk/go rather than
+          #    the in-tree workspace, matching the release build; GOOS/GOARCH pin
+          #    the linux/amd64 artifact. The script keeps CGO off, -trimpath, and
+          #    -buildvcs=false in lockstep with collector/.goreleaser.yaml.
+          ( cd collector && GOWORK=off go mod download )
+          GOWORK=off GOOS=linux GOARCH=amd64 \
+            collector/scripts/reproducible-build.sh collector /tmp/obsigna-collector-rebuild "${VERSION}"
+          rebuilt_hash="$(sha256sum /tmp/obsigna-collector-rebuild | awk '{print $1}')"
+
+          echo "released sha256: $released_hash"
+          echo "rebuilt  sha256: $rebuilt_hash"
+          if [ "$released_hash" != "$rebuilt_hash" ]; then
+            echo "::error::Released obsigna-collector (linux/amd64) does not match an independent clean rebuild ($released_hash vs $rebuilt_hash). The build is not reproducible; refusing to publish an attestation hash."
+            exit 1
+          fi
+
+          # Derive the exact toolchain from go.mod so the published rebuild
+          # command can't drift from the compiler CI actually used: the
+          # `toolchain` directive is the single source of truth (setup-go reads
+          # it via go-version-file). Fall back to the `go` directive if no
+          # explicit toolchain is pinned.
+          toolchain="$(cd collector && go mod edit -json | python3 -c 'import json,sys; m=json.load(sys.stdin); print(m.get("Toolchain") or "go"+m["Go"])')"
+
+          # 3) Publish the known-good hash: a .sha256 asset and a release-notes
+          #    line. The notes append is guarded by a marker so re-runs don't
+          #    duplicate it.
+          hashfile="obsigna-collector-linux-amd64.sha256"
+          echo "${released_hash}  obsigna-collector" > "$hashfile"
+          gh release upload "${GITHUB_REF_NAME}" "$hashfile" --clobber
+
+          marker="<!-- obsigna-collector-attestation -->"
+          notes="$(gh release view "${GITHUB_REF_NAME}" --json body -q .body)"
+          if ! printf '%s' "$notes" | grep -qF "$marker"; then
+            printf '%s\n\n%s\n**Reproducible build (ADR-0035):** linux/amd64 `obsigna-collector` sha256 `%s` — independently rebuilt from source and matched byte-for-byte. Rebuild with `GOTOOLCHAIN=%s GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=v%s" ./cmd/obsigna-collector`.\n' \
+              "$notes" "$marker" "$released_hash" "$toolchain" "$VERSION" | gh release edit "${GITHUB_REF_NAME}" --notes-file -
+          fi

--- a/.github/workflows/release-mcp-proxy.yml
+++ b/.github/workflows/release-mcp-proxy.yml
@@ -137,6 +137,6 @@ jobs:
           marker="<!-- obsigna-mcp-attestation -->"
           notes="$(gh release view "${GITHUB_REF_NAME}" --json body -q .body)"
           if ! printf '%s' "$notes" | grep -qF "$marker"; then
-            printf '%s\n\n%s\n**Reproducible build (ADR-0033):** linux/amd64 `obsigna-mcp` sha256 `%s` — independently rebuilt from source and matched byte-for-byte. Rebuild with `GOTOOLCHAIN=%s GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=v%s" ./cmd/obsigna-mcp`.\n' \
+            printf '%s\n\n%s\n**Reproducible build (ADR-0033):** linux/amd64 `obsigna-mcp` sha256 `%s` — independently rebuilt from source and matched byte-for-byte. Rebuild from a clean checkout with `cd mcp-proxy && GOTOOLCHAIN=%s GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=v%s" ./cmd/obsigna-mcp`.\n' \
               "$notes" "$marker" "$released_hash" "$toolchain" "$VERSION" | gh release edit "${GITHUB_REF_NAME}" --notes-file -
           fi

--- a/collector/.goreleaser.yaml
+++ b/collector/.goreleaser.yaml
@@ -4,9 +4,9 @@ project_name: collector
 
 # Disable the Go workspace so GoReleaser resolves dependencies strictly from
 # collector/go.mod (published versions) rather than the in-tree ./sdk/go module
-# wired up by the repo-root go.work. Without this, the released binary would
-# link the in-tree sdk/go instead of the published version `go install` users
-# resolve.
+# wired up by the repo-root go.work. The release attestation (Gate B) rebuilds
+# with GOWORK=off too, so the released bytes and the independent rebuild resolve
+# the same dependency versions.
 env:
   - GOWORK=off
 
@@ -15,12 +15,33 @@ before:
     - go mod download
     - sh -c "cp ../LICENSE LICENSE"
 
+# Reproducible builds are an attestation requirement (ADR-0035), not a nicety:
+# auditors must independently rebuild obsigna-collector and match the published
+# hash. Determinism comes from CGO_ENABLED=0 (no host toolchain bytes), -trimpath
+# (no absolute $GOPATH/working-dir paths baked in), a patch-pinned toolchain
+# (go.mod `toolchain`, consumed via go-version-file in CI), and version stamping
+# that derives only from the tag/commit — never wall-clock time. mod_timestamp
+# uses the commit timestamp so archive/file mtimes are a function of the commit,
+# not of when the release runner happened to build. -buildvcs=false omits git
+# VCS stamping: the `before` hook copies LICENSE into collector/ (an untracked
+# file), which would otherwise flip go's vcs.modified and make the released
+# binary differ from a clean rebuild that has no such file. Keep these
+# obsigna-collector flags in lockstep with collector/scripts/reproducible-build.sh,
+# the shared script the Gate B reproducibility checks rebuild with (ADR-0035).
 builds:
-  - id: collector
-    main: ./cmd/collector
-    binary: collector
+  # The collector, renamed collector -> obsigna-collector (ADR-0035). This is the
+  # primary binary, launched in production via `obsigna collector run` (ADR-0030,
+  # ADR-0034); the collector entry below is a thin deprecation shim that execs
+  # into it.
+  - id: obsigna-collector
+    main: ./cmd/obsigna-collector
+    binary: obsigna-collector
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - darwin
       - linux
@@ -30,8 +51,36 @@ builds:
     ldflags:
       - -s -w -X main.version=v{{.Version}}
 
+  # Deprecation shim: keeps `collector <flags>` working by exec-forwarding to
+  # obsigna-collector with a one-line stderr notice. Ships alongside
+  # obsigna-collector so existing installers/scripts keep running through the
+  # rename. It carries no main.version symbol (it never prints its own version —
+  # `collector --version` forwards to obsigna-collector), so no -X main.version
+  # stamp is applied here; the determinism flags still match obsigna-collector so
+  # the shim is reproducible too.
+  - id: collector
+    main: ./cmd/collector
+    binary: collector
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - ids:
+      - obsigna-collector
+      - collector
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats: [tar.gz]
     files:
       - README.md
@@ -78,15 +127,31 @@ brews:
       email: bot@agentreceipts.ai
     commit_msg_template: "chore(collector): bump to v{{ .Version }}"
     install: |
+      bin.install "obsigna-collector"
       bin.install "collector"
     test: |
+      system "#{bin}/obsigna-collector", "--version"
       system "#{bin}/collector", "--version"
     # `brew outdated` and `brew livecheck` use this to detect new releases.
     # The `ar` repo ships multiple taggable components, so we can't use
     # `:github_latest` (which returns repo-wide latest). `:github_releases`
     # scans all releases; regex extracts version from the `collector/vX.Y.Z`
     # tag prefix.
+    #
+    # The caveats are emitted via custom_block so they survive formula
+    # regeneration on each release (GoReleaser overwrites the formula file;
+    # anything not in custom_block or the named fields would be lost).
     custom_block: |
+      def caveats
+        <<~EOS
+          The collector binary is now obsigna-collector (was collector). The
+          collector command still works as a thin deprecation shim that forwards
+          to obsigna-collector, so existing installers and scripts keep running —
+          but update them to obsigna-collector (or `obsigna collector run`) when
+          convenient; the shim will be removed in a future release.
+        EOS
+      end
+
       livecheck do
         url "https://github.com/agent-receipts/ar"
         strategy :github_releases

--- a/collector/CHANGELOG.md
+++ b/collector/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to the collector are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file starts at the `obsigna-collector` rename; earlier releases are recorded
+only in git history. A repo-wide effort to auto-generate changelogs from
+Conventional Commits is tracked in
+[#253](https://github.com/agent-receipts/ar/issues/253).
+
+## [Unreleased]
+
+### Changed
+
+- **Binary renamed `collector` → `obsigna-collector` (ADR-0035).** The collector is
+  now its own minimal binary, `obsigna-collector`, launched in production via
+  `obsigna collector run` (ADR-0030, ADR-0034), which `syscall.Exec`s straight into
+  it. **Breaking for installers that invoke the binary by an absolute path to a
+  renamed file.** A thin `collector` deprecation shim ships alongside
+  `obsigna-collector` and exec-forwards to it, so the common `$(which collector)`
+  invocation and existing scripts keep working — update them to `obsigna-collector`
+  (or `obsigna collector run`) when convenient; the shim will be removed in a future
+  release. The Homebrew formula name (`collector`) is unchanged; both binaries are
+  installed.
+
+### Added
+
+- **Gate A — dumb-sink import graph (ADR-0035).** A CI-enforced test asserts the
+  `obsigna-collector` production graph never reaches the daemon library (the signer,
+  ADR-0010) or any operator read-side (`*cli`) package. Unlike the proxy's
+  fail-closed allowlist (ADR-0033), this is a denylist: the collector *legitimately*
+  persists receipts (`sdk/go/store`, `sdk/go/receipt`, a SQLite driver), so the
+  property enforced is "never the signer, never the operator CLI" rather than "no
+  store".
+- **Gate B — reproducible build (ADR-0035).** `obsigna-collector` is built with
+  `CGO_ENABLED=0`, `-trimpath`, `-buildvcs=false`, a patch-pinned toolchain
+  (`toolchain go1.26.1`), and a commit-derived `mod_timestamp`. The PR gate builds it
+  twice from two working-directory paths and asserts byte-identical `sha256`; the
+  release independently rebuilds it, asserts a match against the published archive,
+  and publishes the known-good hash. Both rebuilds share
+  `collector/scripts/reproducible-build.sh` so they cannot drift.

--- a/collector/README.md
+++ b/collector/README.md
@@ -86,8 +86,14 @@ The receipts handler emits these statuses:
 
 ## Running
 
+The collector binary is **`obsigna-collector`** (ADR-0035), launched in
+production via `obsigna collector run`, which `syscall.Exec`s straight into it.
+The legacy `collector` binary still works as a thin deprecation shim that
+forwards to `obsigna-collector` — update installers to the new name when
+convenient; the shim will be removed in a future release.
+
 ```sh
-go run ./cmd/collector --addr 127.0.0.1:8787 --db collector.db
+go run ./cmd/obsigna-collector --addr 127.0.0.1:8787 --db collector.db
 ```
 
 The default `--addr` binds to loopback (`127.0.0.1:8787`) so a `go run` on a
@@ -95,7 +101,7 @@ workstation does not expose an unauthenticated audit-trail endpoint to the
 network. To expose the collector beyond localhost, opt in explicitly:
 
 ```sh
-go run ./cmd/collector --addr 0.0.0.0:8787
+go run ./cmd/obsigna-collector --addr 0.0.0.0:8787
 ```
 
 In production, run the collector behind a reverse proxy or service mesh that
@@ -143,7 +149,7 @@ follow-ups:
 ```sh
 go test ./...        # unit tests
 go vet ./...         # static analysis
-go build ./cmd/collector
+go build ./cmd/...   # obsigna-collector binary + the collector deprecation shim
 ```
 
 Tests use an in-memory `Store` for the HTTP layer and a fresh on-disk SQLite
@@ -153,6 +159,8 @@ database (under `t.TempDir()`) for the SQLite-adapter tests.
 
 - [ADR-0020](../docs/adr/0020-emitter-abstraction-and-remote-receipt-delivery.md)
   — emitter abstraction, collector contract
+- [ADR-0035](../docs/adr/0035-collector-binary-topology.md)
+  — collector binary topology (`obsigna-collector`, `obsigna collector run`)
 - [ADR-0018](../docs/adr/0018-signer-abstraction-and-cloud-agnostic-keyprovider-design.md)
   — `Signer` interface (production key story for HTTP emitters)
 - Issue [#533](https://github.com/agent-receipts/ar/issues/533) — this work

--- a/collector/cmd/collector/main.go
+++ b/collector/cmd/collector/main.go
@@ -1,128 +1,102 @@
-// Command collector runs the agent-receipts reference HTTP collector.
+// Command collector is the deprecation shim for the renamed `obsigna-collector`
+// binary (ADR-0035). The reference HTTP collector is now its own minimal binary,
+// obsigna-collector, launched in production via `obsigna collector run`
+// (ADR-0030, ADR-0034). This shim preserves the old `collector` entrypoint —
+// every flag is identical — by replacing its own process image with
+// obsigna-collector via syscall.Exec, forwarding argv and the environment
+// unchanged. It prints a one-line deprecation notice to STDERR before the exec.
 //
-// The collector accepts signed receipts at POST /receipts and persists them to
-// a SQLite-backed store. It performs no signing, no chain construction, no
-// signature verification, and no semantic validation — its contract is the
-// dumb append-only sink described in ADR-0020.
+// syscall.Exec (not exec.Command) is deliberate: the collector is a long-running
+// HTTP service. Replacing the image keeps the same PID and inherited
+// stdin/stdout/stderr, so the shim adds no extra process and is indistinguishable
+// from invoking obsigna-collector directly. The trade-off is platform restriction
+// to where syscall.Exec exists (darwin, linux) — the only release targets,
+// matching obsigna's launcher.
+//
+// This file must remain a thin shim: it deliberately does not import the
+// collector library or re-implement its flags. The entrypoint-guard test in
+// cmd/obsigna-collector asserts that, so `collector` can never be reintroduced as
+// a primary entrypoint.
 package main
 
 import (
-	"context"
-	"flag"
 	"fmt"
-	"log/slog"
+	"io"
 	"os"
-	"os/signal"
-	"runtime/debug"
-	"strconv"
+	"os/exec"
+	"path/filepath"
 	"syscall"
-	"time"
-
-	"github.com/agent-receipts/ar/collector"
 )
 
-// version is set at build time via -ldflags "-X main.version=vX.Y.Z". Falls
-// back to the module version from Go's build info (set automatically for
-// binaries installed with `go install`), then to "dev". Mirrors the
-// resolveVersion pattern used in daemon/cmd/agent-receipts-daemon/main.go.
-var version string
+// deprecationShimMarker identifies this entrypoint as the collector →
+// obsigna-collector deprecation shim. The entrypoint-guard test
+// (cmd/obsigna-collector) greps for it to prove cmd/collector is only ever the
+// shim.
+const deprecationShimMarker = "collector-deprecation-shim"
 
-func resolveVersion() string {
-	if version != "" {
-		return version
-	}
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
-		return info.Main.Version
-	}
-	return "dev"
-}
+// targetBinary is the binary the shim forwards to. Releases target darwin and
+// linux only, so no platform-specific extension is needed.
+const targetBinary = "obsigna-collector"
 
-// defaultAddr binds to loopback by default so a `go run ./cmd/collector` on a
-// developer workstation does not expose an unauthenticated audit-trail
-// endpoint to the network. Operators who want network reachability must opt
-// in explicitly with --addr 0.0.0.0:8787 (or, preferably, sit a reverse
-// proxy / mesh in front).
-const defaultAddr = "127.0.0.1:8787"
+// execImage replaces the current process image with the named binary, the way
+// execve(2) does. It is a package var so tests can stub it and assert it
+// defaults to syscall.Exec. This MUST be syscall.Exec, never exec.Command:
+// forking would insert an extra process and change the PID the service manager
+// supervises, whereas replacing the image keeps the collector indistinguishable
+// from a direct obsigna-collector invocation.
+var execImage = syscall.Exec
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-
-	addr := flag.String("addr", envOrDefault("AGENTRECEIPTS_COLLECTOR_ADDR", defaultAddr), "HTTP listen address (default loopback; use 0.0.0.0:port to expose)")
-	dbPath := flag.String("db", envOrDefault("AGENTRECEIPTS_COLLECTOR_DB", "collector.db"), "SQLite database path (use ':memory:' for ephemeral storage — not durable)")
-	maxBody := flag.Int64("max-body-bytes", envInt64OrDefault(logger, "AGENTRECEIPTS_COLLECTOR_MAX_BODY_BYTES", collector.DefaultMaxBodyBytes), "Maximum request body size in bytes")
-	drainTimeout := flag.Duration("drain-timeout", envDurationOrDefault(logger, "AGENTRECEIPTS_COLLECTOR_DRAIN_TIMEOUT", 10*time.Second), "Graceful shutdown timeout")
-	showVersion := flag.Bool("version", false, "Print version and exit")
-	flag.Parse()
-
-	if *showVersion {
-		fmt.Println(resolveVersion())
-		return
-	}
-
-	logger.Info("collector starting", "version", resolveVersion(), "addr", *addr, "db", *dbPath)
-
-	store, err := collector.OpenSQLiteStore(*dbPath)
-	if err != nil {
-		logger.Error("failed to open store", slog.Any("err", err))
-		os.Exit(1)
-	}
-	defer store.Close()
-
-	srv, err := collector.NewServer(collector.Config{
-		Addr:         *addr,
-		MaxBodyBytes: *maxBody,
-		Logger:       logger,
-	}, store)
-	if err != nil {
-		logger.Error("failed to construct server", slog.Any("err", err))
-		os.Exit(1)
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	if err := collector.Run(ctx, srv, *drainTimeout, logger); err != nil {
-		logger.Error("collector exited with error", slog.Any("err", err))
-		os.Exit(1)
-	}
-	logger.Info("collector stopped cleanly")
+	os.Exit(run(os.Args[1:], os.Stderr))
 }
 
-func envOrDefault(name, def string) string {
-	if v := os.Getenv(name); v != "" {
-		return v
+// run prints the deprecation notice, resolves obsigna-collector, and replaces
+// this process with it, forwarding args and the current environment. On success
+// it does not return — the image is gone. A return means the exec never happened
+// (binary missing or not executable); that is the only error path, reported with
+// a non-zero exit code.
+func run(args []string, stderr io.Writer) int {
+	fmt.Fprintf(stderr,
+		"collector is deprecated; use 'obsigna-collector' (or 'obsigna collector run'). Forwarding…\n")
+
+	bin, err := resolveSibling(targetBinary)
+	if err != nil {
+		fmt.Fprintf(stderr, "collector: %v\n", err)
+		return 1
 	}
-	return def
+	// argv[0] is the resolved binary path so ps/`/proc/self/cmdline` show
+	// obsigna-collector, not collector. The target parses os.Args[1:] exactly as
+	// if invoked directly — the collector's flag surface is identical.
+	argv := append([]string{bin}, args...)
+	if err := execImage(bin, argv, os.Environ()); err != nil {
+		fmt.Fprintf(stderr, "collector: exec %s: %v\n", bin, err)
+		return 1
+	}
+	return 0 // unreachable with the real syscall.Exec; the image is replaced
 }
 
-// envInt64OrDefault parses an int64 from the named env var. On parse failure
-// it logs a warning and falls back to def — silent fallback hides operator
-// misconfigurations (e.g. setting MAX_BODY_BYTES=1MB and getting a 1 MiB
-// default rather than 1 000 000 bytes).
-func envInt64OrDefault(log *slog.Logger, name string, def int64) int64 {
-	v := os.Getenv(name)
-	if v == "" {
-		return def
+// resolveSibling returns the path to a binary named name, preferring one
+// installed beside the current executable and falling back to $PATH. Resolving
+// beside the current binary first avoids picking up an unrelated binary of the
+// same name earlier on $PATH. This mirrors daemon/internal/binresolve, which the
+// collector module cannot import across the module's internal boundary.
+func resolveSibling(name string) (string, error) {
+	if self, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(self), name)
+		if isExecutableFile(candidate) {
+			return candidate, nil
+		}
 	}
-	parsed, err := strconv.ParseInt(v, 10, 64)
-	if err != nil {
-		log.Warn("invalid env var, using default",
-			"name", name, "value", v, "default", def, slog.Any("err", err))
-		return def
+	if p, err := exec.LookPath(name); err == nil {
+		return p, nil
 	}
-	return parsed
+	return "", fmt.Errorf("cannot locate the %q binary (expected beside the current binary or on $PATH)", name)
 }
 
-func envDurationOrDefault(log *slog.Logger, name string, def time.Duration) time.Duration {
-	v := os.Getenv(name)
-	if v == "" {
-		return def
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
 	}
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		log.Warn("invalid env var, using default",
-			"name", name, "value", v, "default", def, slog.Any("err", err))
-		return def
-	}
-	return d
+	return info.Mode().Perm()&0o111 != 0
 }

--- a/collector/cmd/collector/main_test.go
+++ b/collector/cmd/collector/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestExecImageDefaultsToSyscallExec asserts the shim replaces its image rather
+// than forking a child (ADR-0035): a fork would add a process under the service
+// manager and change the supervised PID.
+func TestExecImageDefaultsToSyscallExec(t *testing.T) {
+	if reflect.ValueOf(execImage).Pointer() != reflect.ValueOf(syscall.Exec).Pointer() {
+		t.Error("execImage must default to syscall.Exec so the shim replaces its image, never forks a child")
+	}
+}
+
+// TestRunForwardsArgvAndEnviron stubs execImage to capture what the shim would
+// exec: argv[0] is the resolved binary, the remaining argv is the shim's args
+// verbatim (the collector flag surface is identical, so there is no translation),
+// and the deprecation notice goes to the provided writer.
+func TestRunForwardsArgvAndEnviron(t *testing.T) {
+	// Place an executable named obsigna-collector beside this test binary so
+	// resolveSibling finds it via os.Executable()'s directory.
+	dir := t.TempDir()
+	target := filepath.Join(dir, targetBinary)
+	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	var gotPath string
+	var gotArgv []string
+	execImage = func(path string, argv []string, _ []string) error {
+		gotPath, gotArgv = path, argv
+		return nil
+	}
+	t.Cleanup(func() { execImage = syscall.Exec })
+
+	var stderr bytes.Buffer
+	code := run([]string{"--addr", "0.0.0.0:8787", "--db", "c.db"}, &stderr)
+	if code != 0 {
+		t.Fatalf("run exit = %d, want 0", code)
+	}
+	if filepath.Base(gotPath) != targetBinary {
+		t.Errorf("exec path = %q, want a path to %q", gotPath, targetBinary)
+	}
+	wantArgv := []string{gotPath, "--addr", "0.0.0.0:8787", "--db", "c.db"}
+	if !reflect.DeepEqual(gotArgv, wantArgv) {
+		t.Errorf("argv = %v, want %v", gotArgv, wantArgv)
+	}
+	if !strings.Contains(stderr.String(), "collector is deprecated") {
+		t.Errorf("missing deprecation notice on stderr: %q", stderr.String())
+	}
+}
+
+// TestRunReportsMissingTarget covers the only error path: when obsigna-collector
+// can't be resolved, the shim reports it and returns non-zero rather than
+// exiting 0.
+func TestRunReportsMissingTarget(t *testing.T) {
+	// An empty PATH and a temp working dir guarantee no obsigna-collector is found.
+	t.Setenv("PATH", t.TempDir())
+	var stderr bytes.Buffer
+	if code := run(nil, &stderr); code != 1 {
+		t.Errorf("run exit = %d, want 1 when target is missing", code)
+	}
+	if !strings.Contains(stderr.String(), "cannot locate") {
+		t.Errorf("stderr = %q, want a 'cannot locate' message", stderr.String())
+	}
+}
+
+// TestShimDoesNotReimplementSurface keeps cmd/collector a thin forwarder: it must
+// carry the shim marker and must NOT import the collector library (which would
+// mean it had grown its own flag surface again).
+func TestShimDoesNotReimplementSurface(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), deprecationShimMarker) {
+		t.Error("cmd/collector is missing the deprecation-shim marker; it must remain a forwarding shim")
+	}
+	if strings.Contains(string(src), `agent-receipts/ar/collector"`) {
+		t.Error("cmd/collector imports the collector library — the shim must forward to obsigna-collector, not re-implement the surface")
+	}
+}
+
+// TestForwardingIntegration builds the shim and obsigna-collector into one
+// directory (the installed layout) and checks the shim execs obsigna-collector:
+// `collector --version` is replaced by `obsigna-collector --version`, so stdout
+// carries obsigna-collector's version line while the deprecation notice appears
+// once on stderr and never on stdout.
+func TestForwardingIntegration(t *testing.T) {
+	if syscall.Getuid() < 0 {
+		t.Skip("syscall.Exec unavailable on this platform")
+	}
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "collector")
+	real := filepath.Join(dir, "obsigna-collector")
+	goBuild(t, shim, "github.com/agent-receipts/ar/collector/cmd/collector")
+	goBuild(t, real, "github.com/agent-receipts/ar/collector/cmd/obsigna-collector")
+
+	out, errOut, code := runBin(t, shim, "--version")
+	if code != 0 {
+		t.Fatalf("collector --version exit = %d (stderr: %q)", code, errOut)
+	}
+	// obsigna-collector --version prints just the version string; the shim itself
+	// has no --version handling, so a clean exit with a non-empty stdout proves
+	// the exec into obsigna-collector took (a non-forwarding shim would never
+	// produce this output).
+	if strings.TrimSpace(out) == "" {
+		t.Errorf("stdout = %q, want obsigna-collector's version line (shim execs obsigna-collector)", out)
+	}
+	const notice = "collector is deprecated"
+	if !strings.Contains(errOut, notice) {
+		t.Errorf("deprecation notice missing from stderr: %q", errOut)
+	}
+	if strings.Contains(out, notice) {
+		t.Errorf("deprecation notice leaked into stdout: %q", out)
+	}
+}
+
+func goBuild(t *testing.T, out, pkg string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build %s: %v\n%s", pkg, err, combined)
+	}
+}
+
+func runBin(t *testing.T, bin string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	code = 0
+	if err != nil {
+		var ee *exec.ExitError
+		if !asExit(err, &ee) {
+			t.Fatalf("run %s %v: %v", bin, args, err)
+		}
+		code = ee.ExitCode()
+	}
+	return out.String(), errOut.String(), code
+}
+
+func asExit(err error, target **exec.ExitError) bool {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*target = ee
+		return true
+	}
+	return false
+}

--- a/collector/cmd/obsigna-collector/entrypoint_guard_test.go
+++ b/collector/cmd/obsigna-collector/entrypoint_guard_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// goreleaserBuild is one entry under the goreleaser `builds:` list.
+type goreleaserBuild struct {
+	id, main, binary string
+}
+
+// parseGoreleaserBuilds extracts (id, main, binary) for each build by scanning
+// the YAML lines. A tiny hand parser avoids pulling a YAML dependency into a
+// guard test. A new build begins at each `  - ` list marker inside the `builds:`
+// section; id/main/binary are captured in ANY order within a build, so
+// reformatting that reorders fields cannot silently misassign them.
+func parseGoreleaserBuilds(t *testing.T, yaml string) []goreleaserBuild {
+	t.Helper()
+	topKey := regexp.MustCompile(`^[a-z]`)
+	itemRe := regexp.MustCompile(`^  - (\w[\w-]*):\s*(\S+)`)
+	keyRe := regexp.MustCompile(`^\s+(\w[\w-]*):\s*(\S+)`)
+
+	set := func(b *goreleaserBuild, key, val string) {
+		switch key {
+		case "id":
+			b.id = val
+		case "main":
+			b.main = val
+		case "binary":
+			b.binary = val
+		}
+	}
+
+	inBuilds := false
+	var builds []goreleaserBuild
+	for _, line := range strings.Split(yaml, "\n") {
+		if topKey.MatchString(line) {
+			inBuilds = strings.HasPrefix(line, "builds:")
+			continue
+		}
+		if !inBuilds {
+			continue
+		}
+		if m := itemRe.FindStringSubmatch(line); m != nil {
+			builds = append(builds, goreleaserBuild{})
+			set(&builds[len(builds)-1], m[1], m[2])
+			continue
+		}
+		if len(builds) == 0 {
+			continue
+		}
+		if m := keyRe.FindStringSubmatch(line); m != nil {
+			set(&builds[len(builds)-1], m[1], m[2])
+		}
+	}
+	return builds
+}
+
+// TestObsignaCollectorIsPrimaryEntrypoint is the anti-regression gate (ADR-0035):
+// the collector must build from ./cmd/obsigna-collector as the `obsigna-collector`
+// binary, and `collector` may appear ONLY as the deprecation shim
+// (./cmd/collector). If someone reintroduces collector as a primary entrypoint —
+// points the obsigna-collector source at a collector binary, or builds the
+// collector binary from the real collector source — this fails.
+func TestObsignaCollectorIsPrimaryEntrypoint(t *testing.T) {
+	yaml := readFile(t, "../../.goreleaser.yaml")
+	builds := parseGoreleaserBuilds(t, yaml)
+
+	var primary *goreleaserBuild
+	for i := range builds {
+		if builds[i].main == "./cmd/obsigna-collector" {
+			primary = &builds[i]
+		}
+		// No build may ship the obsigna-collector source under the collector name.
+		if builds[i].main == "./cmd/obsigna-collector" && builds[i].binary == "collector" {
+			t.Errorf("build %q ships ./cmd/obsigna-collector as binary collector; the primary collector must be 'obsigna-collector'", builds[i].id)
+		}
+		// Anything named collector must be the shim package.
+		if builds[i].binary == "collector" && builds[i].main != "./cmd/collector" {
+			t.Errorf("build %q ships binary collector from %q; only ./cmd/collector (the shim) may", builds[i].id, builds[i].main)
+		}
+	}
+	if primary == nil {
+		t.Fatal("no goreleaser build builds ./cmd/obsigna-collector — the primary collector is missing")
+	}
+	if primary.binary != "obsigna-collector" {
+		t.Errorf("primary collector binary = %q, want \"obsigna-collector\"", primary.binary)
+	}
+}
+
+// TestObsignaCollectorWiresCollectorLibrary is the converse: obsigna-collector is
+// the real collector, so it must wire the collector server. Asserting it imports
+// the collector library keeps the guard honest — the primary entrypoint carries
+// the surface; the shim does not.
+func TestObsignaCollectorWiresCollectorLibrary(t *testing.T) {
+	src := readFile(t, "main.go")
+	if !strings.Contains(src, `agent-receipts/ar/collector"`) {
+		t.Error("cmd/obsigna-collector does not import the collector library; obsigna-collector must be the primary collector entrypoint")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/collector/cmd/obsigna-collector/import_guard_test.go
+++ b/collector/cmd/obsigna-collector/import_guard_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Gate A for the collector (ADR-0035) is a structural DENYLIST, not the
+// fail-closed allowlist mcp-proxy uses (ADR-0033). The difference is load-bearing:
+// the collector is a receipt hub (ADR-0017/ADR-0020) whose whole job is to
+// persist receipts, so it *legitimately* links a store and a SQLite driver
+// (sdk/go/store, modernc.org/sqlite) plus the receipt type (sdk/go/receipt). An
+// allowlist that exists to keep persistence *out* — the proxy's property — is the
+// wrong tool here; enumerating SQLite's large transitive tree would also be
+// brittle. What the collector must *never* grow into is the signer or the
+// operator read-side, so we forbid exactly those, mirroring the daemon's
+// structural Gate A (ADR-0031):
+//
+//   - the daemon library (the signer that owns the private key, ADR-0010) — the
+//     hub must never link signing/chaining code; and
+//   - any operator-facing read-side CLI package (internal/*cli) — receipt
+//     verify/show/list/doctor/keys tooling has no place in a hub process.
+//
+// Keying on the "cli" suffix (rather than an enumerated list) means a newly added
+// operator package is caught automatically. The hub's legitimate dependencies —
+// sdk/go/store, sdk/go/receipt, modernc.org/sqlite, google/uuid — carry neither
+// signal and are allowed.
+var forbiddenImports = []forbiddenRule{
+	{
+		// The daemon library: the signing process (ADR-0010). The collector
+		// receives already-signed receipts over HTTP; it never signs, chains, or
+		// holds a key, so it must not link the daemon — directly or transitively.
+		pattern: regexp.MustCompile(`^github\.com/agent-receipts/ar/daemon($|/)`),
+		reason:  "the daemon library (the signer, ADR-0010); the collector is a sink, not a writer — it must never link signing/chaining code",
+	},
+	{
+		// Operator read-side CLI packages (internal/*cli — verifycli, showcli,
+		// listcli, doctorcli, keyscli, …). These belong to operator tooling, not a
+		// receipt hub.
+		pattern: regexp.MustCompile(`^github\.com/agent-receipts/ar/.*[a-z0-9]+cli$`),
+		reason:  "an operator read-side CLI package (internal/*cli); operator tooling has no place in a hub process",
+	},
+}
+
+type forbiddenRule struct {
+	pattern *regexp.Regexp
+	reason  string
+}
+
+// TestImportGraphExcludesSignerAndOperatorSurface is Gate A (ADR-0035): the
+// collector stays a dumb append-only sink (ADR-0020). Its production import graph
+// must never reach the daemon library (the signer) or any operator read-side
+// (*cli) package; either would mean the hub had grown a responsibility that
+// belongs to the daemon or the operator CLI, eroding the trust boundary the
+// topology exists to keep crisp. Persistence (sdk/go/store, a SQLite driver) is
+// the hub's job and is deliberately *allowed* — that is why this is a denylist,
+// not the allowlist obsigna-mcp uses.
+//
+// This is the source of truth for Gate A; the collector.yml import-graph job just
+// runs this test so the rule lives in one place next to the code it guards.
+func TestImportGraphExcludesSignerAndOperatorSurface(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", ".").Output()
+	if err != nil {
+		t.Fatalf("go list -deps .: %v", err)
+	}
+	for _, dep := range strings.Fields(string(out)) {
+		for _, rule := range forbiddenImports {
+			if rule.pattern.MatchString(dep) {
+				t.Errorf("obsigna-collector reaches forbidden package %q: %s. ADR-0035 keeps the collector a dumb sink — the daemon is the sole writer (ADR-0010) and operator tooling lives in the obsigna CLI", dep, rule.reason)
+			}
+		}
+	}
+}

--- a/collector/cmd/obsigna-collector/import_guard_test.go
+++ b/collector/cmd/obsigna-collector/import_guard_test.go
@@ -45,8 +45,10 @@ var forbiddenImports = []forbiddenRule{
 	{
 		// Operator read-side CLI packages (internal/*cli — verifycli, showcli,
 		// listcli, doctorcli, keyscli, …). These belong to operator tooling, not a
-		// receipt hub.
-		pattern: regexp.MustCompile(`^github\.com/agent-receipts/ar/.*[a-z0-9]+cli$`),
+		// receipt hub. Anchored on an `internal/` segment so the rule matches the
+		// stated target exactly and cannot surprise-deny an unrelated package whose
+		// import path merely ends in "cli".
+		pattern: regexp.MustCompile(`^github\.com/agent-receipts/ar/.*internal/[a-z0-9]+cli$`),
 		reason:  "an operator read-side CLI package (internal/*cli); operator tooling has no place in a hub process",
 	},
 }

--- a/collector/cmd/obsigna-collector/import_guard_test.go
+++ b/collector/cmd/obsigna-collector/import_guard_test.go
@@ -14,9 +14,9 @@ import (
 // (sdk/go/store, modernc.org/sqlite) plus the receipt type (sdk/go/receipt). An
 // allowlist that exists to keep persistence *out* — the proxy's property — is the
 // wrong tool here; enumerating SQLite's large transitive tree would also be
-// brittle. What the collector must *never* grow into is the signer or the
-// operator read-side, so we forbid exactly those, mirroring the daemon's
-// structural Gate A (ADR-0031):
+// brittle. What the collector must *never link* is the daemon's signing/chaining
+// library or the operator read-side, so we forbid exactly those imports, mirroring
+// the daemon's structural Gate A (ADR-0031):
 //
 //   - the daemon library (the signer that owns the private key, ADR-0010) — the
 //     hub must never link signing/chaining code; and
@@ -27,6 +27,13 @@ import (
 // operator package is caught automatically. The hub's legitimate dependencies —
 // sdk/go/store, sdk/go/receipt, modernc.org/sqlite, google/uuid — carry neither
 // signal and are allowed.
+//
+// Scope, so this gate is not over-read: it bounds what the collector *links*, not
+// which functions it calls within an allowed package. sdk/go/receipt is allowed (the
+// hub needs the AgentReceipt type) and also exposes Sign/Create; the collector does
+// not sign because it holds no signing key, not because this gate forbids the call.
+// Gate A's contract is the import boundary — keep the daemon signer and the operator
+// CLI out of the link.
 var forbiddenImports = []forbiddenRule{
 	{
 		// The daemon library: the signing process (ADR-0010). The collector

--- a/collector/cmd/obsigna-collector/main.go
+++ b/collector/cmd/obsigna-collector/main.go
@@ -1,0 +1,132 @@
+// Command obsigna-collector runs the agent-receipts reference HTTP collector.
+//
+// The collector accepts signed receipts at POST /receipts and persists them to
+// a SQLite-backed store. It performs no signing, no chain construction, no
+// signature verification, and no semantic validation — its contract is the
+// dumb append-only sink described in ADR-0020.
+//
+// This is the primary collector entrypoint (ADR-0035), launched in production
+// via `obsigna collector run` (ADR-0030, ADR-0034). The legacy `collector`
+// binary (./cmd/collector) is a thin deprecation shim that execs into this one.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/agent-receipts/ar/collector"
+)
+
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z". Falls
+// back to the module version from Go's build info (set automatically for
+// binaries installed with `go install`), then to "dev". Mirrors the
+// resolveVersion pattern used in daemon/cmd/obsigna-daemon/main.go.
+var version string
+
+func resolveVersion() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}
+
+// defaultAddr binds to loopback by default so a `go run ./cmd/obsigna-collector` on a
+// developer workstation does not expose an unauthenticated audit-trail
+// endpoint to the network. Operators who want network reachability must opt
+// in explicitly with --addr 0.0.0.0:8787 (or, preferably, sit a reverse
+// proxy / mesh in front).
+const defaultAddr = "127.0.0.1:8787"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	addr := flag.String("addr", envOrDefault("AGENTRECEIPTS_COLLECTOR_ADDR", defaultAddr), "HTTP listen address (default loopback; use 0.0.0.0:port to expose)")
+	dbPath := flag.String("db", envOrDefault("AGENTRECEIPTS_COLLECTOR_DB", "collector.db"), "SQLite database path (use ':memory:' for ephemeral storage — not durable)")
+	maxBody := flag.Int64("max-body-bytes", envInt64OrDefault(logger, "AGENTRECEIPTS_COLLECTOR_MAX_BODY_BYTES", collector.DefaultMaxBodyBytes), "Maximum request body size in bytes")
+	drainTimeout := flag.Duration("drain-timeout", envDurationOrDefault(logger, "AGENTRECEIPTS_COLLECTOR_DRAIN_TIMEOUT", 10*time.Second), "Graceful shutdown timeout")
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(resolveVersion())
+		return
+	}
+
+	logger.Info("collector starting", "version", resolveVersion(), "addr", *addr, "db", *dbPath)
+
+	store, err := collector.OpenSQLiteStore(*dbPath)
+	if err != nil {
+		logger.Error("failed to open store", slog.Any("err", err))
+		os.Exit(1)
+	}
+	defer store.Close()
+
+	srv, err := collector.NewServer(collector.Config{
+		Addr:         *addr,
+		MaxBodyBytes: *maxBody,
+		Logger:       logger,
+	}, store)
+	if err != nil {
+		logger.Error("failed to construct server", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := collector.Run(ctx, srv, *drainTimeout, logger); err != nil {
+		logger.Error("collector exited with error", slog.Any("err", err))
+		os.Exit(1)
+	}
+	logger.Info("collector stopped cleanly")
+}
+
+func envOrDefault(name, def string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return def
+}
+
+// envInt64OrDefault parses an int64 from the named env var. On parse failure
+// it logs a warning and falls back to def — silent fallback hides operator
+// misconfigurations (e.g. setting MAX_BODY_BYTES=1MB and getting a 1 MiB
+// default rather than 1 000 000 bytes).
+func envInt64OrDefault(log *slog.Logger, name string, def int64) int64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Warn("invalid env var, using default",
+			"name", name, "value", v, "default", def, slog.Any("err", err))
+		return def
+	}
+	return parsed
+}
+
+func envDurationOrDefault(log *slog.Logger, name string, def time.Duration) time.Duration {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Warn("invalid env var, using default",
+			"name", name, "value", v, "default", def, slog.Any("err", err))
+		return def
+	}
+	return d
+}

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -2,6 +2,11 @@ module github.com/agent-receipts/ar/collector
 
 go 1.26.1
 
+// Pin the toolchain to the patch (ADR-0035): reproducible-build attestation
+// requires every builder use the same compiler bytes. CI consumes this via
+// `setup-go` with go-version-file so it stops floating to the latest 1.26.x.
+toolchain go1.26.1
+
 require (
 	github.com/agent-receipts/ar/sdk/go v0.13.0
 	modernc.org/sqlite v1.50.1

--- a/collector/scripts/reproducible-build.sh
+++ b/collector/scripts/reproducible-build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Canonical reproducible build of obsigna-collector (ADR-0035).
+#
+# Single source of the determinism flags shared by the two CI rebuilds — Gate B
+# (collector.yml, cross-path byte-identity) and the release attestation
+# (release-collector.yml, rebuild-matches-artifact). Keep these flags in lockstep
+# with the obsigna-collector build in collector/.goreleaser.yaml: CGO off (no host
+# C toolchain bytes), -trimpath (no absolute build paths), -buildvcs=false (no git
+# stamp — the release LICENSE-copy hook would otherwise dirty the tree), and a
+# version stamp that derives only from the tag.
+#
+# Usage: reproducible-build.sh <module-dir> <output-path> [version]
+#   version  when given, stamps -X main.version=v<version> to match the released
+#            build; omit it for the cross-path determinism check, where both
+#            builds just need identical (any) flags.
+#
+# GOWORK, GOOS, and GOARCH are read from the environment so callers choose
+# workspace vs published-module resolution and the target platform.
+set -eu
+
+module_dir="$1"
+out="$2"
+version="${3:-}"
+
+ldflags="-s -w"
+if [ -n "$version" ]; then
+  ldflags="$ldflags -X main.version=v${version}"
+fi
+
+cd "$module_dir"
+CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags "$ldflags" -o "$out" ./cmd/obsigna-collector

--- a/daemon/cmd/obsigna/registry.go
+++ b/daemon/cmd/obsigna/registry.go
@@ -54,9 +54,9 @@ type launcher struct {
 // ADR-0030 freezes the canonical grouped form; `verify-event` and `doctor` are
 // carried over from the legacy `agent-receipts` CLI so the deprecation shim can
 // preserve every current subcommand. The reserved process nouns live in the
-// launchers table below: `daemon` is wired (ADR-0031) and `mcp` is wired
-// (ADR-0033, execs obsigna-mcp); `collector` remains out of scope until its
-// consolidation ADR.
+// launchers table below: `daemon` is wired (ADR-0031), `mcp` is wired
+// (ADR-0033, execs obsigna-mcp), and `collector` is wired (ADR-0035, execs
+// obsigna-collector).
 func commandTree() tree {
 	return tree{
 		groupOrder: []string{"receipt", "keys"},
@@ -93,10 +93,11 @@ func commandTree() tree {
 			"verify": {"receipt", "verify"},
 			"show":   {"receipt", "show"},
 		},
-		launcherOrder: []string{"daemon", "mcp"},
+		launcherOrder: []string{"daemon", "mcp", "collector"},
 		launchers: map[string]launcher{
-			"daemon": {"Launch the receipts daemon (execs obsigna-daemon; ADR-0031).", "obsigna-daemon"},
-			"mcp":    {"Launch the MCP proxy (execs obsigna-mcp; ADR-0030, ADR-0033).", "obsigna-mcp"},
+			"daemon":    {"Launch the receipts daemon (execs obsigna-daemon; ADR-0031).", "obsigna-daemon"},
+			"mcp":       {"Launch the MCP proxy (execs obsigna-mcp; ADR-0030, ADR-0033).", "obsigna-mcp"},
+			"collector": {"Launch the receipt collector (execs obsigna-collector; ADR-0034, ADR-0035).", "obsigna-collector"},
 		},
 	}
 }

--- a/daemon/cmd/obsigna/surface_test.go
+++ b/daemon/cmd/obsigna/surface_test.go
@@ -153,14 +153,18 @@ func TestFlatAliasInvariant(t *testing.T) {
 	}
 }
 
-// TestLauncherSurface pins the process-launcher table (ADR-0031, ADR-0033).
-// `daemon` execs obsigna-daemon and `mcp` execs obsigna-mcp; collector stays out
-// until its ADR. A launcher must never collide with a group, top leaf, or alias,
-// or dispatch would be ambiguous.
+// TestLauncherSurface pins the process-launcher table (ADR-0031, ADR-0033,
+// ADR-0035). `daemon` execs obsigna-daemon, `mcp` execs obsigna-mcp, and
+// `collector` execs obsigna-collector. A launcher must never collide with a
+// group, top leaf, or alias, or dispatch would be ambiguous.
 func TestLauncherSurface(t *testing.T) {
 	tr := commandTree()
 
-	want := map[string]string{"daemon": "obsigna-daemon", "mcp": "obsigna-mcp"}
+	want := map[string]string{
+		"daemon":    "obsigna-daemon",
+		"mcp":       "obsigna-mcp",
+		"collector": "obsigna-collector",
+	}
 	if got := keys(tr.launchers); !equalSet(got, mapKeys(want)) {
 		t.Errorf("launcher set = %v, want %v", got, mapKeys(want))
 	}

--- a/docs/adr/0035-collector-binary-topology.md
+++ b/docs/adr/0035-collector-binary-topology.md
@@ -1,0 +1,170 @@
+# ADR-0035: Collector Binary Topology — Minimal `obsigna-collector`, `obsigna collector run`
+
+## Status
+
+Accepted (2026-06-13).
+
+## Context
+
+ADR-0030 consolidates the implementation behind a single `obsigna` entrypoint, with
+the receipt collector as a verb under it (`obsigna collector run`). ADR-0031 applied
+this topology to the daemon, making it its own minimal binary (`obsigna-daemon`)
+launched via `syscall.Exec`; ADR-0033 did the same for the MCP proxy
+(`obsigna-mcp`). This ADR is the collector's analogue: how it is packaged as a
+binary and launched, and which property its import graph must hold.
+
+The collector is a **receipt hub** (ADR-0017, ADR-0020): it receives already-signed
+receipts over HTTP at `POST /receipts` and persists them to a SQLite-backed store.
+Two facts place it differently from the daemon and the proxy, and together they fix
+the shape of its import-graph gate:
+
+1. **It does not hold the signing key.** ADR-0010 makes the daemon the sole receipt
+   writer — it owns redaction, hashing, signing, chaining, and persistence of the
+   *local* chain. The collector signs nothing, chains nothing, and verifies nothing
+   on ingest; it is the "dumb append-only sink" ADR-0020 describes. Its trust story
+   (ADR-0020) is precisely that a compromised collector can drop or refuse receipts
+   but cannot forge, alter, or reorder them, because every receipt is signed and
+   chained client-side before delivery. So the daemon's "blast radius is its import
+   graph because it runs next to the private key" argument does not transfer — the
+   collector holds no key.
+
+2. **It legitimately holds a store.** Unlike the proxy — a *thin emitter* that
+   ADR-0033 keeps free of any persistence (the store, a SQLite driver, receipt
+   construction) — persisting receipts is the collector's *entire job*. Its
+   production graph legitimately reaches `sdk/go/store`, a SQLite driver
+   (`modernc.org/sqlite`), and the receipt type (`sdk/go/receipt`). The proxy's
+   fail-closed *allowlist*, which exists to keep persistence *out*, would therefore
+   be the wrong tool here: the collector's store is a feature, not a smell, and
+   enumerating SQLite's large transitive tree would be brittle besides.
+
+What the collector's graph must enforce is the **converse** of the proxy's: the hub
+must never grow *into the signer* or *into the operator read-side*. If the collector
+could construct, sign, or chain receipts in-process, the "one writer" guarantee
+ADR-0010 rests on would erode; if it linked the operator verify/show/list/keys
+tooling, a hub process would carry an operator surface that has no business in it.
+Those are the two properties to make structural.
+
+Separately, the collector ships as a downstream-installable binary that operators
+wire into deployment scripts and that SDK `HttpEmitter` clients post to. The rename
+from `collector` to `obsigna-collector` would break installers that name the old
+binary, so the old entrypoint is preserved as a deprecation shim rather than removed.
+
+## Decision
+
+**The collector is its own minimal binary, `cmd/obsigna-collector`.** It is the
+primary entrypoint, carrying the full collector surface (the `--addr`/`--db`/
+`--max-body-bytes`/`--drain-timeout`/`--version` flags). It links only what the hub
+needs: the `collector` library and its legitimate dependencies — `sdk/go/store`,
+`sdk/go/receipt`, and a SQLite driver. It never imports the daemon library or any
+operator read-side (`*cli`) package.
+
+**`obsigna collector run` replaces its process image with `obsigna-collector` via
+`syscall.Exec`** — the same generic launcher ADR-0031 introduced for `obsigna daemon
+run` and ADR-0033 reused for `obsigna mcp run`, reusing the existing launcher table
+in `cmd/obsigna` (no new launcher code). `syscall.Exec` (never `exec.Command`) is
+deliberate: the collector is a long-running HTTP service, so replacing the image
+keeps the same PID and the supervisor as parent, indistinguishable from a service
+manager starting `obsigna-collector` directly. In production, the service manager's
+start command points straight at `obsigna-collector`; `obsigna collector run` is the
+same image resolved beside `obsigna` (else `$PATH`) and exec'd into. The launcher
+errors helpfully if the collector formula is not installed.
+
+**The legacy `collector` binary becomes a thin deprecation shim** (`cmd/collector`).
+It prints a one-line deprecation notice to stderr and `syscall.Exec`s into
+`obsigna-collector`, forwarding argv and the environment unchanged — the collector's
+flag surface is identical, so there is no translation. It ships in the same archive
+and Homebrew formula as `obsigna-collector`, so existing installers and scripts that
+name `collector` keep working through the rename. The shim is slated for removal in a
+future release.
+
+**Reproducible builds are part of the contract.** The `obsigna-collector` binary is
+built with `CGO_ENABLED=0`, `-trimpath`, `-buildvcs=false`, a patch-pinned toolchain
+(`toolchain go1.26.1` in `collector/go.mod`, consumed in CI via `go-version-file`),
+and version/stamp inputs that derive only from the tag/commit (`mod_timestamp` uses
+`{{ .CommitTimestamp }}`, never wall-clock). This mirrors ADR-0031/ADR-0033 exactly
+so an auditor can rebuild `obsigna-collector` and match a published hash. The release
+establishes the known-good hash by an independent clean rebuild that must equal the
+binary inside the released archive; a mismatch fails the release.
+
+> Note for independent rebuilders: the pinned `toolchain` directive is a *floor*, so
+> a builder whose local Go is newer than 1.26.1 must force the exact toolchain with
+> `GOTOOLCHAIN=go1.26.1`. The full command is published in each release's notes.
+
+## Gates
+
+Per ADR-0024 (every asserted property has a gate), the claims above are enforced in CI
+rather than trusted:
+
+- **Gate A — dumb-sink import graph** (`cmd/obsigna-collector/import_guard_test.go`):
+  a Go test runs `go list -deps .` and fails on any production dependency that
+  reaches the **daemon library** (`github.com/agent-receipts/ar/daemon…`, the signer)
+  or any **operator read-side CLI package** (`internal/*cli` — verify/show/list/
+  doctor/keys, keyed on the `cli` suffix so a new operator package is caught
+  automatically). This is a **denylist**, the deliberate inverse of ADR-0033's
+  fail-closed allowlist: the proxy fails closed because persistence has no naming
+  convention and must be kept out, whereas the collector *legitimately* persists
+  (`sdk/go/store`, `sdk/go/receipt`, `modernc.org/sqlite` are all allowed), so the
+  property to enforce is not "no store" but "never the signer, never the operator
+  CLI". It runs in the normal test suite and in a dedicated `collector.yml` job.
+- **Gate B — reproducible build** (`collector.yml` + `release-collector.yml`): both
+  rebuilds go through one shared script (`collector/scripts/reproducible-build.sh`)
+  so the PR gate and the release attestation can't drift, and it stays in lockstep
+  with the goreleaser build flags. On every PR, build `obsigna-collector` twice from
+  two working-directory paths of different lengths and assert byte-identical `sha256`
+  (this is what proves `-trimpath` took effect). On release, assert an independent
+  clean rebuild matches the published artifact and emit the hash; fail the release on
+  mismatch.
+
+The launcher exec path and the `collector` → `obsigna-collector` mapping are covered
+by the existing `cmd/obsigna` surface tests (`TestLauncherSurface`); the
+entrypoint guard (`cmd/obsigna-collector/entrypoint_guard_test.go`) asserts
+`obsigna-collector` is the primary build and `collector` appears only as the shim.
+
+## Consequences
+
+- The launcher in `cmd/obsigna` and the `collector` shim are platform-restricted to
+  where `syscall.Exec` exists (darwin, linux) — the only release targets, matching
+  ADR-0031/ADR-0033.
+- `obsigna-collector` and the `collector` shim ship together in the collector archive
+  and are both installed by the Homebrew formula. The formula *name* stays `collector`
+  (a downstream tap concern); only the installed binary is renamed, plus the shim. A
+  formula-name migration is a separate effort (ADR-0034).
+- The binary rename is **breaking for any installer that invokes the binary by its
+  absolute path** rather than the `collector` name on `$PATH`; the shim covers the
+  common `$(which collector)` case but not a hard-coded path to a renamed file.
+- `obsigna collector run` only succeeds when both `obsigna` and `obsigna-collector`
+  are installed. Until ADR-0034's PR-2 folds the collector into the umbrella
+  `obsigna` formula, that means installing the collector formula alongside obsigna;
+  the launcher errors helpfully when the sibling binary is absent.
+- Reproducibility constrains future build changes: anything that introduces a
+  wall-clock stamp, an absolute-path embed, or a floating toolchain will turn Gate B
+  red. That is the point.
+
+## Out of scope
+
+- The unified-train consolidation (ADR-0034 PR-2): the collector keeps its own
+  `collector/v*` train, `release-collector.yml`, CHANGELOG, and `collector` Homebrew
+  formula for now. This ADR delivers the minimal-binary restructure that PR-2
+  sequences ahead of; it does **not** pre-consolidate.
+- The Homebrew formula-name migration (`collector` → an `obsigna` formula, ADR-0034
+  decision 9). No standalone `collector-alpha` track is introduced.
+- Collector ingest-side concerns — authentication, multi-tenant isolation, and
+  optional signature verification on ingest — are unchanged; the collector remains a
+  dumb append-only sink (ADR-0020).
+- The daemon, mcp-proxy, and hook restructures (their own ADRs).
+
+## Amends
+
+- **ADR-0031** (Daemon Binary Topology): generalizes its `syscall.Exec` launcher and
+  minimal-binary pattern from the daemon to the collector, and reuses its
+  reproducible-build contract (Gate B) unchanged.
+- **ADR-0033** (mcp-proxy Binary Topology): reuses its `obsigna-<noun>` binary +
+  deprecation-shim + sibling-resolution template, but **inverts its Gate A**. The
+  proxy uses a fail-closed *allowlist* because it must hold no store; the collector
+  uses a *denylist* because it legitimately holds one — the gate forbids the signer
+  and the operator CLI instead of forbidding persistence.
+- **ADR-0034** (Consolidate the Go Toolset into One obsigna Release Train): supplies
+  the `collector` launcher entry (decision 5) and the `obsigna-collector` binary name
+  (decision 2). ADR-0034's PR-2 lists this collector restructure as its prerequisite;
+  this ADR delivers exactly that restructure while leaving the collector on its own
+  train and formula, which PR-2 will later fold into the unified `obsigna` train.

--- a/docs/adr/0035-collector-binary-topology.md
+++ b/docs/adr/0035-collector-binary-topology.md
@@ -38,11 +38,21 @@ the shape of its import-graph gate:
    enumerating SQLite's large transitive tree would be brittle besides.
 
 What the collector's graph must enforce is the **converse** of the proxy's: the hub
-must never grow *into the signer* or *into the operator read-side*. If the collector
-could construct, sign, or chain receipts in-process, the "one writer" guarantee
-ADR-0010 rests on would erode; if it linked the operator verify/show/list/keys
-tooling, a hub process would carry an operator surface that has no business in it.
-Those are the two properties to make structural.
+must never *link the daemon's signing/chaining library* or the operator read-side. If
+the collector imported the daemon library, the "one writer" guarantee ADR-0010 rests
+on would erode; if it linked the operator verify/show/list/keys tooling, a hub process
+would carry an operator surface that has no business in it. Those are the two import
+edges to make structural.
+
+Note the limit of an import-graph gate, so it is not over-read: it bounds what the
+collector *links*, not which functions it calls within an allowed package.
+`sdk/go/receipt` is allowed — the hub needs the `AgentReceipt` type to deserialize and
+store — and that package also exposes `Sign`/`Create`, so the gate cannot by itself
+prove the collector never signs. That property holds for a *different* reason: the
+collector holds no signing key (point 1 above), so it cannot produce a valid signature
+regardless of what it links. Gate A's job is narrower and structural — keep the
+*daemon's* signing/chaining library and the operator CLI out of the link — not to
+police individual function calls.
 
 Separately, the collector ships as a downstream-installable binary that operators
 wire into deployment scripts and that SDK `HttpEmitter` clients post to. The rename
@@ -104,8 +114,12 @@ rather than trusted:
   fail-closed allowlist: the proxy fails closed because persistence has no naming
   convention and must be kept out, whereas the collector *legitimately* persists
   (`sdk/go/store`, `sdk/go/receipt`, `modernc.org/sqlite` are all allowed), so the
-  property to enforce is not "no store" but "never the signer, never the operator
-  CLI". It runs in the normal test suite and in a dedicated `collector.yml` job.
+  property to enforce is not "no store" but "never *links* the daemon's signing
+  library, never *links* the operator CLI". (The gate bounds the link, not function
+  calls within an allowed package — `sdk/go/receipt` is allowed and also exposes
+  `Sign`/`Create`; the collector does not sign because it holds no key, not because
+  the gate forbids the call.) It runs in the normal test suite and in a dedicated
+  `collector.yml` job.
 - **Gate B — reproducible build** (`collector.yml` + `release-collector.yml`): both
   rebuilds go through one shared script (`collector/scripts/reproducible-build.sh`)
   so the PR gate and the release attestation can't drift, and it stays in lockstep

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ Use `0000-template.md` as the starting point for new ADRs. Name each new ADR fil
 | [ADR-0032](0032-mcp-proxy-transport.md) | mcp-proxy Transport — stdio, HTTP Deferred | Accepted |
 | [ADR-0033](0033-mcp-proxy-binary-topology.md) | mcp-proxy Binary Topology — Minimal obsigna-mcp, obsigna mcp run | Accepted |
 | [ADR-0034](0034-consolidate-go-toolset-release-train.md) | Consolidate the Go Toolset into One obsigna Release Train | Accepted |
+| [ADR-0035](0035-collector-binary-topology.md) | Collector Binary Topology — Minimal obsigna-collector, obsigna collector run | Accepted |
 
 ## References
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -164,7 +164,7 @@ differ, or when you are aggregating receipts from multiple agents across
 multiple hosts. Unlike the daemon emitter (which forwards *unsigned events* for
 daemon-side signing), `emitters` deliver *already-signed* `receipt.AgentReceipt`
 values — sign client-side (or accept pre-signed receipts), then POST them to a
-deployed `agent-receipts-collector`.
+deployed `obsigna-collector`.
 
 <!-- snippet-check: no-run -->
 ```go

--- a/sdk/py/README.md
+++ b/sdk/py/README.md
@@ -138,7 +138,7 @@ print(result.action_type, result.risk_level)
 ## Delivering receipts to a remote collector
 
 When the agent host and the receipt-storage host differ, sign receipts
-client-side and POST them to an `agent-receipts-collector` over HTTPS. This is an
+client-side and POST them to an `obsigna-collector` over HTTPS. This is an
 enterprise / multi-host shape, not the first-run path — the daemon above is what
 most adopters want.
 


### PR DESCRIPTION
## Summary

Applies the binary-topology pattern (ADR-0031 daemon, ADR-0033 mcp-proxy) to the **collector**, one-for-one. Renames the binary `collector` → `obsigna-collector`, makes it the primary minimal entrypoint, and launches it in production via `obsigna collector run` (`syscall.Exec` through the existing generic launcher). The legacy `collector` binary becomes a thin deprecation shim that exec-forwards to `obsigna-collector`.

New **ADR-0035** captures the decision. The collector stays on its own `collector/v*` train and `collector` Homebrew formula for now — ADR-0034 PR-2 folds it into the unified `obsigna` train later, so this PR does **not** pre-consolidate.

## What changed

**Binary topology** (`collector/`)
- `cmd/collector` → `cmd/obsigna-collector` (primary minimal binary, full flag surface).
- New `cmd/collector` deprecation shim: prints a one-line stderr notice and `syscall.Exec`s `obsigna-collector`, forwarding argv + env unchanged (+ tests).
- `.goreleaser.yaml`: two builds (`obsigna-collector` + `collector` shim) with determinism flags (`CGO_ENABLED=0`, `-trimpath`, `-buildvcs=false`, `mod_timestamp: {{ .CommitTimestamp }}`); single `collector` formula installs both binaries with a rename caveat.
- `go.mod`: pin `toolchain go1.26.1` (consumed via `go-version-file`).

**Launcher** (`daemon/cmd/obsigna/`)
- One row added to the launcher table: `collector` → `obsigna-collector`. `TestLauncherSurface` updated. No new launcher code; reuses the generic `syscall.Exec` launcher.

**Gate A — dumb-sink import graph** (`cmd/obsigna-collector/import_guard_test.go`)
- A **structural denylist** (the deliberate inverse of mcp-proxy's fail-closed allowlist): fails on any reach into the **daemon library** (the signer, ADR-0010) or any operator read-side **`*cli`** package. The collector *legitimately* persists receipts (`sdk/go/store`, `sdk/go/receipt`, `modernc.org/sqlite`) — those stay allowed — so the property enforced is "never the signer, never the operator CLI", not "no store".

**Gate B — reproducible build**
- Shared `collector/scripts/reproducible-build.sh`; `collector.yml` PR cross-path double-build byte-identity check; `release-collector.yml` independent rebuild-attest that matches the published archive and publishes the known-good `sha256`.
- `entrypoint_guard_test.go` asserts `obsigna-collector` is the primary build and `collector` appears only as the shim.

**Docs**
- New `docs/adr/0035-collector-binary-topology.md` + index row; `collector/CHANGELOG.md` (rename called out as breaking for installers); `collector/README.md`, `sdk/py/README.md`, `sdk/go/README.md` binary-name updates.

## Gate A: denylist, not allowlist

The collector is a receipt hub (ADR-0017/0020) whose whole job is to persist signed receipts — the opposite of mcp-proxy's thin emitter. An allowlist exists to keep persistence *out*; here persistence is the feature, and enumerating SQLite's large transitive tree would be brittle. So Gate A forbids exactly what the hub must never grow into — the signer and the operator CLI — keyed on the same structural signals as the daemon's Gate A.

## Verification

- `cd collector && go vet ./... && go build ./cmd/... && go test -race ./...` ✅
- `daemon/cmd/obsigna` surface/launcher tests ✅
- Gate A test + cross-path reproducible build (script) verified locally; all workflow YAML parses.

## Out of scope

ADR-0034's unified-train consolidation (PR-2), the Homebrew formula-name migration (no `collector-alpha` track introduced), and the daemon/mcp-proxy/hook restructures. Go module paths and `did:` issuer strings are untouched.