### PR TITLE
feat(opencode-plugin)!: rename exports to Obsigna brand (alpha.3)

### DIFF
--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3] - 2026-06-16
+
+### Changed
+
+- **Renamed the plugin exports to the Obsigna brand**, matching the `@obsigna` package scope: `createAgentReceiptsPlugin` → `createObsignaPlugin`, the prebuilt `AgentReceiptsPlugin` → `ObsignaPlugin`, and the `AgentReceiptsPluginConfig` type → `ObsignaPluginConfig`. Breaking for the named exports only; the `AGENT_RECEIPTS_*` / `AGENTRECEIPTS_SOCKET` environment variables are unchanged. Update imports from `@obsigna/opencode-plugin`.
+
 ## [0.1.0-alpha.2] - 2026-06-16
 
 ### Changed

--- a/integrations/opencode-plugin/README.md
+++ b/integrations/opencode-plugin/README.md
@@ -36,7 +36,7 @@ Configure via environment variables (read at plugin load):
 | `AGENT_RECEIPTS_ALLOW` | — | Comma-separated tool allow-list |
 | `AGENT_RECEIPTS_DENY` | — | Comma-separated tool deny-list |
 
-For programmatic configuration (allow/deny, action-type overrides, custom logger), build the plugin with `createAgentReceiptsPlugin(config)` and export it from your own `.opencode/plugin/` file.
+For programmatic configuration (allow/deny, action-type overrides, custom logger), build the plugin with `createObsignaPlugin(config)` and export it from your own `.opencode/plugin/` file.
 
 ## Failure posture (ADR-0025)
 

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/opencode-plugin",
-	"version": "0.1.0-alpha.2",
+	"version": "0.1.0-alpha.3",
 	"description": "OpenCode plugin that emits Agent Receipts for native tool calls via the Obsigna daemon",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",

--- a/integrations/opencode-plugin/src/config.ts
+++ b/integrations/opencode-plugin/src/config.ts
@@ -4,19 +4,19 @@
  * object, environment variables, then built-in defaults.
  *
  * Environment variables (read by {@link resolveConfig}):
- *   - `AGENT_RECEIPTS_CHANNEL`  → {@link AgentReceiptsPluginConfig.channel}
- *   - `AGENT_RECEIPTS_STRICT`   → {@link AgentReceiptsPluginConfig.strict}
+ *   - `AGENT_RECEIPTS_CHANNEL`  → {@link ObsignaPluginConfig.channel}
+ *   - `AGENT_RECEIPTS_STRICT`   → {@link ObsignaPluginConfig.strict}
  *     (truthy: "1", "true", "yes", case-insensitive)
- *   - `AGENT_RECEIPTS_ALLOW`    → {@link AgentReceiptsPluginConfig.allow}
+ *   - `AGENT_RECEIPTS_ALLOW`    → {@link ObsignaPluginConfig.allow}
  *     (comma-separated tool names)
- *   - `AGENT_RECEIPTS_DENY`     → {@link AgentReceiptsPluginConfig.deny}
+ *   - `AGENT_RECEIPTS_DENY`     → {@link ObsignaPluginConfig.deny}
  *     (comma-separated tool names)
  *
  * The daemon socket path is NOT read here: when `socketPath` is unset the
  * underlying `DaemonEmitter` resolves it from `AGENTRECEIPTS_SOCKET` and the
  * per-OS default, keeping a single source of truth across SDKs.
  */
-export interface AgentReceiptsPluginConfig {
+export interface ObsignaPluginConfig {
 	/** Receipt channel label. Defaults to `"opencode"`. */
 	channel?: string;
 	/**
@@ -86,7 +86,7 @@ function defaultDebugLog(message: string, attrs: Record<string, string>): void {
  * callers omit it and `process.env` is used.
  */
 export function resolveConfig(
-	config: AgentReceiptsPluginConfig = {},
+	config: ObsignaPluginConfig = {},
 	env: NodeJS.ProcessEnv = process.env,
 ): ResolvedConfig {
 	const channel = config.channel ?? env.AGENT_RECEIPTS_CHANNEL ?? "opencode";

--- a/integrations/opencode-plugin/src/index.ts
+++ b/integrations/opencode-plugin/src/index.ts
@@ -1,11 +1,11 @@
 export { DEFAULT_ACTION_MAP, resolveActionType } from "./actions.js";
 export {
-	type AgentReceiptsPluginConfig,
+	type ObsignaPluginConfig,
 	type ResolvedConfig,
 	resolveConfig,
 	shouldEmit,
 } from "./config.js";
-export { AgentReceiptsPlugin, createAgentReceiptsPlugin } from "./plugin.js";
+export { createObsignaPlugin, ObsignaPlugin } from "./plugin.js";
 export {
 	type EmitterFactory,
 	type ReceiptEmitter,

--- a/integrations/opencode-plugin/src/plugin.ts
+++ b/integrations/opencode-plugin/src/plugin.ts
@@ -9,17 +9,17 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
-import { type AgentReceiptsPluginConfig, resolveConfig } from "./config.js";
+import { type ObsignaPluginConfig, resolveConfig } from "./config.js";
 import { ReceiptRecorder } from "./recorder.js";
 
 /**
  * Build an OpenCode {@link Plugin} that emits an Agent Receipt for every native
  * tool call. `userConfig` is layered over environment variables and defaults
  * (see {@link resolveConfig}). Use this when you want to configure the plugin
- * programmatically; most installs use the pre-built {@link AgentReceiptsPlugin}.
+ * programmatically; most installs use the pre-built {@link ObsignaPlugin}.
  */
-export function createAgentReceiptsPlugin(
-	userConfig: AgentReceiptsPluginConfig = {},
+export function createObsignaPlugin(
+	userConfig: ObsignaPluginConfig = {},
 ): Plugin {
 	return async () => {
 		const config = resolveConfig(userConfig);
@@ -70,4 +70,4 @@ export function createAgentReceiptsPlugin(
  * Pre-built plugin configured from environment variables and defaults. This is
  * the export OpenCode loads from `.opencode/plugin/`.
  */
-export const AgentReceiptsPlugin: Plugin = createAgentReceiptsPlugin();
+export const ObsignaPlugin: Plugin = createObsignaPlugin();

--- a/site-obsigna/src/content/docs/opencode/installation.mdx
+++ b/site-obsigna/src/content/docs/opencode/installation.mdx
@@ -41,9 +41,9 @@ OpenCode also loads plugins from `.opencode/plugin/`. To configure the plugin pr
 {/* snippet-check: no-run */}
 ```ts
 // .opencode/plugin/agent-receipts.ts
-import { createAgentReceiptsPlugin } from "@obsigna/opencode-plugin";
+import { createObsignaPlugin } from "@obsigna/opencode-plugin";
 
-export const AgentReceiptsPlugin = createAgentReceiptsPlugin({
+export const ObsignaPlugin = createObsignaPlugin({
   strict: false,
   deny: ["read", "glob", "grep", "list"], // skip read-only noise
 });
@@ -61,7 +61,7 @@ Configure via environment variables (read when the plugin loads):
 | `AGENT_RECEIPTS_ALLOW` | — | Comma-separated tool allow-list (only these emit) |
 | `AGENT_RECEIPTS_DENY` | — | Comma-separated tool deny-list (these never emit) |
 
-`createAgentReceiptsPlugin(config)` accepts the same options plus `actionMap` (per-tool action-type overrides) and `debugLog` (a custom log sink). Explicit config wins over environment variables.
+`createObsignaPlugin(config)` accepts the same options plus `actionMap` (per-tool action-type overrides) and `debugLog` (a custom log sink). Explicit config wins over environment variables.
 
 ## Failure posture
 


### PR DESCRIPTION
Aligns the plugin's public exports with the `@obsigna` package scope and the brand split (Agent Receipts = protocol, Obsigna = toolset). The thing you instantiate is an Obsigna plugin; what it emits is still Agent Receipts.

## Renames (exports only)
- `createAgentReceiptsPlugin` → `createObsignaPlugin`
- `AgentReceiptsPlugin` (prebuilt export) → `ObsignaPlugin`
- `AgentReceiptsPluginConfig` type → `ObsignaPluginConfig`

Updated across `src/`, the README, and the OpenCode installation docs.

## Deliberately unchanged
- **Env vars** (`AGENT_RECEIPTS_*`, `AGENTRECEIPTS_SOCKET`) — shared config convention with the daemon/hook; out of scope for this rename.
- Runtime behaviour — pure identifier rename.

## Versioning
Breaking change to the named exports → bumps to `0.1.0-alpha.3`. Cheap to do now while pre-1.0. After merge I'll tag `opencode-plugin-v0.1.0-alpha.3` → OIDC publish.

## Verification
`pnpm typecheck && lint && build && test` green (31 tests). biome re-sorted the export list (auto-fixed).

Note: branched off main before #865 (the workflow cleanup); no overlapping files, so they merge independently.