### PR TITLE
feat(sdk-ts): add @obsigna/sdk-ts/emitter subpath export (0.14.1)

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,12 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-06-16
+
+### Added
+
+- **`@obsigna/sdk-ts/emitter` subpath export** — exposes `DaemonEmitter` and its frame types (`EmitEvent`, `EmitTool`, `DaemonEmitterOptions`, `EmitTransportError`, `defaultSocketPath`, …) from `daemon-emitter.js` directly, without pulling in the package barrel. The barrel re-exports the SQLite-backed store (`node:sqlite`) and the HTTP/WAL emitters (`undici`); importing it forces those into a consumer's bundle even when only the daemon emitter is used. Emitter-only consumers that bundle for restricted runtimes — notably the OpenCode plugin, whose loader could not resolve `node:sqlite` — should import from `@obsigna/sdk-ts/emitter`. Additive; the main entry point is unchanged.
+
 ## [0.14.0] - 2026-06-16
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",
@@ -14,6 +14,10 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
+		},
+		"./emitter": {
+			"types": "./dist/daemon-emitter.d.ts",
+			"default": "./dist/daemon-emitter.js"
 		},
 		"./receipt": {
 			"types": "./dist/receipt/index.d.ts",


### PR DESCRIPTION
Adds an `@obsigna/sdk-ts/emitter` subpath that exposes `DaemonEmitter` and its frame types directly from `daemon-emitter.js`, bypassing the package barrel.

## Why
The barrel (`@obsigna/sdk-ts`) re-exports the SQLite-backed store (`import "node:sqlite"`) and the HTTP/WAL emitters (`undici`). Any consumer importing `DaemonEmitter` from the barrel drags `node:sqlite` + `undici` into its bundle. The OpenCode plugin's loader (esbuild) **cannot resolve `node:sqlite`** and fails to load — verified against a real npm install.

`daemon-emitter.js` is fully self-contained: one file, imports only `node:crypto/net/os/path`, zero relative imports. The new subpath lets emitter-only consumers pull just that.

## Change
- `package.json`: add `exports["./emitter"]` → `./dist/daemon-emitter.{js,d.ts}`; version `0.14.0` → `0.14.1`.
- CHANGELOG entry.

Purely additive — the main entry point and all existing subpaths are unchanged.

## Verification
- `dist/daemon-emitter.js` import graph traced: only `node:crypto/net/os/path`, no `node:sqlite`/`undici` (1 file, no relative deps).
- `pnpm typecheck && lint && build && test` green (440 tests).

## Unblocks
The opencode-plugin loadability fix (next PR) will import `DaemonEmitter` from `@obsigna/sdk-ts/emitter` and add a `./server` entry.