### PR TITLE
docs(opencode-plugin): use current obsigna binary names

### DIFF
--- a/integrations/opencode-plugin/AGENTS.md
+++ b/integrations/opencode-plugin/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-OpenCode plugin (`@obsigna/opencode-plugin`) that emits one Agent Receipt per native OpenCode tool call. Hooks `tool.execute.before`/`tool.execute.after` from `@opencode-ai/plugin` and forwards each call to `agent-receipts-daemon` via the TS SDK `DaemonEmitter`. The OpenCode analog of the Go [`hook/`](../../hook/) Claude Code integration, for the native-tool channel.
+OpenCode plugin (`@obsigna/opencode-plugin`) that emits one Agent Receipt per native OpenCode tool call. Hooks `tool.execute.before`/`tool.execute.after` from `@opencode-ai/plugin` and forwards each call to `obsigna-daemon` via the TS SDK `DaemonEmitter`. The OpenCode analog of the Go [`hook/`](../../hook/) Claude Code integration, for the native-tool channel.
 
 ## Trust boundary (load-bearing)
 
@@ -48,7 +48,7 @@ src/
 ## Testing
 
 - Unit tests inject a capturing `ReceiptEmitter` fake (no socket) to assert mapping, filtering, intent/params bridging, per-session emitters, and the strict/default failure posture.
-- `roundtrip.test.ts` drives the real `DaemonEmitter` against a fake length-prefixed AF_UNIX server (mirrors sdk/ts `daemon-emitter.test.ts`) and asserts the wire-frame shape. Signed-chain verification is the daemon's job, covered by the docs `agent-receipts verify` walkthrough.
+- `roundtrip.test.ts` drives the real `DaemonEmitter` against a fake length-prefixed AF_UNIX server (mirrors sdk/ts `daemon-emitter.test.ts`) and asserts the wire-frame shape. Signed-chain verification is the daemon's job, covered by the docs `obsigna verify` walkthrough.
 
 ## CI / Release
 

--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs**: refer to the current binary names in `README.md` and `AGENTS.md` — `obsigna-daemon` (was `agent-receipts-daemon`), `obsigna-hook` (was `agent-receipts-hook`), and `obsigna verify` (was `agent-receipts verify`). Documentation-only; no code or behaviour changes.
+
 ## [0.1.0-alpha.3] - 2026-06-16
 
 ### Changed

--- a/integrations/opencode-plugin/README.md
+++ b/integrations/opencode-plugin/README.md
@@ -1,8 +1,8 @@
 # @obsigna/opencode-plugin
 
-[OpenCode](https://opencode.ai) plugin for [Agent Receipts](https://github.com/agent-receipts/obsigna). Emits one cryptographically signed receipt per **native** tool call (`bash`, `edit`, `write`, `webfetch`, …) by forwarding each call to `agent-receipts-daemon` over a Unix-domain socket. The daemon — not this plugin — holds the key, canonicalises, signs, and chains the receipt.
+[OpenCode](https://opencode.ai) plugin for [Agent Receipts](https://github.com/agent-receipts/obsigna). Emits one cryptographically signed receipt per **native** tool call (`bash`, `edit`, `write`, `webfetch`, …) by forwarding each call to `obsigna-daemon` over a Unix-domain socket. The daemon — not this plugin — holds the key, canonicalises, signs, and chains the receipt.
 
-This is the OpenCode analog of the [`agent-receipts-hook`](../../hook/) Claude Code integration, covering the native-tool channel. MCP tool calls are covered separately by [`mcp-proxy`](../../mcp-proxy/).
+This is the OpenCode analog of the [`obsigna-hook`](../../hook/) Claude Code integration, covering the native-tool channel. MCP tool calls are covered separately by [`mcp-proxy`](../../mcp-proxy/).
 
 ## Trust boundary
 
@@ -22,7 +22,7 @@ Register it as an OpenCode plugin in `opencode.json`:
 }
 ```
 
-Requires `agent-receipts-daemon` to be running. See the [OpenCode docs](https://obsigna.dev/opencode/overview/) for the full Tier A + Tier B walkthrough and an end-to-end `agent-receipts verify` example.
+Requires `obsigna-daemon` to be running. See the [OpenCode docs](https://obsigna.dev/opencode/overview/) for the full Tier A + Tier B walkthrough and an end-to-end `obsigna verify` example.
 
 ## Configuration
 


### PR DESCRIPTION
The `integrations/opencode-plugin` README and AGENTS.md still referenced retired binary names from before the Obsigna brand split.

## Changes

- `agent-receipts-daemon` → `obsigna-daemon`
- `agent-receipts-hook` → `obsigna-hook` (the `agent-receipts-hook` name is now only a back-compat shim)
- `agent-receipts verify` → `obsigna verify`

"Agent Receipts" is left intact where it names the protocol/receipts. Docs-only — no code or behaviour changes. CHANGELOG updated under Unreleased.

## Not touched (follow-ups)

- README links to `https://obsigna.dev/opencode/overview/`, but there's no `opencode/` content under `site/src/content/docs` — possible dead link if not published elsewhere.
- `mcp-proxy` references left as-is (its own README still uses that name).