### PR TITLE
docs(roadmap): reconcile v1.5 + v1 tables with issue triage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,26 +29,35 @@ inline. Status values: `planned`, `in-progress`, `done`, `deferred`.
 
 ## Regulated industries readiness (v1.5)
 
-Items required before a bank, insurer, or healthcare provider can deploy
-Agent Receipts in production. These are not optional for adoption in
-regulated industries.
+Items relevant before a bank, insurer, or healthcare provider can deploy
+Agent Receipts in production. Sequenced together because they share one
+target audience (regulated-industries adopters) rather than dripped into v2.
+
+The split below reflects a triage by cost-to-build against existing
+plumbing, not by label: the cheap-and-core items (timestamp anchoring,
+revocation, store-completeness — all of which reuse the daemon's existing
+out-of-band anchoring) stay `planned`; the heavy-and-substitutable items
+(HSM, a separate verifier service, at-scale multi-tenancy docs) are
+`deferred` until a concrete regulated deployment drives them.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #489 | planned |
 | RFC 3161 TSA timestamp anchoring (elevated from v2) | ADR-0019 § P3 | #482 | planned |
+| Regional TSA support (eIDAS, ICP-Brasil, etc.) — layers on #482 | new ADR needed | #492 | planned |
 | Revocation list format and reference implementation (elevated from v2) | ADR-0019 § O1 | #483 | planned |
-| `CheckpointPublisher` with object-lock reference backend (elevated from v2) | ADR-0019 § O2 | #484 | planned |
+| `CheckpointPublisher` with object-lock reference backend — base checkpoint anchoring shipped (#889); production object-lock sink remains | ADR-0019 § O2 | #484 | planned |
 | Content-addressed payload storage (GDPR erasure) | ADR-0019 § S3 (extends) | #731 | planned |
-| Standalone verifier service (separable from SDK) | new ADR needed | #490 | planned |
 | Downloadable conformance test suite (packaged suite extending the base vectors shipped in #474) | ADR-0019 § S1 (extends) | not filed | planned |
-| Multi-tenancy guidance — key management at scale | docs | #491 | planned |
-| Regional TSA support (eIDAS, ICP-Brasil, etc.) | new ADR needed | #492 | planned |
+| PKCS#11 / CloudHSM `Signer` adapter | ADR-0018 | #489 | deferred |
+| Standalone verifier service (separable from SDK) — `obsigna verify` CLI already covers the air-gapped audit case | new ADR needed | #490 | deferred |
+| Multi-tenancy guidance — key management at scale | docs | #491 | deferred |
 
-These items have a coherent target audience (regulated-industries adopters) and
-should be sequenced together rather than dripped into v2. Moving them to
-v1.5 surfaces them as a deliberate milestone rather than indefinitely
-deferred work.
+The `deferred` rows are closed as not-planned (#489, #490, #491). They are
+not required for v1.5 adoption: HSM-backed custody is substitutable by the
+existing file/KMS `Signer` paths, standalone verification is already served
+by the `obsigna verify` static binary, and at-scale multi-tenancy docs would
+describe infrastructure that does not yet exist. Each reopens, or gets a
+fresh scoped issue, when a real regulated deployment needs it.
 
 ---
 
@@ -111,8 +120,8 @@ across workstreams they can be parallelised.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Bounded `input`/`output` payload via `PayloadStrategy` (truncation; content-addressed/GDPR erasure split to #731, v1.5) | ADR-0019 § S3 | #478 | planned |
-| `parameterDisclosure` Phase A — cross-SDK + OpenClaw migration (envelope already shipped in Go #468 / TS #472; Python SDK envelope, OpenClaw rename, cross-SDK tests remain) | ADR-0012 | #280 | in-progress |
+| Bound remaining inline plaintext fields — cap `error` / `prompt_preview` + truncation flag (hash-first model superseded the original `PayloadStrategy` framing; content-addressed/GDPR erasure split to #731, v1.5) | ADR-0019 § S3 | #478 | planned |
+| `parameterDisclosure` Phase A — cross-SDK + OpenClaw migration (envelope, Python SDK, OpenClaw rename, cross-SDK tests all shipped) | ADR-0012 | #280 | done |
 
 ### Cross-SDK parity
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,5 +168,5 @@ The following were originally targeted for v2 but elevated to v1.5
 | ADR | Title | Status |
 |---|---|---|
 | ADR-0018 | Signer abstraction and cloud-agnostic KeyProvider design | Accepted |
-| ADR-0019 | Protocol integrity gaps and mitigations | Proposed |
+| ADR-0019 | Protocol integrity gaps and mitigations | Accepted |
 | ADR-0020 | Emitter abstraction and remote receipt delivery | Accepted |

--- a/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
+++ b/docs/adr/0019-protocol-integrity-gaps-and-mitigations.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed
+Accepted (2026-06-19). All Post 3 / v1 gaps are implemented; the remaining
+gaps are documented limitations sequenced for v1.5 / v2 per `ROADMAP.md`
+(the authoritative sequencing source).
 
 ## Context
 


### PR DESCRIPTION
## What

Consistency sweep after triaging the ADR-0019 protocol-integrity gap issues. `ROADMAP.md` is the authoritative sequencing source of truth, and several rows had drifted from their issue states.

## v1.5 — Regulated industries readiness

- **#489** (PKCS#11/CloudHSM), **#490** (standalone verifier service), **#491** (multi-tenancy docs) → `deferred`. All three were closed as not-planned: they're heavy and substitutable — HSM custody by the existing file/KMS `Signer` paths, standalone verification by the `obsigna verify` static binary, and at-scale multi-tenancy docs would describe infrastructure that doesn't exist yet.
- Reordered the table so the **cheap-and-core** items lead — timestamp anchoring (#482/#492), revocation (#483), store-completeness (#484) — all of which reuse the daemon's existing out-of-band anchoring plumbing.
- **#484** row: noted base checkpoint anchoring shipped (#889); the production object-lock sink is what remains.
- Reworded the section intro to explain the split is by cost-to-build-against-existing-plumbing, not by label.

## v1 blockers

- **#280** → `done` (`parameterDisclosure` Phase A complete: envelope, Python SDK, OpenClaw rename, cross-SDK tests all shipped). Complies with the doc's own rule — done only when the issue is closed, which it now is.
- **#478** row retitled to the reframed scope: cap `error`/`prompt_preview` + truncation flag; the hash-first receipt model superseded the original `PayloadStrategy` framing.

Docs-only. No change to the v2-deferred section (#481, #485 still correctly `deferred`). The ADR-0019 in-document priority table is left untouched — it's explicitly a frozen at-time-of-writing snapshot that defers to this roadmap.