### PR TITLE
docs(site): add Google Search Console verification file for agentreceipts.ai

### DIFF
--- a/site/public/google97e63f282a7b30f9.html
+++ b/site/public/google97e63f282a7b30f9.html
@@ -1,0 +1,1 @@
+google-site-verification: google97e63f282a7b30f9.html


### PR DESCRIPTION
Adds the HTML-file verification token for the agentreceipts.ai URL-prefix property in Google Search Console.

- `site/public/google97e63f282a7b30f9.html` → served at `https://agentreceipts.ai/google97e63f282a7b30f9.html`.

Once deployed, click **Verify** in Search Console, then submit `sitemap-index.xml`. obsigna.dev verification will follow in a separate PR.