### PR TITLE
chore(dependabot): ignore internal ar/* modules in gomod ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,11 @@ updates:
       go:
         patterns:
           - "*"
+    # Internal modules are version-managed by the release cascade and wired
+    # locally via go.work; Dependabot bumping their pins (often to alpha tags)
+    # is noise. Third-party deps still update normally.
+    ignore:
+      - dependency-name: "github.com/agent-receipts/ar/*"
 
   - package-ecosystem: gomod
     directory: /mcp-proxy
@@ -44,6 +49,8 @@ updates:
       go:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "github.com/agent-receipts/ar/*"
 
   - package-ecosystem: gomod
     directory: /cross-sdk-tests
@@ -53,6 +60,8 @@ updates:
       go:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "github.com/agent-receipts/ar/*"
 
   - package-ecosystem: uv
     directory: /sdk/py


### PR DESCRIPTION
## What

Adds an `ignore` condition for `github.com/agent-receipts/ar/*` to the three gomod Dependabot ecosystems (`/sdk/go`, `/mcp-proxy`, `/cross-sdk-tests`).

## Why

The internal monorepo modules (`sdk/go`, `daemon`) are version-managed by the release cascade and wired locally via `go.work`. Dependabot bumping their published pins in consumer `go.mod` files is redundant and surfaces alpha tags — e.g. #876 bumped `sdk/go` to `0.19.0-alpha.1` even though stable `0.19.0` was already in use elsewhere.

Dependabot has no native "exclude prereleases" switch, so ignoring the self-referencing modules is the clean fix. Third-party dependencies (`google/uuid`, `golang.org/x/crypto`, `modernc.org/*`, etc.) continue to update normally.

## Follow-up

#876 can be closed once this merges (or via `@dependabot ignore`).