### PR TITLE
docs(hook): graduate 0.18.0 (pin stable sdk/go v0.19.0)

### DIFF
--- a/hook/CHANGELOG.md
+++ b/hook/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-13
+
+Graduates `0.18.0-alpha.1` after the alpha pass. No code changes since the alpha; the only change is pinning the now-released stable `github.com/agent-receipts/ar/sdk/go` `v0.19.0` (the alpha pinned `v0.19.0-alpha.1`). See the `0.18.0-alpha.1` entry below for the full surface (the `agent-receipts-hook` → `obsigna-hook` binary rename, ADR-0036).
+
 ## [0.18.0-alpha.1] - 2026-06-13
 
 ### Changed

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1
+require github.com/agent-receipts/ar/sdk/go v0.19.0
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -4,6 +4,8 @@ github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMz
 github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
 github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1 h1:8bf6sLLq+ST5A4wZzgTC2dI9CpbTC02fw3Av+yWgggM=
 github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.19.0 h1:4N5qohfN8B9n3ygimCuw2nLMV9LK8W39U6YC7TVtauA=
+github.com/agent-receipts/ar/sdk/go v0.19.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Graduates `hook 0.18.0-alpha.1` → stable `0.18.0`. No code changes since the alpha (the `agent-receipts-hook` → `obsigna-hook` rename, ADR-0036, #809); the only change is pinning the now-released stable `sdk/go v0.19.0` (the alpha pinned `v0.19.0-alpha.1`), so the stable hook no longer depends on a pre-release library — matching the established graduation pattern.

Verified `GOWORK=off go vet/build/test ./...` against the published `sdk/go v0.19.0`.

After merge: tag `hook/v0.18.0` → `release-hook.yml` (stable formula bumps off 0.15.0; Gate B re-attests).