### PR TITLE
daemon/checkpoint: correct Flush docstring (not unconditional)

### DIFF
--- a/daemon/internal/checkpoint/emitter.go
+++ b/daemon/internal/checkpoint/emitter.go
@@ -78,10 +78,13 @@ func (e *Emitter) Observe(chainID string, seq int64, headHash string) {
 	}
 }
 
-// Flush forces a checkpoint for chainID at (seq, headHash) regardless of the
-// cadence counter and resets it. Used on graceful shutdown so the final head
-// of every open chain is anchored even when the last receipts did not land on
-// a cadence boundary.
+// Flush requests a checkpoint for chainID at (seq, headHash) outside the normal
+// cadence and resets the cadence counter. Used on graceful shutdown so the final
+// head of every open chain is anchored even when the last receipts did not land
+// on a cadence boundary. Like the per-receipt path it goes through
+// markEmitLocked, so a head that is already anchored — e.g. the terminator was
+// skipped on a tight shutdown deadline and the tail is unchanged — is a no-op
+// rather than a duplicate checkpoint.
 func (e *Emitter) Flush(chainID string, seq int64, headHash string) {
 	e.mu.Lock()
 	e.counts[chainID] = 0


### PR DESCRIPTION
Follow-up to #871 (post-merge review).

The `Emitter.Flush` docstring still says it "forces a checkpoint … regardless of the cadence counter," but since the duplicate-checkpoint fix in #871, `Flush` goes through `markEmitLocked` like the per-receipt `Observe` path — so a head that is already anchored (e.g. the interrupted-chain terminator was skipped on a tight shutdown deadline and the tail is unchanged) is a no-op, not a duplicate. The stale wording could mislead a maintainer into removing the dedup guard and re-introducing the false-positive `verify --against-anchor` failure that guard prevents.

Comment-only change — no behavior change. Build/vet/`go test ./internal/checkpoint/` green.