### PR TITLE
feat(daemon): derive receipt principal from kernel-attested peer uid

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Receipt principal is derived from the kernel-attested peer uid** instead of always being the `did:user:unknown` sentinel. When an emitter supplies no principal (the common case today), live and `events_dropped` receipts now record `principal.id` as `did:user:<login>`, resolved from the connecting process's uid — the same `LOCAL_PEERCRED`/`SO_PEERCRED` identity the daemon already vouches for in `action.peer_credential`, so the principal inherits that field's tamper-evidence rather than trusting an emitter self-report. The uid is the attested fact; the login name is the daemon's lookup of it on its own host. It falls back to the numeric `did:user:<platform>:<uid>` when the host user database has no entry (containers, directory-only users, deleted accounts), and to `did:user:unknown` on platforms with no POSIX uid and on synthetic chain-interrupted terminator receipts (which have no connecting peer). The derived DID names the OS user, not a configured human or authorization grant; mapping a uid to a named principal or mandate is a higher layer on top of this attested floor. No schema change — `principal.id` was already a free-form DID string.
+
 ## [0.25.0] - 2026-06-13
 
 ### Changed

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os/user"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -776,7 +778,7 @@ func (p *Pipeline) buildAndSign(
 
 	return p.signAndHash(receipt.CreateInput{
 		Issuer:        issuerFromFrame(f, p.IssuerID),
-		Principal:     receipt.Principal{ID: "did:user:unknown"},
+		Principal:     principalFromPeer(peer),
 		Action:        action,
 		Outcome:       outcome,
 		CorrelationID: f.CorrelationID,
@@ -859,7 +861,7 @@ func (p *Pipeline) buildAndSignDropReceipt(
 			Type:      "AgentReceiptsDaemon",
 			SessionID: sessionID,
 		},
-		Principal:  receipt.Principal{ID: "did:user:unknown"},
+		Principal:  principalFromPeer(peer),
 		Delegation: delegation,
 		Action: receipt.Action{
 			Type:           actionTypeEventsDropped,
@@ -900,6 +902,40 @@ func buildPeerCred(peer socket.PeerCred) *receipt.PeerCredential {
 }
 
 func ptrUint32(v uint32) *uint32 { return &v }
+
+// lookupUID resolves a POSIX uid to an OS user. It is a package var so tests can
+// stub the host user database and stay deterministic across machines.
+var lookupUID = user.LookupId
+
+// principalFromPeer derives the receipt Principal from kernel-attested peer
+// credentials. Absent an emitter-supplied principal, the OS user that ran the
+// emitting process is the best attested stand-in for "on whose authority": it is
+// the same LOCAL_PEERCRED/SO_PEERCRED identity the daemon already vouches for in
+// action.peer_credential, so the principal inherits that field's tamper-evidence
+// instead of trusting an emitter self-report.
+//
+// The kernel-attested uid is the stable fact and is preserved verbatim in
+// action.peer_credential. This resolves it to the host's login name for a
+// human-readable principal (did:user:<login>) — the name is the daemon's lookup
+// of an attested uid on its own host, not an emitter self-report. It falls back
+// to the numeric did:user:<platform>:<uid> when the host user database has no
+// entry (containers, directory-only users, deleted accounts), so the principal
+// is always at least the attested uid. The platform gate mirrors buildPeerCred:
+// platforms without a POSIX uid — and synthetic receipts with no connecting peer
+// — fall back to the did:user:unknown sentinel.
+//
+// The derived DID names the OS user, not a configured human or mandate. Mapping
+// a uid to a named principal or an authorization grant is a higher layer that
+// builds on this attested floor.
+func principalFromPeer(peer socket.PeerCred) receipt.Principal {
+	if peer.Platform != "linux" && peer.Platform != "darwin" {
+		return receipt.Principal{ID: "did:user:unknown"}
+	}
+	if u, err := lookupUID(strconv.FormatUint(uint64(peer.UID), 10)); err == nil && u.Username != "" {
+		return receipt.Principal{ID: "did:user:" + u.Username}
+	}
+	return receipt.Principal{ID: fmt.Sprintf("did:user:%s:%d", peer.Platform, peer.UID)}
+}
 
 // EmitTerminator emits interrupted-chain terminal receipts for all open chains
 // (root chain and any per-agent chains). It is called once, synchronously,

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -140,6 +141,50 @@ func TestBuildPeerCred(t *testing.T) {
 	}
 }
 
+// TestPrincipalFromPeer covers derivation of the receipt principal from
+// kernel-attested peer credentials: a resolvable uid yields the host login name
+// (did:user:<login>); an unresolvable uid falls back to the numeric
+// did:user:<platform>:<uid> (the attested uid is never lost, including root);
+// and platforms with no POSIX uid — or an absent peer — fall back to the
+// did:user:unknown sentinel. lookupUID is stubbed so the test is deterministic
+// regardless of the host user database.
+func TestPrincipalFromPeer(t *testing.T) {
+	orig := lookupUID
+	t.Cleanup(func() { lookupUID = orig })
+
+	resolves := func(uid string) (*user.User, error) {
+		return &user.User{Uid: uid, Username: "ottojongerius", Name: "Otto Jongerius"}, nil
+	}
+	emptyName := func(uid string) (*user.User, error) {
+		return &user.User{Uid: uid, Username: ""}, nil
+	}
+	notFound := func(uid string) (*user.User, error) {
+		return nil, user.UnknownUserIdError(0)
+	}
+
+	cases := []struct {
+		name   string
+		lookup func(string) (*user.User, error)
+		peer   socket.PeerCred
+		want   string
+	}{
+		{"resolvable uid yields login name", resolves, socket.PeerCred{Platform: "darwin", PID: 99, UID: 501, GID: 20}, "did:user:ottojongerius"},
+		{"unresolvable uid falls back to numeric", notFound, socket.PeerCred{Platform: "linux", PID: 42, UID: 1000, GID: 1000}, "did:user:linux:1000"},
+		{"empty resolved name falls back to numeric", emptyName, socket.PeerCred{Platform: "darwin", PID: 7, UID: 501, GID: 20}, "did:user:darwin:501"},
+		{"unresolvable root (uid=0 attested, not unknown)", notFound, socket.PeerCred{Platform: "linux", PID: 1, UID: 0, GID: 0}, "did:user:linux:0"},
+		{"non-POSIX platform falls back to unknown", notFound, socket.PeerCred{Platform: "windows", PID: 7}, "did:user:unknown"},
+		{"absent peer falls back to unknown", notFound, socket.PeerCred{}, "did:user:unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lookupUID = tc.lookup
+			if got := principalFromPeer(tc.peer).ID; got != tc.want {
+				t.Errorf("principalFromPeer(%+v).ID = %q, want %q", tc.peer, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)
@@ -180,6 +225,13 @@ func TestProcess_BuildsSignedReceipt(t *testing.T) {
 	}
 	if pc.ExePath != "/usr/bin/mcp-proxy" {
 		t.Errorf("peer_credential.exe_path = %q", pc.ExePath)
+	}
+	// Principal must be derived from the kernel-attested peer uid (sampleFrame's
+	// peer is uid 1000), not the did:user:unknown sentinel. Exact formatting —
+	// resolved login name vs numeric fallback — is covered by TestPrincipalFromPeer;
+	// here we only assert the wiring derives something from the peer.
+	if got := r.CredentialSubject.Principal.ID; got == "did:user:unknown" || !strings.HasPrefix(got, "did:user:") {
+		t.Errorf("principal.id = %q, want a peer-derived did:user:* (not the unknown sentinel)", got)
 	}
 	// Live receipts MUST NOT carry the synthetic emitter_metadata block —
 	// drop_count belongs to events_dropped synthetic receipts only.


### PR DESCRIPTION
## Summary

Every receipt recorded `principal.id` as the `did:user:unknown` sentinel — so the "under whose authority" dimension of attribution was always blank. But the daemon **already** captures the connecting process's OS identity at the socket via `LOCAL_PEERCRED`/`SO_PEERCRED` and stores it in `action.peer_credential`. The attested answer was sitting one field over, thrown away.

This derives the principal from that kernel-attested uid.

## What changes

`principalFromPeer(peer)` (new helper in `daemon/internal/pipeline/build.go`) sets `principal.id` for live and `events_dropped` receipts:

1. **Resolved login name** — `did:user:<login>` (e.g. `did:user:ottojongerius`), resolved from the uid via the host user DB.
2. **Numeric fallback** — `did:user:<platform>:<uid>` when the host DB has no entry (containers, directory-only/LDAP users, deleted accounts). The attested uid is never lost.
3. **Sentinel fallback** — `did:user:unknown` on platforms with no POSIX uid (Windows, today) and on synthetic chain-interrupted terminator receipts (no connecting peer).

The `uid` remains the attested fact in `action.peer_credential`; the login name is the daemon's lookup of it on its own host, **not** an emitter self-report — so the principal inherits `peer_credential`'s tamper-evidence. Mapping a uid to a configured human or authorization grant (`grant_ref`/scopes) stays a higher layer on top of this attested floor.

## Trust / honesty notes

- **Attested, not claimed.** The uid comes from the kernel at socket-accept; the emitter can't forge it. The name is a host-side resolution of that uid.
- **Resolution works under `CGO_ENABLED=0`** (the shipped build) on macOS and Linux; where it can't resolve, it falls back to the numeric uid, never a fabricated name.
- The synthetic terminator (no peer) deliberately keeps `did:user:unknown` — honest, since there's no attested peer to name.

## Testing

- `TestPrincipalFromPeer` — table test over resolve / numeric-fallback / empty-name / root(uid=0) / non-POSIX / absent-peer, with `lookupUID` stubbed (package-var seam) for host-independent determinism.
- `TestProcess_BuildsSignedReceipt` — asserts end-to-end that a live receipt's principal is peer-derived (not the sentinel).
- Full daemon suite green; `go vet ./...` clean.

## Scope

- **No schema change** — `principal.id` was already a free-form DID string.
- CHANGELOG entry under `[Unreleased]`. Ready for the next **alpha** cut.
- Issuer `did:agent-receipts-daemon:local` and the deeper mandate/authorization layer are intentionally untouched.