### PR TITLE
fix(lefthook): don't mask shellcheck failures as 'not installed'

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,7 +42,9 @@ pre-commit:
 
     - name: shellcheck
       glob: "*.sh"
-      run: command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo "shellcheck not installed — skipping"
+      # Skip only when shellcheck is absent; when present, let its exit code
+      # propagate so real lint failures aren't masked as "not installed".
+      run: if command -v shellcheck >/dev/null 2>&1; then shellcheck {staged_files}; else echo "shellcheck not installed — skipping"; fi
 
 pre-push:
   parallel: true


### PR DESCRIPTION
## Problem

The pre-commit `shellcheck` hook is written as:

```yaml
run: command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo "shellcheck not installed — skipping"
```

With `A && B || C`, the `echo` (C) also runs when shellcheck **is** installed but exits non-zero — i.e. on real lint failures. That swallows the failure (hook exits 0) and prints a misleading "not installed — skipping" message, so broken shell scripts sail through pre-commit.

## Fix

Branch on the command's presence with `if/else` so shellcheck's exit code propagates:

```yaml
run: if command -v shellcheck >/dev/null 2>&1; then shellcheck {staged_files}; else echo "shellcheck not installed — skipping"; fi
```

Spotted by a Copilot review on the obsigna-examples repo, which borrowed this hook verbatim — fixing it at the source here too.