### PR TITLE
chore(release): opencode-plugin 0.1.0-alpha.1 (@obsigna scope)

### DIFF
--- a/.github/workflows/opencode-plugin.yml
+++ b/.github/workflows/opencode-plugin.yml
@@ -5,12 +5,10 @@ on:
     branches: [main]
     paths:
       - "integrations/opencode-plugin/**"
-      - "sdk/ts/**"
   pull_request:
     branches: [main]
     paths:
       - "integrations/opencode-plugin/**"
-      - "sdk/ts/**"
 
 permissions:
   contents: read
@@ -28,17 +26,7 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
-          cache-dependency-path: |
-            sdk/ts/pnpm-lock.yaml
-            integrations/opencode-plugin/pnpm-lock.yaml
-
-      # The plugin depends on `@obsigna/sdk-ts` via a `file:../../sdk/ts`
-      # install, so the in-tree SDK's dist/ must be built before the plugin can
-      # typecheck, build, or test against it. This also makes the job fail when
-      # a same-PR sdk/ts change breaks the plugin (hence sdk/ts/** in paths).
-      - name: Build in-tree TypeScript SDK
-        working-directory: sdk/ts
-        run: pnpm install --frozen-lockfile && pnpm run build
+          cache-dependency-path: integrations/opencode-plugin/pnpm-lock.yaml
 
       - name: Install plugin deps
         working-directory: integrations/opencode-plugin

--- a/.github/workflows/release-opencode-plugin.yml
+++ b/.github/workflows/release-opencode-plugin.yml
@@ -26,9 +26,7 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
-          cache-dependency-path: |
-            sdk/ts/pnpm-lock.yaml
-            integrations/opencode-plugin/pnpm-lock.yaml
+          cache-dependency-path: integrations/opencode-plugin/pnpm-lock.yaml
           registry-url: "https://registry.npmjs.org"
 
       - name: Prepare version
@@ -44,13 +42,6 @@ jobs:
             echo "::error::Release tag opencode-plugin-v${PLUGIN_VERSION} does not match package.json version ${PKG_VERSION}"
             exit 1
           fi
-
-      # The plugin's package.json declares a versioned @obsigna/sdk-ts range, but
-      # a pnpm.overrides entry pins it to file:../../sdk/ts for in-tree builds, so
-      # the SDK's dist/ must exist before the plugin can install/typecheck/test.
-      - name: Build in-tree TypeScript SDK
-        working-directory: sdk/ts
-        run: pnpm install --frozen-lockfile && pnpm run build
 
       - name: Install plugin deps
         working-directory: integrations/opencode-plugin

--- a/.github/workflows/release-opencode-plugin.yml
+++ b/.github/workflows/release-opencode-plugin.yml
@@ -1,0 +1,113 @@
+name: "Release: opencode-plugin"
+
+on:
+  push:
+    tags:
+      - "opencode-plugin-v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Deployment environment lets you attach protection rules (required
+    # reviewers, wait timer, branch restrictions) to gate who can trigger
+    # a release. Configure at:
+    # https://github.com/agent-receipts/obsigna/settings/environments
+    environment: release-opencode-plugin
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: |
+            sdk/ts/pnpm-lock.yaml
+            integrations/opencode-plugin/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Prepare version
+        run: |
+          VERSION="${GITHUB_REF_NAME#opencode-plugin-v}"
+          echo "PLUGIN_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Verify release tag matches package.json version
+        working-directory: integrations/opencode-plugin
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "::error::Release tag opencode-plugin-v${PLUGIN_VERSION} does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
+      # The plugin's package.json declares a versioned @obsigna/sdk-ts range, but
+      # a pnpm.overrides entry pins it to file:../../sdk/ts for in-tree builds, so
+      # the SDK's dist/ must exist before the plugin can install/typecheck/test.
+      - name: Build in-tree TypeScript SDK
+        working-directory: sdk/ts
+        run: pnpm install --frozen-lockfile && pnpm run build
+
+      - name: Install plugin deps
+        working-directory: integrations/opencode-plugin
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: integrations/opencode-plugin
+        run: pnpm run typecheck
+
+      - name: Lint
+        working-directory: integrations/opencode-plugin
+        run: pnpm run lint
+
+      - name: Build
+        working-directory: integrations/opencode-plugin
+        run: pnpm run build
+
+      - name: Test
+        working-directory: integrations/opencode-plugin
+        run: pnpm run test
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mark pre-release tags (e.g. v0.1.0-alpha.1) so they don't show up as
+          # "latest" on the GitHub Releases page. Skip creation if the release
+          # already exists so reruns after a failed publish step don't abort
+          # before reaching npm.
+          PRERELEASE_ARG=()
+          if [[ "${PLUGIN_VERSION}" == *-* ]]; then
+            PRERELEASE_ARG+=(--prerelease)
+          fi
+          if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "opencode-plugin ${PLUGIN_VERSION}" \
+              --generate-notes \
+              "${PRERELEASE_ARG[@]}"
+          fi
+
+      - name: Determine npm dist-tag
+        id: dist_tag
+        shell: bash
+        run: |
+          CORE="${PLUGIN_VERSION%%+*}"
+          if [[ "$CORE" == *-* ]]; then
+            PRE="${CORE#*-}"
+            if [[ "$PRE" =~ ^([A-Za-z]+) ]]; then
+              TAG_NAME="${BASH_REMATCH[1],,}"
+            else
+              TAG_NAME="prerelease"
+            fi
+            echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        working-directory: integrations/opencode-plugin
+        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}

--- a/integrations/opencode-plugin/AGENTS.md
+++ b/integrations/opencode-plugin/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-OpenCode plugin (`@agent-receipts/opencode-plugin`) that emits one Agent Receipt per native OpenCode tool call. Hooks `tool.execute.before`/`tool.execute.after` from `@opencode-ai/plugin` and forwards each call to `agent-receipts-daemon` via the TS SDK `DaemonEmitter`. The OpenCode analog of the Go [`hook/`](../../hook/) Claude Code integration, for the native-tool channel.
+OpenCode plugin (`@obsigna/opencode-plugin`) that emits one Agent Receipt per native OpenCode tool call. Hooks `tool.execute.before`/`tool.execute.after` from `@opencode-ai/plugin` and forwards each call to `agent-receipts-daemon` via the TS SDK `DaemonEmitter`. The OpenCode analog of the Go [`hook/`](../../hook/) Claude Code integration, for the native-tool channel.
 
 ## Trust boundary (load-bearing)
 
@@ -52,4 +52,6 @@ src/
 
 ## CI / Release
 
-CI runs via `.github/workflows/opencode-plugin.yml` (path-filtered on `integrations/opencode-plugin/**` and `sdk/ts/**`): it builds the in-tree `sdk/ts` first (the `file:` dependency), then runs typecheck, lint, build, and test. No release/publish workflow ships yet — publishing (swapping the `file:` link to a versioned `@obsigna/sdk-ts` release) is a follow-up.
+CI runs via `.github/workflows/opencode-plugin.yml` (path-filtered on `integrations/opencode-plugin/**` and `sdk/ts/**`): it builds the in-tree `sdk/ts` first, then runs typecheck, lint, build, and test. The published `package.json` declares a versioned `@obsigna/sdk-ts` range; a `pnpm.overrides` entry pins it back to `file:../../sdk/ts` for in-tree dev and CI, so a same-PR `sdk/ts` change still fails the plugin build.
+
+Releases run via `.github/workflows/release-opencode-plugin.yml` on a `opencode-plugin-v*` tag: it verifies the tag matches `package.json`, runs the check suite, creates a GitHub release (pre-release for `-` versions), and publishes to npm with provenance under a dist-tag derived from the pre-release label (`alpha` for `-alpha.N`, `latest` for stable). The tag must match `package.json` version exactly.

--- a/integrations/opencode-plugin/AGENTS.md
+++ b/integrations/opencode-plugin/AGENTS.md
@@ -9,14 +9,14 @@ The plugin runs **inside** the OpenCode process → **emitter only**. It MUST em
 ## Getting started
 
 ```sh
-pnpm install        # @obsigna/sdk-ts is file:-linked from ../../sdk/ts (build it first)
+pnpm install        # installs @obsigna/sdk-ts from npm (versioned dependency)
 pnpm build          # tsc → dist/
 pnpm test           # vitest (unit + round-trip against a fake daemon socket)
 pnpm typecheck      # tsc --noEmit
 pnpm lint           # biome check
 ```
 
-`@obsigna/sdk-ts` resolves from a `file:../../sdk/ts` install, so run `pnpm build` in `sdk/ts` before installing/testing here.
+`@obsigna/sdk-ts` is a versioned dependency resolved from npm, so the SDK does not need to be built locally first. To develop against unreleased SDK changes, publish a pre-release or temporarily `pnpm link` the in-tree `sdk/ts`.
 
 ## Project structure
 
@@ -52,6 +52,6 @@ src/
 
 ## CI / Release
 
-CI runs via `.github/workflows/opencode-plugin.yml` (path-filtered on `integrations/opencode-plugin/**` and `sdk/ts/**`): it builds the in-tree `sdk/ts` first, then runs typecheck, lint, build, and test. The published `package.json` declares a versioned `@obsigna/sdk-ts` range; a `pnpm.overrides` entry pins it back to `file:../../sdk/ts` for in-tree dev and CI, so a same-PR `sdk/ts` change still fails the plugin build.
+CI runs via `.github/workflows/opencode-plugin.yml` (path-filtered on `integrations/opencode-plugin/**`): it installs deps (including the published `@obsigna/sdk-ts`) and runs typecheck, lint, build, and test. The plugin depends on a versioned `@obsigna/sdk-ts` range, so it is tested against exactly what consumers install — a breaking SDK change is opted into by bumping the range, not surfaced automatically.
 
 Releases run via `.github/workflows/release-opencode-plugin.yml` on a `opencode-plugin-v*` tag: it verifies the tag matches `package.json`, runs the check suite, creates a GitHub release (pre-release for `-` versions), and publishes to npm with provenance under a dist-tag derived from the pre-release label (`alpha` for `-alpha.N`, `latest` for stable). The tag must match `package.json` version exactly.

--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
 
-All notable changes to `@agent-receipts/opencode-plugin` are documented in this file.
+All notable changes to `@obsigna/opencode-plugin` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1] - 2026-06-16
+
 ### Added
 
-- **Initial release.** OpenCode plugin (`@agent-receipts/opencode-plugin`) that emits one daemon-signed Agent Receipt per native tool call (`bash`, `edit`, `write`, `webfetch`, …) by hooking `tool.execute.before`/`tool.execute.after` and forwarding each call to `agent-receipts-daemon` via the TS SDK `DaemonEmitter`. Emitter-only by construction — never signs or holds a key (ADR-0010).
+- **Initial release.** OpenCode plugin (`@obsigna/opencode-plugin`) that emits one daemon-signed Agent Receipt per native tool call (`bash`, `edit`, `write`, `webfetch`, …) by hooking `tool.execute.before`/`tool.execute.after` and forwarding each call to `agent-receipts-daemon` via the TS SDK `DaemonEmitter`. Emitter-only by construction — never signs or holds a key (ADR-0010).
   - **Action mapping** from OpenCode tool names to the AR taxonomy (`bash` → `system.command.execute`, `edit`/`write` → `filesystem.file.*`, `webfetch` → `data.api.read`), forwarded to the daemon as `action_type`; overridable via config.
   - **Per-session chain mapping** — each OpenCode `sessionID` gets its own emitter so receipts carry the session id. Per-agent sub-chains with `delegation` (issue #753) are a follow-up; the `tool.execute` hook context does not expose a named-agent identity.
   - **Failure posture (ADR-0025)** — default catch-and-warn never aborts a tool call; `strict` re-throws emit failures.

--- a/integrations/opencode-plugin/README.md
+++ b/integrations/opencode-plugin/README.md
@@ -1,4 +1,4 @@
-# @agent-receipts/opencode-plugin
+# @obsigna/opencode-plugin
 
 [OpenCode](https://opencode.ai) plugin for [Agent Receipts](https://github.com/agent-receipts/obsigna). Emits one cryptographically signed receipt per **native** tool call (`bash`, `edit`, `write`, `webfetch`, …) by forwarding each call to `agent-receipts-daemon` over a Unix-domain socket. The daemon — not this plugin — holds the key, canonicalises, signs, and chains the receipt.
 
@@ -11,14 +11,14 @@ The plugin runs **inside** the OpenCode process, so it is an **emitter only** �
 ## Install
 
 ```sh
-npm install @agent-receipts/opencode-plugin
+npm install @obsigna/opencode-plugin
 ```
 
 Register it as an OpenCode plugin in `opencode.json`:
 
 ```json
 {
-  "plugin": ["@agent-receipts/opencode-plugin"]
+  "plugin": ["@obsigna/opencode-plugin"]
 }
 ```
 

--- a/integrations/opencode-plugin/README.md
+++ b/integrations/opencode-plugin/README.md
@@ -45,7 +45,7 @@ Default is catch-and-warn: a tool call is **never** aborted because the daemon i
 ## Development
 
 ```sh
-pnpm install   # installs deps; @obsigna/sdk-ts is linked from ../../sdk/ts
+pnpm install   # installs deps, including @obsigna/sdk-ts from npm
 pnpm build     # tsc → dist/
 pnpm test      # vitest
 pnpm typecheck # tsc --noEmit

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -35,11 +35,6 @@
 	"dependencies": {
 		"@obsigna/sdk-ts": "^0.14.0"
 	},
-	"pnpm": {
-		"overrides": {
-			"@obsigna/sdk-ts": "file:../../sdk/ts"
-		}
-	},
 	"peerDependencies": {
 		"@opencode-ai/plugin": ">=0.1.0"
 	},

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@agent-receipts/opencode-plugin",
+	"name": "@obsigna/opencode-plugin",
 	"version": "0.1.0-alpha.1",
 	"description": "OpenCode plugin that emits Agent Receipts for native tool calls via the agent-receipts daemon",
 	"license": "Apache-2.0",
@@ -33,7 +33,12 @@
 	},
 	"packageManager": "pnpm@10.33.0",
 	"dependencies": {
-		"@obsigna/sdk-ts": "file:../../sdk/ts"
+		"@obsigna/sdk-ts": "^0.14.0"
+	},
+	"pnpm": {
+		"overrides": {
+			"@obsigna/sdk-ts": "file:../../sdk/ts"
+		}
 	},
 	"peerDependencies": {
 		"@opencode-ai/plugin": ">=0.1.0"

--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@obsigna/sdk-ts': file:../../sdk/ts
+
 importers:
 
   .:

--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -4,16 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@obsigna/sdk-ts': file:../../sdk/ts
-
 importers:
 
   .:
     dependencies:
       '@obsigna/sdk-ts':
-        specifier: file:../../sdk/ts
-        version: file:../../sdk/ts
+        specifier: ^0.14.0
+        version: 0.14.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.9
@@ -138,8 +135,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@obsigna/sdk-ts@file:../../sdk/ts':
-    resolution: {directory: ../../sdk/ts, type: directory}
+  '@obsigna/sdk-ts@0.14.0':
+    resolution: {integrity: sha512-dOVZLZBwBQ3nBnnKh3hTwu3K9/8SX2N8DpBzti5N/Q+Qbpnh22ZqAsmExK77ncDeGtfKt91zzIhinlcdbopHiQ==}
     engines: {node: '>=22.11.0'}
 
   '@opencode-ai/plugin@1.16.2':
@@ -740,7 +737,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@obsigna/sdk-ts@file:../../sdk/ts':
+  '@obsigna/sdk-ts@0.14.0':
     dependencies:
       undici: 8.4.1
       zod: 4.4.3

--- a/site-obsigna/src/content/docs/opencode/installation.mdx
+++ b/site-obsigna/src/content/docs/opencode/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: Plugin Installation
-description: Install and configure the @agent-receipts/opencode-plugin to capture native OpenCode tool calls, then verify the chain end to end.
+description: Install and configure the @obsigna/opencode-plugin to capture native OpenCode tool calls, then verify the chain end to end.
 ---
 
-The `@agent-receipts/opencode-plugin` package (Tier B) emits one daemon-signed receipt per native OpenCode tool call. For the MCP channel (Tier A), see [MCP Proxy](/opencode/mcp-proxy/).
+The `@obsigna/opencode-plugin` package (Tier B) emits one daemon-signed receipt per native OpenCode tool call. For the MCP channel (Tier A), see [MCP Proxy](/opencode/mcp-proxy/).
 
 ## Prerequisites
 
@@ -26,13 +26,13 @@ The plugin reaches the daemon over its default platform socket automatically —
 Add the package to your project and register it in `opencode.json`:
 
 ```bash
-npm install @agent-receipts/opencode-plugin
+npm install @obsigna/opencode-plugin
 ```
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@agent-receipts/opencode-plugin"]
+  "plugin": ["@obsigna/opencode-plugin"]
 }
 ```
 
@@ -41,7 +41,7 @@ OpenCode also loads plugins from `.opencode/plugin/`. To configure the plugin pr
 {/* snippet-check: no-run */}
 ```ts
 // .opencode/plugin/agent-receipts.ts
-import { createAgentReceiptsPlugin } from "@agent-receipts/opencode-plugin";
+import { createAgentReceiptsPlugin } from "@obsigna/opencode-plugin";
 
 export const AgentReceiptsPlugin = createAgentReceiptsPlugin({
   strict: false,

--- a/site-obsigna/src/content/docs/opencode/overview.mdx
+++ b/site-obsigna/src/content/docs/opencode/overview.mdx
@@ -6,7 +6,7 @@ description: How Agent Receipts captures OpenCode tool calls across two channels
 [OpenCode](https://opencode.ai) is a model-agnostic coding agent. Agent Receipts captures its activity across **two channels**, mirroring the [Claude Code](/hook/overview/) setup:
 
 - **Tier A — MCP tools** go through [`mcp-proxy`](/opencode/mcp-proxy/). This is the *ingress-egress*, adversary-resistant placement: the proxy runs out-of-process and signs locally, so it holds even against a misbehaving agent. Docs-only — it reuses a shipped component.
-- **Tier B — native tools** (`bash`, `edit`, `write`, `webfetch`, …) go through the **`@agent-receipts/opencode-plugin`** plugin. This is the *execd-side*, honest-operator placement: maximum coverage of native calls, emitted to the daemon for signing.
+- **Tier B — native tools** (`bash`, `edit`, `write`, `webfetch`, …) go through the **`@obsigna/opencode-plugin`** plugin. This is the *execd-side*, honest-operator placement: maximum coverage of native calls, emitted to the daemon for signing.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
First publish of the OpenCode plugin. Renames it into the `@obsigna` scope (matching `@obsigna/sdk-ts`), depends on the published `@obsigna/sdk-ts@^0.14.0`, and adds the release workflow.

Depends on `@obsigna/sdk-ts@0.14.0` (published in #859) — the plugin sets `EmitEvent.actionType`, which `0.13.0` did not expose.

## Changes
- **Rename** `@agent-receipts/opencode-plugin` → `@obsigna/opencode-plugin` across `package.json`, `README.md`, `CHANGELOG.md`, `AGENTS.md`, and the two `site-obsigna` OpenCode docs.
- **Dependency** `@obsigna/sdk-ts`: `file:../../sdk/ts` → `^0.14.0`, resolved from npm. The plugin is now built and tested against exactly what consumers install. Lockfile regenerated against the registry.
- **CI** (`opencode-plugin.yml`) — drops the in-tree `sdk/ts` build step and the `sdk/ts/**` path trigger; installs the published SDK instead. A breaking SDK change is opted into by bumping the range, not surfaced automatically.
- **CHANGELOG** `[Unreleased]` → `[0.1.0-alpha.1] - 2026-06-16`.
- **New `.github/workflows/release-opencode-plugin.yml`** — triggers on `opencode-plugin-v*`, verifies tag↔version, runs typecheck/lint/build/test, creates a GitHub release (pre-release for `-` versions), and `npm publish --provenance` under a dist-tag derived from the pre-release label (`alpha` here). New CI workflow — please review.

## Trust boundary unchanged
Still emitter-only (ADR-0010): no signer, no key.

## Release
After merge: tag `opencode-plugin-v0.1.0-alpha.1` and push → publishes to npm under the `alpha` dist-tag.

## Notes for review
- The release workflow references a `release-opencode-plugin` deployment environment (mirrors sdk-ts) for optional reviewer gating — create it in repo settings if you want that gate; it runs fine without.
- First publish under the `@obsigna` scope — the npm token needs publish rights on `@obsigna` (already true for sdk-ts).

## Verification
`pnpm typecheck && lint && build && test` green locally against the published `@obsigna/sdk-ts@0.14.0` (31 tests).