### PR TITLE
docs(hook): stamp CHANGELOG 0.18.0-alpha.1

### DIFF
--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0-alpha.1] - 2026-06-13
+
 ### Changed
 
 - **Binary renamed `agent-receipts-hook` → `obsigna-hook`** (ADR-0036) — the hook


### PR DESCRIPTION
Stamps `hook/CHANGELOG.md` for the `0.18.0-alpha.1` release — the `agent-receipts-hook` → `obsigna-hook` binary rename (ADR-0036, #809).

Cut on the standalone `hook/v*` train (the unified obsigna train doesn't build the hook yet — ADR-0034 PR 2 pending). Alpha-first to soak the new Gate B reproducible-attest job on its first real release run.

After merge: tag `hook/v0.18.0-alpha.1` to trigger `release-hook.yml`.