### PR TITLE
docs: reframe README around Agent Receipts (protocol) vs Obsigna (tools) split

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![Go Tests](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-go.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-go.yml)
 [![TS Tests](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-ts.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-ts.yml)
 [![Python Tests](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-py.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/sdk-py.yml)
+[![Daemon](https://github.com/agent-receipts/obsigna/actions/workflows/daemon.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/daemon.yml)
+[![MCP Proxy](https://github.com/agent-receipts/obsigna/actions/workflows/mcp-proxy.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/mcp-proxy.yml)
+[![Hook](https://github.com/agent-receipts/obsigna/actions/workflows/hook.yml/badge.svg)](https://github.com/agent-receipts/obsigna/actions/workflows/hook.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -46,19 +46,36 @@
 
 ## Start here
 
-The fastest way to try Agent Receipts is to put [`mcp-proxy/`](mcp-proxy/) in front of an MCP server you already use.
+Both paths below require the daemon — it holds the signing key and owns the audit chain. Install it first:
 
-In one step, you get:
+```bash
+brew install agent-receipts/tap/obsigna
+obsigna daemon start
+```
 
-- Signed receipts for every tool call
-- A tamper-evident audit chain you can verify later
-- Risk scoring and policy hooks without changing the client or server
+**Fastest path — PostToolUse hook (Claude Code):** one config snippet and every tool call gets a signed receipt automatically:
 
-If you want to audit GitHub MCP in a real agent workflow, start with:
+```json
+{
+  "hooks": {
+    "PostToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "obsigna-hook" }] }]
+  }
+}
+```
 
-- [Claude Desktop integration](https://agentreceipts.ai/mcp-proxy/claude-desktop/)
-- [Claude Code integration](https://agentreceipts.ai/mcp-proxy/claude-code/)
-- [Codex integration](https://agentreceipts.ai/mcp-proxy/codex/)
+Add that to `~/.claude/settings.json`, then inspect the audit trail:
+
+```bash
+obsigna list
+obsigna show <seq>
+obsigna verify
+```
+
+**More control — MCP proxy:** wraps any MCP server and adds policy hooks and risk scoring on top of signed receipts:
+
+- [Claude Desktop setup](https://agentreceipts.ai/mcp-proxy/claude-desktop/)
+- [Claude Code setup](https://agentreceipts.ai/mcp-proxy/claude-code/)
+- [Codex setup](https://agentreceipts.ai/mcp-proxy/codex/)
 
 ## Project layout
 
@@ -75,34 +92,6 @@ If you want to audit GitHub MCP in a real agent workflow, start with:
 | [`docs/adr/`](docs/adr/) | Architecture Decision Records |
 | [dashboard](https://github.com/agent-receipts/dashboard) | Local web UI for browsing and verifying receipt databases |
 | [openclaw](https://github.com/agent-receipts/openclaw) | Agent Receipts plugin for OpenClaw |
-
-## 10-minute audited MCP quick start
-
-Install the proxy:
-
-```bash
-go install github.com/agent-receipts/ar/mcp-proxy/cmd/obsigna-mcp@latest
-```
-
-Wrap any MCP server:
-
-```bash
-obsigna-mcp node /path/to/mcp-server.js
-```
-
-Then point your agent client at the proxy instead of the raw server:
-
-- [Claude Desktop setup](https://agentreceipts.ai/mcp-proxy/claude-desktop/)
-- [Claude Code setup](https://agentreceipts.ai/mcp-proxy/claude-code/)
-- [Codex setup](https://agentreceipts.ai/mcp-proxy/codex/)
-
-Once your agent makes tool calls, inspect the signed audit trail:
-
-```bash
-obsigna list
-obsigna show <seq>
-obsigna verify
-```
 
 ## SDK quick start
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@
 
 ---
 
+## What is this?
+
+**Agent Receipts** is an open protocol for producing cryptographically signed, tamper-evident records of AI agent actions. It defines the receipt format, signing scheme, chain structure, and taxonomy of action types. Anyone can implement it — in any language, in any runtime.
+
+**Obsigna** is the reference toolset that implements the protocol:
+
+| Tool | What it does |
+|------|-------------|
+| `obsigna-mcp` | MCP stdio proxy — signs every tool call, adds policy hooks |
+| `obsigna-daemon` | Out-of-process signing daemon — holds the key, owns the audit chain |
+| `obsigna-hook` | PostToolUse hook for Claude Code and other runtimes |
+| `obsigna` | CLI for browsing and verifying receipt databases |
+| `sdk/go`, `@obsigna/sdk-ts`, `obsigna` (Python) | SDKs for embedding receipt creation in your own code |
+
+<picture>
+  <img alt="How it works: Authorize → Act → Sign → Link → Audit" src=".github/how-it-works.svg">
+</picture>
+
 ## Start here
 
 The fastest way to try Agent Receipts is to put [`mcp-proxy/`](mcp-proxy/) in front of an MCP server you already use.
@@ -39,26 +57,19 @@ If you want to audit GitHub MCP in a real agent workflow, start with:
 - [Claude Code integration](https://agentreceipts.ai/mcp-proxy/claude-code/)
 - [Codex integration](https://agentreceipts.ai/mcp-proxy/codex/)
 
-## What is this?
-
-Agent Receipts is an open protocol and set of SDKs for producing cryptographically signed, tamper-evident records of AI agent actions. Every action an agent takes -- API calls, tool use, data access -- gets a verifiable receipt that can be audited later.
-
-<picture>
-  <img alt="How it works: Authorize → Act → Sign → Link → Audit" src=".github/how-it-works.svg">
-</picture>
-
 ## Project layout
 
 | Project | Description |
 |---------|-------------|
-| [`docs/adr/`](docs/adr/) | Architecture Decision Records |
 | [`spec/`](spec/) | Protocol specification, JSON schemas, governance |
 | [`sdk/go/`](sdk/go/) | Go SDK |
 | [`sdk/ts/`](sdk/ts/) | TypeScript SDK |
 | [`sdk/py/`](sdk/py/) | Python SDK |
 | [`daemon/`](daemon/) | Signing daemon — out-of-process key custody, shared audit chain |
 | [`mcp-proxy/`](mcp-proxy/) | MCP proxy with receipt signing, policy engine, intent tracking |
+| [`hook/`](hook/) | PostToolUse hook binary for Claude Code and other runtimes |
 | [`cross-sdk-tests/`](cross-sdk-tests/) | Cross-language verification tests |
+| [`docs/adr/`](docs/adr/) | Architecture Decision Records |
 | [dashboard](https://github.com/agent-receipts/dashboard) | Local web UI for browsing and verifying receipt databases |
 | [openclaw](https://github.com/agent-receipts/openclaw) | Agent Receipts plugin for OpenClaw |
 


### PR DESCRIPTION
## Summary

- Moves "What is this?" above "Start here" so the two brands are explained before any setup instructions
- Defines **Agent Receipts** as the open protocol (format, signing scheme, chain structure, taxonomy — implementable by anyone in any language)
- Defines **Obsigna** as the reference toolset, with each binary and SDK listed in a table
- Adds the missing `hook/` row to the project layout table; moves `docs/adr/` to the end of that table