### PR TITLE
docs(sdk/go): stamp CHANGELOG 0.20.0-alpha.2

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,8 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.20.0-alpha.2] - 2026-06-19
+
 ### Added
 
 - **`receipt.VerifyRaw(rawJSON []byte, publicKeyPEM string)`** — verifies a receipt's Ed25519 signature directly from its verbatim on-wire JSON bytes, the verification counterpart to `HashRawReceipt`. Because `Sign` canonicalizes the whole signed payload, a newer SDK that adds and signs over a field nested inside the payload (e.g. under `credentialSubject`) produces a receipt that the struct-based `Verify` false-negatives — it drops the unknown field on `Unmarshal` before canonicalizing — but that `VerifyRaw` accepts. Collectors and auditors holding the raw bytes should prefer `VerifyRaw`. The shared Ed25519 proof-check logic is now factored out of `Verify`; behaviour is unchanged.


### PR DESCRIPTION
Stamps the Go SDK CHANGELOG for the `sdk/go/v0.20.0-alpha.2` release: moves the `receipt.VerifyRaw` entry from `[Unreleased]` into a dated `[0.20.0-alpha.2] - 2026-06-19` heading.

Additive release (new exported `VerifyRaw` API; `Verify` behaviour unchanged), so it continues the 0.20.0 alpha line. Once merged, the tag `sdk/go/v0.20.0-alpha.2` is pushed at the stamp commit to trigger `release-sdk-go`.

Follow-up: unblocks the dashboard fix for [agent-receipts/dashboard#73](https://github.com/agent-receipts/dashboard/issues/73), which will pin this release and swap its chain verifier to `VerifyRaw`.