### PR TITLE
chore(release): sdk-ts 0.14.0

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,8 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-16
+
 ### Added
 
 - **`EmitEvent.actionType`** — new optional field on the `DaemonEmitter` frame, forwarded to the daemon as `action_type`. When set, the daemon uses it verbatim as `action.type` and resolves `risk_level` from the taxonomy, rather than falling back to the synthetic `"<channel>.<tool>"` type (which defaults risk to medium). Lets emitters that already know the taxonomic action type — such as the OpenCode plugin — make risk-based controls effective. The daemon already accepted this frame field; this exposes it through the TS emitter. Additive and backwards-compatible: omitting it preserves the previous behaviour.

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Cuts `@obsigna/sdk-ts` 0.14.0, graduating the `EmitEvent.actionType` field from `[Unreleased]`.

## Why now
The OpenCode plugin release (next PR) sets `ev.actionType` and needs a published sdk-ts that exposes it. Published `0.13.0` does not, so this ships first.

## Changes
- `sdk/ts/package.json`: `0.13.0` → `0.14.0`
- `sdk/ts/CHANGELOG.md`: move the `EmitEvent.actionType` entry into `[0.14.0] - 2026-06-16`

Additive, backwards-compatible minor bump — no source changes, omitting `actionType` preserves prior behaviour.

## Release
After merge: tag `sdk-ts-v0.14.0` and push → `release-sdk-ts.yml` publishes to npm `latest` and runs its 7 post-publish gates.

## Verification
`pnpm typecheck && lint && build && test` all green locally (440 tests pass).