### PR TITLE
chore(release): opencode-plugin 0.1.0-alpha.2 — fix description to Obsigna daemon

### DIFF
--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-06-16
+
+### Changed
+
+- **Package description** now refers to the **Obsigna daemon** rather than "the agent-receipts daemon", matching the brand split (Agent Receipts = the protocol, Obsigna = the toolset). Metadata-only; no code changes. Supersedes `0.1.0-alpha.1`.
+
 ## [0.1.0-alpha.1] - 2026-06-16
 
 ### Added

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@obsigna/opencode-plugin",
-	"version": "0.1.0-alpha.1",
-	"description": "OpenCode plugin that emits Agent Receipts for native tool calls via the agent-receipts daemon",
+	"version": "0.1.0-alpha.2",
+	"description": "OpenCode plugin that emits Agent Receipts for native tool calls via the Obsigna daemon",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",
 	"repository": {


### PR DESCRIPTION
The `0.1.0-alpha.1` package description read "via the agent-receipts daemon". Per the brand split (Agent Receipts = the protocol, Obsigna = the toolset), it should reference the **Obsigna daemon**. npm metadata is immutable per version, so this bumps to `0.1.0-alpha.2` with the corrected description.

## Changes
- `package.json`: version `0.1.0-alpha.1` → `0.1.0-alpha.2`; description now says "via the Obsigna daemon".
- `CHANGELOG.md`: `[0.1.0-alpha.2]` entry (metadata-only, supersedes alpha.1).

Prose/brand fix only — the literal `agent-receipts-daemon` binary name in README/docs commands is unchanged.

## Release
After merge: tag `opencode-plugin-v0.1.0-alpha.2` → publish under `alpha`. Then `npm deprecate @obsigna/opencode-plugin@0.1.0-alpha.1` pointing at alpha.2.