### PR TITLE
chore(release): opencode-plugin 0.1.0 (graduate from alpha)

### DIFF
--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-16
+
+First stable release. Graduates `0.1.0-alpha.3` with no source changes — that alpha is the first OpenCode-loadable build. See the `0.1.0-alpha.3` entry for the loadability fixes (server entry, `@obsigna/sdk-ts/emitter` import, V1 default export) and the Obsigna export rename; the earlier `0.1.0-alpha.1`/`0.1.0-alpha.2` builds could not be loaded by OpenCode and are deprecated on npm.
+
 ## [0.1.0-alpha.3] - 2026-06-16
 
 First version OpenCode can actually load (alpha.1/alpha.2 could not — see Fixed).

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/opencode-plugin",
-	"version": "0.1.0-alpha.3",
+	"version": "0.1.0",
 	"description": "OpenCode plugin that emits Agent Receipts for native tool calls via the Obsigna daemon",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Graduates `@obsigna/opencode-plugin` to its first **stable** release, `0.1.0`.

## Changes
- `package.json`: `0.1.0-alpha.3` → `0.1.0`
- CHANGELOG: `[0.1.0]` graduation entry

No source changes — `0.1.0-alpha.3` is the first OpenCode-loadable build (server entry, `@obsigna/sdk-ts/emitter` import, V1 default export), verified against the published tarball. This just drops the prerelease tag.

## Release
After merge: tag `opencode-plugin-v0.1.0` → OIDC publish. Since the version has no prerelease suffix, the workflow publishes under the **`latest`** dist-tag automatically — which also moves `latest` off the deprecated `alpha.2`. GitHub release will be a normal (non-prerelease) release.

Follow-ups after publish: bump the sbx demo pin to `@0.1.0`, and optionally deprecate `0.1.0-alpha.3` pointing at `0.1.0`.