### PR TITLE
chore(collector): stamp CHANGELOG 0.14.0

### DIFF
--- a/collector/CHANGELOG.md
+++ b/collector/CHANGELOG.md
@@ -12,6 +12,8 @@ Conventional Commits is tracked in
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-13
+
 ### Changed
 
 - **Binary renamed `collector` → `obsigna-collector` (ADR-0035).** The collector is


### PR DESCRIPTION
Stamps the collector CHANGELOG ahead of cutting `collector/v0.14.0`.

Promotes the obsigna-collector binary-rename + Gate A/B entries (ADR-0035, #807) from `[Unreleased]` → `[0.14.0] - 2026-06-13`. Docs-only; the release workflow does not read the CHANGELOG, this is hygiene so the changelog doesn't lag the tag.

Minor bump rationale: the `collector` → `obsigna-collector` rename is breaking for installers that invoke the binary by an absolute path (the `collector` shim covers `$(which collector)` but not a hard-coded path).