### PR TITLE
feat(demo): obsigna + sbx side-by-side audit demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,90 @@
+# obsigna + sbx demo
+
+Two non-overlapping audit layers for an AI agent running inside a Docker sbx microVM:
+
+| Layer | Tool | Question answered |
+|-------|------|-------------------|
+| Infrastructure | `sbx policy log` | What did the VM's network policy allow or block? |
+| Agent actions | `obsigna verify` | What did the agent actually do, in what order, with what inputs? |
+
+Neither log alone tells the full story. sbx sees network packets — not tool semantics. obsigna sees signed receipts for every tool call — not network-level verdicts.
+
+## Running the demo
+
+```
+./demo.sh
+```
+
+Prerequisites: `obsigna-daemon`, `obsigna`, `sbx` (authenticated with `sbx login`), `ollama` running locally with `devstral-small-2:latest` pulled.
+
+Override the model:
+```
+./demo.sh openai-compatible/qwen2.5-coder:32b
+```
+
+## What happens
+
+1. `obsigna-daemon` starts on your **host** (outside the VM), holding the Ed25519 signing key. The agent inside sbx cannot reach the key.
+2. An sbx sandbox is created with the workspace bind-mounted. The daemon's Unix socket lives inside the mounted workspace directory, so the plugin inside the VM can connect to it — but the daemon process stays on the host.
+3. `opencode` runs inside sbx with a local ollama model (`host.docker.internal:11434`). The obsigna plugin (`integrations/opencode-plugin`) hooks `tool.execute.before/after` and emits one receipt per native tool call.
+4. The agent writes a Python file, runs it, then attempts an outbound `curl`. sbx blocks the outbound request.
+
+## Reading the output
+
+**`sbx policy log`** — infrastructure view:
+```
+ALLOWED  host.docker.internal:11434   ollama (model inference)
+BLOCKED  worldtimeapi.org:443         default deny — no matching allow rule
+```
+
+**`obsigna receipt list`** — agent action view:
+```
+seq  type                      tool    risk
+1    filesystem.file.modify    write   medium   work/fibonacci.py
+2    system.command.execute    bash    high     python work/fibonacci.py
+3    system.command.execute    bash    high     curl https://worldtimeapi.org/...
+```
+
+**`obsigna verify`** — chain integrity:
+```
+chain verified: 3 receipts, 0 gaps, signatures valid
+```
+
+The curl shows up in **both** logs — sbx blocked it at the network layer, obsigna receipted it at the agent action layer. They see the same event from different vantage points.
+
+## Architecture
+
+```
+your laptop (host)
+├── obsigna-daemon          signing key lives here
+│     ↑ Unix socket
+│     │ (bind-mounted into sbx at the same path)
+│     ↓
+└── sbx microVM
+      ├── opencode (agent)
+      │     └── obsigna plugin  ──→ socket ──→ daemon
+      └── ollama via host.docker.internal:11434
+```
+
+The signing key never enters the VM. Receipts are stored on the host. Even if the agent were compromised, it cannot forge or delete the receipt chain.
+
+## Files
+
+```
+demo/
+├── demo.sh                  orchestrates the full flow
+├── kit/kit.yaml             sbx kit: injects AGENTRECEIPTS_SOCKET
+├── workspace/
+│   ├── .opencode/
+│   │   ├── opencode.json    ollama model config
+│   │   └── plugins/
+│   │       └── agent-receipts.js   bundled obsigna plugin (built by demo.sh)
+│   └── work/                agent writes output here
+└── README.md                this file
+```
+
+## Follow-ups
+
+- The plugin (`integrations/opencode-plugin`, PR #766) is not yet published to npm. `demo.sh` builds it from source.
+- The `kit/kit.yaml` format is sbx experimental. If the kit `env` key is not yet supported, set `AGENTRECEIPTS_SOCKET` manually via `sbx exec`.
+- MCP proxy (Tier A) can be layered on top for adversary-resistant receipts — see `mcp-proxy/` and the opencode Tier A docs in PR #766.

--- a/demo/README.md
+++ b/demo/README.md
@@ -15,7 +15,10 @@ Neither log alone tells the full story. sbx sees network packets — not tool se
 ./demo.sh
 ```
 
-Prerequisites: `obsigna-daemon`, `obsigna`, `sbx` (authenticated with `sbx login`), `ollama` running locally with `devstral-small-2:latest` pulled.
+Prerequisites:
+- `obsigna-daemon`, `obsigna`, `sbx` (authenticated: `sbx login`), `socat`, `ollama`
+- `devstral-small-2:latest` pulled in ollama
+- The demo creates `devstral-demo` (a 32K-context variant) automatically on first run
 
 Override the model:
 ```
@@ -24,67 +27,74 @@ Override the model:
 
 ## What happens
 
-1. `obsigna-daemon` starts on your **host** (outside the VM), holding the Ed25519 signing key. The agent inside sbx cannot reach the key.
-2. An sbx sandbox is created with the workspace bind-mounted. The daemon's Unix socket lives inside the mounted workspace directory, so the plugin inside the VM can connect to it — but the daemon process stays on the host.
-3. `opencode` runs inside sbx with a local ollama model (`host.docker.internal:11434`). The obsigna plugin (`integrations/opencode-plugin`) hooks `tool.execute.before/after` and emits one receipt per native tool call.
-4. The agent writes a Python file, runs it, then attempts an outbound `curl`. sbx blocks the outbound request.
+1. `obsigna-daemon` starts on your **host** (outside the VM), holding the Ed25519 signing key.
+2. A `socat` TCP bridge forwards from `host.docker.internal:3923` to the daemon's Unix socket, because macOS host sockets can't be connected to from inside a Linux container via bind-mount.
+3. An sbx sandbox is created with the workspace bind-mounted.
+4. `opencode` runs inside sbx. Inside the container, a second `socat` creates a Linux Unix socket that tunnels to the host via TCP. The obsigna plugin connects to that socket and emits one signed receipt per tool call.
+5. The agent writes a Python file, runs it, then attempts an outbound `curl`. sbx blocks the curl.
 
 ## Reading the output
 
 **`sbx policy log`** — infrastructure view:
 ```
-ALLOWED  host.docker.internal:11434   ollama (model inference)
-BLOCKED  worldtimeapi.org:443         default deny — no matching allow rule
+ALLOWED  localhost:11434   ollama (model inference)
+ALLOWED  localhost:3923    obsigna receipt tunnel
+BLOCKED  worldtimeapi.org:443   default deny
 ```
 
 **`obsigna receipt list`** — agent action view:
 ```
-seq  type                      tool    risk
-1    filesystem.file.modify    write   medium   work/fibonacci.py
-2    system.command.execute    bash    high     python work/fibonacci.py
-3    system.command.execute    bash    high     curl https://worldtimeapi.org/...
+SEQ  TIMESTAMP             CHAIN       TOOL / ACTION TYPE
+1    2026-06-16T...        2026-06-16  write   ← fibonacci.py created
+2    2026-06-16T...        2026-06-16  bash    ← python3 work/fibonacci.py
+3    2026-06-16T...        2026-06-16  bash    ← curl (blocked at network layer)
 ```
 
 **`obsigna verify`** — chain integrity:
 ```
-chain verified: 3 receipts, 0 gaps, signatures valid
+Chain 2026-06-16: VALID (3 receipts)
 ```
 
-The curl shows up in **both** logs — sbx blocked it at the network layer, obsigna receipted it at the agent action layer. They see the same event from different vantage points.
+The curl shows up in **both** logs — sbx blocked it at the network layer, obsigna receipted it at the agent action layer.
 
 ## Architecture
 
 ```
 your laptop (host)
-├── obsigna-daemon          signing key lives here
-│     ↑ Unix socket
-│     │ (bind-mounted into sbx at the same path)
-│     ↓
+├── obsigna-daemon          signing key lives here (Ed25519)
+│     ↑ Unix socket (/tmp/obsigna-sbx/obsigna.sock)
+│     │
+│     socat (host)          TCP bridge: port 3923 → Unix socket
+│     ↑ TCP :3923
+│     │
 └── sbx microVM
+      ├── socat (container) TCP → Linux Unix socket (/tmp/obsigna.sock)
+      │     ↑
       ├── opencode (agent)
-      │     └── obsigna plugin  ──→ socket ──→ daemon
+      │     └── obsigna plugin ──→ /tmp/obsigna.sock ──→ tunnel ──→ daemon
       └── ollama via host.docker.internal:11434
 ```
 
-The signing key never enters the VM. Receipts are stored on the host. Even if the agent were compromised, it cannot forge or delete the receipt chain.
+The signing key never enters the VM. Receipts are written to the host's SQLite DB. Even if the agent were compromised, it cannot forge or delete the receipt chain.
 
 ## Files
 
 ```
 demo/
 ├── demo.sh                  orchestrates the full flow
-├── kit/kit.yaml             sbx kit: injects AGENTRECEIPTS_SOCKET
+├── undici-stub.mjs          esbuild stub replacing undici (not available in opencode runtime)
+├── kit/spec.yaml            sbx kit spec (mixin)
 ├── workspace/
 │   ├── .opencode/
-│   │   ├── opencode.json    ollama model config
+│   │   ├── opencode.json    provider + model config (ollama via openai-compatible)
 │   │   └── plugins/
-│   │       └── agent-receipts.js   bundled obsigna plugin (built by demo.sh)
+│   │       └── agent-receipts.js   bundled obsigna plugin (built by demo.sh on first run)
 │   └── work/                agent writes output here
 └── README.md                this file
 ```
 
 ## Follow-ups
 
-- The plugin (`integrations/opencode-plugin`, PR #766) is not yet published to npm. `demo.sh` builds it from source.
-- The `kit/kit.yaml` format is sbx experimental. If the kit `env` key is not yet supported, set `AGENTRECEIPTS_SOCKET` manually via `sbx exec`.
-- MCP proxy (Tier A) can be layered on top for adversary-resistant receipts — see `mcp-proxy/` and the opencode Tier A docs in PR #766.
+- The plugin (`integrations/opencode-plugin`, PR #766) is not yet published to npm. `demo.sh` builds it from source on first run.
+- This demo also serves as the end-to-end acceptance test for PR #766.
+- MCP proxy (Tier A) can be layered on top for adversary-resistant receipts — see `mcp-proxy/`.

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# demo.sh — obsigna + sbx side-by-side audit demo
+#
+# Shows two non-overlapping audit layers:
+#   sbx policy log  → what the infrastructure allowed / blocked
+#   obsigna verify  → what the agent actually did (signed receipts, outside the VM)
+#
+# Prerequisites: obsigna-daemon, obsigna, sbx (authenticated), ollama running locally
+# Usage: ./demo.sh [MODEL]
+#   MODEL defaults to openai-compatible/devstral-small-2:latest
+
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE="$DEMO_DIR/workspace"
+SOCKET_PATH="$WORKSPACE/obsigna.sock"
+DB_PATH="$WORKSPACE/receipts.db"
+KEY_PATH="$WORKSPACE/signing.key"
+SANDBOX_NAME="obsigna-sbx-demo"
+MODEL="${1:-openai-compatible/devstral-small-2:latest}"
+
+BOLD=$'\033[1m'
+GREEN=$'\033[0;32m'
+BLUE=$'\033[0;34m'
+YELLOW=$'\033[1;33m'
+RED=$'\033[0;31m'
+NC=$'\033[0m'
+
+DAEMON_PID=""
+
+cleanup() {
+  [ -n "$DAEMON_PID" ] && kill "$DAEMON_PID" 2>/dev/null || true
+  sbx rm -f "$SANDBOX_NAME" 2>/dev/null || true
+  rm -f "$SOCKET_PATH"
+}
+trap cleanup EXIT
+
+# ── preflight ──────────────────────────────────────────────────────────────────
+
+echo "${BOLD}obsigna + sbx demo${NC}"
+echo
+
+missing=0
+for cmd in obsigna-daemon obsigna sbx; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "${RED}missing: $cmd${NC}"; missing=1; }
+done
+if ! sbx ls >/dev/null 2>&1; then
+  echo "${RED}sbx not authenticated — run: sbx login${NC}"; missing=1
+fi
+if ! curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
+  echo "${RED}ollama not reachable at localhost:11434${NC}"; missing=1
+fi
+[ "$missing" -eq 0 ] || { echo "Fix the above and re-run."; exit 1; }
+
+# ── plugin bundle ──────────────────────────────────────────────────────────────
+
+PLUGIN_PATH="$WORKSPACE/.opencode/plugins/agent-receipts.js"
+if [ ! -f "$PLUGIN_PATH" ]; then
+  echo "${BLUE}==> Building opencode plugin from PR #766...${NC}"
+  BUILD_DIR="$(mktemp -d)"
+  trap 'rm -rf "$BUILD_DIR"; cleanup' EXIT
+
+  REPO_ROOT="$(cd "$DEMO_DIR/.." && pwd)"
+  git -C "$REPO_ROOT" archive pr-766 -- integrations/opencode-plugin/src integrations/opencode-plugin/package.json | tar -x -C "$BUILD_DIR"
+  mkdir -p "$BUILD_DIR/sdk/ts"
+  # Use the in-tree sdk/ts (already built)
+  cp -r "$REPO_ROOT/sdk/ts/dist" "$BUILD_DIR/sdk/ts/dist"
+  cp "$REPO_ROOT/sdk/ts/package.json" "$BUILD_DIR/sdk/ts/package.json"
+
+  node -e "
+    const fs = require('fs');
+    const p = '$BUILD_DIR/integrations/opencode-plugin/package.json';
+    const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+    pkg.dependencies['@agnt-rcpt/sdk-ts'] = 'file:../../sdk/ts';
+    fs.writeFileSync(p, JSON.stringify(pkg, null, 2));
+  "
+
+  cd "$BUILD_DIR/integrations/opencode-plugin"
+  pnpm install --no-frozen-lockfile --silent
+
+  mkdir -p "$(dirname "$PLUGIN_PATH")"
+  npx esbuild src/plugin.ts \
+    --bundle \
+    --format=esm \
+    --platform=node \
+    --external:@opencode-ai/plugin \
+    --outfile="$PLUGIN_PATH" \
+    --log-level=warning
+
+  cd "$DEMO_DIR"
+  echo "   plugin → $PLUGIN_PATH ($(wc -c < "$PLUGIN_PATH" | tr -d ' ') bytes)"
+else
+  echo "${BLUE}==> Plugin bundle already built, skipping.${NC}"
+fi
+
+# ── signing key ────────────────────────────────────────────────────────────────
+
+if [ ! -f "$KEY_PATH" ]; then
+  echo "${BLUE}==> Generating signing key...${NC}"
+  obsigna keys generate --key "$KEY_PATH"
+fi
+
+# ── daemon (host side, outside the VM) ────────────────────────────────────────
+
+rm -f "$SOCKET_PATH" "$DB_PATH"
+echo "${BLUE}==> Starting obsigna-daemon on host (outside the VM)...${NC}"
+obsigna-daemon \
+  --socket "$SOCKET_PATH" \
+  --db "$DB_PATH" \
+  --key "$KEY_PATH" \
+  --issuer-id "did:user:${USER}@local" \
+  --unsafe-socket-path \
+  2>/dev/null &
+DAEMON_PID=$!
+
+# Wait for socket to become ready
+for _ in $(seq 1 40); do
+  [ -S "$SOCKET_PATH" ] && break
+  sleep 0.25
+done
+[ -S "$SOCKET_PATH" ] || { echo "${RED}daemon failed to create socket${NC}"; exit 1; }
+echo "   daemon PID=$DAEMON_PID  socket=$(basename "$SOCKET_PATH")"
+
+# ── sbx network policy ─────────────────────────────────────────────────────────
+
+echo "${BLUE}==> Configuring sbx network policy (allow ollama on host)...${NC}"
+sbx policy allow network host.docker.internal:11434 2>/dev/null || true
+
+# ── sandbox ────────────────────────────────────────────────────────────────────
+
+sbx rm -f "$SANDBOX_NAME" 2>/dev/null || true
+echo "${BLUE}==> Creating sbx sandbox...${NC}"
+sbx create opencode "$WORKSPACE" \
+  --name "$SANDBOX_NAME" \
+  --quiet
+
+# ── agent task ─────────────────────────────────────────────────────────────────
+
+TASK="Complete these steps in order without asking questions:
+1. Write a Python script to work/fibonacci.py that prints the first 10 Fibonacci numbers.
+2. Run it with bash and show the output.
+3. Run this exact command and show the output: curl -s --max-time 3 https://worldtimeapi.org/api/timezone/UTC || echo '[blocked by network policy]'"
+
+echo "${BLUE}==> Running opencode agent inside sbx (model: $MODEL)...${NC}"
+echo "${YELLOW}    Task: write fibonacci.py → run it → attempt outbound network call${NC}"
+echo
+
+sbx exec "$SANDBOX_NAME" -- \
+  sh -c "AGENTRECEIPTS_SOCKET='$SOCKET_PATH' opencode run --model '$MODEL' '$TASK'"
+
+# ── output ─────────────────────────────────────────────────────────────────────
+
+echo
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+echo "${YELLOW}${BOLD}  sbx policy log — what the infrastructure allowed / blocked${NC}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+sbx policy log "$SANDBOX_NAME"
+
+echo
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+echo "${GREEN}${BOLD}  obsigna receipt list — what the agent actually did${NC}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+obsigna receipt list --db "$DB_PATH"
+
+echo
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+echo "${GREEN}${BOLD}  obsigna verify — chain integrity${NC}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
+obsigna verify --db "$DB_PATH"
+
+echo
+echo "${GREEN}${BOLD}Done.${NC} Receipts stored at: $DB_PATH"
+echo "To inspect a receipt: obsigna receipt show --db $DB_PATH --seq 1"

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -5,19 +5,32 @@
 #   sbx policy log  → what the infrastructure allowed / blocked
 #   obsigna verify  → what the agent actually did (signed receipts, outside the VM)
 #
-# Prerequisites: obsigna-daemon, obsigna, sbx (authenticated), ollama running locally
+# Architecture:
+#   obsigna-daemon runs on the HOST (signing key never enters the VM).
+#   On macOS, host Unix sockets can't be connected to from inside a Linux
+#   container, so we use a socat TCP tunnel:
+#
+#     plugin (container) → /tmp/obsigna.sock (Linux)
+#       → socat (container) → host.docker.internal:3923 (TCP)
+#         → socat (host) → /tmp/obsigna-sbx/obsigna.sock (macOS)
+#           → obsigna-daemon (host)
+#
+# Prerequisites: obsigna-daemon, obsigna, sbx (authenticated), socat, ollama
 # Usage: ./demo.sh [MODEL]
-#   MODEL defaults to openai-compatible/devstral-small-2:latest
+#   MODEL defaults to openai-compatible/devstral-demo:latest
+#   (devstral-demo is a devstral-small-2 variant with 32K context window)
 
 set -euo pipefail
 
 DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE="$DEMO_DIR/workspace"
+WORKSPACE=/tmp/obsigna-sbx
 SOCKET_PATH="$WORKSPACE/obsigna.sock"
+TCP_PORT=3923
+CONTAINER_SOCKET=/tmp/obsigna.sock
 DB_PATH="$WORKSPACE/receipts.db"
 KEY_PATH="$WORKSPACE/signing.key"
 SANDBOX_NAME="obsigna-sbx-demo"
-MODEL="${1:-openai-compatible/devstral-small-2:latest}"
+MODEL="${1:-openai-compatible/devstral-demo:latest}"
 
 BOLD=$'\033[1m'
 GREEN=$'\033[0;32m'
@@ -27,8 +40,10 @@ RED=$'\033[0;31m'
 NC=$'\033[0m'
 
 DAEMON_PID=""
+SOCAT_PID=""
 
 cleanup() {
+  [ -n "$SOCAT_PID" ] && kill "$SOCAT_PID" 2>/dev/null || true
   [ -n "$DAEMON_PID" ] && kill "$DAEMON_PID" 2>/dev/null || true
   sbx rm -f "$SANDBOX_NAME" 2>/dev/null || true
   rm -f "$SOCKET_PATH"
@@ -41,7 +56,7 @@ echo "${BOLD}obsigna + sbx demo${NC}"
 echo
 
 missing=0
-for cmd in obsigna-daemon obsigna sbx; do
+for cmd in obsigna-daemon obsigna sbx socat; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "${RED}missing: $cmd${NC}"; missing=1; }
 done
 if ! sbx ls >/dev/null 2>&1; then
@@ -50,20 +65,40 @@ fi
 if ! curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
   echo "${RED}ollama not reachable at localhost:11434${NC}"; missing=1
 fi
+# Check that devstral-demo exists in ollama (one-time setup: ollama create devstral-demo)
+if ! curl -sf http://localhost:11434/api/show -d '{"name":"devstral-demo:latest"}' >/dev/null 2>&1; then
+  echo "${YELLOW}devstral-demo not found in ollama — creating it (32K context window)...${NC}"
+  cat > /tmp/devstral-demo.modelfile << 'EOF'
+FROM devstral-small-2:latest
+PARAMETER num_ctx 32768
+EOF
+  ollama create devstral-demo -f /tmp/devstral-demo.modelfile || { echo "${RED}failed to create devstral-demo${NC}"; missing=1; }
+fi
 [ "$missing" -eq 0 ] || { echo "Fix the above and re-run."; exit 1; }
+
+# ── workspace setup ────────────────────────────────────────────────────────────
+
+mkdir -p "$WORKSPACE/.opencode/plugins" "$WORKSPACE/work"
+cp "$DEMO_DIR/workspace/.opencode/opencode.json" "$WORKSPACE/.opencode/opencode.json"
 
 # ── plugin bundle ──────────────────────────────────────────────────────────────
 
+SRC_PLUGIN="$DEMO_DIR/workspace/.opencode/plugins/agent-receipts.js"
 PLUGIN_PATH="$WORKSPACE/.opencode/plugins/agent-receipts.js"
-if [ ! -f "$PLUGIN_PATH" ]; then
+
+if [ ! -f "$SRC_PLUGIN" ]; then
   echo "${BLUE}==> Building opencode plugin from PR #766...${NC}"
   BUILD_DIR="$(mktemp -d)"
   trap 'rm -rf "$BUILD_DIR"; cleanup' EXIT
 
   REPO_ROOT="$(cd "$DEMO_DIR/.." && pwd)"
   git -C "$REPO_ROOT" archive pr-766 -- integrations/opencode-plugin/src integrations/opencode-plugin/package.json | tar -x -C "$BUILD_DIR"
+  # Build the TS SDK if dist/ is missing (e.g. in a fresh worktree)
+  if [ ! -d "$REPO_ROOT/sdk/ts/dist" ]; then
+    echo "   building sdk/ts..."
+    (cd "$REPO_ROOT/sdk/ts" && pnpm install --frozen-lockfile --silent && pnpm build)
+  fi
   mkdir -p "$BUILD_DIR/sdk/ts"
-  # Use the in-tree sdk/ts (already built)
   cp -r "$REPO_ROOT/sdk/ts/dist" "$BUILD_DIR/sdk/ts/dist"
   cp "$REPO_ROOT/sdk/ts/package.json" "$BUILD_DIR/sdk/ts/package.json"
 
@@ -78,20 +113,31 @@ if [ ! -f "$PLUGIN_PATH" ]; then
   cd "$BUILD_DIR/integrations/opencode-plugin"
   pnpm install --no-frozen-lockfile --silent
 
-  mkdir -p "$(dirname "$PLUGIN_PATH")"
+  # The SDK's index.js re-exports store/store.js which has a static
+  # `import { DatabaseSync } from "node:sqlite"`. Strip those exports so
+  # esbuild doesn't bundle the store (the plugin only uses DaemonEmitter).
+  SDK_INDEX="$BUILD_DIR/integrations/opencode-plugin/node_modules/@agnt-rcpt/sdk-ts/dist/index.js"
+  cp -r "$REPO_ROOT/sdk/ts/dist" "$BUILD_DIR/integrations/opencode-plugin/node_modules/@agnt-rcpt/sdk-ts/dist"
+  sed -i.bak \
+    -e 's|export { openStore, openStoreReadOnly, ReceiptStore, } from "./store/store.js";||' \
+    -e 's|export { verifyStoredChain } from "./store/verify.js";||' \
+    "$SDK_INDEX"
+
+  # undici (an SDK dep) uses webidl internals that fail in the opencode runtime;
+  # replace it with a stub since HttpEmitter is never used by this plugin.
   npx esbuild src/plugin.ts \
     --bundle \
     --format=esm \
     --platform=node \
     --external:@opencode-ai/plugin \
-    --outfile="$PLUGIN_PATH" \
+    --external:node:sqlite \
+    --alias:undici="$DEMO_DIR/undici-stub.mjs" \
+    --outfile="$SRC_PLUGIN" \
     --log-level=warning
-
   cd "$DEMO_DIR"
-  echo "   plugin → $PLUGIN_PATH ($(wc -c < "$PLUGIN_PATH" | tr -d ' ') bytes)"
-else
-  echo "${BLUE}==> Plugin bundle already built, skipping.${NC}"
+  echo "   built → $SRC_PLUGIN"
 fi
+cp "$SRC_PLUGIN" "$PLUGIN_PATH"
 
 # ── signing key ────────────────────────────────────────────────────────────────
 
@@ -102,6 +148,7 @@ fi
 
 # ── daemon (host side, outside the VM) ────────────────────────────────────────
 
+CHAIN_ID="$(date -u +%Y-%m-%d)"
 rm -f "$SOCKET_PATH" "$DB_PATH"
 echo "${BLUE}==> Starting obsigna-daemon on host (outside the VM)...${NC}"
 obsigna-daemon \
@@ -109,11 +156,11 @@ obsigna-daemon \
   --db "$DB_PATH" \
   --key "$KEY_PATH" \
   --issuer-id "did:user:${USER}@local" \
+  --chain-id "$CHAIN_ID" \
   --unsafe-socket-path \
   2>/dev/null &
 DAEMON_PID=$!
 
-# Wait for socket to become ready
 for _ in $(seq 1 40); do
   [ -S "$SOCKET_PATH" ] && break
   sleep 0.25
@@ -121,10 +168,22 @@ done
 [ -S "$SOCKET_PATH" ] || { echo "${RED}daemon failed to create socket${NC}"; exit 1; }
 echo "   daemon PID=$DAEMON_PID  socket=$(basename "$SOCKET_PATH")"
 
+# ── socat TCP bridge (host side) ───────────────────────────────────────────────
+# On macOS, host Unix sockets can't be connected to from inside a Linux
+# container via bind-mount. Bridge: TCP port → Unix socket.
+
+echo "${BLUE}==> Starting socat TCP bridge (host.docker.internal:$TCP_PORT → daemon)...${NC}"
+socat TCP4-LISTEN:"$TCP_PORT",fork,reuseaddr UNIX-CONNECT:"$SOCKET_PATH" &
+SOCAT_PID=$!
+sleep 0.3
+echo "   socat PID=$SOCAT_PID  port=$TCP_PORT"
+
 # ── sbx network policy ─────────────────────────────────────────────────────────
 
-echo "${BLUE}==> Configuring sbx network policy (allow ollama on host)...${NC}"
-sbx policy allow network host.docker.internal:11434 2>/dev/null || true
+echo "${BLUE}==> Configuring sbx network policy...${NC}"
+# host.docker.internal resolves to fe80::1 inside sbx, which sbx classifies as localhost
+sbx policy allow network localhost:11434 2>/dev/null || true   # ollama
+sbx policy allow network localhost:"$TCP_PORT" 2>/dev/null || true  # obsigna tunnel
 
 # ── sandbox ────────────────────────────────────────────────────────────────────
 
@@ -137,16 +196,21 @@ sbx create opencode "$WORKSPACE" \
 # ── agent task ─────────────────────────────────────────────────────────────────
 
 TASK="Complete these steps in order without asking questions:
-1. Write a Python script to work/fibonacci.py that prints the first 10 Fibonacci numbers.
-2. Run it with bash and show the output.
+1. Write a Python script to work/fibonacci.py that prints the first 10 Fibonacci numbers (no user input, hardcoded to 10).
+2. Run it with python3 and show the output.
 3. Run this exact command and show the output: curl -s --max-time 3 https://worldtimeapi.org/api/timezone/UTC || echo '[blocked by network policy]'"
 
 echo "${BLUE}==> Running opencode agent inside sbx (model: $MODEL)...${NC}"
 echo "${YELLOW}    Task: write fibonacci.py → run it → attempt outbound network call${NC}"
 echo
 
+# The container-side socat bridges the plugin's Unix socket to the host via TCP.
+# Container: /tmp/obsigna.sock → host.docker.internal:TCP_PORT → daemon socket
+CONTAINER_SOCAT_CMD="rm -f $CONTAINER_SOCKET; socat UNIX-LISTEN:$CONTAINER_SOCKET,fork,reuseaddr TCP4:host.docker.internal:$TCP_PORT &"
+WAIT_FOR_SOCK="for i in \$(seq 1 20); do [ -S $CONTAINER_SOCKET ] && break; sleep 0.25; done"
+
 sbx exec "$SANDBOX_NAME" -- \
-  sh -c "AGENTRECEIPTS_SOCKET='$SOCKET_PATH' opencode run --model '$MODEL' '$TASK'"
+  sh -c "$CONTAINER_SOCAT_CMD $WAIT_FOR_SOCK && AGENTRECEIPTS_SOCKET='$CONTAINER_SOCKET' OPENCODE_CONFIG_DIR='$WORKSPACE/.opencode' opencode run --model '$MODEL' '$TASK'"
 
 # ── output ─────────────────────────────────────────────────────────────────────
 
@@ -166,8 +230,8 @@ echo
 echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
 echo "${GREEN}${BOLD}  obsigna verify — chain integrity${NC}"
 echo "${BOLD}══════════════════════════════════════════════════════════════${NC}"
-obsigna verify --db "$DB_PATH"
+obsigna verify --db "$DB_PATH" --public-key "${KEY_PATH}.pub" --chain-id "$CHAIN_ID"
 
 echo
 echo "${GREEN}${BOLD}Done.${NC} Receipts stored at: $DB_PATH"
-echo "To inspect a receipt: obsigna receipt show --db $DB_PATH --seq 1"
+echo "To inspect: obsigna receipt show 1 --db $DB_PATH --chain-id $CHAIN_ID"

--- a/demo/kit/spec.yaml
+++ b/demo/kit/spec.yaml
@@ -1,0 +1,10 @@
+schemaVersion: 2
+name: obsigna-demo
+description: |
+  Mixin that provisions the network allowance for the obsigna + sbx demo.
+  Allows the opencode agent to reach ollama on the host at port 11434.
+  AGENTRECEIPTS_SOCKET is injected at runtime via the sbx exec call in demo.sh
+  rather than here, because the socket path is machine-specific.
+kind: mixin
+network:
+  {}

--- a/demo/undici-stub.mjs
+++ b/demo/undici-stub.mjs
@@ -1,0 +1,17 @@
+// Stub replacing undici for the opencode plugin bundle.
+// The plugin uses DaemonEmitter (Unix socket via node:net) — never HttpEmitter.
+// Stubbing undici prevents its webidl internals from failing at load time.
+export class Client {}
+export class Pool {}
+export class Agent {}
+export class Dispatcher {}
+export class BalancedPool {}
+export class ProxyAgent {}
+export class EnvHttpProxyAgent {}
+export class RetryAgent {}
+export class RetryHandler {}
+export class MockPool {}
+export class MockAgent {}
+export const fetch = undefined;
+export const getGlobalDispatcher = () => null;
+export const setGlobalDispatcher = () => {};

--- a/demo/workspace/.opencode/opencode.json
+++ b/demo/workspace/.opencode/opencode.json
@@ -5,8 +5,26 @@
       "options": {
         "baseURL": "http://host.docker.internal:11434/v1",
         "apiKey": "ollama"
+      },
+      "models": {
+        "devstral-small-2:latest": {
+          "name": "Devstral Small 2",
+          "tool_call": true
+        },
+        "qwen2.5-coder:32b": {
+          "name": "Qwen 2.5 Coder 32B",
+          "tool_call": true
+        },
+        "qwen3:30b": {
+          "name": "Qwen3 30B",
+          "tool_call": true
+        },
+        "devstral-demo:latest": {
+          "name": "Devstral Demo (32K ctx)",
+          "tool_call": true
+        }
       }
     }
   },
-  "model": "openai-compatible/devstral-small-2:latest"
+  "model": "openai-compatible/devstral-demo:latest"
 }

--- a/demo/workspace/.opencode/opencode.json
+++ b/demo/workspace/.opencode/opencode.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai-compatible": {
+      "options": {
+        "baseURL": "http://host.docker.internal:11434/v1",
+        "apiKey": "ollama"
+      }
+    }
+  },
+  "model": "openai-compatible/devstral-small-2:latest"
+}


### PR DESCRIPTION
## Summary

- Adds \`demo/\` — a self-contained \`./demo.sh\` that runs an opencode agent inside a Docker sbx microVM and shows two non-overlapping audit layers side by side: \`sbx policy log\` (infrastructure) and \`obsigna verify\` (signed receipt chain)
- Adds \`demo/undici-stub.mjs\` — esbuild stub replacing undici at bundle time (its webidl internals fail in the opencode runtime; HttpEmitter is unused here)
- Also serves as the end-to-end acceptance test for PR #766 (opencode plugin)

## What the demo does

1. Starts \`obsigna-daemon\` on the **host** (signing key never enters the VM)
2. Bridges the daemon's Unix socket to TCP via \`socat\` (macOS host sockets can't be connected from inside Linux containers via bind-mount)
3. Creates an sbx sandbox; inside the container a second \`socat\` creates a Linux Unix socket tunnelled back to the host daemon
4. Runs \`opencode\` inside sbx with a local ollama model. The obsigna plugin (PR #766) emits one signed receipt per tool call
5. Agent writes \`fibonacci.py\`, runs it, attempts an outbound \`curl\` that sbx blocks
6. Prints \`sbx policy log\` + \`obsigna receipt list\` + \`obsigna verify\` side by side

## Notable build fixes for the plugin bundle

- **node:sqlite**: strip store exports from SDK index before bundling — only \`DaemonEmitter\` is needed, not the SQLite-backed store
- **undici**: stubbed out at esbuild time — its webidl internals fail in the opencode runtime
- **num_ctx**: \`devstral-small-2\` hits ollama's 4096-token default with opencode's system prompt; demo auto-creates a \`devstral-demo\` modelfile with \`num_ctx=32768\`
- **socat tunnel**: macOS host Unix sockets return ECONNREFUSED from inside a Linux container — two-hop socat tunnel keeps the daemon on the host