### PR TITLE
feat(verify): add --json to `obsigna receipt verify` (#885)

### DIFF
--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -294,13 +294,13 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 			}
 			return emit(ExitOK)
 		}
-		anchorResult := "fail"
+		anchorResultLabel := "fail"
 		label := "FAIL"
 		if ar.Truncated {
-			anchorResult = "fail_truncation"
+			anchorResultLabel = "fail_truncation"
 			label = "FAIL (truncation)"
 		}
-		outcome.Anchor = &anchorOutcome{Checked: ar.Checked, Result: anchorResult, Reason: ar.Reason, HeadSeq: headSeq}
+		outcome.Anchor = &anchorOutcome{Checked: ar.Checked, Result: anchorResultLabel, Reason: ar.Reason, HeadSeq: headSeq}
 		if !*asJSON {
 			fmt.Fprintf(stdout, "Anchor %s: %s — %s\n", *againstAnchor, label, ar.Reason)
 		}

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -18,6 +18,7 @@ package verifycli
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/agent-receipts/ar/daemon"
@@ -40,6 +42,41 @@ const (
 	ExitChainBad   = 1 // chain failed verification
 	ExitUsageError = 2 // bad flags / unreadable DB or key file
 )
+
+// receiptStatus is one receipt's per-check status in a broken-chain --json
+// report, mirroring the human `[i] id — STATUS` lines.
+type receiptStatus struct {
+	Index     int    `json:"index"`
+	ReceiptID string `json:"receipt_id"`
+	Status    string `json:"status"` // "ok" | "bad_signature" | "bad_hash_link" | "bad_sequence"
+}
+
+// anchorOutcome is the structured --against-anchor result carried in --json
+// output (ADR-0008). Reason is empty on pass.
+type anchorOutcome struct {
+	Checked int    `json:"checked"` // verified checkpoints for the chain
+	Result  string `json:"result"`  // "pass" | "fail" | "fail_truncation"
+	Reason  string `json:"reason,omitempty"`
+	HeadSeq int64  `json:"head_seq"`
+}
+
+// verifyOutcome is the full result of a `receipt verify` run, emitted as a
+// single JSON object under --json. A wrapper object (rather than a bare value)
+// mirrors the verify-event pattern so the contract can grow new fields without
+// breaking parsers that key off the existing ones. ExitCode duplicates the
+// process exit code so a caller capturing only stdout still sees the verdict.
+type verifyOutcome struct {
+	ChainID    string          `json:"chain_id"`
+	Verified   bool            `json:"verified"`
+	ExitCode   int             `json:"exit_code"`
+	Length     int             `json:"length"`
+	Head       string          `json:"head,omitempty"`
+	BrokenAt   *int            `json:"broken_at,omitempty"`
+	Cause      string          `json:"cause,omitempty"`
+	Receipts   []receiptStatus `json:"receipts,omitempty"`
+	Advisories []string        `json:"advisories"`
+	Anchor     *anchorOutcome  `json:"anchor,omitempty"`
+}
 
 // Run executes the verify subcommand with the given args (sans the program
 // name and "verify" subcommand token), writing human-readable output to
@@ -74,6 +111,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	pubKeyPath := fs.String("public-key", defaultPubKey, "PEM-encoded SPKI public key path (env: AGENTRECEIPTS_PUBLIC_KEY)")
 	chainID := fs.String("chain-id", envOr("AGENTRECEIPTS_CHAIN_ID", time.Now().UTC().Format("2006-01-02")), "Chain id to verify (env: AGENTRECEIPTS_CHAIN_ID)")
 	againstAnchor := fs.String("against-anchor", envOr("AGENTRECEIPTS_AGAINST_ANCHOR", ""), "Path to an out-of-band checkpoint anchor log (ADR-0008). When set, verify additionally checks the chain HEAD against the latest signed checkpoint and fails on tail truncation. Default off: behaviour without this flag is unchanged. (env: AGENTRECEIPTS_AGAINST_ANCHOR)")
+	asJSON := fs.Bool("json", false, "Emit a single machine-readable JSON object on stdout instead of human-readable text. Exit codes are unchanged; diagnostics stay on stderr.")
 	if err := fs.Parse(args); err != nil {
 		// `-h` / `--help` is intentional, not an error — flag.ContinueOnError
 		// surfaces it as flag.ErrHelp after writing the usage message. Exit 0
@@ -145,6 +183,30 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 
 	result := receipt.VerifyChain(receipts, genesisPEM)
 
+	// Accumulate the structured outcome alongside the human-readable output so
+	// --json can emit it without a second code path. Advisories starts as a
+	// non-nil empty slice so it serialises as [] rather than null. emit renders
+	// JSON when --json is set, otherwise it is a no-op and the inline
+	// fmt.Fprintf calls (guarded by !*asJSON) carry the human output.
+	outcome := verifyOutcome{
+		ChainID:    *chainID,
+		Length:     result.Length,
+		Advisories: []string{},
+	}
+	if n := len(receipts); n > 0 {
+		if head, herr := receipt.HashReceipt(receipts[n-1]); herr == nil {
+			outcome.Head = head
+		}
+	}
+	emit := func(code int) int {
+		if *asJSON {
+			outcome.ExitCode = code
+			outcome.Verified = code == ExitOK
+			return writeJSON(stdout, stderr, outcome)
+		}
+		return code
+	}
+
 	// Pin a rotation-resolved chain back to the operator's published key.
 	// resolveGenesisKey anchors on whatever archived key signed receipt[0], so a
 	// chain forged end-to-end under an attacker key — with a matching
@@ -165,13 +227,19 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		currentFp, rotated := currentChainKeyFingerprint(receipts)
 		switch {
 		case !rotated:
-			fmt.Fprintf(stdout, "Chain %s: BROKEN — verified against an archived key, but the chain has no key rotation that installs the published key %s\n", *chainID, *pubKeyPath)
-			return ExitChainBad
+			outcome.Cause = fmt.Sprintf("verified against an archived key, but the chain has no key rotation that installs the published key %s", *pubKeyPath)
+			if !*asJSON {
+				fmt.Fprintf(stdout, "Chain %s: BROKEN — %s\n", *chainID, outcome.Cause)
+			}
+			return emit(ExitChainBad)
 		case currentFp != publishedFp:
-			fmt.Fprintf(stdout, "Chain %s: BROKEN — rotation chain does not terminate at the published key\n", *chainID)
-			fmt.Fprintf(stdout, "  cause: verified from archived genesis %s, but the chain's current key %s is not the published key %s (%s)\n",
+			outcome.Cause = fmt.Sprintf("verified from archived genesis %s, but the chain's current key %s is not the published key %s (%s)",
 				genesisPath, currentFp, *pubKeyPath, publishedFp)
-			return ExitChainBad
+			if !*asJSON {
+				fmt.Fprintf(stdout, "Chain %s: BROKEN — rotation chain does not terminate at the published key\n", *chainID)
+				fmt.Fprintf(stdout, "  cause: %s\n", outcome.Cause)
+			}
+			return emit(ExitChainBad)
 		}
 	}
 
@@ -184,18 +252,26 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	// ADR-0020). It does NOT break the chain, so it never changes the exit
 	// code — surface it as an advisory line regardless of Valid.
 	if result.IncompleteToolRoundtrip {
-		fmt.Fprintln(stdout, "Advisory: incomplete tool roundtrip: final tool call has no result receipt")
+		outcome.Advisories = append(outcome.Advisories, "incomplete tool roundtrip: final tool call has no result receipt")
+		if !*asJSON {
+			fmt.Fprintln(stdout, "Advisory: incomplete tool roundtrip: final tool call has no result receipt")
+		}
 	}
 	if result.IncompleteSession {
-		fmt.Fprintln(stdout, "Advisory: incomplete session: PTY open/close imbalance")
+		outcome.Advisories = append(outcome.Advisories, "incomplete session: PTY open/close imbalance")
+		if !*asJSON {
+			fmt.Fprintln(stdout, "Advisory: incomplete session: PTY open/close imbalance")
+		}
 	}
 
 	if result.Valid {
-		noun := "receipts"
-		if result.Length == 1 {
-			noun = "receipt"
+		if !*asJSON {
+			noun := "receipts"
+			if result.Length == 1 {
+				noun = "receipt"
+			}
+			fmt.Fprintf(stdout, "Chain %s: VALID (%d %s)\n", *chainID, result.Length, noun)
 		}
-		fmt.Fprintf(stdout, "Chain %s: VALID (%d %s)\n", *chainID, result.Length, noun)
 
 		// Out-of-band anchor check (ADR-0008), opt-in via --against-anchor. A
 		// tail-truncated chain still verifies as VALID above — its remaining
@@ -203,7 +279,7 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		// that can catch a dropped tail. Default off: without the flag this
 		// returns here, byte-identical to before.
 		if *againstAnchor == "" {
-			return ExitOK
+			return emit(ExitOK)
 		}
 		headSeq, headHash, headFound, terr := s.GetChainTail(*chainID)
 		if terr != nil {
@@ -212,36 +288,90 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		}
 		ar := verifyAgainstAnchor(*againstAnchor, *chainID, string(pubPEM), headSeq, headHash, headFound)
 		if ar.OK {
-			fmt.Fprintf(stdout, "Anchor %s: PASS (%d checkpoint(s); head seq %d anchored)\n", *againstAnchor, ar.Checked, headSeq)
-			return ExitOK
+			outcome.Anchor = &anchorOutcome{Checked: ar.Checked, Result: "pass", HeadSeq: headSeq}
+			if !*asJSON {
+				fmt.Fprintf(stdout, "Anchor %s: PASS (%d checkpoint(s); head seq %d anchored)\n", *againstAnchor, ar.Checked, headSeq)
+			}
+			return emit(ExitOK)
 		}
+		anchorResult := "fail"
 		label := "FAIL"
 		if ar.Truncated {
+			anchorResult = "fail_truncation"
 			label = "FAIL (truncation)"
 		}
-		fmt.Fprintf(stdout, "Anchor %s: %s — %s\n", *againstAnchor, label, ar.Reason)
-		return ExitChainBad
-	}
-	fmt.Fprintf(stdout, "Chain %s: BROKEN at receipt %d\n", *chainID, result.BrokenAt)
-	if result.Error != "" {
-		// Surface the structured failure cause from VerifyChain — for hash
-		// recompute / response_hash / chain-length / terminal-receipt errors
-		// it carries detail the per-receipt status lines can't express.
-		fmt.Fprintf(stdout, "  cause: %s\n", result.Error)
-	}
-	for _, rv := range result.Receipts {
-		status := "ok"
-		switch {
-		case !rv.SignatureValid:
-			status = "BAD SIGNATURE"
-		case !rv.HashLinkValid:
-			status = "BAD HASH LINK"
-		case !rv.SequenceValid:
-			status = "BAD SEQUENCE"
+		outcome.Anchor = &anchorOutcome{Checked: ar.Checked, Result: anchorResult, Reason: ar.Reason, HeadSeq: headSeq}
+		if !*asJSON {
+			fmt.Fprintf(stdout, "Anchor %s: %s — %s\n", *againstAnchor, label, ar.Reason)
 		}
-		fmt.Fprintf(stdout, "  [%d] %s — %s\n", rv.Index, rv.ReceiptID, status)
+		return emit(ExitChainBad)
 	}
-	return ExitChainBad
+
+	brokenAt := result.BrokenAt
+	outcome.BrokenAt = &brokenAt
+	// Surface the structured failure cause from VerifyChain — for hash
+	// recompute / response_hash / chain-length / terminal-receipt errors it
+	// carries detail the per-receipt status lines can't express.
+	outcome.Cause = result.Error
+	for _, rv := range result.Receipts {
+		outcome.Receipts = append(outcome.Receipts, receiptStatus{Index: rv.Index, ReceiptID: rv.ReceiptID, Status: receiptStatusCode(rv)})
+	}
+	if !*asJSON {
+		fmt.Fprintf(stdout, "Chain %s: BROKEN at receipt %d\n", *chainID, result.BrokenAt)
+		if result.Error != "" {
+			fmt.Fprintf(stdout, "  cause: %s\n", result.Error)
+		}
+		for _, rv := range result.Receipts {
+			fmt.Fprintf(stdout, "  [%d] %s — %s\n", rv.Index, rv.ReceiptID, receiptStatusLabel(rv))
+		}
+	}
+	return emit(ExitChainBad)
+}
+
+// receiptStatusCode maps a per-receipt verification to its machine-readable
+// --json status token.
+func receiptStatusCode(rv receipt.ReceiptVerification) string {
+	switch {
+	case !rv.SignatureValid:
+		return "bad_signature"
+	case !rv.HashLinkValid:
+		return "bad_hash_link"
+	case !rv.SequenceValid:
+		return "bad_sequence"
+	default:
+		return "ok"
+	}
+}
+
+// receiptStatusLabel maps a per-receipt verification to its human-readable
+// status label.
+func receiptStatusLabel(rv receipt.ReceiptVerification) string {
+	switch {
+	case !rv.SignatureValid:
+		return "BAD SIGNATURE"
+	case !rv.HashLinkValid:
+		return "BAD HASH LINK"
+	case !rv.SequenceValid:
+		return "BAD SEQUENCE"
+	default:
+		return "ok"
+	}
+}
+
+// writeJSON encodes the outcome as an indented JSON object on stdout and
+// returns the process exit code. A closed stdout pipe (the reader hung up) is
+// not a verify failure, so the verdict exit code is preserved.
+func writeJSON(stdout, stderr io.Writer, o verifyOutcome) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(o); err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			return o.ExitCode
+		}
+		fmt.Fprintf(stderr, "obsigna receipt verify: encode JSON: %v\n", err)
+		return ExitUsageError
+	}
+	return o.ExitCode
 }
 
 // validatePublicKeyPEM rejects PEM bytes that don't decode to an Ed25519 SPKI

--- a/daemon/internal/verifycli/verify_json_test.go
+++ b/daemon/internal/verifycli/verify_json_test.go
@@ -1,0 +1,168 @@
+package verifycli
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// decodeOutcome parses the --json stdout into a verifyOutcome, failing the test
+// if stdout is not a single well-formed JSON object.
+func decodeOutcome(t *testing.T, stdout string) verifyOutcome {
+	t.Helper()
+	var o verifyOutcome
+	if err := json.Unmarshal([]byte(stdout), &o); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout=%q", err, stdout)
+	}
+	return o
+}
+
+func TestRun_JSONValidChain(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath := fixtureChain(t, dir, "chain-1", 3)
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+		"--json",
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	// --json must emit machine-readable output only: none of the human verdict
+	// strings may leak onto stdout.
+	if strings.Contains(stdout, "VALID") {
+		t.Errorf("stdout = %q, --json must not emit the human 'VALID' line", stdout)
+	}
+	o := decodeOutcome(t, stdout)
+	if !o.Verified || o.ExitCode != ExitOK {
+		t.Errorf("outcome = %+v, want verified with exit_code 0", o)
+	}
+	if o.ChainID != "chain-1" {
+		t.Errorf("chain_id = %q, want chain-1", o.ChainID)
+	}
+	if o.Length != 3 {
+		t.Errorf("length = %d, want 3", o.Length)
+	}
+	if !strings.HasPrefix(o.Head, "sha256:") {
+		t.Errorf("head = %q, want a sha256 chain head", o.Head)
+	}
+	if o.Advisories == nil {
+		t.Error("advisories should serialise as [] for a clean chain, got null")
+	}
+	if len(o.Advisories) != 0 || o.BrokenAt != nil || o.Anchor != nil || len(o.Receipts) != 0 {
+		t.Errorf("clean chain carried failure detail: %+v", o)
+	}
+}
+
+func TestRun_JSONBrokenChainCarriesFailureDetail(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, _ := fixtureChain(t, dir, "chain-1", 2)
+
+	// A different public key makes every signature fail to verify.
+	otherPub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDER, err := x509.MarshalPKIXPublicKey(otherPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPubPath := filepath.Join(dir, "wrong.pub")
+	if err := os.WriteFile(wrongPubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: otherDER}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", wrongPubPath,
+		"--chain-id", "chain-1",
+		"--json",
+	})
+	if code != ExitChainBad {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitChainBad, stderr)
+	}
+	if strings.Contains(stdout, "BROKEN") {
+		t.Errorf("stdout = %q, --json must not emit the human 'BROKEN' line", stdout)
+	}
+	o := decodeOutcome(t, stdout)
+	if o.Verified || o.ExitCode != ExitChainBad {
+		t.Errorf("outcome = %+v, want not-verified with exit_code 1", o)
+	}
+	if o.BrokenAt == nil || *o.BrokenAt != 0 {
+		t.Errorf("broken_at = %v, want 0", o.BrokenAt)
+	}
+	if len(o.Receipts) != 2 {
+		t.Fatalf("receipts = %+v, want 2 per-receipt statuses", o.Receipts)
+	}
+	if o.Receipts[0].Status != "bad_signature" {
+		t.Errorf("receipts[0].status = %q, want bad_signature", o.Receipts[0].Status)
+	}
+	if o.Receipts[0].ReceiptID == "" {
+		t.Error("receipts[0].receipt_id is empty")
+	}
+}
+
+func TestRun_JSONSurfacesAdvisory(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath := fixturePendingTailChain(t, dir, "chain-1", 3)
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+		"--json",
+	})
+	// The advisory is informational only — it must not change the exit code.
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitOK, stderr)
+	}
+	o := decodeOutcome(t, stdout)
+	if !o.Verified {
+		t.Errorf("outcome = %+v, an incomplete-roundtrip chain still verifies", o)
+	}
+	if len(o.Advisories) != 1 || !strings.Contains(o.Advisories[0], "incomplete tool roundtrip") {
+		t.Errorf("advisories = %v, want one incomplete-tool-roundtrip advisory", o.Advisories)
+	}
+}
+
+func TestRun_JSONAnchorFailureIsStructured(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, pubKeyPath := fixtureChain(t, dir, "chain-1", 2)
+
+	// An anchor with no verified checkpoint for this chain (signed by an
+	// unrelated key, checkpoints for a different chain) drives the anchor branch
+	// to a structured failure without changing the chain's own verdict.
+	signer, _ := newAnchorSigner(t)
+	anchorPath := writeAnchor(t, signer, cp("other-chain", 1, "sha256:1"))
+
+	code, stdout, stderr := runOnce(t, []string{
+		"--db", dbPath,
+		"--public-key", pubKeyPath,
+		"--chain-id", "chain-1",
+		"--against-anchor", anchorPath,
+		"--json",
+	})
+	if code != ExitChainBad {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", code, ExitChainBad, stderr)
+	}
+	o := decodeOutcome(t, stdout)
+	if o.Anchor == nil {
+		t.Fatalf("outcome carries no anchor block: %+v", o)
+	}
+	if o.Anchor.Result != "fail" {
+		t.Errorf("anchor.result = %q, want fail", o.Anchor.Result)
+	}
+	if o.Anchor.Reason == "" {
+		t.Error("anchor.reason is empty for a failed anchor check")
+	}
+	if o.Verified {
+		t.Error("an anchor failure must not report verified=true")
+	}
+}


### PR DESCRIPTION
Closes #885.

`obsigna receipt verify` was the only inspection command without `--json` — every sibling (`list`, `show`, `disclose`, `doctor`, `verify-event`) already offers machine-readable output. Since the chain verifier is the command most likely to be wired into CI trust gates, callers were forced to string-match human stdout (`Chain X: VALID (n receipts)`, `BROKEN at receipt N`, per-receipt `BAD SIGNATURE`, `Advisory:`/`Anchor:` lines) that was never meant to be a contract.

## What changed

Add an opt-in `--json` flag to `verifycli` that emits a single structured object on **stdout**, mirroring the `verify-event` wrapper pattern (an object, not a bare value, so it can grow without breaking parsers).

```json
{
  "chain_id": "2026-06-18",
  "verified": true,
  "exit_code": 0,
  "length": 128,
  "head": "sha256:…",
  "advisories": ["incomplete tool roundtrip: final tool call has no result receipt"],
  "anchor": { "checked": 3, "result": "pass", "head_seq": 128 }
}
```

Failure cases carry the structured break detail that today is text-only: `broken_at` index, `cause` (the `VerifyChain` structured error), per-receipt `receipts[]` with `bad_signature`/`bad_hash_link`/`bad_sequence` status, the rotation-pinning break reason, and the `--against-anchor` result (`pass`/`fail`/`fail_truncation` + reason).

## Constraints honoured

- **Exit-code contract unchanged.** Still `0/1/2`; `--json` changes output format only.
- **Stream discipline preserved.** JSON object on stdout; `Note:`/diagnostics stay on stderr.
- **Human output byte-identical** when `--json` is absent (inline writes guarded by `!*asJSON`; the single status switch is split into machine/human label helpers).
- **Tests first.** `verify_json_test.go` covers valid, broken (per-receipt detail), advisory, and anchor-failure cases in the style of `verify_event_test.go`, and asserts no human strings leak onto stdout under `--json`.

## Out of scope

The two verify commands' differing exit-code schemes (`verify` = `0/1/2`, `verify-event` = `0/1/2/3`) are left as-is — a documented house style for verifier CLIs is a separate docs/ADR task.

## Testing

- `go test ./...` (daemon module) — all pass
- `go vet ./...` — clean