### PR TITLE
test(daemon): harden socket-wait loops to break only on ENOENT/ECONNREFUSED

### DIFF
--- a/daemon/tests_chainresume_test.go
+++ b/daemon/tests_chainresume_test.go
@@ -3,8 +3,10 @@
 package daemon
 
 import (
+	"errors"
 	"net"
 	"sort"
+	"syscall"
 	"testing"
 	"time"
 
@@ -113,10 +115,12 @@ func TestResumesChainAfterUncleanShutdown(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		conn, err := net.DialTimeout("unix", cfg.SocketPath, 100*time.Millisecond)
-		if err != nil {
-			break // Socket is unconnectable, safe to restart
+		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ECONNREFUSED) {
+			break // Socket is truly gone, safe to restart
 		}
-		conn.Close()
+		if err == nil {
+			conn.Close()
+		}
 		if time.Now().After(deadline) {
 			t.Fatalf("first daemon socket still listening after 2s, restart would conflict")
 		}

--- a/daemon/tests_interrupted_chain_test.go
+++ b/daemon/tests_interrupted_chain_test.go
@@ -10,11 +10,13 @@ package daemon_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -356,10 +358,12 @@ func TestNoTerminatorOnAlreadyTerminatedChain(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		conn, dialErr := net.DialTimeout("unix", mkCfg().SocketPath, 100*time.Millisecond)
-		if dialErr != nil {
+		if errors.Is(dialErr, syscall.ENOENT) || errors.Is(dialErr, syscall.ECONNREFUSED) {
 			break
 		}
-		conn.Close()
+		if dialErr == nil {
+			conn.Close()
+		}
 		if time.Now().After(deadline) {
 			t.Fatal("first daemon socket still listening — cannot start second run")
 		}
@@ -425,10 +429,12 @@ func TestDaemonAutoAdvancesTerminatedChain(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		conn, dialErr := net.DialTimeout("unix", cfg.SocketPath, 100*time.Millisecond)
-		if dialErr != nil {
+		if errors.Is(dialErr, syscall.ENOENT) || errors.Is(dialErr, syscall.ECONNREFUSED) {
 			break
 		}
-		conn.Close()
+		if dialErr == nil {
+			conn.Close()
+		}
 		if time.Now().After(deadline) {
 			t.Fatal("first daemon socket still listening — cannot start second daemon")
 		}


### PR DESCRIPTION
Closes #736

## Problem

The socket-gone polling loops in the daemon integration tests broke on **any** `net.DialTimeout` error. A spurious or transient dial error could let the next daemon start race while the previous socket was still live, causing test flakes. Surfaced by Copilot review on #735.

## Fix

Break only when the socket is truly gone (`syscall.ENOENT` / `syscall.ECONNREFUSED`); keep polling on transient errors until the deadline:

```go
if errors.Is(dialErr, syscall.ENOENT) || errors.Is(dialErr, syscall.ECONNREFUSED) {
    break
}
```

Applied consistently to all three socket-gone wait loops:
- `daemon/tests_interrupted_chain_test.go` (TestNoTerminatorOnAlreadyTerminatedChain, TestDaemonAutoAdvancesTerminatedChain)
- `daemon/tests_chainresume_test.go` (TestResumesChainAfterUncleanShutdown)

The 'wait for socket ready' loops (break on `err == nil`) are correct as-is and untouched. Added `errors`/`syscall` imports where missing.

## Verification

From `daemon/`: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` all pass. Interrupted-chain and chain-resume integration tests pass (`TestResumePrevHashIntegrity`, `TestInterruptedChainOnSIGTERM`, `TestInterruptedChainOnSIGINT`, plus the two edited interrupted-chain tests). Remaining integration failures are pre-existing TS-emitter tests that require `sdk/ts/dist/` to be built, unrelated to this change.