### PR TITLE
Refine EU AI Act traceability language in design principles

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -48,7 +48,7 @@ graph LR
 
 ## Design principles
 
-The protocol is privacy-preserving by default, built on existing standards (W3C VCs, Ed25519, SHA-256, RFC 3161), agent-agnostic, and minimal by default with room for domain-specific extensions. The EU AI Act mandates traceability for high-risk AI systems (Article 12); Agent Receipts produces a record that meets that bar.
+The protocol is privacy-preserving by default, built on existing standards (W3C VCs, Ed25519, SHA-256, RFC 3161), agent-agnostic, and minimal by default with room for domain-specific extensions. The EU AI Act mandates traceability for high-risk AI systems (Article 12); Agent Receipts is designed to produce records suited to that requirement.
 
 See the [Specification Overview](/specification/overview/) for the full design.
 


### PR DESCRIPTION
## What

Updated the design principles section in the documentation to clarify how Agent Receipts addresses EU AI Act traceability requirements. Changed "produces a record that meets that bar" to "is designed to produce records suited to that requirement" for more precise language.

## Why

The original phrasing was overly definitive about compliance. The revised language more accurately reflects that Agent Receipts is designed with these requirements in mind, while acknowledging that actual compliance depends on implementation and use context.

## Checklist

- [x] No real keys or secrets in the diff
- [x] Documentation-only change (no code or tests affected)