### PR TITLE
docs(blog): address reviewer feedback on attribution-over-undo

### DIFF
--- a/site/src/content/docs/blog/attribution-over-undo.mdx
+++ b/site/src/content/docs/blog/attribution-over-undo.mdx
@@ -16,6 +16,8 @@ Three agents ran the deploy below, each in its own isolated worktree. None could
 
 ![Agent Receipts dashboard: an orchestrator delegating to three subagents, each in its own worktree, joined by edges because all three wrote to the same shared credentials vault.](/blog/vault-swarm-graph.png)
 
+_Those edges come from a shared **file** (the vault). Shared databases and APIs land in the receipts too, but aren't drawn as edges yet; [Honest by construction](#honest-by-construction) below covers what the graph can and can't show today._
+
 Sandboxing an agent fences its working tree, but the database it writes to and the API it calls live outside that fence. When two agents touch the same resource there, isolation has no view of it. The only record that both touched it, and who they were, is the receipt.
 
 ---
@@ -89,7 +91,7 @@ That one record answers all three questions, each anchored to something the agen
 - **Under whose authority** — `principal.id` is `did:user:ottojongerius`, resolved from `peer_credential.uid: 501`, the OS user the kernel reported at the socket (`LOCAL_PEERCRED`). The agent has no hand in setting it; the raw uid stays in the record as the verifiable backing.
 - **What signed it** — `issuer.id` is the daemon, running as its own OS user the agents can't reach (the [out-of-agent boundary](/blog/daemon-process-separation/)).
 
-Group every receipt by `action.target.resource` and the contention falls out: three agents, three isolated worktrees, one shared file. The race was real — two wrote cleanly, but the third's chain runs longer, re-reading the vault several times before its write landed as the file shifted under it. The dashboard draws an edge between agents that touched the same resource, so the three show up tied together through the vault, even though nothing in their working trees overlapped. No sandbox shows you that edge, and no snapshot records it.
+Group every receipt by `action.target.resource` and the contention falls out: three agents, three isolated worktrees, one shared file. The race was real — two wrote cleanly, but the third's chain runs longer, re-reading the vault several times before its write landed as the file shifted under it. The chain recorded that race; it didn't referee it. Agent Receipts is attribution, not arbitration: a lost update would surface in the receipts afterward, not be blocked at write time. The dashboard draws an edge between agents that touched the same resource, so the three show up tied together through the vault, even though nothing in their working trees overlapped. No sandbox shows you that edge, and no snapshot records it.
 
 ---
 
@@ -102,6 +104,8 @@ The edges are drawn from `action.target.resource`, and that field is populated w
 The same gap shows up in shell commands. An `rm` is recorded as `claude-code.Bash` with no `action.target` and a default `medium` risk — the same as a harmless `echo`. To the pipeline it's just a shell call; what it did is hidden inside it. But it isn't lost: the command and its intent live in the receipt's HPKE-encrypted disclosure, recoverable with the forensic key. The structured view covers what the runtime exposes; the sealed disclosure holds the rest.
 
 There's one more honest edge, on authority. The principal is the **OS user**, kernel-attested — a real answer to *who*. What it isn't yet is the **mandate**: which delegated grant let this agent reach the vault, and whether reverting its write would exceed that grant. The schema reserves the slots (`authorization.scopes`, `authorization.grant_ref`); nothing populates them today, so the receipts give you an attested principal and, for now, an empty mandate, surfaced plainly. Mandate is the next layer up, building on the attested principal floor.
+
+The attestation has a boundary of its own. That `uid` is unforgeable because the emitter reaches the daemon over a **local Unix socket**, where the kernel reports the peer (`LOCAL_PEERCRED`). That holds when the daemon runs on the same host as the agent. Move it off-box (remote MCP, ephemeral compute) and same-host attestation no longer applies; the [trust model](https://agentreceipts.ai/specification/trust-model/) covers that case.
 
 ---
 


### PR DESCRIPTION
Follow-up to #849, addressing three points from a senior review.

1. **Coverage caveat was buried (priority fix).** The graph only draws edges for shared *files*, the demo's shared resource is a file, yet the opening leads with database/API — the cases that don't draw edges yet — and the disclosure was three sections down. A skimmer left overclaiming. Pulled a one-line caveat up directly under the dashboard screenshot (links down to *Honest by construction*), so the graph never visually overclaims before it's qualified.
2. **"The race was real" lacked its boundary.** Added one sentence: Agent Receipts is attribution, not arbitration — a lost update would surface in the receipts afterward, not be blocked at write time. Turns a loose end into a stated boundary (record, don't enforce).
3. **The `uid` trust root is same-host only.** Noted that the kernel attestation (`LOCAL_PEERCRED`) holds over a local Unix socket on the same host, and linked the [trust model](https://agentreceipts.ai/specification/trust-model/) for the off-box case (remote MCP, ephemeral compute). Absolute link so it resolves from the obsigna.dev mirror too.

No new em-dash clusters; the in-page anchor and the trust-model link both resolve; renders 200 on the local build. Mirrors to obsigna.dev via sync-blog on next build.