### PR TITLE
docs: finish obsigna rename in cli-commands intro; note how to get a receipts.db

### DIFF
--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -29,6 +29,8 @@ make build
 
 ## Usage
 
+The dashboard is read-only — it visualises an existing receipt database, it does not create one. If you were handed a colleague's `receipts.db`, point at it with `-db`. To produce one yourself, run the [daemon](/getting-started/daemon-setup/) and emit a receipt from any SDK (see the [Quick Start](/getting-started/quick-start/)) or wrap an MCP server with the [MCP proxy](/mcp-proxy/overview/); the daemon writes the store at the per-user path below.
+
 If you use the standard per-user path (`~/.local/share/agent-receipts/receipts.db`), no flags are needed:
 
 ```sh

--- a/site/src/content/docs/reference/cli-commands.mdx
+++ b/site/src/content/docs/reference/cli-commands.mdx
@@ -6,10 +6,10 @@ description: Command reference for the Agent Receipts CLI tools — the mcp-prox
 This page covers three binaries:
 
 - **`mcp-proxy`** — wraps an MCP server, enforces policy, and forwards completed tool-call events to `obsigna-daemon`. Since v0.9.0 the proxy holds **no store of its own** — signing, chaining, and persistence are the daemon's job ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md)). It has no signing key and no `list`/`verify` subcommands.
-- **`agent-receipts`** — the daemon's read-side companion CLI. Lists, shows, and verifies receipts from the daemon-written store. Installed alongside `obsigna-daemon` (Homebrew installs both).
+- **`obsigna`** — the daemon's read-side companion CLI. Lists, shows, and verifies receipts from the daemon-written store. Installed alongside `obsigna-daemon` (Homebrew installs both). The legacy `agent-receipts` command still works as a thin deprecation shim (ADR-0030).
 - **`obsigna-hook`** — the PostToolUse hook binary that captures native host tool calls (formerly `agent-receipts-hook`, which still works as a deprecation shim).
 
-> The `agent-receipts` `--db` and `--public-key` defaults resolve via the same per-user paths the daemon uses (`$XDG_DATA_HOME/agent-receipts/`, falling back to `~/.local/share/agent-receipts/`). See [Daemon Setup](/getting-started/daemon-setup/) for how those paths are chosen and how to override them.
+> The `obsigna` `--db` and `--public-key` defaults resolve via the same per-user paths the daemon uses (`$XDG_DATA_HOME/agent-receipts/`, falling back to `~/.local/share/agent-receipts/`). See [Daemon Setup](/getting-started/daemon-setup/) for how those paths are chosen and how to override them.
 
 ## `mcp-proxy`
 


### PR DESCRIPTION
## What

Two small documentation follow-ups, both surfaced by the doc-e2e persona fan-out (#708 harness) run against the docs **after #823 merged**:

1. **Finish the `agent-receipts` → `obsigna` CLI rename in `cli-commands.mdx`.** #823 renamed the section heading and every command example to `obsigna`, but missed the page's intro bullet list and the `--db`/`--public-key` blockquote, which still called the read CLI `agent-receipts` (the deprecation shim). Caught by the *Maya/TypeScript* runner. Both now say `obsigna`, keeping a one-line note that `agent-receipts` still works as a shim (ADR-0030).
2. **Tell readers how to obtain a `receipts.db`.** The dashboard is read-only and never creates a database, but the docs gave a no-SDK reviewer no path to get one — the binary's own error message was more helpful than the docs. Caught by the *Priya/dashboard* runner. Added a short note under Usage pointing at the daemon + an SDK/MCP-proxy emit path.

## Not included (need separate follow-up / other repos)

- `dashboard/overview.mdx` stale `v0.3.0` caveat (binary ships v0.8.0) and the undocumented `public_key` verify param — both need verification against the separate `agent-receipts/dashboard` repo before changing wording.
- The `obsigna doctor` **binary** still prints `agent-receipts doctor` (contradicts `daemon/CHANGELOG.md:25` / `daemon/README.md:311`) — belongs in the daemon repo, not the site.

All other persona journeys (Maya, Raj, Priya) ran end-to-end against current `main` with no blockers.
