### PR TITLE
docs(site): add Google Search Console verification file for obsigna.dev

### DIFF
--- a/site-obsigna/public/google97e63f282a7b30f9.html
+++ b/site-obsigna/public/google97e63f282a7b30f9.html
@@ -1,0 +1,1 @@
+google-site-verification: google97e63f282a7b30f9.html


### PR DESCRIPTION
Adds the HTML-file verification token for the obsigna.dev URL-prefix property in Google Search Console.

- `site-obsigna/public/google97e63f282a7b30f9.html` → served at `https://obsigna.dev/google97e63f282a7b30f9.html`.

Google's HTML-file token is account-level, so this is the same file already added for agentreceipts.ai in #841. Once deployed, click **Verify** in Search Console, then submit `sitemap-index.xml`.