### PR TITLE
fix(daemon): pin sdk/go v0.20.0-alpha.1 for release builds

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -9,7 +9,7 @@ toolchain go1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1 h1:8bf6sLLq+ST5A4wZzgTC2dI9CpbTC02fw3Av+yWgggM=
-github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1 h1:ty9GWmGRPYEU3o7SZjFoXMSLxDYU9Qoj3r4M/IlT6f8=
+github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
**Release blocker fix.** `main` cannot currently be released as `obsigna/v0.24.0`: the doctor auto-detect fix (#802) calls `store.LatestRootChainID`, which existed only in the in-tree `sdk/go`. Under release conditions (`GOWORK=off`, published deps) the `obsigna` CLI fails to compile against the pinned `sdk/go v0.19.0-alpha.1`:

```
internal/doctorcli/doctor.go:652: s.LatestRootChainID undefined
```

The workspace build (local dev + daemon CI, which use `go.work`) compiles fine, which is why this slipped through — only the `GOWORK=off` release path exercises published deps.

## Change
- `daemon/go.mod`: `sdk/go v0.19.0-alpha.1` → `v0.20.0-alpha.1` (published in #812 → `sdk/go/v0.20.0-alpha.1`, which adds `Store.LatestRootChainID()`).
- `daemon/go.sum`: swap the corresponding hashes.
- `toolchain go1.26.1` directive unchanged (ADR-0031).

## Verification
`GOWORK=off go build ./...` resolves the symbol against the published module (exit 0). The `reproducible-build` CI gate (native go1.26.1, `GOWORK=off`) is the authoritative check.

Unblocks `obsigna/v0.24.0`. Same class as #806 ("pin sdk/go so release builds against published deps").