### PR TITLE
docs(sdk/go): stamp CHANGELOG 0.20.0-alpha.1

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,8 @@ tracked in [#253](https://github.com/agent-receipts/ar/issues/253).
 
 ## [Unreleased]
 
+## [0.20.0-alpha.1] - 2026-06-13
+
 ### Added
 
 - **`Store.LatestRootChainID()`** — returns the chain id of the most recently written root receipt (the chain the daemon is currently appending to), or `found=false` for an empty store. Recency is by `rowid` (write order), not timestamp, so it is correct even when many receipts share the same RFC3339 second. Agent sub-chains (`…/agent/…`) are excluded. Used by `obsigna doctor` to target the live chain instead of guessing today's date.


### PR DESCRIPTION
Stamps `sdk/go/CHANGELOG.md` for the `0.20.0-alpha.1` cut: moves the `[Unreleased]` entry under `## [0.20.0-alpha.1] - 2026-06-13` and reopens an empty `[Unreleased]`.

The only change since `v0.19.0-alpha.1` is the additive **`Store.LatestRootChainID()`** (from the doctor auto-detect fix #802) — no other exported surface changed.

**Why now:** `daemon` (the obsigna train) calls `store.LatestRootChainID`, which exists only in the in-tree `sdk/go`. Under release conditions (`GOWORK=off`, published deps) the `obsigna` CLI fails to compile against the currently-pinned published `sdk/go v0.19.0-alpha.1`. Publishing `v0.20.0-alpha.1` and bumping `daemon/go.mod` to it unblocks the `obsigna/v0.24.0` release. Prereq for cutting `sdk/go/v0.20.0-alpha.1`.