### PR TITLE
docs(dashboard): stop pinning the false-negative caveat to v0.3.0

### DIFF
--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -34,7 +34,7 @@ Enter your Ed25519 public key in PEM format in the textarea beside the **Verify 
 For command-line verification, [`obsigna receipt verify`](/reference/cli-commands/) provides the same full check without a browser.
 
 :::caution[Known issue: false negatives]
-The dashboard (v0.3.0) can report a chain as **broken** when `obsigna receipt verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalization. If the dashboard flags a break, confirm with `obsigna receipt verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).
+The dashboard can report a chain as **broken** when `obsigna receipt verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalization. If the dashboard flags a break, confirm with `obsigna receipt verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719) — see that issue for the current status.
 :::
 
 ## How it works


### PR DESCRIPTION
## What

The dashboard `overview.mdx` "Known issue: false negatives" caution hard-coded `(v0.3.0)`. The shipped dashboard is now v0.8.0, so the pin is stale and tells a reader nothing about whether the caveat applies to their build.

Surfaced by the doc-e2e *Priya/dashboard* persona (#708 harness).

## Change

- Drop the `(v0.3.0)` version pin; reference [#719](https://github.com/agent-receipts/ar/issues/719) (still **open**) as the live source of truth for current status.

The caveat itself stays — #719 is open and the false negative is unconfirmed-fixed on later builds.