### PR TITLE
Document trust model and deployment spectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,15 @@ mcp-proxy verify --key pub.pem <chain-id>
 
 ## SDK quick start
 
-> **Not for production.** The snippets below keep the signing key inside the
-> agent process. Anyone with code execution in the agent can forge receipts. For
-> real deployments, use the
+> **Choose your trust model.** The snippets below keep the signing key inside the
+> agent process — a deliberate deployment model where the agent host is trusted
+> and tamper-evidence is aimed at downstream parties. In this model, anyone with
+> code execution in the agent can forge receipts. To defend against a compromised
+> agent, use the
 > [daemon-mediated path](https://agentreceipts.ai/getting-started/daemon-setup/),
-> where the daemon owns the key and your app only sends events over a socket.
+> where a separate daemon owns the key and your app only sends events over a
+> socket. See the [Trust Model](https://agentreceipts.ai/specification/trust-model/)
+> page for the full spectrum (in-process → daemon-isolated → HSM/KMS).
 
 ### Go
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-**Status:** Forward-looking. The body of this document describes the v2 architecture introduced by [ADR-0010](adr/0010-daemon-process-separation.md) (daemon process separation, Accepted) and [ADR-0015](adr/0015-key-rotation-byok-anchoring.md) (key rotation, BYOK, external anchoring, Proposed). The shipped v1 architecture differs in load-bearing ways; those differences are captured in [v1 caveats (current state)](#v1-caveats-current-state) below.
+**Status:** Current. The daemon architecture from [ADR-0010](adr/0010-daemon-process-separation.md) (daemon process separation) is shipped — the MCP proxy and the hook are thin emitters that hold no key, and `agent-receipts-daemon` is the sole signer. Claims that depend on not-yet-shipped pieces of [ADR-0015](adr/0015-key-rotation-byok-anchoring.md) (production external-anchor adapters, checkpoint anchoring, and HSM/KMS key custody) are flagged inline and summarised under [Current implementation status](#current-implementation-status) below. For the full deployment spectrum behind these boundaries — in-process SDK signing through HSM/KMS custody — see the [Trust Model](https://agentreceipts.ai/specification/trust-model/) page.
 
 **Audience:** Security leads evaluating Agent Receipts for their environment, white-hat reviewers probing the system, and compliance teams writing audit narratives. The intent is that trust assumptions are stated upfront — not discovered.
 
@@ -109,26 +109,24 @@ The IPC transport between emitter and daemon is a Unix domain socket (Linux/macO
 
 A malicious daemon binary can do anything. Out of scope here; tracked separately at [#151](https://github.com/agent-receipts/ar/issues/151) (binary signing, reproducible builds, distribution channel hardening).
 
-## v1 caveats (current state)
+## Current implementation status
 
-> **This section is intended to be deleted as an atomic block when ADR-0010 implementation ships ([#236](https://github.com/agent-receipts/ar/issues/236)).** Until then, readers must understand which guarantees above are aspirational versus shipped.
+The daemon architecture is shipped. The MCP proxy and the PostToolUse hook are thin emitters: they hold no Ed25519 key, generate none, and contain no signing path at all — they send event frames over a Unix socket to `agent-receipts-daemon`, which is the sole signer and the sole writer of the store. Peer credentials are captured via `SO_PEERCRED` / `LOCAL_PEERCRED` at `accept()` (before any frame is read) and recorded in the signed `action.peer_credential`. The daemon refuses to load a signing key whose file mode grants any group or world access and opens it `O_NOFOLLOW`. So the **compromised-agent defence above is shipped, not aspirational**, for the daemon-mediated deployment.
 
-In v1 (the architecture currently shipped on `main`), the signing key lives **in the agent process**. The MCP proxy, the OpenClaw plugin, and SDK consumers each load or generate their own Ed25519 keypair in-process and sign receipts directly. There is no daemon, no IPC, and no peer-credential attestation.
+In-process SDK signing still exists — but as a deliberate deployment model, not a footgun. An operator who trusts the agent host and only needs tamper-evidence against downstream parties may choose it for its portability, accepting that code execution in the agent can forge receipts in that model. The daemon deployment is the default precisely for operators who must defend against a compromised agent. The full spectrum is documented on the [Trust Model](https://agentreceipts.ai/specification/trust-model/) page; this threat model describes the daemon deployment unless stated otherwise.
 
-This means, today:
+What remains partial — and therefore bounds the claims above:
 
-- **The "compromised agent process" defence above is aspirational.** A compromised agent process *can* read its own signing key, forge receipts, and present a tampered chain that verifies cleanly against its own public key. The site documentation audit ([docs/audits/site-technical-architecture.md](https://github.com/agent-receipts/ar/blob/4d163ad62246fcdb485812eaa3e3d2d2ea9141d3/docs/audits/site-technical-architecture.md)) describes the resulting positioning gap in detail.
-- **No external anchor exists yet.** Tail truncation and forged rotation history are not defended against in v1, regardless of operator configuration. ADR-0015 is Proposed; the anchor adapter ecosystem ships in follow-on issues.
-- **The asymmetric `parameterDisclosure` envelope (ADR-0012) is not yet wired end-to-end.** The receipt-side `parameters_disclosure` field exists across all three SDKs (`sdk/ts`, `sdk/py`, `sdk/go`) and the cross-language vectors round-trip it, but the responder-keyed asymmetric envelope flow that ADR-0012 specifies is not yet implemented. The MCP proxy uses a separate symmetric scheme via `BEACON_ENCRYPTION_KEY` for redacted-field encryption; that is not the asymmetric forensic-keypair design ADR-0012 describes.
-
-The v1-to-v2 transition is a hard breaking change for emitters, by deliberate design ([ADR-0010 Negative consequences](adr/0010-daemon-process-separation.md)). v1 in-process behaviour is being deprecated and removed rather than left available, because shipping the "agent signs its own receipts" footgun under the agent-receipts name is worse than a major version bump.
+- **External anchoring is partially shipped.** Key rotation and anchor-first rotation writes are implemented, with a dependency-free file-log *reference* adapter (a plain file is only as append-only as the filesystem around it). Production-grade anchor adapters (S3 object-lock, transparency log, SIEM ingest) and checkpoint anchoring for tail-truncation detection (ADR-0015 Phase B) are **not yet shipped**. So the post-compromise integrity guarantee in [What we explicitly claim](#what-we-explicitly-claim) remains conditional on configuring a qualifying external sink, and that adapter ecosystem is still landing.
+- **HSM / cloud-KMS key custody is not yet shipped.** The `KeySource` interface is in place and the file-backed adapter is the default; PKCS#11 and KMS backends (ADR-0015 Phase C) are designed but unimplemented. Against a host-level compromise, the file-backed key is readable by the daemon user — see [Compromised daemon process](#compromised-daemon-process--daemon-user-filesystem-access).
+- **Forensic parameter disclosure (ADR-0012) is wired in the daemon.** When a forensic public key is configured, the daemon pipeline encrypts elected parameters into an HPKE envelope addressed to that key; the matching private key lives with the offline responder, not the daemon. This is no longer an open gap.
 
 ## Mitigations and roadmap
 
 | Concern | ADR | Issue | Status |
 |---|---|---|---|
-| Daemon process separation (signing/storage isolation from agent) | [ADR-0010](adr/0010-daemon-process-separation.md) | [#236](https://github.com/agent-receipts/ar/issues/236) | Accepted; Phase 1 shipped, Phase 2+ pending |
-| Key rotation, BYOK, external anchoring | [ADR-0015](adr/0015-key-rotation-byok-anchoring.md) | [#307](https://github.com/agent-receipts/ar/issues/307) (PR [#319](https://github.com/agent-receipts/ar/pull/319)) | Proposed; implementation phased (rotation anchoring → checkpoint anchoring) |
+| Daemon process separation (signing/storage isolation from agent) | [ADR-0010](adr/0010-daemon-process-separation.md) | [#236](https://github.com/agent-receipts/ar/issues/236) | Accepted; shipped — MCP proxy and hook are keyless emitters; the daemon is the sole signer |
+| Key rotation, BYOK, external anchoring | [ADR-0015](adr/0015-key-rotation-byok-anchoring.md) | [#307](https://github.com/agent-receipts/ar/issues/307) (PR [#319](https://github.com/agent-receipts/ar/pull/319)) | Accepted; rotation + anchor-first writes + file-log reference adapter shipped; production anchor adapters & checkpoint anchoring (Phase B), HSM/KMS (Phase C) pending |
 | DID-based identity for issuer/key resolution | [ADR-0007](adr/0007-did-method-strategy.md) | [#46](https://github.com/agent-receipts/ar/issues/46) | Proposed |
 | Algorithm agility (PQ-ready signing) | — (`KeySource` interface in ADR-0015 is algorithm-agnostic by design) | [#32](https://github.com/agent-receipts/ar/issues/32) | Tracked |
 | Supply-chain integrity of the daemon binary | — | [#151](https://github.com/agent-receipts/ar/issues/151) | Tracked |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -66,7 +66,9 @@ An attacker who compromises the daemon could rewrite the chain's rotation events
 
 ### Sensitive data in storage
 
-Parameters are committed via `parameters_hash` by default (privacy-preserving, tamper-evident). Operators who need on-demand forensic recovery opt into [ADR-0012](adr/0012-payload-disclosure-policy.md) `parameterDisclosure`, which puts a separately-keyed asymmetrically-encrypted envelope into the signed receipt body. The forensic decryption key lives with the responder, not the daemon — the daemon (and therefore a compromised daemon) cannot decrypt past disclosures.
+Action parameters are committed via `parameters_hash` by default (privacy-preserving, tamper-evident). Operators who need on-demand forensic recovery enable [ADR-0012](adr/0012-payload-disclosure-policy.md) parameter disclosure: the daemon encrypts elected parameters into a separately-keyed HPKE envelope (`action.parameters_disclosure`) inside the signed receipt body, and an offline responder recovers them with the matching private key (SDK `DecryptDisclosure`). **Both the daemon-side sealing and the responder-side decryption are shipped.** The forensic decryption key lives with the responder, not the daemon — so the daemon (and therefore a compromised daemon) cannot decrypt past disclosures.
+
+Tool **output/response is committed via `response_hash` only** — there is no response-disclosure envelope yet, so responses (which often carry the sensitive payload: file contents, query results) cannot be forensically recovered. This input/output asymmetry is tracked in [#819](https://github.com/agent-receipts/obsigna/issues/819).
 
 Plaintext secrets in receipts are forbidden by policy (see [AGENTS.md security section](../AGENTS.md)).
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -77,6 +77,10 @@ export default defineConfig({
               slug: "specification/how-it-works",
             },
             {
+              label: "Trust Model",
+              slug: "specification/trust-model",
+            },
+            {
               label: "Agent Receipt Schema",
               slug: "specification/agent-receipt-schema",
             },

--- a/site/src/content/docs/specification/trust-model.mdx
+++ b/site/src/content/docs/specification/trust-model.mdx
@@ -1,0 +1,153 @@
+---
+title: Trust Model
+description: Who signs, who is attested, and where the trust boundary sits — Agent Receipts separates the receipt mechanism from the deployment policy that places the signing key.
+---
+
+Agent Receipts separates **mechanism** from **policy**. The mechanism is fixed: a
+canonical receipt (RFC 8785), an Ed25519 signature over its canonical bytes, and
+a hash chain linking each receipt to its predecessor. The policy — *where the
+signing authority sits relative to the agent* — is a deployment choice the
+operator makes.
+
+This distinction matters because it is easy to mistake one deployment for the
+protocol. Agent Receipts does **not** place the signing key anywhere. The
+deployment does. The same receipt format and the same verifier work whether the
+key lives inside the agent process, inside a separate daemon the agent cannot
+read, or inside an HSM the daemon itself cannot extract.
+
+## Who signs is not who acted
+
+Four roles are deliberately distinct. Collapsing them is the most common source
+of confusion about what a receipt proves.
+
+| Role | What it is | Where it appears |
+|---|---|---|
+| **Issuer** (`issuer.id`) | An identity claim — the agent or platform on whose behalf the action was recorded. A *subject* of the receipt, not necessarily the key holder. | Receipt body |
+| **Operator** (`issuer.operator`) | The entity running the agent or host. Orthogonal to the signer. | Receipt body |
+| **Signer** | The process that holds the private key and produces the signature. | Outside the receipt — a deployment fact |
+| **Key custody** (`KeySource`) | Where the private key physically lives: a file, an HSM, or a cloud KMS. May be non-extractable. | Configured per deployment |
+
+In the daemon deployment (below), the signer attests the agent's identity rather
+than *being* it: the daemon captures the connecting process's OS credentials
+(`SO_PEERCRED` / `LOCAL_PEERCRED`) at connection time and records them in
+`action.peer_credential`, signed. The agent's self-asserted identity is never
+trusted; it is witnessed. A receipt is therefore not "the agent vouching for
+itself" — it is the signing authority vouching for what it independently
+observed the agent do.
+
+## The trust boundary is a dial
+
+There is no single trust boundary. There is a dial the operator turns, trading
+deployment simplicity for stronger isolation of the key.
+
+| Deployment | Signer location | Boundary drawn at | What the operator is choosing to defend against |
+|---|---|---|---|
+| **In-process (SDK)** | Agent *is* the signer | agent + operator ↔ external verifier | Downstream tampering and portability. The agent host is *trusted* in this model. |
+| **Daemon-isolated** (default for the MCP proxy and hook) | Separate OS user; key unreachable by the agent | agent ↔ signing authority | A compromised or lying agent process. |
+| **HSM / cloud KMS** (`KeySource` backend) | Key non-extractable even from the daemon host | operator / host ↔ verifier (with external anchor) | A compromised operator, root, or daemon. |
+
+Each row is a legitimate choice, not a ladder of "wrong" to "right." An operator
+who trusts the agent host and only needs tamper-evidence against downstream
+parties may deliberately pick in-process signing for its portability — accepting
+that code execution in the agent can forge receipts, because in that model the
+agent is inside the trust boundary by design. An operator defending against a
+compromised agent picks the daemon. An operator defending against their own
+infrastructure picks HSM/KMS plus an external anchor.
+
+## The default: daemon-isolated signing
+
+The production integration surfaces — the MCP proxy and the PostToolUse hook —
+ship as **thin emitters with no key material of their own**. They fire a
+fire-and-forget event frame over a local Unix socket; a separate
+`agent-receipts-daemon` process builds, canonicalizes, signs, and stores the
+receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)).
+
+```mermaid
+flowchart LR
+  A["Agent process<br/>(emitter — no key)"] -->|event frame, Unix socket| D["agent-receipts-daemon<br/>(sole signer, sole key)"]
+  D -->|signed receipt| S[("receipts.db")]
+  D -.->|rotation / checkpoint| K[["external anchor<br/>(operator-controlled? no)"]]
+  P{{"peer credential<br/>SO_PEERCRED at accept()"}} -.-> D
+```
+
+This boundary is enforced in code, not merely asserted:
+
+- The daemon **refuses to load a key** whose file mode grants any group or world
+  access (`perm & 0o077 != 0` → refuse; requires `0600`).
+- The key file is opened `O_NOFOLLOW` with an `fstat` on the descriptor, closing
+  the symlink-swap TOCTOU window.
+- Peer credentials are captured at `accept()` — before any frame is read — so a
+  forking emitter cannot mislabel itself.
+- The emitter binaries contain no Ed25519, key-generation, or key-loading code
+  paths at all.
+
+The consequence: **a compromised agent cannot read the signing key, write the
+store, canonicalize, or forge a signature.** The worst it can do is lie in the
+fields it sends — and the daemon records that lie next to the OS-attested ground
+truth of which process sent it.
+
+## Defending against a compromised operator
+
+The daemon boundary defends against the agent. Defending against the *operator*
+— or against a daemon that has itself been compromised — is a different boundary,
+and Agent Receipts answers it with two interlocking constructs from
+[ADR-0015](https://github.com/agent-receipts/ar/blob/main/docs/adr/0015-key-rotation-byok-anchoring.md):
+
+1. **Non-extractable key custody.** The `KeySource` interface lets the signing
+   key live in an HSM (PKCS#11) or a cloud KMS, where the daemon submits
+   canonical bytes for signing and never holds the key. Compromising the daemon
+   host no longer yields the key.
+
+2. **External anchoring.** Key-rotation events are written **anchor-first** —
+   to a sink the daemon does not control — *before* the local chain commits, and
+   periodic checkpoints commit the chain tip to that same sink. A sink only
+   qualifies if it is append-only and orders/timestamps records itself
+   (object-lock storage, a transparency log, a sequence-stamping SIEM). With such
+   a sink, an attacker who compromises the daemon key can forge only *future*
+   receipts under that key; the chain's history, its rotation lineage, and its
+   tail are fixed by witnesses the attacker cannot rewrite.
+
+Together these move the post-compromise integrity *witness* off the operator's
+side of the boundary — which is precisely the property a self-signed scheme
+cannot have on its own.
+
+:::caution[Implementation status]
+Lead-with-the-design above describes the target architecture. As shipped today:
+
+- **Key rotation** and **anchor-first rotation writes** are implemented, with a
+  dependency-free **file-log reference adapter**. That adapter appends, but a
+  plain file is only as tamper-evident as the filesystem around it — it is for
+  development and for fronting a medium that enforces append-only retention.
+- **Production anchor adapters** (S3 object-lock, transparency log, SIEM ingest)
+  and **checkpoint anchoring** for tail-truncation detection (ADR-0015 Phase B)
+  are **not yet shipped**.
+- **HSM / cloud-KMS `KeySource` backends** (Phase C) are designed but not yet
+  shipped; the file-backed adapter is the current default.
+
+So post-compromise integrity is **conditional on configuring a qualifying
+external sink**, and that ecosystem is still landing. The agent-isolation
+boundary (the previous section) is fully shipped; the operator-isolation
+boundary is partially shipped. We state both rather than blur them.
+:::
+
+## Verification is uniform across all models
+
+A verifier does not need to know which deployment produced a receipt. It checks
+the Ed25519 signature against the issuer's public key, recomputes the canonical
+bytes (RFC 8785), and walks `chain.previous_receipt_hash` — and, across
+rotations, the inline `keyRotation.new_public_key` witness. The trust model an
+operator chose changes *what a valid receipt lets you conclude about a
+compromised agent or operator*; it does not change *how* you validate one.
+
+## Summary
+
+- The receipt mechanism is fixed; trust-boundary placement is a deployment
+  parameter.
+- "The agent platform signs, so the key is on the operator's side" describes one
+  point on the dial — not the protocol, and not the shipped default.
+- The default daemon deployment puts the signer outside the agent, under its own
+  OS user, with a key the agent cannot reach, and attests the agent's identity
+  rather than trusting it.
+- Defending against the operator is a separate, designed boundary
+  (non-extractable custody + external anchoring) that is partially shipped today;
+  we mark exactly what is and is not in place.

--- a/site/src/content/docs/specification/trust-model.mdx
+++ b/site/src/content/docs/specification/trust-model.mdx
@@ -64,10 +64,10 @@ receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010
 
 ```mermaid
 flowchart LR
-  A["Agent process<br/>(emitter — no key)"] -->|event frame, Unix socket| D["agent-receipts-daemon<br/>(sole signer, sole key)"]
-  D -->|signed receipt| S[("receipts.db")]
-  D -.->|rotation / checkpoint| K[["external anchor<br/>(operator-controlled? no)"]]
-  P{{"peer credential<br/>SO_PEERCRED at accept()"}} -.-> D
+  A["Agent process (emitter, holds no key)"] -->|event frame over Unix socket| D["agent-receipts-daemon (sole signer, sole key)"]
+  P["peer credential: SO_PEERCRED captured at accept()"] -->|attested into receipt| D
+  D -->|signed receipt| S["receipts.db"]
+  D -->|rotation and checkpoint records| K["external anchor (not daemon-controlled)"]
 ```
 
 This boundary is enforced in code, not merely asserted:

--- a/site/src/content/docs/specification/trust-model.mdx
+++ b/site/src/content/docs/specification/trust-model.mdx
@@ -57,17 +57,20 @@ infrastructure picks HSM/KMS plus an external anchor.
 ## The default: daemon-isolated signing
 
 The production integration surfaces — the MCP proxy and the PostToolUse hook —
-ship as **thin emitters with no key material of their own**. They fire a
-fire-and-forget event frame over a local Unix socket; a separate
-`agent-receipts-daemon` process builds, canonicalizes, signs, and stores the
+ship as **thin emitters with no key material of their own**. They send an event
+frame over a local Unix socket; a separate `agent-receipts-daemon` process
+builds, canonicalizes, signs, and stores the
 receipt ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)).
+Delivery semantics differ by emitter: the MCP proxy logs emit failures and lets
+the tool call proceed, while the hook exits non-zero so a failure to record the
+action is surfaced.
 
 ```mermaid
 flowchart LR
   A["Agent process (emitter, holds no key)"] -->|event frame over Unix socket| D["agent-receipts-daemon (sole signer, sole key)"]
   P["peer credential: SO_PEERCRED captured at accept()"] -->|attested into receipt| D
   D -->|signed receipt| S["receipts.db"]
-  D -->|rotation and checkpoint records| K["external anchor (not daemon-controlled)"]
+  D -->|rotation records| K["external anchor (not daemon-controlled)"]
 ```
 
 This boundary is enforced in code, not merely asserted:


### PR DESCRIPTION
## What

Added comprehensive Trust Model documentation explaining how Agent Receipts separates mechanism from policy, and updated threat model and README to reflect the shipped daemon architecture and the full deployment spectrum (in-process SDK → daemon-isolated → HSM/KMS).

**New content:**
- `site/src/content/docs/specification/trust-model.mdx`: Full Trust Model specification covering the four distinct roles (Issuer, Operator, Signer, Key custody), the trust-boundary dial across three deployment models, the default daemon-isolated architecture with code-enforced boundaries, and the partial implementation status of operator-isolation defenses.

**Updated content:**
- `docs/threat-model.md`: Reframed from forward-looking v2 architecture to current shipped state. Clarified that daemon separation (ADR-0010) is shipped and the compromised-agent defence is no longer aspirational. Moved v1 caveats into "Current implementation status" section and documented what remains partial (external anchoring, HSM/KMS backends).
- `README.md`: Reframed SDK quick-start warning from "not for production" to "choose your trust model," explaining in-process signing as a deliberate deployment choice for operators who trust the agent host, with links to daemon-mediated and Trust Model documentation.
- `site/astro.config.mjs`: Added Trust Model page to specification navigation.

## Why

The shipped codebase now has the daemon architecture (thin emitters, separate signer process, peer-credential attestation) but documentation was either forward-looking or unclear about what was actually deployed. This created confusion about:

1. Whether in-process signing was a footgun or a legitimate choice
2. What the threat model actually covers in the shipped product
3. What the full deployment spectrum looks like (many operators need HSM/KMS but didn't know it was designed in)

The Trust Model page separates mechanism (fixed: canonical receipt, Ed25519, hash chain) from policy (operator's choice: where the key lives), making it clear that the same receipt format works across all three models. The threat model and README now accurately reflect what is shipped, what is partial, and what is designed but not yet shipped — with explicit pointers to the Trust Model for the full picture.

## Checklist

- [x] No real keys or secrets in the diff
- [x] Spec changes reviewed (documentation-only, no code changes to crypto, auth, or signing paths)
- [x] Cross-references updated (README links to Trust Model, threat model links to Trust Model, site nav includes Trust Model)

## Security

- [x] This PR touches threat model and trust boundaries (documentation only, no code changes)
- [x] Threat model accurately reflects shipped daemon architecture and partial external-anchor implementation
- [x] Implementation status clearly marked (daemon ✓, external anchoring partial, HSM/KMS designed but not shipped)
- [x] No security claims made beyond what is actually shipped and code-enforced