### PR TITLE
fix(opencode-plugin): make the package loadable by opencode (alpha.3)

### DIFF
--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0-alpha.3] - 2026-06-16
 
+First version OpenCode can actually load (alpha.1/alpha.2 could not — see Fixed).
+
+### Fixed
+
+- **OpenCode can now load the plugin.** Three problems blocked it when installed from npm:
+  - **`node:sqlite` in the import graph.** The recorder imported `DaemonEmitter` from the `@obsigna/sdk-ts` barrel, which re-exports the SQLite store (`node:sqlite`) and undici; opencode's loader could not resolve `node:sqlite`. Now imports from the `@obsigna/sdk-ts/emitter` subpath (added in sdk-ts 0.14.1), which pulls only the daemon emitter — no `node:sqlite`/undici. Dependency bumped to `^0.14.1`.
+  - **No server entry point.** opencode resolves `server` plugins via `exports["./server"]` (or `main`); the package exposed neither. Added a `./server` export (and `main`) pointing at a dedicated entry.
+  - **Entry exported non-function values.** The library barrel exports `DEFAULT_ACTION_MAP`, `ReceiptRecorder`, config helpers, etc.; opencode's legacy loader throws "Plugin export is not a function" on the first such export. The new `src/server.ts` default-exports only `{ server: ObsignaPlugin }` (V1 shape), keeping opencode on the V1 path. The `.` barrel is unchanged for programmatic use.
+
 ### Changed
 
 - **Renamed the plugin exports to the Obsigna brand**, matching the `@obsigna` package scope: `createAgentReceiptsPlugin` → `createObsignaPlugin`, the prebuilt `AgentReceiptsPlugin` → `ObsignaPlugin`, and the `AgentReceiptsPluginConfig` type → `ObsignaPluginConfig`. Breaking for the named exports only; the `AGENT_RECEIPTS_*` / `AGENTRECEIPTS_SOCKET` environment variables are unchanged. Update imports from `@obsigna/opencode-plugin`.

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -10,10 +10,15 @@
 		"directory": "integrations/opencode-plugin"
 	},
 	"type": "module",
+	"main": "./dist/server.js",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
+		},
+		"./server": {
+			"types": "./dist/server.d.ts",
+			"default": "./dist/server.js"
 		}
 	},
 	"files": [
@@ -33,7 +38,7 @@
 	},
 	"packageManager": "pnpm@10.33.0",
 	"dependencies": {
-		"@obsigna/sdk-ts": "^0.14.0"
+		"@obsigna/sdk-ts": "^0.14.1"
 	},
 	"peerDependencies": {
 		"@opencode-ai/plugin": ">=0.1.0"

--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@obsigna/sdk-ts':
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.14.1
+        version: 0.14.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.9
@@ -135,8 +135,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@obsigna/sdk-ts@0.14.0':
-    resolution: {integrity: sha512-dOVZLZBwBQ3nBnnKh3hTwu3K9/8SX2N8DpBzti5N/Q+Qbpnh22ZqAsmExK77ncDeGtfKt91zzIhinlcdbopHiQ==}
+  '@obsigna/sdk-ts@0.14.1':
+    resolution: {integrity: sha512-J2GkZMwD9CGcAv88iAC8r0SfHSAmyk1Hr+HjiI2hm663tOpMxMxqa6N2RCzNUWCMq9IBVk504JNTig7xHw4o1Q==}
     engines: {node: '>=22.11.0'}
 
   '@opencode-ai/plugin@1.16.2':
@@ -737,7 +737,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@obsigna/sdk-ts@0.14.0':
+  '@obsigna/sdk-ts@0.14.1':
     dependencies:
       undici: 8.4.1
       zod: 4.4.3

--- a/integrations/opencode-plugin/src/recorder.test.ts
+++ b/integrations/opencode-plugin/src/recorder.test.ts
@@ -1,4 +1,4 @@
-import type { EmitEvent } from "@obsigna/sdk-ts";
+import type { EmitEvent } from "@obsigna/sdk-ts/emitter";
 import { describe, expect, it, vi } from "vitest";
 import { type ResolvedConfig, resolveConfig } from "./config.js";
 import {

--- a/integrations/opencode-plugin/src/recorder.ts
+++ b/integrations/opencode-plugin/src/recorder.ts
@@ -24,7 +24,7 @@
  * guessing.
  */
 
-import { DaemonEmitter, type EmitEvent } from "@obsigna/sdk-ts";
+import { DaemonEmitter, type EmitEvent } from "@obsigna/sdk-ts/emitter";
 import { resolveActionType } from "./actions.js";
 import { type ResolvedConfig, shouldEmit } from "./config.js";
 

--- a/integrations/opencode-plugin/src/server.ts
+++ b/integrations/opencode-plugin/src/server.ts
@@ -1,0 +1,19 @@
+import { ObsignaPlugin } from "./plugin.js";
+
+/**
+ * OpenCode server-plugin entry point.
+ *
+ * opencode resolves a `kind: "server"` plugin through this package's
+ * `exports["./server"]` and reads the module's **default** export, expecting a
+ * V1 plugin descriptor: an object whose `server` field is the plugin function
+ * (see opencode's `readV1Plugin` / `resolvePackageEntrypoint`).
+ *
+ * This entry deliberately default-exports *only* `{ server }`. The library
+ * barrel (`./index.ts`) also exports values that are not plugin functions
+ * (`DEFAULT_ACTION_MAP`, `ReceiptRecorder`, config helpers, the factory); if
+ * opencode fell back to its legacy loader — which iterates `Object.values(mod)`
+ * and calls each as a plugin — those would throw "Plugin export is not a
+ * function". Providing a valid V1 default export keeps opencode on the V1 path
+ * and never reaches that fallback.
+ */
+export default { server: ObsignaPlugin };


### PR DESCRIPTION
`@obsigna/opencode-plugin@0.1.0-alpha.2` cannot be loaded by opencode (verified against a real npm install while building the sbx demo). This fixes the three blockers. Folds into the unpublished **alpha.3** (which already carried the Obsigna rename), so alpha.3 becomes the first build that's both renamed and loadable — alpha.3 was never cut, so no version is skipped.

## The three fixes
1. **`node:sqlite`/undici in the import graph.** `recorder.ts` imported `DaemonEmitter` from the `@obsigna/sdk-ts` barrel, which re-exports the SQLite store (`node:sqlite`) and undici; opencode's loader could not resolve `node:sqlite`. Now imports from `@obsigna/sdk-ts/emitter` (added in sdk-ts 0.14.1) — only the daemon emitter, no `node:sqlite`/undici. Dep bumped to `^0.14.1`.
2. **No server entry point.** opencode resolves `server` plugins via `exports["./server"]` (or `main`); the package had neither. Added both, pointing at a dedicated `src/server.ts`.
3. **Entry exported non-function values.** opencode's legacy loader iterates `Object.values(mod)` and throws "Plugin export is not a function" on the barrel's `DEFAULT_ACTION_MAP`/`ReceiptRecorder`/etc. `src/server.ts` default-exports only `{ server: ObsignaPlugin }` (V1 shape), keeping opencode on the V1 path. The `.` barrel is unchanged for programmatic use.

## Verification (esbuild, mimicking opencode's bundler)
| Bundle | `node:sqlite` | `undici` |
|---|---|---|
| barrel import (old path) | 11 | 309 |
| new `./server` entry | **0** | **0** |

The server bundle's default export is `{ server: <function> }` — exactly what opencode's `readV1Plugin` expects. `pnpm typecheck && lint && build && test` green (31 tests).

End-to-end confirmation (opencode actually loading it from npm via the sbx demo) follows after publish.

## Versioning
Stays at `0.1.0-alpha.3` (never published). After merge: tag `opencode-plugin-v0.1.0-alpha.3` → OIDC publish → move `latest` → alpha.3.