### PR TITLE
chore(release): stamp CHANGELOG 0.26.0

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-14
+
 ### Changed
 
 - **Receipt principal is derived from the kernel-attested peer uid** instead of always being the `did:user:unknown` sentinel. When an emitter supplies no principal (the common case today), live and `events_dropped` receipts now record `principal.id` as `did:user:<login>`, resolved from the connecting process's uid — the same `LOCAL_PEERCRED`/`SO_PEERCRED` identity the daemon already vouches for in `action.peer_credential`, so the principal inherits that field's tamper-evidence rather than trusting an emitter self-report. The uid is the attested fact; the login name is the daemon's lookup of it on its own host. It falls back to the numeric `did:user:<platform>:<uid>` when the host user database has no entry (containers, directory-only users, deleted accounts), and to `did:user:unknown` on platforms with no POSIX uid and on synthetic chain-interrupted terminator receipts (which have no connecting peer). The derived DID names the OS user, not a configured human or authorization grant; mapping a uid to a named principal or mandate is a higher layer on top of this attested floor. No schema change — `principal.id` was already a free-form DID string.


### PR DESCRIPTION
Stamps the obsigna toolset CHANGELOG for **0.26.0** (stable).

Captures the single `[Unreleased]` change merged in #847: receipt `principal` is now derived from the kernel-attested peer uid (`did:user:<login>`, with numeric and `did:user:unknown` fallbacks) instead of the `did:user:unknown` sentinel.

- Minor bump (feat) over `0.25.0`.
- CHANGELOG-only — GoReleaser derives the version from the tag; no version files.

**After merge:** tag `obsigna/v0.26.0` on the merge commit to trigger `release-obsigna.yml` (builds the five binaries + shims, publishes the archive, updates the Homebrew tap). I have not tagged or published — that's the maintainer step.

_(Branch name still reads `…-alpha.1` cosmetically; the release is stable `0.26.0`. Branch is deleted on merge.)_