### PR TITLE
refactor(cli): migrate read-cli usage strings to 'obsigna receipt <verb>'

### DIFF
--- a/daemon/internal/listcli/list.go
+++ b/daemon/internal/listcli/list.go
@@ -1,4 +1,4 @@
-// Package listcli implements the `agent-receipts list` subcommand:
+// Package listcli implements the `obsigna receipt list` subcommand:
 // query recent receipts from a daemon-written SQLite store and print them in
 // tabular or JSON form. It opens the database read-only so it is safe to run
 // while the daemon is the active writer.
@@ -48,7 +48,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return fallback
 	}
 
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs := flag.NewFlagSet("receipt list", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	asJSON := fs.Bool("json", false, "Output raw JSON array instead of tabular text")
@@ -60,21 +60,21 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitUsageError
 	}
 	if fs.NArg() > 0 {
-		fmt.Fprintf(stderr, "agent-receipts list: unexpected positional argument(s): %v\n", fs.Args())
+		fmt.Fprintf(stderr, "obsigna receipt list: unexpected positional argument(s): %v\n", fs.Args())
 		return ExitUsageError
 	}
 	if *dbPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts list: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt list: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError
 	}
 	if *limit <= 0 {
-		fmt.Fprintln(stderr, "agent-receipts list: --limit must be a positive integer")
+		fmt.Fprintln(stderr, "obsigna receipt list: --limit must be a positive integer")
 		return ExitUsageError
 	}
 
 	s, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts list: open store: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt list: open store: %v\n", err)
 		return ExitUsageError
 	}
 	defer s.Close()
@@ -85,7 +85,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		NewestFirst: true,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts list: query: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt list: query: %v\n", err)
 		return ExitUsageError
 	}
 
@@ -102,7 +102,7 @@ func writeJSON(stdout, stderr io.Writer, receipts []receipt.AgentReceipt) int {
 	enc := json.NewEncoder(stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(receipts); err != nil {
-		fmt.Fprintf(stderr, "agent-receipts list: encode JSON: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt list: encode JSON: %v\n", err)
 		return ExitUsageError
 	}
 	return ExitOK

--- a/daemon/internal/showcli/show.go
+++ b/daemon/internal/showcli/show.go
@@ -1,4 +1,4 @@
-// Package showcli implements the `agent-receipts show <seq>` subcommand:
+// Package showcli implements the `obsigna receipt show <seq>` subcommand:
 // inspect a single receipt by its chain sequence number, read from a
 // daemon-written SQLite store. It opens the database read-only so it is safe
 // to run while the daemon is the active writer.
@@ -49,10 +49,10 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return fallback
 	}
 
-	fs := flag.NewFlagSet("show", flag.ContinueOnError)
+	fs := flag.NewFlagSet("receipt show", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: agent-receipts show <seq> [flags]")
+		fmt.Fprintln(stderr, "Usage: obsigna receipt show <seq> [flags]")
 		fmt.Fprintln(stderr, "\nPrint the full fields of the receipt at chain sequence <seq>.")
 		fmt.Fprintln(stderr, "\nFlags:")
 		fs.PrintDefaults()
@@ -83,27 +83,27 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	}
 
 	if len(rest) == 0 {
-		fmt.Fprintln(stderr, "agent-receipts show: missing <seq> argument (the chain sequence number, 1-indexed)")
+		fmt.Fprintln(stderr, "obsigna receipt show: missing <seq> argument (the chain sequence number, 1-indexed)")
 		return ExitUsageError
 	}
 	if len(rest) > 1 {
-		fmt.Fprintf(stderr, "agent-receipts show: unexpected positional argument(s): %v (only one <seq> is accepted)\n", rest[1:])
+		fmt.Fprintf(stderr, "obsigna receipt show: unexpected positional argument(s): %v (only one <seq> is accepted)\n", rest[1:])
 		return ExitUsageError
 	}
 	seq, err := strconv.Atoi(rest[0])
 	if err != nil || seq < 1 {
-		fmt.Fprintf(stderr, "agent-receipts show: <seq> must be a positive integer, got %q\n", rest[0])
+		fmt.Fprintf(stderr, "obsigna receipt show: <seq> must be a positive integer, got %q\n", rest[0])
 		return ExitUsageError
 	}
 
 	if *dbPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts show: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt show: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError
 	}
 
 	s, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts show: open store: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt show: open store: %v\n", err)
 		return ExitUsageError
 	}
 	defer s.Close()
@@ -115,11 +115,11 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 
 	r, err := s.GetByChainSequence(resolved, seq)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts show: read chain %q: %v\n", resolved, err)
+		fmt.Fprintf(stderr, "obsigna receipt show: read chain %q: %v\n", resolved, err)
 		return ExitUsageError
 	}
 	if r == nil {
-		fmt.Fprintf(stderr, "agent-receipts show: no receipt at sequence %d in chain %q\n", seq, resolved)
+		fmt.Fprintf(stderr, "obsigna receipt show: no receipt at sequence %d in chain %q\n", seq, resolved)
 		return ExitNotFound
 	}
 	if *asJSON {
@@ -139,17 +139,17 @@ func resolveChainID(s *store.Store, requested string, stderr io.Writer) (string,
 
 	chains, err := s.DistinctChainIDs()
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts show: enumerate chains: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt show: enumerate chains: %v\n", err)
 		return "", ExitUsageError
 	}
 	switch len(chains) {
 	case 0:
-		fmt.Fprintln(stderr, "agent-receipts show: store holds no receipts")
+		fmt.Fprintln(stderr, "obsigna receipt show: store holds no receipts")
 		return "", ExitNotFound
 	case 1:
 		return chains[0], ExitOK
 	default:
-		fmt.Fprintf(stderr, "agent-receipts show: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
+		fmt.Fprintf(stderr, "obsigna receipt show: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
 		for _, c := range chains {
 			fmt.Fprintf(stderr, "  %s\n", c)
 		}
@@ -164,7 +164,7 @@ func writeJSON(stdout, stderr io.Writer, r *receipt.AgentReceipt) int {
 		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
 			return ExitOK
 		}
-		fmt.Fprintf(stderr, "agent-receipts show: encode JSON: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt show: encode JSON: %v\n", err)
 		return ExitUsageError
 	}
 	return ExitOK
@@ -224,7 +224,7 @@ func writeHuman(stdout io.Writer, r *receipt.AgentReceipt) int {
 }
 
 // exitFromFlush maps a tabwriter flush result to an exit code. A broken pipe
-// (e.g. `agent-receipts show ... | head`) is normal CLI behaviour, not a
+// (e.g. `obsigna receipt show ... | head`) is normal CLI behaviour, not a
 // failure, so it exits 0 — matching listcli.
 func exitFromFlush(w *tabwriter.Writer) int {
 	if err := w.Flush(); err != nil {

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -1,4 +1,4 @@
-// Package verifycli implements the `agent-receipts verify` subcommand:
+// Package verifycli implements the `obsigna receipt verify` subcommand:
 // validate a stored chain's signatures and hash links using a daemon-written
 // SQLite store and the daemon-published public key. For a chain that has
 // survived an offline key rotation the published key is the post-rotation key,
@@ -70,7 +70,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	keyPath := envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
 	defaultPubKey := envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath))
 
-	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	fs := flag.NewFlagSet("receipt verify", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dbPath := fs.String("db", envOr("AGENTRECEIPTS_DB", daemon.DefaultDBPath()), "SQLite receipt-store path (env: AGENTRECEIPTS_DB)")
 	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
@@ -78,7 +78,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	if err := fs.Parse(args); err != nil {
 		// `-h` / `--help` is intentional, not an error — flag.ContinueOnError
 		// surfaces it as flag.ErrHelp after writing the usage message. Exit 0
-		// so scripts that probe `agent-receipts verify -h` don't see a failure.
+		// so scripts that probe `obsigna receipt verify -h` don't see a failure.
 		if errors.Is(err, flag.ErrHelp) {
 			return ExitOK
 		}
@@ -86,24 +86,24 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	}
 	// `verify` takes no positional arguments — chain selection is via
 	// --chain-id. Surface stray args as a usage error so a typo like
-	// `agent-receipts verify --db /path/to.db extra` doesn't silently succeed
+	// `obsigna receipt verify --db /path/to.db extra` doesn't silently succeed
 	// and hide a scripting mistake.
 	if fs.NArg() > 0 {
-		fmt.Fprintf(stderr, "agent-receipts verify: unexpected positional argument(s): %v (use --chain-id for chain selection)\n", fs.Args())
+		fmt.Fprintf(stderr, "obsigna receipt verify: unexpected positional argument(s): %v (use --chain-id for chain selection)\n", fs.Args())
 		return ExitUsageError
 	}
 	if *dbPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts verify: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt verify: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError
 	}
 	if *pubKeyPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts verify: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived; both are unset and no home directory is available)")
+		fmt.Fprintln(stderr, "obsigna receipt verify: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived; both are unset and no home directory is available)")
 		return ExitUsageError
 	}
 
 	pubPEM, err := os.ReadFile(*pubKeyPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify: read public key: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify: read public key: %v\n", err)
 		return ExitUsageError
 	}
 	// Validate the public key's PEM/SPKI shape upfront so a malformed key
@@ -111,20 +111,20 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	// VerifyStoredChain → ExitChainBad, which would falsely suggest the chain
 	// itself was tampered with.
 	if err := validatePublicKeyPEM(pubPEM); err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify: invalid public key at %s: %v\n", *pubKeyPath, err)
+		fmt.Fprintf(stderr, "obsigna receipt verify: invalid public key at %s: %v\n", *pubKeyPath, err)
 		return ExitUsageError
 	}
 
 	s, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify: open store: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify: open store: %v\n", err)
 		return ExitUsageError
 	}
 	defer s.Close()
 
 	receipts, err := s.GetChain(*chainID)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify: load chain: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify: load chain: %v\n", err)
 		return ExitUsageError
 	}
 
@@ -160,7 +160,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	if result.Valid && resolvedFromArchive {
 		publishedFp, err := publicKeyFingerprint(pubPEM)
 		if err != nil {
-			fmt.Fprintf(stderr, "agent-receipts verify: fingerprint published key: %v\n", err)
+			fmt.Fprintf(stderr, "obsigna receipt verify: fingerprint published key: %v\n", err)
 			return ExitUsageError
 		}
 		currentFp, rotated := currentChainKeyFingerprint(receipts)

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -1,4 +1,4 @@
-// Package verifyeventcli implements the `agent-receipts verify-event`
+// Package verifyeventcli implements the `obsigna receipt verify-event`
 // subcommand: end-to-end pipeline-provenance evidence for a single historical
 // receipt. Where `verify` answers "is this chain internally consistent?",
 // verify-event answers the narrower question that matters most for trust: "was
@@ -135,10 +135,10 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	keyPath := envOr("AGENTRECEIPTS_KEY", daemon.DefaultKeyPath())
 	defaultPubKey := envOr("AGENTRECEIPTS_PUBLIC_KEY", daemon.DefaultPublicKeyPath(keyPath))
 
-	fs := flag.NewFlagSet("verify-event", flag.ContinueOnError)
+	fs := flag.NewFlagSet("receipt verify-event", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: agent-receipts verify-event (--id <id> | --chain-head | --since <dur>) [flags]")
+		fmt.Fprintln(stderr, "Usage: obsigna receipt verify-event (--id <id> | --chain-head | --since <dur>) [flags]")
 		fmt.Fprintln(stderr, "\nVerify that a specific historical receipt was produced by the documented")
 		fmt.Fprintln(stderr, "emitter→daemon→chain pipeline, not written to the store by another path.")
 		fmt.Fprintln(stderr, "\nExactly one selector is required:")
@@ -164,7 +164,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitUsageError
 	}
 	if fs.NArg() > 0 {
-		fmt.Fprintf(stderr, "agent-receipts verify-event: unexpected positional argument(s): %v (use a selector flag)\n", fs.Args())
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: unexpected positional argument(s): %v (use a selector flag)\n", fs.Args())
 		return ExitUsageError
 	}
 
@@ -181,33 +181,33 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		selectors++
 	}
 	if selectors == 0 {
-		fmt.Fprintln(stderr, "agent-receipts verify-event: a selector is required (--id, --chain-head, or --since)")
+		fmt.Fprintln(stderr, "obsigna receipt verify-event: a selector is required (--id, --chain-head, or --since)")
 		return ExitUsageError
 	}
 	if selectors > 1 {
-		fmt.Fprintln(stderr, "agent-receipts verify-event: selectors --id, --chain-head and --since are mutually exclusive")
+		fmt.Fprintln(stderr, "obsigna receipt verify-event: selectors --id, --chain-head and --since are mutually exclusive")
 		return ExitUsageError
 	}
 
 	if *dbPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts verify-event: --db is required (no AGENTRECEIPTS_DB and no home directory)")
+		fmt.Fprintln(stderr, "obsigna receipt verify-event: --db is required (no AGENTRECEIPTS_DB and no home directory)")
 		return ExitUsageError
 	}
 	if *pubKeyPath == "" {
-		fmt.Fprintln(stderr, "agent-receipts verify-event: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived)")
+		fmt.Fprintln(stderr, "obsigna receipt verify-event: --public-key is required (set AGENTRECEIPTS_PUBLIC_KEY directly, or AGENTRECEIPTS_KEY so its <KeyPath>.pub default can be derived)")
 		return ExitUsageError
 	}
 
 	pubPEM, err := os.ReadFile(*pubKeyPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify-event: read public key: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: read public key: %v\n", err)
 		return ExitUsageError
 	}
 	// Validate key shape upfront so a malformed key surfaces as a usage error
 	// rather than being routed through per-receipt signature failures, which
 	// would falsely implicate the receipts.
 	if err := validatePublicKeyPEM(pubPEM); err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify-event: invalid public key at %s: %v\n", *pubKeyPath, err)
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: invalid public key at %s: %v\n", *pubKeyPath, err)
 		return ExitUsageError
 	}
 
@@ -215,7 +215,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 
 	s, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify-event: open store: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: open store: %v\n", err)
 		return ExitUsageError
 	}
 	defer s.Close()
@@ -235,7 +235,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		if !ok {
 			chain, err := s.GetChain(t.chainID)
 			if err != nil {
-				fmt.Fprintf(stderr, "agent-receipts verify-event: read chain %q: %v\n", t.chainID, err)
+				fmt.Fprintf(stderr, "obsigna receipt verify-event: read chain %q: %v\n", t.chainID, err)
 				return ExitUsageError
 			}
 			cv := receipt.VerifyChain(chain, string(pubPEM))
@@ -253,7 +253,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 			// The receipt resolved from the store but is absent from its own
 			// chain load — only possible under concurrent deletion or a store
 			// inconsistency. Treat as a usage-level read error, not a verdict.
-			fmt.Fprintf(stderr, "agent-receipts verify-event: receipt %q not found in chain %q\n", t.receiptID, t.chainID)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: receipt %q not found in chain %q\n", t.receiptID, t.chainID)
 			return ExitUsageError
 		}
 		results = append(results, evaluate(ctx, idx, allowlist))
@@ -291,11 +291,11 @@ func resolveTargets(s *store.Store, id string, chainHead bool, since, chainID st
 	case id != "":
 		r, err := s.GetByID(id)
 		if err != nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: read receipt %q: %v\n", id, err)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: read receipt %q: %v\n", id, err)
 			return nil, ExitUsageError
 		}
 		if r == nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: no receipt with id %q\n", id)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: no receipt with id %q\n", id)
 			return nil, ExitUsageError
 		}
 		return []target{{receiptID: r.ID, chainID: r.CredentialSubject.Chain.ChainID}}, ExitOK
@@ -307,11 +307,11 @@ func resolveTargets(s *store.Store, id string, chainHead bool, since, chainID st
 		}
 		r, err := s.GetChainTailReceipt(resolved)
 		if err != nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: read chain head %q: %v\n", resolved, err)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: read chain head %q: %v\n", resolved, err)
 			return nil, ExitUsageError
 		}
 		if r == nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: chain %q holds no receipts\n", resolved)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: chain %q holds no receipts\n", resolved)
 			return nil, ExitUsageError
 		}
 		return []target{{receiptID: r.ID, chainID: resolved}}, ExitOK
@@ -319,11 +319,11 @@ func resolveTargets(s *store.Store, id string, chainHead bool, since, chainID st
 	default: // since
 		d, err := time.ParseDuration(since)
 		if err != nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: invalid --since duration %q: %v\n", since, err)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: invalid --since duration %q: %v\n", since, err)
 			return nil, ExitUsageError
 		}
 		if d <= 0 {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: --since must be positive, got %q\n", since)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: --since must be positive, got %q\n", since)
 			return nil, ExitUsageError
 		}
 		cutoff := time.Now().UTC().Add(-d).Format(time.RFC3339)
@@ -333,11 +333,11 @@ func resolveTargets(s *store.Store, id string, chainHead bool, since, chainID st
 		}
 		rs, err := s.QueryReceipts(q)
 		if err != nil {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: query receipts: %v\n", err)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: query receipts: %v\n", err)
 			return nil, ExitUsageError
 		}
 		if len(rs) == 0 {
-			fmt.Fprintf(stderr, "agent-receipts verify-event: no receipts issued within %s\n", since)
+			fmt.Fprintf(stderr, "obsigna receipt verify-event: no receipts issued within %s\n", since)
 			return nil, ExitUsageError
 		}
 		targets := make([]target, len(rs))
@@ -356,17 +356,17 @@ func resolveChainID(s *store.Store, requested string, stderr io.Writer) (string,
 	}
 	chains, err := s.DistinctChainIDs()
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-receipts verify-event: enumerate chains: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: enumerate chains: %v\n", err)
 		return "", ExitUsageError
 	}
 	switch len(chains) {
 	case 0:
-		fmt.Fprintln(stderr, "agent-receipts verify-event: store holds no receipts")
+		fmt.Fprintln(stderr, "obsigna receipt verify-event: store holds no receipts")
 		return "", ExitUsageError
 	case 1:
 		return chains[0], ExitOK
 	default:
-		fmt.Fprintf(stderr, "agent-receipts verify-event: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: store holds %d chains; pass --chain-id to select one. Available chains:\n", len(chains))
 		for _, c := range chains {
 			fmt.Fprintf(stderr, "  %s\n", c)
 		}
@@ -614,7 +614,7 @@ func writeJSON(stdout, stderr io.Writer, results []eventResult) int {
 		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
 			return exitCode(results)
 		}
-		fmt.Fprintf(stderr, "agent-receipts verify-event: encode JSON: %v\n", err)
+		fmt.Fprintf(stderr, "obsigna receipt verify-event: encode JSON: %v\n", err)
 		return ExitUsageError
 	}
 	return exitCode(results)


### PR DESCRIPTION
Follow-up sweep to the `obsigna receipt disclose` PR (#843). Cleans up the last of the legacy CLI prog-name strings.

## Problem

`showcli`, `listcli`, `verifycli`, and `verifyeventcli` still printed `agent-receipts <verb>:` in their usage and error output — even though the command is invoked as `obsigna receipt <verb>`. So a user who runs `obsigna receipt show` and hits an error sees `agent-receipts show: …`, naming a different (legacy) binary. `keyscli` and `doctorcli` had already migrated to `obsigna keys generate:` / `obsigna doctor:`; this brings the read clis in line.

## Changes (4 files, ~48 strings)

- `daemon/internal/showcli/show.go`
- `daemon/internal/listcli/list.go`
- `daemon/internal/verifycli/verify.go`
- `daemon/internal/verifyeventcli/verify_event.go`

For each: usage/error strings and package doc comments `agent-receipts <verb>` → `obsigna receipt <verb>`, and the FlagSet renamed `<verb>` → `receipt <verb>` (matching keyscli's `keys generate`).

## Deliberately NOT touched

These uses of `agent-receipts` are intentional and stay:
- `AGENTRECEIPTS_*` env vars (stability surface)
- `github.com/agent-receipts/ar` module/import path (ADR-0034)
- the `agent-receipts` deprecation-shim binary (`daemon/cmd/agent-receipts/`)
- the `~/.local/share/agent-receipts/` default data dir

## Verification

- No test asserted on the old prefix (checked before editing).
- `go build`, `go vet`, full `go test ./...` (daemon) all pass.
- Built binary spot-check: `obsigna receipt show` → `obsigna receipt show: missing <seq> …`; `obsigna receipt verify-event` → `obsigna receipt verify-event: a selector is required …`.

No behavior change — strings only.