### PR TITLE
feat(cli): wire `obsigna receipt disclose` forensic decryption subcommand

### DIFF
--- a/daemon/cmd/obsigna/registry.go
+++ b/daemon/cmd/obsigna/registry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 
+	"github.com/agent-receipts/ar/daemon/internal/disclosecli"
 	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
 	"github.com/agent-receipts/ar/daemon/internal/keyscli"
 	"github.com/agent-receipts/ar/daemon/internal/listcli"
@@ -63,12 +64,13 @@ func commandTree() tree {
 		groups: map[string]group{
 			"receipt": {
 				heading: "Receipt commands",
-				order:   []string{"verify", "show", "list", "verify-event"},
+				order:   []string{"verify", "show", "list", "verify-event", "disclose"},
 				leaves: map[string]leaf{
 					"verify":       {"Verify a stored chain's signatures and hash links.", verifycli.Run},
 					"show":         {"Print the full fields of a single receipt by sequence number.", showcli.Run},
 					"list":         {"List recent receipts from the store.", listcli.Run},
 					"verify-event": {"Verify one historical receipt's end-to-end pipeline provenance.", verifyeventcli.Run},
+					"disclose":     {"Decrypt a receipt's parameters_disclosure with the forensic key.", disclosecli.Run},
 				},
 			},
 			"keys": {

--- a/daemon/cmd/obsigna/surface_test.go
+++ b/daemon/cmd/obsigna/surface_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/agent-receipts/ar/daemon/internal/disclosecli"
 	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
 	"github.com/agent-receipts/ar/daemon/internal/keyscli"
 	"github.com/agent-receipts/ar/daemon/internal/listcli"
@@ -28,7 +29,7 @@ func TestGoldenSurface(t *testing.T) {
 	tr := commandTree()
 
 	wantGroups := map[string][]string{
-		"receipt": {"verify", "show", "list", "verify-event"},
+		"receipt": {"verify", "show", "list", "verify-event", "disclose"},
 		"keys":    {"generate", "pubkey", "rotate"},
 	}
 	wantTopLeaves := []string{"doctor"}
@@ -106,6 +107,7 @@ func TestLeafWiring(t *testing.T) {
 			"show":         showcli.Run,
 			"list":         listcli.Run,
 			"verify-event": verifyeventcli.Run,
+			"disclose":     disclosecli.Run,
 		},
 		"keys": {
 			"generate": keyscli.RunGenerate,

--- a/daemon/internal/disclosecli/disclose.go
+++ b/daemon/internal/disclosecli/disclose.go
@@ -1,0 +1,310 @@
+// Package disclosecli implements the `agent-receipts disclose <seq>` subcommand:
+// decrypt the parameters_disclosure envelope of a single stored receipt using
+// the operator's X25519 forensic private key and print the recovered plaintext.
+//
+// Logic lives here, away from cmd/agent-receipts/main.go, so tests can drive
+// the subcommand directly with arbitrary args / captured I/O without shelling
+// out to a built binary.
+package disclosecli
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+const (
+	ExitOK           = 0 // parameters decrypted and printed (or no disclosure on receipt)
+	ExitNotFound     = 1 // no receipt at the requested sequence
+	ExitUsageError   = 2 // bad flags / unreadable DB / ambiguous chain
+	ExitDecryptError = 3 // key missing, wrong recipient, or HPKE failure
+)
+
+// Run executes the disclose subcommand with the given args (sans the program
+// name and "disclose" subcommand token), writing output to stdout and
+// diagnostics to stderr. Returns one of the Exit* constants.
+//
+// envLookup is split out so tests can inject a deterministic environment
+// without touching the real process env. Pass os.Getenv for the production
+// caller.
+func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string) int {
+	if envLookup == nil {
+		envLookup = os.Getenv
+	}
+	envOr := func(key, fallback string) string {
+		if v := envLookup(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+
+	fs := flag.NewFlagSet("disclose", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: agent-receipts disclose <seq> [flags]")
+		fmt.Fprintln(stderr, "\nDecrypt the parameters_disclosure envelope of a single stored receipt")
+		fmt.Fprintln(stderr, "using the operator's X25519 forensic private key.")
+		fmt.Fprintln(stderr, "\nThe key may be supplied as a raw 32-byte file, hex (64 chars),")
+		fmt.Fprintln(stderr, "standard or URL-safe base64, or a PKCS#8 PEM-wrapped X25519 key.")
+		fmt.Fprintln(stderr, "\nFlags:")
+		fs.PrintDefaults()
+	}
+
+	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()),
+		"SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
+	chainID := fs.String("chain-id", envLookup("AGENTRECEIPTS_CHAIN_ID"),
+		"Chain id to read from (env: AGENTRECEIPTS_CHAIN_ID); required only when the store holds more than one chain")
+	keyPath := fs.String("key", envOr("AGENTRECEIPTS_FORENSIC_KEY", daemon.DefaultForensicKeyPath()),
+		"Forensic private-key path (raw 32-byte X25519, hex, base64, or PKCS#8 PEM) (env: AGENTRECEIPTS_FORENSIC_KEY)")
+	asJSON := fs.Bool("json", false, "Output decrypted parameters as JSON")
+
+	var rest []string
+	remaining := args
+	for {
+		if err := fs.Parse(remaining); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return ExitOK
+			}
+			return ExitUsageError
+		}
+		if fs.NArg() == 0 {
+			break
+		}
+		rest = append(rest, fs.Arg(0))
+		remaining = fs.Args()[1:]
+	}
+
+	if len(rest) == 0 {
+		fmt.Fprintln(stderr, "agent-receipts disclose: missing <seq> argument (the chain sequence number, 1-indexed)")
+		return ExitUsageError
+	}
+	if len(rest) > 1 {
+		fmt.Fprintf(stderr, "agent-receipts disclose: unexpected positional argument(s): %v (only one <seq> is accepted)\n", rest[1:])
+		return ExitUsageError
+	}
+	seq, err := strconv.Atoi(rest[0])
+	if err != nil || seq < 1 {
+		fmt.Fprintf(stderr, "agent-receipts disclose: <seq> must be a positive integer, got %q\n", rest[0])
+		return ExitUsageError
+	}
+
+	if *dbPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts disclose: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		return ExitUsageError
+	}
+	if *keyPath == "" {
+		fmt.Fprintln(stderr, "agent-receipts disclose: --key is required (no AGENTRECEIPTS_FORENSIC_KEY and no home directory)")
+		return ExitDecryptError
+	}
+
+	raw, err := os.ReadFile(*keyPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: read key %q: %v\n", *keyPath, err)
+		return ExitDecryptError
+	}
+	privKey, err := parseForensicPrivateKey(raw)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: invalid forensic key: %v\n", err)
+		return ExitDecryptError
+	}
+	defer zeroSlice(privKey)
+
+	s, err := store.OpenReadOnly(*dbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: open store: %v\n", err)
+		return ExitUsageError
+	}
+	defer s.Close()
+
+	resolved, code := resolveChainID(s, *chainID, stderr)
+	if code != ExitOK {
+		return code
+	}
+
+	r, err := s.GetByChainSequence(resolved, seq)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: read chain %q: %v\n", resolved, err)
+		return ExitUsageError
+	}
+	if r == nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: no receipt at sequence %d in chain %q\n", seq, resolved)
+		return ExitNotFound
+	}
+
+	env := r.CredentialSubject.Action.ParametersDisclosure
+	if env == nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: receipt at sequence %d has no parameters_disclosure\n", seq)
+		return ExitOK
+	}
+
+	params, err := receipt.DecryptDisclosure(env, privKey)
+	if err != nil {
+		// Classify: if our key's fingerprint matches a recipient kid the envelope
+		// is corrupt; otherwise we're the wrong key holder.
+		pub, pubErr := receipt.ForensicPublicFromPrivate(privKey)
+		if pubErr == nil {
+			fp, fpErr := receipt.ForensicKeyFingerprint(pub)
+			if fpErr == nil {
+				for _, rcpt := range env.Recipients {
+					if rcpt.KID == fp {
+						fmt.Fprintf(stderr, "agent-receipts disclose: decryption failed (envelope may be corrupt): %v\n", err)
+						return ExitDecryptError
+					}
+				}
+			}
+		}
+		fmt.Fprintf(stderr, "agent-receipts disclose: key does not match any recipient in the envelope\n")
+		return ExitDecryptError
+	}
+
+	if *asJSON {
+		return writeJSON(stdout, stderr, params)
+	}
+	return writeHuman(stdout, params)
+}
+
+func writeJSON(stdout, stderr io.Writer, params map[string]any) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(params); err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			return ExitOK
+		}
+		fmt.Fprintf(stderr, "agent-receipts disclose: encode JSON: %v\n", err)
+		return ExitUsageError
+	}
+	return ExitOK
+}
+
+func writeHuman(stdout io.Writer, params map[string]any) int {
+	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	// Sort keys for stable output.
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	for _, k := range keys {
+		v := params[k]
+		var s string
+		switch val := v.(type) {
+		case string:
+			s = val
+		default:
+			b, _ := json.Marshal(val)
+			s = string(b)
+		}
+		fmt.Fprintf(w, "%s:\t%s\n", k, s)
+	}
+	if err := w.Flush(); err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			return ExitOK
+		}
+		return ExitUsageError
+	}
+	return ExitOK
+}
+
+// resolveChainID returns the chain id to read from. When requested is non-empty
+// it is used verbatim. Otherwise the store must hold exactly one chain.
+func resolveChainID(s *store.Store, requested string, stderr io.Writer) (string, int) {
+	if requested != "" {
+		return requested, ExitOK
+	}
+	chains, err := s.DistinctChainIDs()
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-receipts disclose: enumerate chains: %v\n", err)
+		return "", ExitUsageError
+	}
+	switch len(chains) {
+	case 0:
+		fmt.Fprintln(stderr, "agent-receipts disclose: store holds no receipts")
+		return "", ExitNotFound
+	case 1:
+		return chains[0], ExitOK
+	default:
+		fmt.Fprintf(stderr, "agent-receipts disclose: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
+		for _, c := range chains {
+			fmt.Fprintf(stderr, "  %s\n", c)
+		}
+		return "", ExitUsageError
+	}
+}
+
+// parseForensicPrivateKey accepts the forensic private key in any of the forms
+// a solo operator is likely to hand it over: raw 32-byte file, hex (64 chars),
+// standard or URL-safe base64 (padded or unpadded), or PKCS#8 PEM-wrapped X25519.
+// Returns the raw 32-byte key on success.
+func parseForensicPrivateKey(raw []byte) ([]byte, error) {
+	if len(raw) == 32 {
+		return append([]byte(nil), raw...), nil
+	}
+	// Raw key file with a trailing newline appended by a text editor or shell.
+	stripped := raw
+	for len(stripped) > 32 && (stripped[len(stripped)-1] == '\n' || stripped[len(stripped)-1] == '\r') {
+		stripped = stripped[:len(stripped)-1]
+	}
+	if len(stripped) == 32 {
+		return append([]byte(nil), stripped...), nil
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+
+	if block, _ := pem.Decode(trimmed); block != nil {
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#8 PEM: %w", err)
+		}
+		xkey, ok := key.(*ecdh.PrivateKey)
+		if !ok || xkey.Curve() != ecdh.X25519() {
+			return nil, fmt.Errorf("PEM key is not an X25519 private key")
+		}
+		return xkey.Bytes(), nil
+	}
+
+	s := string(trimmed)
+	if len(s) == 64 {
+		if b, err := hex.DecodeString(s); err == nil && len(b) == 32 {
+			return b, nil
+		}
+	}
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) == 32 {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("unrecognised key encoding or wrong length")
+}
+
+func zeroSlice(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func sortStrings(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
+}

--- a/daemon/internal/disclosecli/disclose.go
+++ b/daemon/internal/disclosecli/disclose.go
@@ -118,6 +118,10 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		fmt.Fprintf(stderr, "obsigna receipt disclose: read key %q: %v\n", *keyPath, err)
 		return ExitDecryptError
 	}
+	// The on-disk bytes hold key material too; wipe them alongside the parsed
+	// key. Best-effort — the Go runtime may still retain copies — but it keeps
+	// the raw buffer from sitting around for the rest of Run.
+	defer zeroSlice(raw)
 	privKey, err := parseForensicPrivateKey(raw)
 	if err != nil {
 		fmt.Fprintf(stderr, "obsigna receipt disclose: invalid forensic key: %v\n", err)

--- a/daemon/internal/disclosecli/disclose.go
+++ b/daemon/internal/disclosecli/disclose.go
@@ -1,4 +1,4 @@
-// Package disclosecli implements the `agent-receipts disclose <seq>` subcommand:
+// Package disclosecli implements the `obsigna receipt disclose <seq>` subcommand:
 // decrypt the parameters_disclosure envelope of a single stored receipt using
 // the operator's X25519 forensic private key and print the recovered plaintext.
 //
@@ -54,10 +54,10 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return fallback
 	}
 
-	fs := flag.NewFlagSet("disclose", flag.ContinueOnError)
+	fs := flag.NewFlagSet("receipt disclose", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: agent-receipts disclose <seq> [flags]")
+		fmt.Fprintln(stderr, "Usage: obsigna receipt disclose <seq> [flags]")
 		fmt.Fprintln(stderr, "\nDecrypt the parameters_disclosure envelope of a single stored receipt")
 		fmt.Fprintln(stderr, "using the operator's X25519 forensic private key.")
 		fmt.Fprintln(stderr, "\nThe key may be supplied as a raw 32-byte file, hex (64 chars),")
@@ -91,43 +91,43 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	}
 
 	if len(rest) == 0 {
-		fmt.Fprintln(stderr, "agent-receipts disclose: missing <seq> argument (the chain sequence number, 1-indexed)")
+		fmt.Fprintln(stderr, "obsigna receipt disclose: missing <seq> argument (the chain sequence number, 1-indexed)")
 		return ExitUsageError
 	}
 	if len(rest) > 1 {
-		fmt.Fprintf(stderr, "agent-receipts disclose: unexpected positional argument(s): %v (only one <seq> is accepted)\n", rest[1:])
+		fmt.Fprintf(stderr, "obsigna receipt disclose: unexpected positional argument(s): %v (only one <seq> is accepted)\n", rest[1:])
 		return ExitUsageError
 	}
 	seq, err := strconv.Atoi(rest[0])
 	if err != nil || seq < 1 {
-		fmt.Fprintf(stderr, "agent-receipts disclose: <seq> must be a positive integer, got %q\n", rest[0])
+		fmt.Fprintf(stderr, "obsigna receipt disclose: <seq> must be a positive integer, got %q\n", rest[0])
 		return ExitUsageError
 	}
 
 	if *dbPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts disclose: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt disclose: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError
 	}
 	if *keyPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts disclose: --key is required (no AGENTRECEIPTS_FORENSIC_KEY and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt disclose: --key is required (no AGENTRECEIPTS_FORENSIC_KEY and no home directory)")
 		return ExitDecryptError
 	}
 
 	raw, err := os.ReadFile(*keyPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: read key %q: %v\n", *keyPath, err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: read key %q: %v\n", *keyPath, err)
 		return ExitDecryptError
 	}
 	privKey, err := parseForensicPrivateKey(raw)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: invalid forensic key: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: invalid forensic key: %v\n", err)
 		return ExitDecryptError
 	}
 	defer zeroSlice(privKey)
 
 	s, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: open store: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: open store: %v\n", err)
 		return ExitUsageError
 	}
 	defer s.Close()
@@ -139,17 +139,17 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 
 	r, err := s.GetByChainSequence(resolved, seq)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: read chain %q: %v\n", resolved, err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: read chain %q: %v\n", resolved, err)
 		return ExitUsageError
 	}
 	if r == nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: no receipt at sequence %d in chain %q\n", seq, resolved)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: no receipt at sequence %d in chain %q\n", seq, resolved)
 		return ExitNotFound
 	}
 
 	env := r.CredentialSubject.Action.ParametersDisclosure
 	if env == nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: receipt at sequence %d has no parameters_disclosure\n", seq)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: receipt at sequence %d has no parameters_disclosure\n", seq)
 		return ExitOK
 	}
 
@@ -163,13 +163,13 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 			if fpErr == nil {
 				for _, rcpt := range env.Recipients {
 					if rcpt.KID == fp {
-						fmt.Fprintf(stderr, "agent-receipts disclose: decryption failed (envelope may be corrupt): %v\n", err)
+						fmt.Fprintf(stderr, "obsigna receipt disclose: decryption failed (envelope may be corrupt): %v\n", err)
 						return ExitDecryptError
 					}
 				}
 			}
 		}
-		fmt.Fprintf(stderr, "agent-receipts disclose: key does not match any recipient in the envelope\n")
+		fmt.Fprintf(stderr, "obsigna receipt disclose: key does not match any recipient in the envelope\n")
 		return ExitDecryptError
 	}
 
@@ -186,7 +186,7 @@ func writeJSON(stdout, stderr io.Writer, params map[string]any) int {
 		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
 			return ExitOK
 		}
-		fmt.Fprintf(stderr, "agent-receipts disclose: encode JSON: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: encode JSON: %v\n", err)
 		return ExitUsageError
 	}
 	return ExitOK
@@ -229,17 +229,17 @@ func resolveChainID(s *store.Store, requested string, stderr io.Writer) (string,
 	}
 	chains, err := s.DistinctChainIDs()
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts disclose: enumerate chains: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: enumerate chains: %v\n", err)
 		return "", ExitUsageError
 	}
 	switch len(chains) {
 	case 0:
-		fmt.Fprintln(stderr, "agent-receipts disclose: store holds no receipts")
+		fmt.Fprintln(stderr, "obsigna receipt disclose: store holds no receipts")
 		return "", ExitNotFound
 	case 1:
 		return chains[0], ExitOK
 	default:
-		fmt.Fprintf(stderr, "agent-receipts disclose: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
+		fmt.Fprintf(stderr, "obsigna receipt disclose: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
 		for _, c := range chains {
 			fmt.Fprintf(stderr, "  %s\n", c)
 		}

--- a/daemon/internal/disclosecli/disclose_test.go
+++ b/daemon/internal/disclosecli/disclose_test.go
@@ -1,0 +1,308 @@
+package disclosecli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/store"
+)
+
+// fixtureDB builds a test store with `count` receipts on the given chain.
+// Odd-numbered receipts carry an encrypted parameters_disclosure (file path
+// in params); even-numbered receipts have no disclosure so we can test both
+// code paths. Returns the db path and the forensic private key bytes.
+func fixtureDB(t *testing.T, dir string, count int) (dbPath string, forensicPriv []byte) {
+	t.Helper()
+
+	_, sigPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(sigPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sigPrivPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+
+	forensicKP, err := receipt.GenerateForensicKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub, err := receipt.ForensicPublicFromPrivate(forensicKP.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kid, err := receipt.ForensicKeyFingerprint(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath = filepath.Join(dir, "receipts.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var prevHash *string
+	for i := 1; i <= count; i++ {
+		action := receipt.Action{
+			Type:      "claude-code.Read",
+			ToolName:  "Read",
+			RiskLevel: receipt.RiskMedium,
+			Timestamp: fmt.Sprintf("2024-01-01T%02d:00:00Z", i),
+		}
+
+		// Odd sequences get an encrypted disclosure; even ones do not.
+		if i%2 == 1 {
+			params := map[string]any{
+				"file_path": fmt.Sprintf("/tmp/file%d.txt", i),
+			}
+			env, err := receipt.EncryptDisclosure(params, forensicKP.PublicKey, kid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			action.ParametersDisclosure = env
+		}
+
+		unsigned := receipt.Create(receipt.CreateInput{
+			Issuer:    receipt.Issuer{ID: "did:test"},
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action:    action,
+			Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:     receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: "test-chain"},
+		})
+		signed, err := receipt.Sign(unsigned, sigPrivPEM, "did:test#k1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := receipt.HashReceipt(signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Insert(signed, h); err != nil {
+			t.Fatal(err)
+		}
+		prevHash = &h
+	}
+
+	return dbPath, forensicKP.PrivateKey
+}
+
+func writeKeyFile(t *testing.T, dir string, key []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, "forensic.key")
+	if err := os.WriteFile(p, key, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func env(db, chainID, key string) func(string) string {
+	return func(k string) string {
+		switch k {
+		case "AGENTRECEIPTS_DB":
+			return db
+		case "AGENTRECEIPTS_CHAIN_ID":
+			return chainID
+		case "AGENTRECEIPTS_FORENSIC_KEY":
+			return key
+		}
+		return ""
+	}
+}
+
+func TestDisclose_HumanReadable(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 3)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"1", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "file_path") {
+		t.Errorf("expected file_path in output, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "/tmp/file1.txt") {
+		t.Errorf("expected /tmp/file1.txt in output, got: %s", out.String())
+	}
+}
+
+func TestDisclose_JSON(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 3)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"1", "--json", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+	var params map[string]any
+	if err := json.Unmarshal(out.Bytes(), &params); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if params["file_path"] != "/tmp/file1.txt" {
+		t.Errorf("wrong file_path: %v", params["file_path"])
+	}
+}
+
+func TestDisclose_NoDisclosure(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 3)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	// Sequence 2 has no disclosure (even-numbered).
+	code := Run([]string{"2", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "no parameters_disclosure") {
+		t.Errorf("expected 'no parameters_disclosure' message, got stderr: %s", errOut.String())
+	}
+}
+
+func TestDisclose_WrongKey(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _ := fixtureDB(t, dir, 1)
+
+	// Generate a different key and write it.
+	wrongKP, err := receipt.GenerateForensicKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := writeKeyFile(t, dir, wrongKP.PrivateKey)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"1", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitDecryptError {
+		t.Fatalf("want ExitDecryptError, got %d; stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "does not match") {
+		t.Errorf("expected mismatch message, got: %s", errOut.String())
+	}
+}
+
+func TestDisclose_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 2)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"99", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitNotFound {
+		t.Fatalf("want ExitNotFound, got %d", code)
+	}
+}
+
+func TestDisclose_MissingSeq(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Run(nil, &out, &errOut, func(string) string { return "" })
+	if code != ExitUsageError {
+		t.Fatalf("want ExitUsageError, got %d", code)
+	}
+}
+
+func TestDisclose_AutoChain(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 1)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	// Do not pass --chain-id; store has exactly one chain so it should auto-resolve.
+	var out, errOut bytes.Buffer
+	code := Run([]string{"1"}, &out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+}
+
+func TestParseForensicPrivateKey_Formats(t *testing.T) {
+	kp, err := receipt.GenerateForensicKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := kp.PrivateKey
+
+	// hex
+	hexKey := fmt.Sprintf("%x", raw)
+	got, err := parseForensicPrivateKey([]byte(hexKey))
+	if err != nil {
+		t.Fatalf("hex: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("hex: mismatch")
+	}
+
+	// base64 standard padded
+	import64 := encodeBase64Std(raw)
+	got, err = parseForensicPrivateKey([]byte(import64))
+	if err != nil {
+		t.Fatalf("base64: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("base64: mismatch")
+	}
+
+	// raw with trailing newline
+	withNL := append(append([]byte(nil), raw...), '\n')
+	got, err = parseForensicPrivateKey(withNL)
+	if err != nil {
+		t.Fatalf("raw+newline: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("raw+newline: mismatch")
+	}
+}
+
+func encodeBase64Std(b []byte) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	var buf strings.Builder
+	for i := 0; i < len(b); i += 3 {
+		remaining := len(b) - i
+		var b0, b1, b2 byte
+		b0 = b[i]
+		if remaining > 1 {
+			b1 = b[i+1]
+		}
+		if remaining > 2 {
+			b2 = b[i+2]
+		}
+		buf.WriteByte(alphabet[b0>>2])
+		buf.WriteByte(alphabet[((b0&0x3)<<4)|(b1>>4)])
+		if remaining > 1 {
+			buf.WriteByte(alphabet[((b1&0xf)<<2)|(b2>>6)])
+		} else {
+			buf.WriteByte('=')
+		}
+		if remaining > 2 {
+			buf.WriteByte(alphabet[b2&0x3f])
+		} else {
+			buf.WriteByte('=')
+		}
+	}
+	return buf.String()
+}

--- a/docs/adr/0030-cli-command-taxonomy.md
+++ b/docs/adr/0030-cli-command-taxonomy.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted (2026-06-12).
+Accepted (2026-06-12). Amended (2026-06-14): added the grouped verb
+`obsigna receipt disclose` — an additive change permitted by the "new
+functionality only ever receives a grouped command" rule below (no rename, no
+removal, no new flat alias).
 
 ## Context
 
@@ -28,6 +31,7 @@ obsigna receipt verify <file|->     # alias: obsigna verify
 obsigna receipt show <id>           # alias: obsigna show
 obsigna receipt list
 obsigna receipt verify-event        # carried over from agent-receipts (PR #788)
+obsigna receipt disclose <seq>      # decrypt a receipt's parameters_disclosure (forensic key); added 2026-06-14
 
 obsigna daemon run                  # foreground primitive
 obsigna daemon status

--- a/site-obsigna/src/content/docs/reference/cli-commands.mdx
+++ b/site-obsigna/src/content/docs/reference/cli-commands.mdx
@@ -196,7 +196,7 @@ obsigna receipt disclose 42 --key ~/forensic.key     # explicit forensic key pat
 | `-key` | Forensic private-key path — raw 32-byte X25519, hex, standard/URL-safe base64, or PKCS#8 PEM (default: per-user path; env: `AGENTRECEIPTS_FORENSIC_KEY`) |
 | `-json` | Output the decrypted parameters as JSON |
 
-The key never leaves the machine and is zeroed from memory after use. A receipt with no `parameters_disclosure` is reported and exits successfully.
+The key never leaves the machine, and its in-memory buffers are zeroed after use on a best-effort basis (Go's runtime may still retain copies). A receipt with no `parameters_disclosure` is reported and exits successfully.
 
 **Exit codes:** `0` parameters decrypted and printed (or the receipt carries no disclosure); `1` no receipt at the requested sequence; `2` usage error (bad flags, ambiguous chain, unreadable database); `3` decryption error — the key is missing, does not match any recipient in the envelope, or the envelope is corrupt.
 

--- a/site-obsigna/src/content/docs/reference/cli-commands.mdx
+++ b/site-obsigna/src/content/docs/reference/cli-commands.mdx
@@ -86,7 +86,7 @@ mcp-proxy init -http-port 9000              # custom approval listener port in s
 
 ## `obsigna`
 
-The daemon's read-side CLI. `obsigna receipt list`, `show`, `verify`, and `verify-event` open the store **read-only** — safe to run while the daemon is the active writer, and verification does not require the daemon socket to be reachable. `obsigna doctor` is the exception: by default it writes a synthetic round-trip event to confirm the full pipeline is live; pass `--no-roundtrip` to skip the write. Subcommands: `receipt list`, `receipt show`, `receipt verify`, `receipt verify-event`, `doctor`.
+The daemon's read-side CLI. `obsigna receipt list`, `show`, `verify`, and `verify-event` open the store **read-only** — safe to run while the daemon is the active writer, and verification does not require the daemon socket to be reachable. `obsigna doctor` is the exception: by default it writes a synthetic round-trip event to confirm the full pipeline is live; pass `--no-roundtrip` to skip the write. Subcommands: `receipt list`, `receipt show`, `receipt verify`, `receipt verify-event`, `receipt disclose`, `doctor`.
 
 > The legacy `agent-receipts` command still works as a thin deprecation shim (ADR-0030): it forwards each subcommand to `obsigna` and prints a one-line notice to stderr. Use `obsigna` for new work.
 
@@ -178,6 +178,27 @@ obsigna receipt verify-event --since 24h                      # every receipt in
 | `-chain-id` | Chain id; selects/filters the chain (env: `AGENTRECEIPTS_CHAIN_ID`) |
 | `-emitter-allowlist` | Comma-separated `exe_path` allowlist of expected emitters (env: `AGENTRECEIPTS_EMITTER_ALLOWLIST`); mismatches warn, never fail |
 | `-json` | Machine-readable JSON output |
+
+### `obsigna receipt disclose`
+
+Decrypt the `parameters_disclosure` envelope of a single stored receipt using the operator's X25519 forensic private key, and print the recovered plaintext parameters. This is the headless counterpart to the dashboard's inline forensic decryption — the privacy model hashes parameters by default; `disclose` is the controlled "break the glass" path for an operator who holds the forensic key.
+
+```bash
+obsigna receipt disclose 42                          # human-readable key/value table
+obsigna receipt disclose 42 --json                   # decrypted parameters as JSON
+obsigna receipt disclose 42 --key ~/forensic.key     # explicit forensic key path
+```
+
+| Flag | Description |
+|------|-------------|
+| `-db` | Receipt-store path (default: per-user path; env: `AGENTRECEIPTS_DB`) |
+| `-chain-id` | Chain to read from (env: `AGENTRECEIPTS_CHAIN_ID`); required only when the store holds more than one chain |
+| `-key` | Forensic private-key path — raw 32-byte X25519, hex, standard/URL-safe base64, or PKCS#8 PEM (default: per-user path; env: `AGENTRECEIPTS_FORENSIC_KEY`) |
+| `-json` | Output the decrypted parameters as JSON |
+
+The key never leaves the machine and is zeroed from memory after use. A receipt with no `parameters_disclosure` is reported and exits successfully.
+
+**Exit codes:** `0` parameters decrypted and printed (or the receipt carries no disclosure); `1` no receipt at the requested sequence; `2` usage error (bad flags, ambiguous chain, unreadable database); `3` decryption error — the key is missing, does not match any recipient in the envelope, or the envelope is corrupt.
 
 ### `obsigna doctor`
 


### PR DESCRIPTION
## What

The `disclosecli` package — which decrypts a stored receipt's `parameters_disclosure` envelope using the operator's X25519 forensic private key and prints the recovered plaintext — was fully implemented and tested but **never registered in the obsigna command tree**, so it was unreachable from the CLI. This wires it in.

`obsigna receipt disclose <seq>` is the headless, scriptable counterpart to the dashboard's inline forensic decryption: the system hashes parameters for privacy by default, and this is the controlled "break the glass" path for an operator holding the forensic key.

## Changes

- **Register** `receipt disclose` in `daemon/cmd/obsigna/registry.go` (import + leaf + order).
- **Golden surface test** (`surface_test.go`) updated in lockstep — verb membership and leaf-wiring map — as the test's own contract requires.
- **ADR-0030 amended**: adds the grouped verb `obsigna receipt disclose`. The sanctioned extension path — "new functionality only ever receives a grouped command." Purely additive: no rename, no removal, no new flat alias.
- **Docs**: new `obsigna receipt disclose` section in the CLI reference (`site-obsigna`).
- **Usage strings**: phrased as `obsigna receipt disclose` to match the migrated convention already used by `keyscli`/`doctorcli` (`obsigna keys generate:`, `obsigna doctor:`), rather than the legacy `agent-receipts <verb>` phrasing the read clis still carry. The FlagSet is named `receipt disclose` (matching keyscli's `keys generate`). A brand-new command shouldn't bake in the old prog name.

## On the older clis

`showcli`, `listcli`, `verifycli`, and `verifyeventcli` still print `agent-receipts <verb>` in their usage/error strings — a pre-existing, mid-migration inconsistency (keyscli/doctorcli already moved). That's intentionally **out of scope** here; it belongs in its own focused sweep PR. This PR just avoids adding a sixth laggard.

## Why no other implementation changes

It predates the obsigna CLI consolidation (file dated 2026-06-11; ADR-0030 accepted 2026-06-12) but already matched current conventions: same `AGENTRECEIPTS_*` env-var names, the same `daemon.Default*Path()` helpers (still present). Only the prog-name strings needed updating.

## Verification

- `go build ./...`, `go vet ./...`, full `go test ./...` (daemon) all pass.
- Built binary: `obsigna --help` lists `obsigna receipt disclose`; `obsigna receipt disclose` (no seq) prints the missing-arg usage.

## Note for review

This amends the ADR-0030 frozen command surface (additively, per the ADR's own extension rule). Flagging explicitly since that surface is a deliberate stability contract.