### PR TITLE
chore(daemon): de-redundant go toolchain pin; install.sh → obsigna repo

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,11 +1,13 @@
 module github.com/agent-receipts/ar/daemon
 
+// Pin the exact patch in the go directive (ADR-0031): reproducible-build
+// attestation requires every builder use the same compiler bytes. `setup-go`
+// installs exactly this version from go-version-file, so CI never floats to a
+// later 1.26.x. A standalone `toolchain go1.26.1` directive would duplicate this
+// patch-level go line; `go mod tidy` strips it as redundant, which also makes
+// `-mod=readonly` builds (the release path, GOWORK=off) demand a tidy. So the go
+// directive itself is the pin.
 go 1.26.1
-
-// Pin the toolchain to the patch (ADR-0031): reproducible-build attestation
-// requires every builder use the same compiler bytes. CI consumes this via
-// `setup-go` with go-version-file so it stops floating to the latest 1.26.x.
-toolchain go1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -10,7 +10,7 @@
 
 set -eu
 
-REPO="agent-receipts/ar"
+REPO="agent-receipts/obsigna"
 INSTALL_DIR="${HOME}/.local/bin"
 # KEY_FILE is the XDG default path. The installer targets the default install layout;
 # custom AGENTRECEIPTS_KEY or XDG_DATA_HOME overrides are out of scope here.


### PR DESCRIPTION
Two release-process papercuts found while cutting `obsigna/v0.24.0`.

## 1. `daemon/go.mod`: redundant `toolchain` directive broke the release preflight
`go.mod` had `toolchain go1.26.1` equal to the `go 1.26.1` directive. `go mod tidy` treats that as redundant and strips it, and **`-mod=readonly` builds (the `GOWORK=off` release path) refuse to run**, demanding `go mod tidy` — which made `scripts/release.sh`'s local preflight (`GOWORK=off go vet/test`) unrunnable on any machine.

Fix: drop the redundant `toolchain` line. The patch-level `go 1.26.1` directive **is** the pin — `setup-go` installs exactly `1.26.1` from `go-version-file`, so the ADR-0031 reproducible-build guarantee is unchanged (same toolchain, byte-identical builds; the `toolchain` directive isn't embedded in the binary).

Verified:
- `GOWORK=off go mod tidy -diff` → empty (go.mod is tidy)
- `GOWORK=off go vet ./...` and `go build ./...` → clean under both local go1.26.4 and pinned go1.26.1

## 2. `daemon/install.sh`: `REPO` still pointed at the pre-rename repo
`REPO="agent-receipts/ar"` → `agent-receipts/obsigna`. It worked only via GitHub's rename redirect; point it directly. (Go *module paths* stay `…/ar/…` per ADR-0034 decision 10 — this is a repo reference, not a module path.)

Both are pure follow-ups to the ADR-0034 PR 1 rename; no functional change to the binaries.