### PR TITLE
feat(receipt): add VerifyRaw for raw-bytes signature verification

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+### Added
+
+- **`receipt.VerifyRaw(rawJSON []byte, publicKeyPEM string)`** — verifies a receipt's Ed25519 signature directly from its verbatim on-wire JSON bytes, the verification counterpart to `HashRawReceipt`. Because `Sign` canonicalizes the whole signed payload, a newer SDK that adds and signs over a field nested inside the payload (e.g. under `credentialSubject`) produces a receipt that the struct-based `Verify` false-negatives — it drops the unknown field on `Unmarshal` before canonicalizing — but that `VerifyRaw` accepts. Collectors and auditors holding the raw bytes should prefer `VerifyRaw`. The shared Ed25519 proof-check logic is now factored out of `Verify`; behaviour is unchanged.
+
 ## [0.20.0-alpha.1] - 2026-06-13
 
 ### Added

--- a/sdk/go/receipt/signing.go
+++ b/sdk/go/receipt/signing.go
@@ -152,13 +152,23 @@ func VerifyRaw(rawJSON []byte, publicKeyPEM string) (bool, error) {
 // rawProof extracts proof.type and proof.proofValue from a raw receipt's
 // generic representation. A missing field yields the empty string, which
 // verifyCanonical rejects with the same error a struct receipt would produce.
+// A field that is present but not a JSON string is malformed and rejected here,
+// rather than being coerced to "" and producing a misleading downstream error.
 func rawProof(generic map[string]any) (proofType, proofValue string, err error) {
 	proof, ok := generic["proof"].(map[string]any)
 	if !ok {
 		return "", "", errors.New("raw receipt has no proof object")
 	}
-	proofType, _ = proof["type"].(string)
-	proofValue, _ = proof["proofValue"].(string)
+	if v, present := proof["type"]; present {
+		if proofType, ok = v.(string); !ok {
+			return "", "", errors.New("raw receipt proof.type is not a string")
+		}
+	}
+	if v, present := proof["proofValue"]; present {
+		if proofValue, ok = v.(string); !ok {
+			return "", "", errors.New("raw receipt proof.proofValue is not a string")
+		}
+	}
 	return proofType, proofValue, nil
 }
 

--- a/sdk/go/receipt/signing.go
+++ b/sdk/go/receipt/signing.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -83,18 +84,99 @@ func Sign(unsigned UnsignedAgentReceipt, privateKeyPEM string, verificationMetho
 }
 
 // Verify checks the Ed25519 signature on a signed receipt.
+//
+// Verify canonicalizes a re-marshal of the Go struct, so any field a newer SDK
+// added inside the signed payload (e.g. nested under credentialSubject) is
+// dropped on the way in and does not contribute to the verified bytes — turning
+// a genuinely valid signature into a false negative. When you hold the verbatim
+// wire bytes (as a collector or auditor does), prefer VerifyRaw, which is to
+// Verify what HashRawReceipt is to HashReceipt.
 func Verify(r AgentReceipt, publicKeyPEM string) (bool, error) {
-	if r.Proof.Type != ProofTypeEd25519Signature2020 {
-		return false, fmt.Errorf("unsupported proof type %q: only %s is accepted", r.Proof.Type, ProofTypeEd25519Signature2020)
+	unsigned := UnsignedAgentReceipt{
+		Context:           r.Context,
+		ID:                r.ID,
+		Type:              r.Type,
+		Version:           r.Version,
+		Issuer:            r.Issuer,
+		IssuanceDate:      r.IssuanceDate,
+		CredentialSubject: r.CredentialSubject,
 	}
-	if len(r.Proof.ProofValue) < 2 {
-		return false, errors.New("proof value too short")
+	canonical, err := Canonicalize(unsigned)
+	if err != nil {
+		return false, fmt.Errorf("canonicalize for verification: %w", err)
 	}
-	if r.Proof.ProofValue[0] != 'u' {
-		return false, fmt.Errorf("unsupported multibase prefix: %q", r.Proof.ProofValue[0])
+	return verifyCanonical(canonical, r.Proof.Type, r.Proof.ProofValue, publicKeyPEM)
+}
+
+// VerifyRaw checks the Ed25519 signature on a receipt directly from its on-wire
+// JSON bytes, without round-tripping through the Go struct.
+//
+// This is the verification counterpart to HashRawReceipt: it canonicalizes the
+// verbatim wire bytes (minus the proof block), so every field present on the
+// wire — including ones the current Go struct does not know about — contributes
+// to the verified payload. Sign canonicalizes the whole UnsignedAgentReceipt,
+// so a newer SDK that adds and signs over a field nested in the payload produces
+// a receipt that VerifyRaw accepts but the struct-based Verify rejects.
+//
+// The proof block is read from the raw bytes and stripped before
+// canonicalization, matching Sign's "unsigned receipt" signing scheme.
+//
+// Returns an error if rawJSON is not a JSON object, carries no usable proof, or
+// the proof encoding is malformed; returns (false, nil) when the signature is
+// well-formed but does not verify against publicKeyPEM.
+func VerifyRaw(rawJSON []byte, publicKeyPEM string) (bool, error) {
+	var generic map[string]any
+	if err := json.Unmarshal(rawJSON, &generic); err != nil {
+		return false, fmt.Errorf("unmarshal raw receipt: %w", err)
+	}
+	// json.Unmarshal of "null" into *map sets generic to nil rather than
+	// failing — reject explicitly, mirroring HashRawReceipt.
+	if generic == nil {
+		return false, errors.New("raw receipt is not a JSON object")
 	}
 
-	signature, err := base64.RawURLEncoding.DecodeString(r.Proof.ProofValue[1:])
+	proofType, proofValue, err := rawProof(generic)
+	if err != nil {
+		return false, err
+	}
+
+	delete(generic, "proof")
+	canonical, err := Canonicalize(generic)
+	if err != nil {
+		return false, fmt.Errorf("canonicalize raw receipt: %w", err)
+	}
+
+	return verifyCanonical(canonical, proofType, proofValue, publicKeyPEM)
+}
+
+// rawProof extracts proof.type and proof.proofValue from a raw receipt's
+// generic representation. A missing field yields the empty string, which
+// verifyCanonical rejects with the same error a struct receipt would produce.
+func rawProof(generic map[string]any) (proofType, proofValue string, err error) {
+	proof, ok := generic["proof"].(map[string]any)
+	if !ok {
+		return "", "", errors.New("raw receipt has no proof object")
+	}
+	proofType, _ = proof["type"].(string)
+	proofValue, _ = proof["proofValue"].(string)
+	return proofType, proofValue, nil
+}
+
+// verifyCanonical checks an Ed25519 proof over an already-canonicalized payload.
+// It is the shared crypto core of Verify and VerifyRaw; the two differ only in
+// how they derive the canonical bytes (struct re-marshal vs verbatim wire bytes).
+func verifyCanonical(canonical, proofType, proofValue, publicKeyPEM string) (bool, error) {
+	if proofType != ProofTypeEd25519Signature2020 {
+		return false, fmt.Errorf("unsupported proof type %q: only %s is accepted", proofType, ProofTypeEd25519Signature2020)
+	}
+	if len(proofValue) < 2 {
+		return false, errors.New("proof value too short")
+	}
+	if proofValue[0] != 'u' {
+		return false, fmt.Errorf("unsupported multibase prefix: %q", proofValue[0])
+	}
+
+	signature, err := base64.RawURLEncoding.DecodeString(proofValue[1:])
 	if err != nil {
 		return false, fmt.Errorf("decode proof value: %w", err)
 	}
@@ -105,21 +187,6 @@ func Verify(r AgentReceipt, publicKeyPEM string) (bool, error) {
 	pubKey, err := parsePublicKey(publicKeyPEM)
 	if err != nil {
 		return false, err
-	}
-
-	unsigned := UnsignedAgentReceipt{
-		Context:           r.Context,
-		ID:                r.ID,
-		Type:              r.Type,
-		Version:           r.Version,
-		Issuer:            r.Issuer,
-		IssuanceDate:      r.IssuanceDate,
-		CredentialSubject: r.CredentialSubject,
-	}
-
-	canonical, err := Canonicalize(unsigned)
-	if err != nil {
-		return false, fmt.Errorf("canonicalize for verification: %w", err)
 	}
 
 	return ed25519.Verify(pubKey, []byte(canonical), signature), nil

--- a/sdk/go/receipt/signing_test.go
+++ b/sdk/go/receipt/signing_test.go
@@ -1,10 +1,12 @@
 package receipt
 
 import (
+	"crypto/ed25519"
 	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"strings"
 	"testing"
@@ -254,5 +256,225 @@ func TestVerifyRejectsTamperedReceipt(t *testing.T) {
 	}
 	if valid {
 		t.Error("expected tampered receipt to fail verification")
+	}
+}
+
+// signRawPayload signs a generic receipt payload (without a proof block) the
+// same way Sign signs an UnsignedAgentReceipt, returning the full receipt bytes
+// with the proof spliced in. It lets tests construct receipts whose signed
+// payload carries fields the Go struct does not model.
+func signRawPayload(t *testing.T, payload map[string]any, privateKeyPEM string) []byte {
+	t.Helper()
+	priv, err := parsePrivateKey(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("parsePrivateKey: %v", err)
+	}
+	canonical, err := Canonicalize(payload)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	sig := ed25519.Sign(priv, []byte(canonical))
+	payload["proof"] = map[string]any{
+		"type":               ProofTypeEd25519Signature2020,
+		"created":            "2026-01-01T00:00:00Z",
+		"verificationMethod": "did:agent:test#key-1",
+		"proofPurpose":       "assertionMethod",
+		"proofValue":         multibaseBase64URL + base64.RawURLEncoding.EncodeToString(sig),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return raw
+}
+
+func TestVerifyRaw_MatchesVerifyForKnownFields(t *testing.T) {
+	// For a receipt whose every field is known to the Go struct, VerifyRaw and
+	// Verify operate on identical canonical bytes, so both must accept a valid
+	// signature and both must reject a wrong key.
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsigned := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	signed, err := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := VerifyRaw(raw, kp.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("VerifyRaw rejected a validly-signed receipt")
+	}
+
+	other, _ := GenerateKeyPair()
+	ok, err = VerifyRaw(raw, other.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("VerifyRaw accepted a receipt under the wrong key")
+	}
+}
+
+func TestVerifyRaw_AcceptsForwardCompatNestedField(t *testing.T) {
+	// The reason VerifyRaw exists: a newer SDK can add a field nested inside
+	// the signed payload (e.g. under credentialSubject) and sign over it. The
+	// struct-based Verify drops that field on Unmarshal and false-negatives;
+	// VerifyRaw canonicalizes the verbatim wire bytes and accepts the receipt.
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsigned := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-fc"},
+	})
+
+	// Derive the payload from the real struct so field names match the wire
+	// exactly, then splice in one field the current struct does not model.
+	ub, err := json.Marshal(unsigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(ub, &payload); err != nil {
+		t.Fatal(err)
+	}
+	payload["credentialSubject"].(map[string]any)["_future_nested"] = "v2"
+
+	raw := signRawPayload(t, payload, kp.PrivateKey)
+
+	ok, err := VerifyRaw(raw, kp.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("VerifyRaw rejected a validly-signed forward-compat receipt")
+	}
+
+	// Confirm the divergence is real: the struct path drops the nested field
+	// before canonicalizing, so Verify computes different bytes and fails.
+	var parsed AgentReceipt
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	structOK, err := Verify(parsed, kp.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if structOK {
+		t.Fatal("expected struct-based Verify to false-negative on the nested field; VerifyRaw would then be redundant")
+	}
+}
+
+func TestVerifyRaw_RejectsTamperedBytes(t *testing.T) {
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsigned := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	signed, err := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Flip a value inside the signed payload without touching the proof.
+	tampered := strings.Replace(string(raw), "filesystem.file.read", "filesystem.file.delete", 1)
+	if tampered == string(raw) {
+		t.Fatal("tamper splice did not change the bytes")
+	}
+
+	ok, err := VerifyRaw([]byte(tampered), kp.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("VerifyRaw accepted tampered bytes")
+	}
+}
+
+func TestVerifyRaw_RejectsWrongProofType(t *testing.T) {
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsigned := Create(CreateInput{
+		Issuer:    Issuer{ID: "did:agent:test"},
+		Principal: Principal{ID: "did:user:test"},
+		Action:    Action{Type: "filesystem.file.read", RiskLevel: RiskLow},
+		Outcome:   Outcome{Status: StatusSuccess},
+		Chain:     Chain{Sequence: 1, ChainID: "chain-1"},
+	})
+	signed, err := Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Swap proof.type in the raw bytes. The Ed25519 signature stays valid, but
+	// VerifyRaw must reject any scheme other than Ed25519Signature2020.
+	swapped := strings.Replace(string(raw), ProofTypeEd25519Signature2020, "RsaSignature2018", 1)
+	if swapped == string(raw) {
+		t.Fatal("proof.type splice did not change the bytes")
+	}
+
+	ok, err := VerifyRaw([]byte(swapped), kp.PublicKey)
+	if err == nil {
+		t.Error("expected error for wrong proof.type")
+	}
+	if ok {
+		t.Error("expected VerifyRaw=false for wrong proof.type")
+	}
+}
+
+func TestVerifyRaw_RejectsMalformedInput(t *testing.T) {
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		"non-object array":  `[1,2,3]`,
+		"non-object number": `42`,
+		"non-object null":   `null`,
+		"empty":             ``,
+		"no proof block":    `{"id":"urn:r:1","credentialSubject":{"x":1}}`,
+		"proof not object":  `{"id":"urn:r:1","proof":"u-AAA"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := VerifyRaw([]byte(body), kp.PublicKey); err == nil {
+				t.Errorf("VerifyRaw(%q): err=nil, want error", body)
+			}
+		})
 	}
 }

--- a/sdk/go/receipt/signing_test.go
+++ b/sdk/go/receipt/signing_test.go
@@ -463,12 +463,14 @@ func TestVerifyRaw_RejectsMalformedInput(t *testing.T) {
 		t.Fatal(err)
 	}
 	cases := map[string]string{
-		"non-object array":  `[1,2,3]`,
-		"non-object number": `42`,
-		"non-object null":   `null`,
-		"empty":             ``,
-		"no proof block":    `{"id":"urn:r:1","credentialSubject":{"x":1}}`,
-		"proof not object":  `{"id":"urn:r:1","proof":"u-AAA"}`,
+		"non-object array":            `[1,2,3]`,
+		"non-object number":           `42`,
+		"non-object null":             `null`,
+		"empty":                       ``,
+		"no proof block":              `{"id":"urn:r:1","credentialSubject":{"x":1}}`,
+		"proof not object":            `{"id":"urn:r:1","proof":"u-AAA"}`,
+		"proof.type not string":       `{"id":"urn:r:1","proof":{"type":123,"proofValue":"uAAA"}}`,
+		"proof.proofValue not string": `{"id":"urn:r:1","proof":{"type":"Ed25519Signature2020","proofValue":123}}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Adds `receipt.VerifyRaw(rawJSON []byte, publicKeyPEM string) (bool, error)` — the verification counterpart to `HashRawReceipt`.

## Why

`Sign` canonicalizes the whole `UnsignedAgentReceipt`, including `credentialSubject`. The struct-based `Verify` rebuilds an `UnsignedAgentReceipt` from the Go struct and canonicalizes *that*, so any field a newer SDK added and signed over — nested inside the signed payload (e.g. under `credentialSubject`) — is silently dropped on `json.Unmarshal` before verification. The Ed25519 check then runs over different bytes than were signed and **false-negatives a genuinely valid signature**.

This is the signature-side twin of the hash-linkage divergence already fixed by `HashRawReceipt` vs `HashReceipt`. It surfaced downstream in the dashboard chain verifier ([agent-receipts/dashboard#73](https://github.com/agent-receipts/dashboard/issues/73)), which has a `HashRawReceipt` hash path but no raw-bytes signature verifier to pair with it.

## What

- **`VerifyRaw`** canonicalizes the verbatim wire bytes minus `proof` (mirroring `HashRawReceipt`) and Ed25519-verifies, so every field present on the wire contributes to the verified payload.
- The shared Ed25519 proof-check (proof type, multibase prefix, base64url decode, signature length, key parse, verify) is factored into an unexported `verifyCanonical`; `Verify` now derives its canonical bytes from the struct and delegates. **`Verify` behaviour is unchanged** — all existing `Verify*` tests pass without modification.

## Tests

- `TestVerifyRaw_MatchesVerifyForKnownFields` — parity with `Verify` for a fully-known receipt (accepts valid, rejects wrong key).
- `TestVerifyRaw_AcceptsForwardCompatNestedField` — the core case: a receipt whose signed payload carries a field nested in `credentialSubject` that the struct does not model. `VerifyRaw` accepts it; the same bytes through struct-`Verify` false-negative — asserting the divergence is real.
- `TestVerifyRaw_RejectsTamperedBytes`, `TestVerifyRaw_RejectsWrongProofType` (signature stays valid but scheme name swapped), `TestVerifyRaw_RejectsMalformedInput` (non-object, empty, missing/non-object proof).

`go vet ./...` clean, `go test ./...` green. CHANGELOG updated under `[Unreleased]`.

## Follow-up

Once released, the dashboard (#73) swaps its `receipt.Verify(struct, …)` call for `receipt.VerifyRaw(cr.Raw, …)`, pairing the signature path with its existing `HashRawReceipt` hash path.
