### PR TITLE
docs(site): wire Plausible analytics for obsigna.dev

### DIFF
--- a/site-obsigna/astro.config.mjs
+++ b/site-obsigna/astro.config.mjs
@@ -63,6 +63,19 @@ export default defineConfig({
           tag: "meta",
           attrs: { name: "twitter:card", content: "summary_large_image" },
         },
+        // Privacy-friendly, cookieless analytics (Plausible per-site script).
+        {
+          tag: "script",
+          attrs: {
+            async: true,
+            src: "https://plausible.io/js/pa-hqsQgQA7hN9-7bMthXXP8.js",
+          },
+        },
+        {
+          tag: "script",
+          content:
+            "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+        },
       ],
       social: [
         {


### PR DESCRIPTION
Follow-up to #838, which deferred obsigna.dev analytics until the domain was registered in Plausible.

## What

- Adds obsigna.dev's per-site Plausible script (`pa-hqsQgQA7hN9-7bMthXXP8.js` async loader + `plausible.init()` stub) to `site-obsigna/astro.config.mjs`, matching the agentreceipts.ai setup shipped in #838.

## Notes

- Cookieless, no consent banner.
- Verified the tags render in `dist/` after `pnpm build`.