### PR TITLE
ci(site): retrigger obsigna.dev build on blog source changes

### DIFF
--- a/.github/workflows/site-obsigna.yml
+++ b/.github/workflows/site-obsigna.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [main]
     paths: [site-obsigna/**, site/src/content/docs/blog/**, site/public/blog/**]
+  # Manual rebuild — e.g. to resync the blog mirror after a missed trigger.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,7 +45,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy to obsigna-site gh-pages
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           personal_token: ${{ secrets.OBSIGNA_SITE_DEPLOY_PAT }}

--- a/.github/workflows/site-obsigna.yml
+++ b/.github/workflows/site-obsigna.yml
@@ -3,10 +3,13 @@ name: Site (obsigna.dev)
 on:
   push:
     branches: [main]
-    paths: [site-obsigna/**, sdk/go/**, sdk/ts/**, sdk/py/**, mcp-proxy/**, hook/**]
+    # The blog source of truth lives in site/; sync-blog.mjs mirrors it into
+    # this site at build time. Without site/blog paths here, a blog-only edit
+    # never retriggers an obsigna.dev rebuild, leaving the mirror stale.
+    paths: [site-obsigna/**, site/src/content/docs/blog/**, site/public/blog/**, sdk/go/**, sdk/ts/**, sdk/py/**, mcp-proxy/**, hook/**]
   pull_request:
     branches: [main]
-    paths: [site-obsigna/**]
+    paths: [site-obsigna/**, site/src/content/docs/blog/**, site/public/blog/**]
 
 permissions:
   contents: read

--- a/.github/workflows/site-obsigna.yml
+++ b/.github/workflows/site-obsigna.yml
@@ -16,6 +16,12 @@ on:
 permissions:
   contents: read
 
+# Serialize deploys per ref so a slower older run can't finish last and
+# overwrite obsigna.dev with stale output.
+concurrency:
+  group: site-obsigna-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: site-obsigna


### PR DESCRIPTION
## Problem

The blog source of truth lives in `site/src/content/docs/blog/`. obsigna.dev has no blog files in the repo — `site-obsigna/scripts/sync-blog.mjs` mirrors them from `site/` **at build time** (the synced files are gitignored).

The obsigna.dev workflow (`site-obsigna.yml`) only triggered on:

```yaml
paths: [site-obsigna/**, sdk/go/**, sdk/ts/**, sdk/py/**, mcp-proxy/**, hook/**]
```

`site/**` was absent. So a **blog-only** edit under `site/` never fired an obsigna.dev rebuild, and the mirror went stale.

This is why the [attribution-over-undo](https://obsigna.dev/blog/attribution-over-undo/) update from #850 never reached obsigna.dev:

- **#849** (new post) also touched `site-obsigna/**` files → build fired → `sync-blog.mjs` ran → post mirrored (as a side effect).
- **#850** (the update) touched only `site/src/content/docs/blog/attribution-over-undo.mdx` → matched no obsigna trigger → no build → no sync → stale.

## Fix

1. Add `site/src/content/docs/blog/**` and `site/public/blog/**` to the `push` and `pull_request` path filters so any change to the blog source of truth retriggers the build (and thus the sync).
2. Add a `workflow_dispatch` trigger so the build/deploy can be run on demand (e.g. to resync the mirror after a missed trigger). The deploy gate now runs for any non-`pull_request` event on `main`, so manual dispatches deploy too.

## Catching obsigna.dev up now

Merging this PR does **not** itself redeploy — the merge commit only touches the workflow file, which isn't a blog path. After merge, run `gh workflow run site-obsigna.yml --ref main` (now possible via the new `workflow_dispatch`) to rebuild from current `main` and push #850's content live.