### PR TITLE
docs(dashboard): refresh site pages for v0.8.0; link out to canonical README

### DIFF
--- a/site/src/content/docs/dashboard/installation.mdx
+++ b/site/src/content/docs/dashboard/installation.mdx
@@ -48,7 +48,11 @@ If port 8080 is already in use, `dashboard` exits immediately with `bind: addres
 | `-db` | `~/.local/share/agent-receipts/receipts.db` | Path to a receipt SQLite database |
 | `-host` | `127.0.0.1` | Address to bind the web server to |
 | `-port` | `8080` | Port to serve on |
-| `-poll-interval` | `5s` | How often to poll the database for new receipts |
+| `-poll-interval` | `5s` | How often to poll the database for new receipts (also set via `AR_DASHBOARD_POLL_INTERVAL`) |
+
+### Forensic decryption
+
+If the dashboard runs on a loopback address (the default) and a forensic key exists at `~/.local/share/agent-receipts/forensic.key`, it is loaded automatically and encrypted parameter disclosures are decrypted inline. You can also load a key from the UI. See the [overview](/dashboard/overview/#forensic-decryption) and the dashboard [README](https://github.com/agent-receipts/dashboard#forensic-decryption) for the security model and accepted key formats.
 
 ### Example
 

--- a/site/src/content/docs/dashboard/overview.mdx
+++ b/site/src/content/docs/dashboard/overview.mdx
@@ -3,44 +3,43 @@ title: Dashboard
 description: Local web UI for browsing and verifying Agent Receipt databases.
 ---
 
-:::caution
-The dashboard is an early prototype. Expect rough edges and breaking changes.
-:::
-
 The Agent Receipts Dashboard is a lightweight, read-only web UI for browsing receipt databases produced by any Agent Receipts SDK or the MCP proxy. It ships as a single Go binary with no external runtime dependencies.
 
 ![Dashboard overview showing stats, risk distribution, and recent receipts](/images/dashboard-overview.png)
 
-**Repository:** [agent-receipts/dashboard](https://github.com/agent-receipts/dashboard)
+**Repository:** [agent-receipts/dashboard](https://github.com/agent-receipts/dashboard) — the [README](https://github.com/agent-receipts/dashboard#readme) is the canonical reference for the full feature set, CLI flags, and HTTP API. This page is a conceptual overview.
 
-## Features
+## What you can do
 
-- Browse receipts stored in any Agent Receipts SQLite database
-- Filter by action type, risk level, status, time range, and chain ID
-- Chain verification — hash linkage, sequence ordering, and Ed25519 signature verification when a public key is supplied
-- Receipt detail view with raw JSON
-- Dark theme with risk-level color coding
+- **Browse & filter** receipts from any Agent Receipts SQLite database — by action type, risk level, status, time range, chain, server/tool, session, or free-text search.
+- **Verify chains** — hash linkage and sequence ordering, plus Ed25519 signatures when you supply a public key (see below).
+- **Decrypt parameter previews** — when a forensic key is available, the dashboard decrypts HPKE-encrypted disclosures inline so you can see the real tool inputs/outputs (see below).
+- **See multi-agent attribution** — for sessions with sub-agents, a delegation graph with cross-agent file dependencies, blast-radius, and risk rings.
+- **Read analytics** — activity timeline, error-rate and throughput trends, top actions by failure rate, and per-server/tool breakdowns.
+- **Inspect & export** — full raw JSON for any receipt, with one-click JSON export of a receipt or a whole chain.
 
 ## What "verify" checks
 
-Clicking **Verify signatures** on a chain runs one of two modes depending on whether a public key is supplied:
+Clicking **Verify** on a chain runs one of two modes depending on whether a public key is supplied:
 
 **Without a public key — structural verification only**
 Checks hash linkage and sequence ordering. A green "valid" means the receipts link and are correctly ordered; signatures are not checked.
 
 **With a public key — full cryptographic verification**
-Enter your Ed25519 public key in PEM format in the textarea beside the **Verify signatures** button. The dashboard passes the key to `/api/chains/:id/verify`, which performs hash linkage and sequence checks as usual and additionally calls the SDK's `receipt.Verify` for each receipt to validate its Ed25519 signature. Each receipt in the response carries a `signature_valid` field.
+Enter your Ed25519 public key in PEM format in the textarea beside the **Verify** button. The dashboard passes the key to `/api/chains/:id/verify`, which performs the structural checks and additionally validates each receipt's Ed25519 signature. Each receipt in the response carries a `signature_valid` field.
 
-For command-line verification, [`obsigna receipt verify`](/reference/cli-commands/) provides the same full check without a browser.
+Verification recomputes each receipt's canonical hash from the verbatim bytes stored in the database, so a chain that [`obsigna receipt verify`](/reference/cli-commands/) accepts verifies in the dashboard too.
 
-:::caution[Known issue: false negatives]
-The dashboard (v0.3.0) can report a chain as **broken** when `obsigna receipt verify` confirms it is **valid** — its hash recomputation does not match the SDK's canonicalization. If the dashboard flags a break, confirm with `obsigna receipt verify` before treating it as real. Tracked in [#719](https://github.com/agent-receipts/ar/issues/719).
-:::
+## Forensic decryption
+
+If your receipts carry HPKE-encrypted parameter disclosures (the daemon's parameter-disclosure mode), the dashboard can decrypt them inline to preview the real tool inputs and outputs — the private key never leaves the machine.
+
+When the dashboard is bound to a loopback address and a key exists at the default path `~/.local/share/agent-receipts/forensic.key`, it loads automatically and previews decrypt on the fly. You can also load a key manually from the UI. Because this is the one feature that touches key material, the forensic endpoints are **loopback-only** and guarded against DNS-rebinding and cross-origin requests.
+
+See the dashboard [README](https://github.com/agent-receipts/dashboard#forensic-decryption) for accepted key formats and the full security model.
 
 ## How it works
 
-The dashboard opens your SQLite receipt database in **read-only** mode and serves a web UI at localhost. It never modifies your data.
-
-All three SDKs and the MCP proxy use an identical SQLite schema for receipt storage. The dashboard reads from any of them.
+The dashboard opens your SQLite receipt database in **read-only** mode and serves a web UI at localhost. It never modifies your data. All three SDKs and the MCP proxy use an identical SQLite schema, so the dashboard reads from any of them.
 
 See [Installation](/dashboard/installation/) to get started.


### PR DESCRIPTION
## What

The site `dashboard/` pages described a ~v0.2–0.3 dashboard; the shipped dashboard is **v0.8.0** with whole capability areas missing from the docs. Surfaced while reviewing the dashboard CHANGELOG against our docs (originally the doc-e2e *Priya* persona).

Adopts a **"README is canonical, site links out"** model so the two surfaces stop re-drifting: the [dashboard README](https://github.com/agent-receipts/dashboard#readme) (updated in [dashboard#132](https://github.com/agent-receipts/dashboard/pull/132)) holds the exhaustive feature/API reference; these pages are a concise conceptual overview that links to it.

## Changes

**overview.mdx**
- Drop the "early prototype" caution (it's v0.8.0).
- Replace the 5-bullet feature list with current capabilities at overview altitude — verification (incl. signatures), forensic decryption + auto-load, multi-agent attribution, analytics, JSON export — each linking to the README.
- Add a **Forensic decryption** concept section.
- **Remove the stale #719 false-negative caveat** — fixed in dashboard v0.4.0 (verification recomputes from the verbatim `receipt_json` bytes; confirmed in `internal/store/reader.go:102` + regression test `server_test.go:363`). ar#719 is now closed.

**installation.mdx**
- Note the `AR_DASHBOARD_POLL_INTERVAL` env var.
- Add a **Forensic decryption** note (loopback auto-load from the default key path).

## Supersedes #825

#825 only **de-pinned** the #719 caveat; this PR **removes** it (the bug is fixed). I'll close #825 in favour of this.