### PR TITLE
chore(release): rename daemon release train to obsigna (ADR-0034 PR 1)

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -109,7 +109,7 @@ jobs:
   # sha256. This is what proves -trimpath actually took: without it the absolute
   # build path is baked into the binary and the two hashes diverge. The release
   # workflow extends this to an independent rebuild that must match the published
-  # artifact (release-daemon.yml), which is the auditor-facing attestation.
+  # artifact (release-obsigna.yml), which is the auditor-facing attestation.
   reproducible-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-obsigna.yml
+++ b/.github/workflows/release-obsigna.yml
@@ -1,9 +1,9 @@
-name: "Release: daemon"
+name: "Release: obsigna"
 
 on:
   push:
     tags:
-      - "daemon/v*"
+      - "obsigna/v*"
 
 permissions:
   contents: write
@@ -28,13 +28,13 @@ jobs:
           # with, not a floating latest 1.26.x.
           go-version-file: daemon/go.mod
 
-      # GoReleaser can't parse the prefixed tag `daemon/vX.Y.Z` as semver.
+      # GoReleaser can't parse the prefixed tag `obsigna/vX.Y.Z` as semver.
       # Create a local lightweight `vX.Y.Z` tag at the same commit so
       # GoReleaser computes a clean .Version; this tag is never pushed.
       - name: Prepare version
         run: |
-          VERSION="${GITHUB_REF_NAME#daemon/}"
-          echo "DAEMON_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          VERSION="${GITHUB_REF_NAME#obsigna/}"
+          echo "OBSIGNA_VERSION=${VERSION}" >> "$GITHUB_ENV"
           git tag "${VERSION}" HEAD
 
       # Single GoReleaser run: builds, archives, pushes Homebrew formula.
@@ -50,7 +50,7 @@ jobs:
           args: release --clean --skip=validate,announce
           workdir: daemon
         env:
-          GORELEASER_CURRENT_TAG: ${{ env.DAEMON_VERSION }}
+          GORELEASER_CURRENT_TAG: ${{ env.OBSIGNA_VERSION }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           # Disable the Go workspace so builds resolve from daemon/go.mod
           # (published sdk/go) rather than the in-tree ./sdk/go module.
@@ -63,7 +63,7 @@ jobs:
           # Mark pre-release tags (e.g. v0.8.0-alpha.1) so they don't show
           # up as "latest" on the GitHub Releases page.
           PRERELEASE_ARG=()
-          if [[ "${DAEMON_VERSION}" == *-* ]]; then
+          if [[ "${OBSIGNA_VERSION}" == *-* ]]; then
             PRERELEASE_ARG+=(--prerelease)
           fi
           # Create the release if it doesn't already exist (e.g. pre-created
@@ -73,11 +73,11 @@ jobs:
           # a pre-release tag to appear as the latest stable release.
           if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
             gh release edit "${GITHUB_REF_NAME}" \
-              --title "daemon ${DAEMON_VERSION}" \
+              --title "obsigna ${OBSIGNA_VERSION}" \
               "${PRERELEASE_ARG[@]}"
           else
             gh release create "${GITHUB_REF_NAME}" \
-              --title "daemon ${DAEMON_VERSION}" \
+              --title "obsigna ${OBSIGNA_VERSION}" \
               --generate-notes \
               "${PRERELEASE_ARG[@]}"
           fi
@@ -118,7 +118,7 @@ jobs:
           python-version: "3.13"
       - name: Verify daemon ↔ SDK protocol compatibility (Gate #8)
         run: |
-          VERSION="${GITHUB_REF_NAME#daemon/v}"
+          VERSION="${GITHUB_REF_NAME#obsigna/v}"
           python3 scripts/daemon_protocol/check.py \
             --sdk-lang ${{ matrix.lang }} --sdk-version latest --daemon-version "$VERSION"
       - name: Run unit tests for daemon-protocol gate
@@ -146,8 +146,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#daemon/v}"   # e.g. 0.20.0-alpha.1 (no leading v)
-          asset="daemon_${VERSION}_linux_amd64.tar.gz"
+          VERSION="${GITHUB_REF_NAME#obsigna/v}"   # e.g. 0.20.0-alpha.1 (no leading v)
+          asset="obsigna_${VERSION}_linux_amd64.tar.gz"
 
           # 1) Hash obsigna-daemon as shipped, from the archive uploaded by the
           #    release job above.

--- a/daemon/.goreleaser.yaml
+++ b/daemon/.goreleaser.yaml
@@ -1,6 +1,6 @@
 version: 2
 
-project_name: daemon
+project_name: obsigna
 
 # Disable the Go workspace so GoReleaser resolves dependencies strictly from
 # daemon/go.mod (published versions) rather than the in-tree ./sdk/go module
@@ -102,17 +102,17 @@ checksum:
   name_template: "checksums.txt"
 
 # GitHub release is created outside GoReleaser (against the prefixed tag
-# `daemon/vX.Y.Z`). GoReleaser only builds archives and publishes the
+# `obsigna/vX.Y.Z`). GoReleaser only builds archives and publishes the
 # Homebrew formula; the workflow uploads binaries with `gh`.
 release:
   disable: true
 
 brews:
-  - name: obsigna-daemon
+  - name: obsigna
     # `auto` skips the formula bump PR when the release version contains a
     # pre-release suffix (e.g. v0.8.0-alpha.1). The Homebrew tap stays
-    # locked to the latest stable daemon until a non-pre-release tag is cut,
-    # so `brew install agent-receipts/tap/obsigna-daemon` keeps giving
+    # locked to the latest stable release until a non-pre-release tag is cut,
+    # so `brew install agent-receipts/tap/obsigna` keeps giving
     # users a stable build during alpha/beta soak periods.
     skip_upload: auto
     repository:
@@ -130,14 +130,14 @@ brews:
         base:
           branch: main
     directory: Formula
-    url_template: "https://github.com/agent-receipts/obsigna/releases/download/daemon%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/agent-receipts/obsigna/releases/download/obsigna%2Fv{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/agent-receipts/obsigna/tree/main/daemon"
-    description: "Agent Receipts daemon and companion verify CLI"
+    description: "Obsigna — Agent Receipts CLI, signing daemon, and verify tooling"
     license: "Apache-2.0"
     commit_author:
       name: agent-receipts-bot
       email: bot@agentreceipts.ai
-    commit_msg_template: "chore(daemon): bump to v{{ .Version }}"
+    commit_msg_template: "chore(obsigna): bump to v{{ .Version }}"
     install: |
       bin.install "obsigna-daemon"
       bin.install "obsigna"
@@ -149,7 +149,7 @@ brews:
     # `brew outdated` and `brew livecheck` use this to detect new releases.
     # The `ar` repo ships multiple taggable components, so we can't use
     # `:github_latest` (which returns repo-wide latest). `:github_releases`
-    # scans all releases; regex extracts version from the `daemon/vX.Y.Z`
+    # scans all releases; regex extracts version from the `obsigna/vX.Y.Z`
     # tag prefix.
     #
     # post_install, service, and caveats are also emitted here so they survive
@@ -173,7 +173,7 @@ brews:
           If you reference the old binary name in any install script, systemd unit,
           launchd plist, or `brew services` wrapper, update it to obsigna-daemon and
           restart the service after upgrading:
-            brew services restart agent-receipts/tap/obsigna-daemon
+            brew services restart agent-receipts/tap/obsigna
 
           agent-receipts-hook is now a separate formula. If you previously installed
           it via this formula, run:
@@ -183,7 +183,7 @@ brews:
             obsigna-daemon --init
 
           Then start the daemon:
-            brew services start agent-receipts/tap/obsigna-daemon
+            brew services start agent-receipts/tap/obsigna
 
           Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
                              (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)
@@ -202,19 +202,19 @@ brews:
         EOS
       end
 
-      conflicts_with "obsigna-daemon-alpha", because: "both install the same binaries"
+      conflicts_with "obsigna-alpha", because: "both install the same binaries"
 
       livecheck do
         url "https://github.com/agent-receipts/obsigna"
         strategy :github_releases
-        regex(/^daemon\/v?(\d+(?:\.\d+)+)$/i)
+        regex(/^obsigna\/v?(\d+(?:\.\d+)+)$/i)
       end
 
   # Alpha-track formula — updated on every release (stable and pre-release).
-  # `brew install agent-receipts/tap/obsigna-daemon-alpha` always gives
+  # `brew install agent-receipts/tap/obsigna-alpha` always gives
   # the latest cut; conflicts with the stable formula since both install the
   # same binaries.
-  - name: obsigna-daemon-alpha
+  - name: obsigna-alpha
     repository:
       owner: agent-receipts
       name: homebrew-tap
@@ -225,14 +225,14 @@ brews:
         base:
           branch: main
     directory: Formula
-    url_template: "https://github.com/agent-receipts/obsigna/releases/download/daemon%2Fv{{ .Version }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/agent-receipts/obsigna/releases/download/obsigna%2Fv{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/agent-receipts/obsigna/tree/main/daemon"
-    description: "Agent Receipts daemon and companion verify CLI (alpha/beta track)"
+    description: "Obsigna — Agent Receipts CLI, signing daemon, and verify tooling (alpha/beta track)"
     license: "Apache-2.0"
     commit_author:
       name: agent-receipts-bot
       email: bot@agentreceipts.ai
-    commit_msg_template: "chore(daemon): bump alpha to v{{ .Version }}"
+    commit_msg_template: "chore(obsigna): bump alpha to v{{ .Version }}"
     install: |
       bin.install "obsigna-daemon"
       bin.install "obsigna"
@@ -242,7 +242,7 @@ brews:
       system "#{bin}/obsigna", "--help"
       system "#{bin}/agent-receipts", "--help"
     custom_block: |
-      conflicts_with "obsigna-daemon", because: "both install the same binaries"
+      conflicts_with "obsigna", because: "both install the same binaries"
 
       def post_install
         (var/"log/agent-receipts").mkpath
@@ -258,19 +258,19 @@ brews:
       def caveats
         <<~EOS
           This is the alpha/beta track — it tracks every release including pre-releases.
-          For stable-only installs use: brew install agent-receipts/tap/obsigna-daemon
+          For stable-only installs use: brew install agent-receipts/tap/obsigna
 
           The daemon binary is now obsigna-daemon (was agent-receipts-daemon).
           If you reference the old binary name in any install script, systemd unit,
           launchd plist, or `brew services` wrapper, update it to obsigna-daemon and
           restart the service after upgrading:
-            brew services restart agent-receipts/tap/obsigna-daemon-alpha
+            brew services restart agent-receipts/tap/obsigna-alpha
 
           Before starting the service for the first time, generate your signing key:
             obsigna-daemon --init
 
           Then start the daemon:
-            brew services start agent-receipts/tap/obsigna-daemon-alpha
+            brew services start agent-receipts/tap/obsigna-alpha
 
           Receipts database: $XDG_DATA_HOME/agent-receipts/receipts.db
                              (falls back to ~/.local/share/agent-receipts/receipts.db when $XDG_DATA_HOME is unset or relative)
@@ -292,5 +292,5 @@ brews:
       livecheck do
         url "https://github.com/agent-receipts/obsigna"
         strategy :github_releases
-        regex(/^daemon\/v?(\d+(?:\.\d+)+(?:-[a-z0-9.]+)?)$/i)
+        regex(/^obsigna\/v?(\d+(?:\.\d+)+(?:-[a-z0-9.]+)?)$/i)
       end

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -10,14 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Release train renamed `daemon` → `obsigna`** (ADR-0034, PR 1) — the GoReleaser project, the release archive (`daemon_<ver>_<os>_<arch>.tar.gz` → `obsigna_<ver>_<os>_<arch>.tar.gz`), the tag scheme (`daemon/v*` → `obsigna/v*`), the release workflow (`release-daemon.yml` → `release-obsigna.yml`), and the Homebrew formulae (`obsigna-daemon` → `obsigna`, `obsigna-daemon-alpha` → `obsigna-alpha`) now carry the Obsigna brand, so `brew install agent-receipts/tap/obsigna` installs the toolset. This is the packaging-identity rename ADR-0031 deferred as a "downstream tap concern"; the next hop (folding `mcp-proxy`/`collector`/`hook` into the train) lands in PR 2. The tap's `tap_migrations.json` maps the retired formula names so `brew update && brew upgrade` moves existing installs with no manual step. **Binary names are unchanged** — the archive still ships `obsigna`, `obsigna-daemon`, and the `agent-receipts` shim, the Go module path stays `github.com/agent-receipts/ar/daemon`, and `did:agent-receipts-daemon:` issuer strings are untouched.
+- **Doctor output and error messages now say `obsigna doctor`** (not `agent-receipts doctor`), matching the renamed CLI.
 
 ### Fixed
 
+- **Linux `install.sh` extracts the release archive correctly** — the installer passed `tar --strip-components=1`, assuming a wrapping top-level directory, but GoReleaser archives are flat (binaries at the root, as the release attestation gate and `scripts/daemon_protocol/check.py` already assume). The strip dropped every file, so the post-extract smoke-test failed and no binaries were installed. Removed the strip so the curl-pipe installer works.
 - **`obsigna doctor` auto-detects the daemon's active chain** — with no `--chain-id`/`AGENTRECEIPTS_CHAIN_ID`, doctor now resolves the chain to inspect from the store's most recently written root chain (via `store.LatestRootChainID`) instead of assuming today's UTC date. The old default produced a spurious `chain head` warn and a `round-trip` **fail** ("did not land … the daemon may not be the sole writer") whenever the daemon's chain id was not literally today's UTC date — i.e. a configured `chain_id`, a daemon running across a UTC-midnight rollover, or a rolled `-N` suffix. The synthetic event was traversing the pipeline correctly all along; doctor was just polling the wrong chain. The bare UTC date remains the fallback only for an empty store.
-
-### Changed
-
-- **Doctor output and error messages now say `obsigna doctor`** (not `agent-receipts doctor`), matching the renamed CLI.
 
 ## [0.23.0] - 2026-06-12
 

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release train renamed `daemon` → `obsigna`** (ADR-0034, PR 1) — the GoReleaser project, the release archive (`daemon_<ver>_<os>_<arch>.tar.gz` → `obsigna_<ver>_<os>_<arch>.tar.gz`), the tag scheme (`daemon/v*` → `obsigna/v*`), the release workflow (`release-daemon.yml` → `release-obsigna.yml`), and the Homebrew formulae (`obsigna-daemon` → `obsigna`, `obsigna-daemon-alpha` → `obsigna-alpha`) now carry the Obsigna brand, so `brew install agent-receipts/tap/obsigna` installs the toolset. This is the packaging-identity rename ADR-0031 deferred as a "downstream tap concern"; the next hop (folding `mcp-proxy`/`collector`/`hook` into the train) lands in PR 2. The tap's `tap_migrations.json` maps the retired formula names so `brew update && brew upgrade` moves existing installs with no manual step. **Binary names are unchanged** — the archive still ships `obsigna`, `obsigna-daemon`, and the `agent-receipts` shim, the Go module path stays `github.com/agent-receipts/ar/daemon`, and `did:agent-receipts-daemon:` issuer strings are untouched.
+
 ### Fixed
 
 - **`obsigna doctor` auto-detects the daemon's active chain** — with no `--chain-id`/`AGENTRECEIPTS_CHAIN_ID`, doctor now resolves the chain to inspect from the store's most recently written root chain (via `store.LatestRootChainID`) instead of assuming today's UTC date. The old default produced a spurious `chain head` warn and a `round-trip` **fail** ("did not land … the daemon may not be the sole writer") whenever the daemon's chain id was not literally today's UTC date — i.e. a configured `chain_id`, a daemon running across a UTC-midnight rollover, or a rolled `-N` suffix. The synthetic event was traversing the pipeline correctly all along; doctor was just polling the wrong chain. The bare UTC date remains the fallback only for an empty store.

--- a/daemon/cmd/obsigna/entrypoint_guard_test.go
+++ b/daemon/cmd/obsigna/entrypoint_guard_test.go
@@ -120,11 +120,11 @@ func brewFormulaNames(yaml string) []string {
 }
 
 // TestBrewFormulaeUseObsignaName is the anti-regression gate for the Homebrew
-// formula rename (agent-receipts-daemon -> obsigna-daemon). The installed binary
-// has been obsigna-daemon since ADR-0031; this guards the final step where the
-// formula itself carries the Obsigna brand. The tap's tap_migrations.json moves
-// existing installs off the legacy names, so reintroducing them here would fork
-// users back onto an unmigrated formula.
+// formula rename (obsigna-daemon -> obsigna; ADR-0034 PR 1). The umbrella
+// formula carries the bare Obsigna brand — `brew install agent-receipts/tap/obsigna`
+// installs the toolset. The tap's tap_migrations.json moves existing installs off
+// the legacy names (agent-receipts-daemon, obsigna-daemon), so reintroducing them
+// here would fork users back onto an unmigrated formula.
 func TestBrewFormulaeUseObsignaName(t *testing.T) {
 	yaml := readFile(t, "../../.goreleaser.yaml")
 	names := brewFormulaNames(yaml)
@@ -132,10 +132,13 @@ func TestBrewFormulaeUseObsignaName(t *testing.T) {
 		t.Fatal("no formula names found under goreleaser brews:")
 	}
 
-	want := map[string]bool{"obsigna-daemon": false, "obsigna-daemon-alpha": false}
+	want := map[string]bool{"obsigna": false, "obsigna-alpha": false}
 	for _, name := range names {
-		if strings.HasPrefix(name, "agent-receipts-daemon") {
-			t.Errorf("brew formula %q uses the legacy name; the daemon formula must be obsigna-daemon(-alpha)", name)
+		// "obsigna-daemon"/"obsigna-daemon-alpha" are the retired train-identity
+		// names; "agent-receipts-daemon" the hop before that. Both are migrated
+		// away in tap_migrations.json and must not reappear here.
+		if strings.HasPrefix(name, "obsigna-daemon") || strings.HasPrefix(name, "agent-receipts-daemon") {
+			t.Errorf("brew formula %q uses a legacy name; the umbrella formula must be obsigna(-alpha)", name)
 		}
 		if _, ok := want[name]; ok {
 			want[name] = true

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -89,8 +89,10 @@ main() {
   step "Installing binaries to ${INSTALL_DIR}..."
   mkdir -p "$INSTALL_DIR"
   mkdir -p "${WORK_DIR}/extract"
-  # Tarballs have a top-level directory (e.g. obsigna_0.8.0_linux_amd64/); strip it.
-  tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
+  # GoReleaser archives are flat: obsigna-daemon, obsigna, and agent-receipts sit
+  # at the archive root (no wrapping directory), matching how the release
+  # attestation gate and scripts/daemon_protocol/check.py extract them.
+  tar -xzf "${WORK_DIR}/${ARCHIVE}" -C "${WORK_DIR}/extract"
 
   # Smoke-test the extracted binary BEFORE overwriting any installed version.
   # If the new binary is incompatible (glibc mismatch, bad arch) the existing

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -30,7 +30,7 @@ die()  { printf '\nerror: %s\n' "$*" >&2; exit 1; }
 main() {
   # Linux only
   [ "$(uname -s)" = "Linux" ] || \
-    die "Linux only. For macOS: brew install agent-receipts/tap/obsigna-daemon"
+    die "Linux only. For macOS: brew install agent-receipts/tap/obsigna"
 
   # Require systemd
   command -v systemctl >/dev/null 2>&1 || \
@@ -47,28 +47,28 @@ main() {
     *)             die "Unsupported architecture: $(uname -m)" ;;
   esac
 
-  # Resolve latest stable daemon release.
+  # Resolve latest stable obsigna release.
   # The repo has multiple component release trains (sdk/go/v*, mcp-proxy/v*,
-  # daemon/v*) so we filter by tag prefix and skip pre-releases explicitly —
+  # obsigna/v*) so we filter by tag prefix and skip pre-releases explicitly —
   # the repo-wide "latest" pointer is not reliable here.
   step "Resolving latest release..."
   VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" | \
     awk '
-      /"tag_name":.*"daemon\/v/ {
-        match($0, /"daemon\/v[^"]+/)
-        tag = substr($0, RSTART + 9, RLENGTH - 9)
+      /"tag_name":.*"obsigna\/v/ {
+        match($0, /"obsigna\/v[^"]+/)
+        tag = substr($0, RSTART + 10, RLENGTH - 10)
       }
       tag != "" && /"prerelease": false/ { print tag; exit }
       /"prerelease": true/ { tag = "" }
     ')
-  [ -n "$VERSION" ] || die "Could not resolve latest stable daemon version from GitHub API"
+  [ -n "$VERSION" ] || die "Could not resolve latest stable obsigna version from GitHub API"
   echo "    version: ${VERSION}"
 
   # Download
-  ARCHIVE="daemon_${VERSION}_linux_${GOARCH}.tar.gz"
+  ARCHIVE="obsigna_${VERSION}_linux_${GOARCH}.tar.gz"
   # %2F-encode the slash in the tag so the URL matches the canonical form used
   # by the Homebrew formula (daemon/.goreleaser.yaml url_template).
-  RELEASE_BASE="https://github.com/${REPO}/releases/download/daemon%2Fv${VERSION}"
+  RELEASE_BASE="https://github.com/${REPO}/releases/download/obsigna%2Fv${VERSION}"
 
   step "Downloading ${ARCHIVE}..."
   WORK_DIR=$(mktemp -d)
@@ -89,7 +89,7 @@ main() {
   step "Installing binaries to ${INSTALL_DIR}..."
   mkdir -p "$INSTALL_DIR"
   mkdir -p "${WORK_DIR}/extract"
-  # Tarballs have a top-level directory (e.g. daemon_0.8.0_linux_amd64/); strip it.
+  # Tarballs have a top-level directory (e.g. obsigna_0.8.0_linux_amd64/); strip it.
   tar -xzf "${WORK_DIR}/${ARCHIVE}" --strip-components=1 -C "${WORK_DIR}/extract"
 
   # Smoke-test the extracted binary BEFORE overwriting any installed version.

--- a/daemon/scripts/reproducible-build.sh
+++ b/daemon/scripts/reproducible-build.sh
@@ -3,7 +3,7 @@
 #
 # Single source of the determinism flags shared by the two CI rebuilds — Gate B
 # (daemon.yml, cross-path byte-identity) and the release attestation
-# (release-daemon.yml, rebuild-matches-artifact). Keep these flags in lockstep
+# (release-obsigna.yml, rebuild-matches-artifact). Keep these flags in lockstep
 # with the obsigna-daemon build in daemon/.goreleaser.yaml: CGO off (no host C
 # toolchain bytes), -trimpath (no absolute build paths), -buildvcs=false (no git
 # stamp — the release LICENSE-copy hook would otherwise dirty the tree), and a

--- a/scripts/daemon_protocol/check.py
+++ b/scripts/daemon_protocol/check.py
@@ -73,9 +73,9 @@ PY_PACKAGE = "obsigna"
 
 REPO = "agent-receipts/obsigna"
 
-# The daemon GoReleaser archive is named daemon_<version>_<os>_<arch>.tar.gz and
-# uploaded to the GitHub release for the prefixed tag daemon/v<version>. The
-# gate runs on linux/amd64.
+# The obsigna GoReleaser archive is named obsigna_<version>_<os>_<arch>.tar.gz
+# and uploaded to the GitHub release for the prefixed tag obsigna/v<version>.
+# The gate runs on linux/amd64.
 DAEMON_ASSET_OS = "linux"
 DAEMON_ASSET_ARCH = "amd64"
 
@@ -177,14 +177,14 @@ def count_receipts(list_json_stdout: str) -> int:
 
 
 def daemon_asset_url(version: str) -> str:
-    """Build the GitHub release download URL for the daemon tarball.
+    """Build the GitHub release download URL for the obsigna tarball.
 
-    ``version`` carries no leading ``v``; the tag is ``daemon/v<version>`` and
-    the asset is ``daemon_<version>_<os>_<arch>.tar.gz``.
+    ``version`` carries no leading ``v``; the tag is ``obsigna/v<version>`` and
+    the asset is ``obsigna_<version>_<os>_<arch>.tar.gz``.
     """
-    asset = f"daemon_{version}_{DAEMON_ASSET_OS}_{DAEMON_ASSET_ARCH}.tar.gz"
+    asset = f"obsigna_{version}_{DAEMON_ASSET_OS}_{DAEMON_ASSET_ARCH}.tar.gz"
     # The tag's slash is percent-encoded in the download path.
-    return f"https://github.com/{REPO}/releases/download/daemon%2Fv{version}/{asset}"
+    return f"https://github.com/{REPO}/releases/download/obsigna%2Fv{version}/{asset}"
 
 
 class NoStableReleaseError(Exception):
@@ -307,7 +307,7 @@ def _http_json(url: str) -> dict | list:
 def resolve_latest_daemon(allow_prerelease: bool) -> str:
     """Newest released daemon version (no leading v) from the GitHub releases.
 
-    Pages the newest-first releases list until ``daemon/v*`` tags satisfying the
+    Pages the newest-first releases list until ``obsigna/v*`` tags satisfying the
     stable/prerelease filter appear (or ``MAX_RELEASE_PAGES`` are exhausted), so
     the most recent daemon release is found even when many other-component
     releases sit above it. Raises ``NoReleaseError`` if no such release exists
@@ -324,15 +324,15 @@ def resolve_latest_daemon(allow_prerelease: bool) -> str:
             break  # ran off the end of the releases list
         for rel in batch:
             tag = rel.get("tag_name", "")
-            if tag.startswith("daemon/v"):
-                versions.append(tag[len("daemon/v") :])
+            if tag.startswith("obsigna/v"):
+                versions.append(tag[len("obsigna/v") :])
         # Releases are newest-first, so once a daemon version matching the filter
         # has appeared we have the most recent ones — stop rather than page
         # through the entire release history of every other component.
         if any(allow_prerelease or not is_prerelease(v) for v in versions):
             break
     if not versions:
-        raise NoReleaseError("no daemon/v* release found in recent releases")
+        raise NoReleaseError("no obsigna/v* release found in recent releases")
     try:
         return pick_latest(versions, allow_prerelease)
     except NoStableReleaseError as exc:  # only pre-releases exist, excluded

--- a/scripts/daemon_protocol/test_check.py
+++ b/scripts/daemon_protocol/test_check.py
@@ -121,13 +121,13 @@ class TestDaemonAssetURL:
         url = check.daemon_asset_url("0.8.0")
         assert url == (
             "https://github.com/agent-receipts/obsigna/releases/download/"
-            "daemon%2Fv0.8.0/daemon_0.8.0_linux_amd64.tar.gz"
+            "obsigna%2Fv0.8.0/obsigna_0.8.0_linux_amd64.tar.gz"
         )
 
     def test_prerelease_version(self) -> None:
         url = check.daemon_asset_url("0.9.0-alpha.1")
-        assert "daemon%2Fv0.9.0-alpha.1/" in url
-        assert url.endswith("daemon_0.9.0-alpha.1_linux_amd64.tar.gz")
+        assert "obsigna%2Fv0.9.0-alpha.1/" in url
+        assert url.endswith("obsigna_0.9.0-alpha.1_linux_amd64.tar.gz")
 
 
 class TestPickLatest:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,7 +10,7 @@ Validate and push the git tag for a module in this monorepo.
 The script tags only. Each module has a dedicated per-module release
 workflow in .github/workflows/release-<module>.yml that triggers on the
 tag, runs CI tests in a clean environment, and creates the GitHub Release.
-For modules with binaries (hook, mcp-proxy, daemon, collector) it also
+For modules with binaries (hook, mcp-proxy, obsigna, collector) it also
 builds artifacts via GoReleaser and publishes a Homebrew formula.
 
 Modules:
@@ -19,7 +19,7 @@ Modules:
   sdk-py       Python SDK             (tag: sdk-py-vVERSION)
   hook         agent-receipts-hook    (tag: hook/vVERSION)
   mcp-proxy    MCP proxy              (tag: mcp-proxy/vVERSION)
-  daemon       agent-receipts daemon  (tag: daemon/vVERSION)
+  obsigna      obsigna toolset        (tag: obsigna/vVERSION)
   collector    reference collector    (tag: collector/vVERSION)
 
 Flags:
@@ -34,7 +34,7 @@ Notes:
 Examples:
   $(basename "$0") sdk-go 0.2.0
   $(basename "$0") --dry-run mcp-proxy 0.8.0-alpha.1
-  $(basename "$0") daemon 0.8.0-alpha.1
+  $(basename "$0") obsigna 0.8.0-alpha.1
   $(basename "$0") collector 0.13.0
 EOF
   exit 1
@@ -64,7 +64,7 @@ VERSION="${ARGS[1]}"
 
 # Validate version format. PEP 440 pre-release form (e.g. 0.8.0a1) is
 # accepted only for sdk-py because PyPI rejects SemVer-style hyphenated
-# pre-releases. Go modules (sdk-go, mcp-proxy, daemon) and the npm
+# pre-releases. Go modules (sdk-go, mcp-proxy, obsigna) and the npm
 # module (sdk-ts) require SemVer; accepting PEP 440 there would silently
 # create tags that go.mod / npm cannot resolve.
 SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
@@ -74,7 +74,7 @@ case "$MODULE" in
     [[ "$VERSION" =~ $SEMVER_RE ]] || [[ "$VERSION" =~ $PEP440_PRE_RE ]] || \
       fail "invalid version '$VERSION' for sdk-py — expected SemVer (e.g. 0.5.0, 1.0.0-beta.1) or PEP 440 pre-release (e.g. 0.8.0a1)"
     ;;
-  sdk-go|sdk-ts|hook|mcp-proxy|daemon|collector)
+  sdk-go|sdk-ts|hook|mcp-proxy|obsigna|collector)
     [[ "$VERSION" =~ $SEMVER_RE ]] || \
       fail "invalid version '$VERSION' for $MODULE — expected SemVer (e.g. 0.2.0, 1.0.0-beta.1). PEP 440 form (e.g. 0.8.0a1) is accepted only for sdk-py."
     ;;
@@ -96,7 +96,7 @@ REMOTE=$(git rev-parse origin/main)
 
 # Go modules don't support build metadata in tags
 case "$MODULE" in
-  sdk-go|hook|mcp-proxy|daemon|collector)
+  sdk-go|hook|mcp-proxy|obsigna|collector)
     [[ "$VERSION" != *+* ]] || fail "Go module versions cannot contain build metadata (+...)"
     ;;
 esac
@@ -122,8 +122,10 @@ case "$MODULE" in
     TAG="mcp-proxy/v${VERSION}"
     DIR="mcp-proxy"
     ;;
-  daemon)
-    TAG="daemon/v${VERSION}"
+  obsigna)
+    # The release train is named obsigna (ADR-0034); its sources live in the
+    # daemon/ module directory, which did not move.
+    TAG="obsigna/v${VERSION}"
     DIR="daemon"
     ;;
   collector)
@@ -168,7 +170,7 @@ case "$MODULE" in
     echo "--- Running Go checks in $DIR"
     (cd "$DIR" && go vet ./... && go test ./...)
     ;;
-  daemon)
+  obsigna)
     command -v go >/dev/null 2>&1 || fail "go is not installed"
     echo "--- Checking for replace directive in $DIR/go.mod"
     if grep -Eq '^[[:space:]]*replace[[:space:]]' "$DIR/go.mod"; then


### PR DESCRIPTION
Implements **PR 1 of [ADR-0034](docs/adr/0034-consolidate-go-toolset-release-train.md)** — the decision-9 identity rename. Renames the Go toolset's *release identity* from `daemon` to `obsigna` so the packaging is right-side up (`brew install agent-receipts/tap/obsigna` installs the toolset; the daemon is one binary within it, not the thing that names the bundle). This is a config/release-infra change only — no new binaries, no code behaviour change. PR 2 will fold `mcp-proxy`/`collector`/`hook` into the train.

## What moves to `obsigna` (train/archive/project/tag/formula identity only)

- **`daemon/.goreleaser.yaml`** — `project_name: daemon` → `obsigna` (the archive `name_template` derives from `{{ .ProjectName }}`, so the tarball becomes `obsigna_<ver>_<os>_<arch>.tar.gz`); both formulae `obsigna-daemon` → `obsigna` and `obsigna-daemon-alpha` → `obsigna-alpha` (name, `url_template` `daemon%2Fv` → `obsigna%2Fv`, `conflicts_with`, `livecheck` regex, caveats `brew …/obsigna-daemon` → `…/obsigna`, commit/description strings).
- **`.github/workflows/release-daemon.yml` → `release-obsigna.yml`** — tag trigger `daemon/v*` → `obsigna/v*`; version parse `#daemon/` → `#obsigna/` (env var `DAEMON_VERSION` → `OBSIGNA_VERSION`); GH-release title `daemon …` → `obsigna …`; the reproducible-attest asset `daemon_<ver>_…` → `obsigna_<ver>_…` (it still extracts the unchanged `obsigna-daemon` binary and publishes `obsigna-daemon-linux-amd64.sha256`).
- **`scripts/daemon_protocol/check.py`** (Gate #8) — asset name `daemon_` → `obsigna_`, tag parse `daemon/v` → `obsigna/v`. Binary extracted stays `obsigna-daemon`; CLI stays the `agent-receipts` shim; `REPO` stays `agent-receipts/obsigna`.
- **`daemon/install.sh`** — `ARCHIVE`, `RELEASE_BASE` `daemon%2Fv` → `obsigna%2Fv`, and the latest-version `awk` `"daemon\/v"` → `"obsigna\/v"` (offsets adjusted +9/-9 → +10/-10 for the longer prefix). Installed binary stays `obsigna-daemon`; systemd unit name left as-is (separate concern).
- **`entrypoint_guard_test.go`** — `TestBrewFormulaeUseObsignaName` now asserts `obsigna`/`obsigna-alpha` and rejects the retired `obsigna-daemon(-alpha)` / `agent-receipts-daemon` names.
- **Comment-only**: `daemon.yml` and `daemon/scripts/reproducible-build.sh` references to `release-daemon.yml` → `release-obsigna.yml`.
- **`daemon/CHANGELOG.md`** — Unreleased note recording the train/archive/formula rename.

## Explicitly **not** changed (the boundary)

- The **`obsigna-daemon` binary** name — the umbrella archive still ships `obsigna` + `obsigna-daemon` + the `agent-receipts` shim. `builds[].binary` values untouched.
- The **`daemon/` module directory** and the **module path** `github.com/agent-receipts/ar/daemon`.
- **`did:agent-receipts-daemon:` issuer strings** (protocol/trust concern, not packaging).
- `daemon.yml`'s `daemon/**` path filter (the directory didn't move).

## Verification

- `go test ./cmd/obsigna/...` — passes (entrypoint guard parses unchanged build/binary names; brew-name test updated to the new formula names).
- `python3 -m py_compile scripts/daemon_protocol/check.py` and `python3 scripts/daemon_protocol/test_check.py` — pass (asset-URL tests updated).
- All three touched YAML files parse.
- `awk` prefix-offset spot-checked against a sample `obsigna/v0.24.0` tag line → extracts `0.24.0`.

Full validation needs a real tag: **after merge, cut the first `obsigna/v…-alpha`** to exercise the renamed train end-to-end (the alpha track protects the stable `obsigna` formula during soak).

## Companion change (separate repo)

`agent-receipts/homebrew-tap` needs a separate PR: extend `tap_migrations.json` with `obsigna-daemon → obsigna` and `obsigna-daemon-alpha → obsigna-alpha`, and remove the old `Formula/obsigna-daemon*.rb` (GoReleaser regenerates `Formula/obsigna*.rb` on the next release).

## Notes / follow-ups

- The release workflow's `environment: release-daemon` (a GitHub deployment environment with protection rules) is **left as-is** — renaming it in the workflow without first creating `release-obsigna` in repo settings would silently drop its protection rules. Rename it in GitHub settings as a separate step if desired.
- `daemon/install.sh` still uses `REPO="agent-receipts/ar"` (vs `agent-receipts/obsigna` elsewhere) — pre-existing and orthogonal to this train rename (relies on GitHub's renamed-repo redirect); flagged here rather than fixed to keep scope tight.