### PR TITLE
docs: align SDK package names and stale cmd paths with what ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Agent Receipts is an open protocol and set of SDKs for producing cryptographical
 Install the proxy:
 
 ```bash
-go install github.com/agent-receipts/mcp-proxy/cmd/mcp-proxy@latest
+go install github.com/agent-receipts/ar/mcp-proxy/cmd/obsigna-mcp@latest
 ```
 
 Wrap any MCP server:
 
 ```bash
-mcp-proxy node /path/to/mcp-server.js
+obsigna-mcp node /path/to/mcp-server.js
 ```
 
 Then point your agent client at the proxy instead of the raw server:
@@ -85,9 +85,9 @@ Then point your agent client at the proxy instead of the raw server:
 Once your agent makes tool calls, inspect the signed audit trail:
 
 ```bash
-mcp-proxy list
-mcp-proxy inspect <receipt-id>
-mcp-proxy verify --key pub.pem <chain-id>
+obsigna list
+obsigna show <seq>
+obsigna verify
 ```
 
 ## SDK quick start

--- a/scripts/legacy_name_guard/check.py
+++ b/scripts/legacy_name_guard/check.py
@@ -48,6 +48,11 @@ GATED_FILES = [
     "sdk/ts/README.md",
     "sdk/ts-aws/README.md",
     "sdk/py/README.md",
+    # User-facing install docs on the site — same shape as the README install
+    # commands, so they regress the same way (a snippet drifting back onto the
+    # legacy npm scope / PyPI name).
+    "site/src/content/docs/sdk-ts/installation.mdx",
+    "site/src/content/docs/sdk-py/installation.mdx",
 ]
 
 # Each entry: (compiled pattern, human description). The patterns match only the

--- a/site/README.md
+++ b/site/README.md
@@ -52,8 +52,8 @@ Sidebar order is controlled by `astro.config.mjs`, not by file naming.
 | Repository | Description |
 |:---|:---|
 | [agent-receipts/spec](https://github.com/agent-receipts/ar/tree/main/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
-| [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
-| [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
+| [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript SDK ([npm](https://www.npmjs.com/package/@obsigna/sdk-ts)) |
+| [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python SDK ([PyPI](https://pypi.org/project/obsigna/)) |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
 | **agent-receipts/site** (this repo) | Documentation site |
 

--- a/site/src/content/docs/deployment/collector-operations.mdx
+++ b/site/src/content/docs/deployment/collector-operations.mdx
@@ -37,15 +37,15 @@ POST /receipts ───▶ │  (TLS termination, auth) │
 Build the binary. From the repo root, build the collector's main package by its module-qualified path and name the output binary explicitly:
 
 ```sh
-go build -o collector github.com/agent-receipts/ar/collector/cmd/collector
+go build -o obsigna-collector github.com/agent-receipts/ar/collector/cmd/obsigna-collector
 ```
 
-(The bare `go build ./cmd/collector` only resolves from inside the `collector/` module directory.)
+(The bare `go build ./cmd/obsigna-collector` only resolves from inside the `collector/` module directory.)
 
 Run it:
 
 ```sh
-./collector --addr 0.0.0.0:8787 --db /data/collector.db
+./obsigna-collector --addr 0.0.0.0:8787 --db /data/collector.db
 ```
 
 The default `--addr` binds loopback only (`127.0.0.1:8787`) — opt in explicitly when exposing beyond localhost. See [Configuration](#configuration) for the full flag reference.

--- a/site/src/content/docs/deployment/ephemeral-compute.mdx
+++ b/site/src/content/docs/deployment/ephemeral-compute.mdx
@@ -252,7 +252,7 @@ import {
   MemoryWal,
   createReceipt,
   signReceipt,
-} from "@agnt-rcpt/sdk-ts";
+} from "@obsigna/sdk-ts";
 
 // Module scope: reused across warm invocations.
 const http = new HttpEmitter({
@@ -294,7 +294,7 @@ process.on("SIGTERM", async () => {
 import os
 import signal
 
-from agent_receipts import (
+from obsigna import (
     HttpEmitter,
     HttpEmitterConfig,
     BearerAuth,
@@ -340,7 +340,7 @@ Run the reference collector as your long-lived service (behind TLS termination a
 
 ```sh
 # The collector binds loopback by default; expose it explicitly in production.
-go run github.com/agent-receipts/ar/collector/cmd/collector --addr 0.0.0.0:8787
+go run github.com/agent-receipts/ar/collector/cmd/obsigna-collector --addr 0.0.0.0:8787
 
 curl -s http://localhost:8787/healthz          # 200 when the store is reachable
 ```

--- a/site/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site/src/content/docs/getting-started/daemon-setup.mdx
@@ -189,13 +189,13 @@ if err != nil {
 Install:
 
 ```bash
-npm install @agnt-rcpt/sdk-ts
+npm install @obsigna/sdk-ts
 ```
 
 **Option A: explicit socket path**
 
 ```typescript
-import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@obsigna/sdk-ts";
 
 const e = new DaemonEmitter({ socketPath: "/path/to/events.sock" });
 ```
@@ -203,7 +203,7 @@ const e = new DaemonEmitter({ socketPath: "/path/to/events.sock" });
 **Option B: via environment variable (`AGENTRECEIPTS_SOCKET`)**
 
 ```typescript
-import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@obsigna/sdk-ts";
 
 const e = new DaemonEmitter();
 ```
@@ -213,13 +213,13 @@ const e = new DaemonEmitter();
 Install:
 
 ```bash
-pip install agent-receipts
+pip install obsigna
 ```
 
 **Option A: explicit socket path**
 
 ```python
-from agent_receipts import DaemonEmitter
+from obsigna import DaemonEmitter
 
 e = DaemonEmitter(socket_path="/path/to/events.sock")
 ```
@@ -227,7 +227,7 @@ e = DaemonEmitter(socket_path="/path/to/events.sock")
 **Option B: via environment variable (`AGENTRECEIPTS_SOCKET`)**
 
 ```python
-from agent_receipts import DaemonEmitter
+from obsigna import DaemonEmitter
 
 e = DaemonEmitter()
 ```

--- a/site/src/content/docs/getting-started/end-to-end.mdx
+++ b/site/src/content/docs/getting-started/end-to-end.mdx
@@ -22,7 +22,7 @@ sequence numbers.
 ## 1. Install the SDK
 
 ```sh
-npm install @agnt-rcpt/sdk-ts
+npm install @obsigna/sdk-ts
 ```
 
 ---
@@ -33,7 +33,7 @@ Create `emit.ts`:
 
 {/* snippet-check: no-run */}
 ```typescript
-import { DaemonEmitter } from '@agnt-rcpt/sdk-ts';
+import { DaemonEmitter } from '@obsigna/sdk-ts';
 
 async function main() {
   const emitter = new DaemonEmitter();

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -43,7 +43,7 @@ Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setu
 for your platform), then the Python SDK:
 
 ```bash
-pip install agent-receipts
+pip install obsigna
 ```
 
 ### 2. Start the daemon
@@ -64,7 +64,7 @@ and chains the receipt. It is fire-and-forget — start the daemon before your a
 
 {/* snippet-check: no-run */}
 ```python
-from agent_receipts import DaemonEmitter
+from obsigna import DaemonEmitter
 
 with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
     e.emit(
@@ -97,7 +97,7 @@ Install `agent-receipts-daemon` (see [Daemon Setup](/getting-started/daemon-setu
 for your platform), then the TypeScript SDK:
 
 ```bash
-npm install @agnt-rcpt/sdk-ts
+npm install @obsigna/sdk-ts
 ```
 
 ### 2. Start the daemon
@@ -118,7 +118,7 @@ and chains the receipt. It is fire-and-forget — start the daemon before your a
 
 {/* snippet-check: no-run */}
 ```typescript
-import { DaemonEmitter } from "@agnt-rcpt/sdk-ts";
+import { DaemonEmitter } from "@obsigna/sdk-ts";
 
 async function main() {
   const e = new DaemonEmitter();  // uses AGENTRECEIPTS_SOCKET or the per-OS default
@@ -248,7 +248,7 @@ shown above (see also [Daemon Setup](/getting-started/daemon-setup/)).
 :::
 
 ```python
-from agent_receipts import (
+from obsigna import (
     CreateReceiptInput,
     create_receipt,
     generate_key_pair,

--- a/site/src/content/docs/sdk-py/api-reference.mdx
+++ b/site/src/content/docs/sdk-py/api-reference.mdx
@@ -12,7 +12,7 @@ it, and chains it. Your process never touches the key. See
 [Quick Start](/getting-started/quick-start/) for the full emit → list → verify loop.
 
 ```python
-from agent_receipts import DaemonEmitter, EmitTransportError, default_socket_path
+from obsigna import DaemonEmitter, EmitTransportError, default_socket_path
 ```
 
 ### `DaemonEmitter`
@@ -67,7 +67,7 @@ emitter was constructed with `best_effort=True`.
 
 {/* snippet-check: no-run */}
 ```python
-from agent_receipts import DaemonEmitter
+from obsigna import DaemonEmitter
 
 with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
     e.emit(
@@ -106,7 +106,7 @@ Honours `AGENTRECEIPTS_SOCKET` when set.
 ## Receipts
 
 ```python
-from agent_receipts import (
+from obsigna import (
     create_receipt,
     sign_receipt,
     verify_receipt,
@@ -372,7 +372,7 @@ VERSION: str                # current package version
 ## Parameter disclosure (HPKE)
 
 ```python
-from agent_receipts import (
+from obsigna import (
     generate_forensic_key_pair,
     encrypt_disclosure,
     decrypt_disclosure,
@@ -443,7 +443,7 @@ malformed, or if AEAD authentication fails.
 
 {/* snippet-check: no-run */}
 ```python
-from agent_receipts import (
+from obsigna import (
     generate_forensic_key_pair,
     encrypt_disclosure,
     decrypt_disclosure,
@@ -479,7 +479,7 @@ receipt JSON at `credentialSubject.action.parameters_disclosure`:
 {/* snippet-check: no-run */}
 ```python
 import json
-from agent_receipts import decrypt_disclosure
+from obsigna import decrypt_disclosure
 
 # raw 32-byte private key written by --init-forensic-key (kept offline)
 with open("/path/to/forensic.key", "rb") as f:
@@ -534,7 +534,7 @@ to compute the `sha256:<hex>` fingerprint string in Python.
 ## Store
 
 ```python
-from agent_receipts import ReceiptStore, open_store, verify_stored_chain
+from obsigna import ReceiptStore, open_store, verify_stored_chain
 ```
 
 SQLite-backed receipt persistence and querying.
@@ -606,7 +606,7 @@ class StoreStats:
 ## Taxonomy
 
 ```python
-from agent_receipts import (
+from obsigna import (
     classify_tool_call,
     get_action_type,
     resolve_action_type,
@@ -684,7 +684,7 @@ UNKNOWN_ACTION: ActionTypeEntry
 `DATA_ACTIONS` (3 data/API types) is exported from the `taxonomy` submodule, not the package root:
 
 ```python
-from agent_receipts.taxonomy import DATA_ACTIONS
+from obsigna.taxonomy import DATA_ACTIONS
 ```
 
 ### Backwards compatibility aliases

--- a/site/src/content/docs/sdk-py/installation.mdx
+++ b/site/src/content/docs/sdk-py/installation.mdx
@@ -6,13 +6,13 @@ description: Install and configure the Python SDK.
 ## Install
 
 ```bash
-pip install agent-receipts
+pip install obsigna
 ```
 
 Or with uv:
 
 ```bash
-uv add agent-receipts
+uv add obsigna
 ```
 
 ## Requirements
@@ -21,7 +21,7 @@ uv add agent-receipts
 
 ## You also need the daemon
 
-`pip install agent-receipts` installs the library only. Receipts are signed by a
+`pip install obsigna` installs the library only. Receipts are signed by a
 separate `agent-receipts-daemon` process, which also ships the `agent-receipts`
 CLI (`list`, `show`, `verify`). Install it on macOS or Linux — Windows is not
 supported yet:
@@ -31,7 +31,7 @@ supported yet:
 brew install agent-receipts/tap/obsigna-daemon
 
 # Linux / from source (requires Go 1.26.1+) — builds the daemon and the agent-receipts CLI
-go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts-daemon@latest
+go install github.com/agent-receipts/ar/daemon/cmd/obsigna-daemon@latest
 go install github.com/agent-receipts/ar/daemon/cmd/agent-receipts@latest
 ```
 

--- a/site/src/content/docs/sdk-py/overview.mdx
+++ b/site/src/content/docs/sdk-py/overview.mdx
@@ -23,7 +23,7 @@ receipt, signs it, and chains it. This is the canonical path — reach for it fi
 
 {/* snippet-check: no-run */}
 ```python
-from agent_receipts import DaemonEmitter
+from obsigna import DaemonEmitter
 
 with DaemonEmitter() as e:  # uses AGENTRECEIPTS_SOCKET or the per-OS default
     e.emit(
@@ -43,7 +43,7 @@ This pattern keeps the signing key inside the agent process. Anyone with code ex
 :::
 
 ```python
-from agent_receipts import (
+from obsigna import (
     CreateReceiptInput,
     create_receipt,
     generate_key_pair,

--- a/site/src/content/docs/sdk-ts/api-reference.mdx
+++ b/site/src/content/docs/sdk-ts/api-reference.mdx
@@ -13,7 +13,7 @@ import {
   generateKeyPair,
   hashReceipt,
   verifyChain,
-} from "@agnt-rcpt/sdk-ts";
+} from "@obsigna/sdk-ts";
 ```
 
 ### Functions
@@ -281,7 +281,7 @@ import {
   type ForensicKeyPair,
   type DisclosureEnvelope,
   type DisclosureRecipient,
-} from "@agnt-rcpt/sdk-ts";
+} from "@obsigna/sdk-ts";
 ```
 
 HPKE-based envelope for encrypting tool-call parameters into a receipt's
@@ -372,7 +372,7 @@ of the receipt JSON at `credentialSubject.action.parameters_disclosure`:
 {/* snippet-check: skip */}
 ```typescript
 import { readFileSync } from "node:fs";
-import { decryptDisclosure } from "@agnt-rcpt/sdk-ts";
+import { decryptDisclosure } from "@obsigna/sdk-ts";
 
 // raw 32-byte private key written by --init-forensic-key (kept offline)
 const priv = new Uint8Array(readFileSync("/path/to/forensic.key"));
@@ -426,7 +426,7 @@ existing `sha256` export to compute the fingerprint string in TypeScript.
 ## Store
 
 ```typescript
-import { ReceiptStore, openStore, verifyStoredChain } from "@agnt-rcpt/sdk-ts";
+import { ReceiptStore, openStore, verifyStoredChain } from "@obsigna/sdk-ts";
 ```
 
 SQLite-backed receipt persistence and querying.
@@ -510,7 +510,7 @@ import {
   resolveActionType,
   loadTaxonomyConfig,
   ALL_ACTIONS,
-} from "@agnt-rcpt/sdk-ts";
+} from "@obsigna/sdk-ts";
 ```
 
 Action type registry and tool call classification.
@@ -582,5 +582,5 @@ const UNKNOWN_ACTION: ActionTypeEntry
 `DATA_ACTIONS` (3 data/API types) is exported from the `taxonomy` subpath, not the package root:
 
 ```typescript
-import { DATA_ACTIONS } from "@agnt-rcpt/sdk-ts/taxonomy";
+import { DATA_ACTIONS } from "@obsigna/sdk-ts/taxonomy";
 ```

--- a/site/src/content/docs/sdk-ts/installation.mdx
+++ b/site/src/content/docs/sdk-ts/installation.mdx
@@ -6,13 +6,13 @@ description: Install and configure the TypeScript SDK.
 ## Install
 
 ```bash
-npm install @agnt-rcpt/sdk-ts
+npm install @obsigna/sdk-ts
 ```
 
 Or with pnpm:
 
 ```bash
-pnpm add @agnt-rcpt/sdk-ts
+pnpm add @obsigna/sdk-ts
 ```
 
 ## Requirements

--- a/site/src/content/docs/sdk-ts/overview.mdx
+++ b/site/src/content/docs/sdk-ts/overview.mdx
@@ -3,7 +3,7 @@ title: TypeScript SDK
 description: TypeScript SDK for creating, signing, and verifying Agent Receipts.
 ---
 
-The TypeScript SDK (`@agnt-rcpt/sdk-ts`) provides tools for creating, signing, and verifying Agent Receipts in Node.js and browser environments.
+The TypeScript SDK (`@obsigna/sdk-ts`) provides tools for creating, signing, and verifying Agent Receipts in Node.js and browser environments.
 
 **Repository:** [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts)
 
@@ -22,7 +22,7 @@ This pattern keeps the signing key inside the agent process. Anyone with code ex
 :::
 
 ```typescript
-import { createReceipt, signReceipt, generateKeyPair } from "@agnt-rcpt/sdk-ts";
+import { createReceipt, signReceipt, generateKeyPair } from "@obsigna/sdk-ts";
 
 const keys = generateKeyPair();
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -131,9 +131,9 @@ The canonical definitions live in [`spec/taxonomy/action-types.json`](spec/taxon
 
 | Repository | Language | Description |
 |:---|:---|:---|
-| [@agnt-rcpt/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript | SDK — receipt creation, signing, hashing, storage, taxonomy ([npm](https://www.npmjs.com/package/@agnt-rcpt/sdk-ts)) |
+| [@obsigna/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript | SDK — receipt creation, signing, hashing, storage, taxonomy ([npm](https://www.npmjs.com/package/@obsigna/sdk-ts)) |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | TypeScript | MCP proxy + CLI — reference implementation |
-| [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python | SDK — receipt creation, signing, hashing, chain verification ([PyPI](https://pypi.org/project/agent-receipts/)) |
+| [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python | SDK — receipt creation, signing, hashing, chain verification ([PyPI](https://pypi.org/project/obsigna/)) |
 
 ## Contributing
 


### PR DESCRIPTION
Docs & install consistency sweep for the obsigna rebrand. Makes user-facing text match the **published** artifacts. Scoped to two release-packaging-agnostic buckets — the umbrella-formula consolidation is owned by #820, so **brew/formula lines are deliberately untouched** here (no collision: this PR's files are disjoint from #820's).

## A. SDK package rename (`@agnt-rcpt` → `@obsigna`, PyPI `agent-receipts` → `obsigna`)
The published packages are now `@obsigna/sdk-ts` and `obsigna` (the legacy names are deprecated redirects); the docs lagged.
- `npm install` / TS import sites → `@obsigna/sdk-ts` (incl. `…/taxonomy` subpath).
- `pip install` / `uv add` / Python imports → `obsigna` / `from obsigna …`.
- npm + PyPI links in the `spec/README.md` and `site/README.md` ecosystem tables.
- **Excludes** `@agnt-rcpt/openclaw` (separate package), ADRs, CHANGELOGs, `sdk/PUBLISH.md`, and the `dist/sdk-py-deprecation/` shim (the one place the legacy name is intentionally kept).
- `scripts/legacy_name_guard/check.py`: gated set extended to the two site SDK install docs so they can't silently regress onto the legacy names.

## B. Stale build / `cmd` paths
The binaries were renamed; `collector/cmd/collector` no longer exists (only `obsigna-collector`).
- `go install`/`go build`/`go run` → `cmd/obsigna-mcp` and `cmd/obsigna-collector`.
- Root `README.md` `go install` line also had a **malformed module path** (missing `/ar/`) — fixed alongside the binary name; the quick-start proxy invocations now use `obsigna-mcp` (the binary that from-source install actually produces).

## Deliberately NOT touched (flagged for follow-up)
- **Brew / formula lines** (`tap/mcp-proxy`, `tap/agent-receipts-hook`, etc.) — correct against today's per-formula goreleaser; the umbrella consolidation + tap migration is #820's job.
- **Daemon-binary rename in prose** — `agent-receipts-daemon` is no longer a shipped binary name (the daemon train ships `obsigna-daemon` + `obsigna` + `agent-receipts` CLI shim), so command examples like `agent-receipts-daemon --init`, `brew install …/tap/obsigna-daemon` (no such formula — it's `obsigna`), and `go install …/cmd/agent-receipts-daemon` (dir gone) are **stale across `site/**`** (daemon-setup.mdx ~20 mentions, quick-start, sdk-py, blog). This is a large, coherent *third* rename, separate from both buckets above; left out to keep this PR self-consistent rather than half-renaming those files. Recommend a dedicated follow-up. `did:agent-receipts-daemon:` issuer strings stay regardless.

## Validation
- `cd site && pnpm build` — 59 pages, all MDX valid.
- TS (8) and Py (7) `.mdx` snippets **run and exit 0** against the in-tree SDK (`scripts/readme_snippets/check.py --mode run`) — confirms the renamed imports resolve.
- `python3 scripts/legacy_name_guard/check.py` clean (with the extended gated set).