### PR TITLE
feat(hook): classify shell rm/mv/cp so deletes carry a target and real risk

### DIFF
--- a/daemon/internal/pipeline/parity_test.go
+++ b/daemon/internal/pipeline/parity_test.go
@@ -11,13 +11,12 @@ import (
 // exactly match the expected list. The expected list is the contract:
 // updating it forces a deliberate review of the wire format change.
 //
-// EmitterFrame mirrors sdk/go/emitter.frame field-for-field, plus the
-// extra "action_type" field that the daemon reads but the emitter omits.
-// A divergence here means a daemon that reads fields the emitter never
-// writes, or vice versa.
+// EmitterFrame mirrors sdk/go/emitter.frame field-for-field. A divergence
+// here means a daemon that reads fields the emitter never writes, or vice
+// versa.
 func TestEmitterFrameParityKnownFields(t *testing.T) {
 	expected := []string{
-		"action_type", // EmitterFrame-only: taxonomic action type resolved by emitter
+		"action_type", // taxonomic action type the emitter resolved (e.g. filesystem.file.delete)
 		"agent_id",
 		"agent_type",
 		"capture_method",

--- a/hook/cmd/obsigna-hook/claude_code.go
+++ b/hook/cmd/obsigna-hook/claude_code.go
@@ -69,10 +69,23 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 	// slices and the daemon expects nil to mean "no payload".
 	if len(f.ToolInput) > 0 {
 		ev.Input = f.ToolInput
-		if sys, res, warn := extractFileTarget(f.ToolName, f.ToolInput); res != "" {
-			ev.Target = emitter.Target{System: sys, Resource: res}
-		} else if warn != "" {
-			fmt.Fprintln(os.Stderr, warn)
+		switch {
+		case f.ToolName == "Bash":
+			// Best-effort: classify common filesystem-mutating shell commands
+			// (rm/mv/cp and > redirects) so a destructive delete carries a
+			// filesystem target and its real (high) risk instead of looking
+			// like a harmless command. Unparseable commands fall through with
+			// no target, preserving current behaviour.
+			if sys, res, at := extractBashTarget(f.ToolInput); res != "" {
+				ev.Target = emitter.Target{System: sys, Resource: res}
+				ev.ActionType = at
+			}
+		default:
+			if sys, res, warn := extractFileTarget(f.ToolName, f.ToolInput); res != "" {
+				ev.Target = emitter.Target{System: sys, Resource: res}
+			} else if warn != "" {
+				fmt.Fprintln(os.Stderr, warn)
+			}
 		}
 	}
 	if len(f.ToolResponse) > 0 {

--- a/hook/cmd/obsigna-hook/main_test.go
+++ b/hook/cmd/obsigna-hook/main_test.go
@@ -610,6 +610,81 @@ func TestReadClaudeCode_Target(t *testing.T) {
 	}
 }
 
+// TestReadClaudeCode_BashTarget verifies that readClaudeCode classifies common
+// filesystem-mutating Bash commands, populating ev.Target and ev.ActionType so
+// a destructive delete carries a filesystem target and its real risk, while
+// non-mutating or unparseable commands leave both empty (current behaviour).
+func TestReadClaudeCode_BashTarget(t *testing.T) {
+	cases := []struct {
+		name       string
+		command    string
+		wantSys    string
+		wantRes    string
+		wantAction string
+	}{
+		{
+			name:       "rm -rf gets filesystem target and delete action",
+			command:    "rm -rf build",
+			wantSys:    "filesystem",
+			wantRes:    "build",
+			wantAction: "filesystem.file.delete",
+		},
+		{
+			name:       "mv gets move action with dest target",
+			command:    "mv a.txt b.txt",
+			wantSys:    "filesystem",
+			wantRes:    "b.txt",
+			wantAction: "filesystem.file.move",
+		},
+		{
+			name:       "redirect gets create action",
+			command:    "echo hi > out.txt",
+			wantSys:    "filesystem",
+			wantRes:    "out.txt",
+			wantAction: "filesystem.file.create",
+		},
+		{
+			name:    "non-mutating command leaves target and action empty",
+			command: "go test ./...",
+		},
+		{
+			name:    "glob falls back cleanly",
+			command: "rm *.log",
+		},
+	}
+	noEnv := func(string) string { return "" }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := json.Marshal(map[string]string{"command": tc.command})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			stdin, err := json.Marshal(map[string]any{
+				"hook_event_name": "PostToolUse",
+				"session_id":      "s",
+				"tool_name":       "Bash",
+				"tool_input":      json.RawMessage(input),
+			})
+			if err != nil {
+				t.Fatalf("marshal stdin: %v", err)
+			}
+			ev, _, err := readClaudeCode(stdin, noEnv)
+			if err != nil {
+				t.Fatalf("readClaudeCode: %v", err)
+			}
+			if ev.Target.System != tc.wantSys {
+				t.Errorf("Target.System = %q; want %q", ev.Target.System, tc.wantSys)
+			}
+			if ev.Target.Resource != tc.wantRes {
+				t.Errorf("Target.Resource = %q; want %q", ev.Target.Resource, tc.wantRes)
+			}
+			if ev.ActionType != tc.wantAction {
+				t.Errorf("ActionType = %q; want %q", ev.ActionType, tc.wantAction)
+			}
+		})
+	}
+}
+
 // --- resolveVersion unit tests ---
 
 // TestResolveVersion_PrefersLDFlagInjection pins the precedence the

--- a/hook/cmd/obsigna-hook/shell_target.go
+++ b/hook/cmd/obsigna-hook/shell_target.go
@@ -137,11 +137,14 @@ func extractBashTarget(input json.RawMessage) (system, resource, actionType stri
 
 // lex splits a single shell command into word and output-redirect tokens,
 // honouring single and double quotes so a quoted metacharacter (`"a > b"`,
-// `"x;y"`) is part of a word, never an operator. It returns ok=false when the
-// command contains a construct we refuse to classify: an unquoted forbidden
-// operator (pipe, chain, substitution, input redirect, brace/paren group), an
-// fd-prefixed or fd-duplicating redirect (`2>`, `>&`), a tripled redirect, or
-// an unterminated quote. Quotes are stripped from the emitted word text.
+// `"x;y"`) is part of a word, never an operator. Single quotes make their
+// contents fully literal; double quotes do not suppress `$`/backtick, so those
+// still mean expansion and cause a decline. It returns ok=false when the command
+// contains a construct we refuse to classify: an unquoted forbidden operator
+// (pipe, chain, substitution, input redirect, brace/paren group), a `$`/backtick
+// inside double quotes, an fd-prefixed or fd-duplicating redirect (`2>`, `>&`),
+// a tripled redirect, or an unterminated quote. Quotes are stripped from the
+// emitted word text.
 func lex(s string) ([]token, bool) {
 	var tokens []token
 	var cur strings.Builder
@@ -166,9 +169,14 @@ func lex(s string) ([]token, bool) {
 				cur.WriteRune(r)
 			}
 		case inDouble:
-			if r == '"' {
+			switch {
+			case r == '"':
 				inDouble = false
-			} else {
+			case r == '$' || r == '`':
+				// Double quotes don't suppress variable expansion or command
+				// substitution, so the literal tokens aren't the real target.
+				return nil, false
+			default:
 				cur.WriteRune(r)
 			}
 		case r == '\'':

--- a/hook/cmd/obsigna-hook/shell_target.go
+++ b/hook/cmd/obsigna-hook/shell_target.go
@@ -15,25 +15,31 @@ const (
 	actionFileCreate = "filesystem.file.create"
 )
 
-// shellMetacharacters are control operators and expansion triggers that make a
-// command line impossible to classify with confidence: the target path may be
-// the result of a pipe, a substitution, a variable, or one of several chained
-// commands. When any appear in the command we decline to extract a target
-// rather than guess — preserving the coverage-fraction honesty the codebase
-// already uses for native tools.
-const shellMetacharacters = "|;&\n`$()<{}"
-
-// chainMetacharacters are the control operators that mean a command line runs
-// more than one command (pipe, sequence, background, substitution, here-doc).
-// A redirect target is only authoritative when none of these appear: otherwise
-// `... > out.txt; rm secret` would report the harmless write and mask the
-// destructive delete. It omits `>` so the redirect operator itself is allowed.
-const chainMetacharacters = "|;&\n`$(){}"
+// forbiddenOps are unquoted shell metacharacters that make a command line
+// impossible to classify with confidence: the effective target may be the
+// result of a pipe, a substitution, a variable, an input redirect, or one of
+// several chained commands. When the lexer meets any of these outside quotes it
+// declines, preserving the coverage-fraction honesty the codebase already uses
+// for native tools. Output redirects ('>') are handled separately, not here.
+const forbiddenOps = "|;&<(){}$`\n"
 
 // pathExpansionChars mark a single operand whose final value is decided by the
 // shell, not the literal token: globs (*, ?, [) and home expansion (~). A path
 // containing any of these cannot be reported verbatim, so we skip extraction.
 const pathExpansionChars = "*?[~"
+
+// tokenKind distinguishes a literal word from an output-redirect operator.
+type tokenKind int
+
+const (
+	kindWord tokenKind = iota
+	kindRedirect
+)
+
+type token struct {
+	kind tokenKind
+	text string
+}
 
 // extractBashTarget attempts to classify a Bash tool call as a filesystem
 // mutation and return its target. It handles the common, unambiguous shapes:
@@ -48,6 +54,10 @@ const pathExpansionChars = "*?[~"
 // whose effective target the shell — not the literal tokens — decides, it
 // returns ("", "", "") so the caller falls back to current behaviour (no
 // target, default risk). It never claims a target it did not parse.
+//
+// A mutating verb takes precedence over a redirect: `rm foo > log` is the
+// delete of foo (high risk), not a create of log — otherwise the redirect would
+// mask the destructive command and downgrade its risk.
 //
 // On a confident match it returns ("filesystem", path, actionType); the caller
 // sets ev.Target and ev.ActionType from these. actionType is one of the
@@ -67,81 +77,149 @@ func extractBashTarget(input json.RawMessage) (system, resource, actionType stri
 		return "", "", ""
 	}
 
-	// A redirect target is unambiguous even when the left-hand command is
-	// arbitrary (`echo x > file`), so check redirects before bailing on the
-	// metacharacter scan — but only when the line runs a single command. With
-	// a chain operator present (`... > out.txt; rm secret`) the redirect would
-	// report the harmless write and mask a destructive sibling, so we decline.
-	// We also accept only a single redirect with a literal operand; anything
-	// fancier (fd duplication, here-docs, multiple redirects) falls through.
-	if !strings.ContainsAny(cmd, chainMetacharacters) {
-		if path, ok := redirectTarget(cmd); ok {
-			return "filesystem", path, actionFileCreate
-		}
-	}
-
-	// Beyond redirects, classification requires a single, self-contained
-	// command. Any control operator or expansion trigger means the literal
-	// tokens may not be the real target — decline rather than guess.
-	if strings.ContainsAny(cmd, shellMetacharacters) {
+	tokens, ok := lex(cmd)
+	if !ok || len(tokens) == 0 {
 		return "", "", ""
 	}
 
-	fields := splitFields(cmd)
-	if len(fields) == 0 {
+	// Separate the word tokens from a single output redirect and its operand.
+	// More than one redirect, or a redirect with no literal operand, is too
+	// ambiguous to classify.
+	var words []string
+	redirCount := 0
+	redirTarget := ""
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].kind != kindRedirect {
+			words = append(words, tokens[i].text)
+			continue
+		}
+		redirCount++
+		if i+1 >= len(tokens) || tokens[i+1].kind != kindWord {
+			return "", "", ""
+		}
+		redirTarget = tokens[i+1].text
+		i++ // consume the operand
+	}
+	if redirCount > 1 {
 		return "", "", ""
 	}
 
-	switch fields[0] {
-	case "rm":
-		if path, ok := singleOperand(fields[1:]); ok {
-			return "filesystem", path, actionFileDelete
+	// A mutating verb wins over the redirect: classify by the verb so a
+	// destructive command keeps its real risk even when its output is redirected.
+	if len(words) > 0 {
+		switch words[0] {
+		case "rm":
+			if path, ok := singleOperand(words[1:]); ok {
+				return "filesystem", path, actionFileDelete
+			}
+			return "", "", ""
+		case "mv":
+			if path, ok := lastOperand(words[1:]); ok {
+				return "filesystem", path, actionFileMove
+			}
+			return "", "", ""
+		case "cp":
+			if path, ok := lastOperand(words[1:]); ok {
+				return "filesystem", path, actionFileCreate
+			}
+			return "", "", ""
 		}
-	case "mv":
-		if path, ok := lastOperand(fields[1:]); ok {
-			return "filesystem", path, actionFileMove
-		}
-	case "cp":
-		if path, ok := lastOperand(fields[1:]); ok {
+	}
+
+	// No mutating verb: a lone output redirect creates/truncates its target.
+	if redirCount == 1 {
+		if path, ok := cleanPath(redirTarget); ok {
 			return "filesystem", path, actionFileCreate
 		}
 	}
 	return "", "", ""
 }
 
-// redirectTarget returns the file written by a single output redirect (> or >>)
-// when the operand is a literal path. It returns ok=false when there is no
-// redirect, more than one, or the operand is missing/expandable. fd-prefixed
-// redirects (e.g. `2>file`) are intentionally not matched: they are rare in
-// agent commands and ambiguous to classify.
-func redirectTarget(cmd string) (string, bool) {
-	idx := strings.Index(cmd, ">")
-	if idx < 0 {
-		return "", false
-	}
-	// Reject an fd-duplication or fd-prefixed redirect (`>&`, `2>`): the
-	// character before > is part of the operator, not a clean stdout redirect.
-	if idx > 0 {
-		prev := cmd[idx-1]
-		if prev >= '0' && prev <= '9' {
-			return "", false
+// lex splits a single shell command into word and output-redirect tokens,
+// honouring single and double quotes so a quoted metacharacter (`"a > b"`,
+// `"x;y"`) is part of a word, never an operator. It returns ok=false when the
+// command contains a construct we refuse to classify: an unquoted forbidden
+// operator (pipe, chain, substitution, input redirect, brace/paren group), an
+// fd-prefixed or fd-duplicating redirect (`2>`, `>&`), a tripled redirect, or
+// an unterminated quote. Quotes are stripped from the emitted word text.
+func lex(s string) ([]token, bool) {
+	var tokens []token
+	var cur strings.Builder
+	started := false
+	inSingle, inDouble := false, false
+	flush := func() {
+		if started {
+			tokens = append(tokens, token{kindWord, cur.String()})
+			cur.Reset()
+			started = false
 		}
 	}
-	rest := cmd[idx+1:]
-	rest = strings.TrimPrefix(rest, ">") // collapse >> to the same handling
-	// A second redirect operator anywhere means we cannot pick one target.
-	if strings.Contains(rest, ">") {
-		return "", false
+
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case inSingle:
+			if r == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteRune(r)
+			}
+		case inDouble:
+			if r == '"' {
+				inDouble = false
+			} else {
+				cur.WriteRune(r)
+			}
+		case r == '\'':
+			inSingle = true
+			started = true
+		case r == '"':
+			inDouble = true
+			started = true
+		case r == ' ' || r == '\t':
+			flush()
+		case r == '>':
+			// An fd-prefixed redirect (`2>file`) glues digits to '>': the
+			// pending word is all digits with no separating space. Decline.
+			if started && isAllDigits(cur.String()) {
+				return nil, false
+			}
+			flush()
+			if i+1 < len(runes) && runes[i+1] == '>' {
+				i++ // collapse '>>' to the same redirect
+			}
+			// A further '>' (tripled) or '&' (fd duplication, `>&2`) is not a
+			// clean output redirect to a literal file.
+			if i+1 < len(runes) && (runes[i+1] == '>' || runes[i+1] == '&') {
+				return nil, false
+			}
+			tokens = append(tokens, token{kindRedirect, ">"})
+		case strings.ContainsRune(forbiddenOps, r):
+			return nil, false
+		default:
+			cur.WriteRune(r)
+			started = true
+		}
 	}
-	if strings.HasPrefix(rest, "&") {
-		return "", false
+	if inSingle || inDouble {
+		return nil, false // unterminated quote
 	}
-	operand := strings.TrimSpace(rest)
-	fields := splitFields(operand)
-	if len(fields) != 1 {
-		return "", false
+	flush()
+	return tokens, true
+}
+
+// isAllDigits reports whether s is non-empty and every byte is an ASCII digit.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
 	}
-	return cleanPath(fields[0])
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // singleOperand returns the sole non-flag operand from args, or ok=false when
@@ -187,77 +265,15 @@ func operandsOnly(args []string) []string {
 	return out
 }
 
-// cleanPath unquotes a single literal operand and rejects it when the value is
-// still shell-dependent (glob/tilde, or it expanded to empty). ok=false signals
-// the caller to skip extraction.
+// cleanPath rejects a literal operand when its value is still shell-dependent
+// (glob/tilde) or empty. The lexer has already stripped quotes, so the token is
+// the literal path. ok=false signals the caller to skip extraction.
 func cleanPath(tok string) (string, bool) {
-	p := unquote(tok)
-	if p == "" {
+	if tok == "" {
 		return "", false
 	}
-	if strings.ContainsAny(p, pathExpansionChars) {
+	if strings.ContainsAny(tok, pathExpansionChars) {
 		return "", false
 	}
-	return p, true
-}
-
-// splitFields splits a command into whitespace-separated tokens, honouring
-// single and double quotes so a quoted path with spaces stays one token. It is
-// a minimal shell-word splitter, not a full parser: the metacharacter scan in
-// extractBashTarget has already excluded the inputs it could not handle.
-func splitFields(s string) []string {
-	var fields []string
-	var cur strings.Builder
-	inSingle, inDouble := false, false
-	started := false
-	flush := func() {
-		if started {
-			fields = append(fields, cur.String())
-			cur.Reset()
-			started = false
-		}
-	}
-	for _, r := range s {
-		switch {
-		case inSingle:
-			if r == '\'' {
-				inSingle = false
-			} else {
-				cur.WriteRune(r)
-			}
-		case inDouble:
-			if r == '"' {
-				inDouble = false
-			} else {
-				cur.WriteRune(r)
-			}
-		case r == '\'':
-			inSingle = true
-			started = true
-		case r == '"':
-			inDouble = true
-			started = true
-		case r == ' ' || r == '\t':
-			flush()
-		default:
-			cur.WriteRune(r)
-			started = true
-		}
-	}
-	flush()
-	return fields
-}
-
-// unquote strips a single matched pair of surrounding quotes from a token that
-// splitFields kept whole. splitFields already removes interior quotes, so this
-// is a defensive no-op for tokens it produced; it stays for callers passing raw
-// operands (e.g. a redirect operand lifted before field splitting).
-func unquote(tok string) string {
-	if len(tok) >= 2 {
-		if (tok[0] == '\'' && tok[len(tok)-1] == '\'') ||
-			(tok[0] == '"' && tok[len(tok)-1] == '"') {
-			return tok[1 : len(tok)-1]
-		}
-	}
-	return tok
+	return tok, true
 }

--- a/hook/cmd/obsigna-hook/shell_target.go
+++ b/hook/cmd/obsigna-hook/shell_target.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Taxonomy action types for filesystem mutations. These mirror the entries in
+// sdk/go/taxonomy so the daemon resolves a real risk level from action.type
+// (delete → high, move/copy/create → medium/low) instead of defaulting to the
+// UnknownAction medium risk a synthetic "claude-code.Bash" type would yield.
+const (
+	actionFileDelete = "filesystem.file.delete"
+	actionFileMove   = "filesystem.file.move"
+	actionFileCreate = "filesystem.file.create"
+)
+
+// shellMetacharacters are control operators and expansion triggers that make a
+// command line impossible to classify with confidence: the target path may be
+// the result of a pipe, a substitution, a variable, or one of several chained
+// commands. When any appear in the command we decline to extract a target
+// rather than guess — preserving the coverage-fraction honesty the codebase
+// already uses for native tools.
+const shellMetacharacters = "|;&\n`$()<{}"
+
+// chainMetacharacters are the control operators that mean a command line runs
+// more than one command (pipe, sequence, background, substitution, here-doc).
+// A redirect target is only authoritative when none of these appear: otherwise
+// `... > out.txt; rm secret` would report the harmless write and mask the
+// destructive delete. It omits `>` so the redirect operator itself is allowed.
+const chainMetacharacters = "|;&\n`$(){}"
+
+// pathExpansionChars mark a single operand whose final value is decided by the
+// shell, not the literal token: globs (*, ?, [) and home expansion (~). A path
+// containing any of these cannot be reported verbatim, so we skip extraction.
+const pathExpansionChars = "*?[~"
+
+// extractBashTarget attempts to classify a Bash tool call as a filesystem
+// mutation and return its target. It handles the common, unambiguous shapes:
+//
+//   - rm FILE / rm -rf DIR        → filesystem.file.delete
+//   - mv SRC DST                  → filesystem.file.move (target = DST)
+//   - cp SRC DST                  → filesystem.file.create (target = DST)
+//   - CMD > FILE / CMD >> FILE    → filesystem.file.create (target = FILE)
+//
+// It is deliberately conservative. When the command contains shell control
+// operators, command substitution, variable expansion, globs, or anything else
+// whose effective target the shell — not the literal tokens — decides, it
+// returns ("", "", "") so the caller falls back to current behaviour (no
+// target, default risk). It never claims a target it did not parse.
+//
+// On a confident match it returns ("filesystem", path, actionType); the caller
+// sets ev.Target and ev.ActionType from these. actionType is one of the
+// taxonomy filesystem types so the daemon resolves the real risk level.
+func extractBashTarget(input json.RawMessage) (system, resource, actionType string) {
+	if len(input) == 0 {
+		return "", "", ""
+	}
+	var inp struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(input, &inp); err != nil {
+		return "", "", ""
+	}
+	cmd := strings.TrimSpace(inp.Command)
+	if cmd == "" {
+		return "", "", ""
+	}
+
+	// A redirect target is unambiguous even when the left-hand command is
+	// arbitrary (`echo x > file`), so check redirects before bailing on the
+	// metacharacter scan — but only when the line runs a single command. With
+	// a chain operator present (`... > out.txt; rm secret`) the redirect would
+	// report the harmless write and mask a destructive sibling, so we decline.
+	// We also accept only a single redirect with a literal operand; anything
+	// fancier (fd duplication, here-docs, multiple redirects) falls through.
+	if !strings.ContainsAny(cmd, chainMetacharacters) {
+		if path, ok := redirectTarget(cmd); ok {
+			return "filesystem", path, actionFileCreate
+		}
+	}
+
+	// Beyond redirects, classification requires a single, self-contained
+	// command. Any control operator or expansion trigger means the literal
+	// tokens may not be the real target — decline rather than guess.
+	if strings.ContainsAny(cmd, shellMetacharacters) {
+		return "", "", ""
+	}
+
+	fields := splitFields(cmd)
+	if len(fields) == 0 {
+		return "", "", ""
+	}
+
+	switch fields[0] {
+	case "rm":
+		if path, ok := singleOperand(fields[1:]); ok {
+			return "filesystem", path, actionFileDelete
+		}
+	case "mv":
+		if path, ok := lastOperand(fields[1:]); ok {
+			return "filesystem", path, actionFileMove
+		}
+	case "cp":
+		if path, ok := lastOperand(fields[1:]); ok {
+			return "filesystem", path, actionFileCreate
+		}
+	}
+	return "", "", ""
+}
+
+// redirectTarget returns the file written by a single output redirect (> or >>)
+// when the operand is a literal path. It returns ok=false when there is no
+// redirect, more than one, or the operand is missing/expandable. fd-prefixed
+// redirects (e.g. `2>file`) are intentionally not matched: they are rare in
+// agent commands and ambiguous to classify.
+func redirectTarget(cmd string) (string, bool) {
+	idx := strings.Index(cmd, ">")
+	if idx < 0 {
+		return "", false
+	}
+	// Reject an fd-duplication or fd-prefixed redirect (`>&`, `2>`): the
+	// character before > is part of the operator, not a clean stdout redirect.
+	if idx > 0 {
+		prev := cmd[idx-1]
+		if prev >= '0' && prev <= '9' {
+			return "", false
+		}
+	}
+	rest := cmd[idx+1:]
+	rest = strings.TrimPrefix(rest, ">") // collapse >> to the same handling
+	// A second redirect operator anywhere means we cannot pick one target.
+	if strings.Contains(rest, ">") {
+		return "", false
+	}
+	if strings.HasPrefix(rest, "&") {
+		return "", false
+	}
+	operand := strings.TrimSpace(rest)
+	fields := splitFields(operand)
+	if len(fields) != 1 {
+		return "", false
+	}
+	return cleanPath(fields[0])
+}
+
+// singleOperand returns the sole non-flag operand from args, or ok=false when
+// there is not exactly one (zero operands, or several — `rm a b` mutates two
+// paths and a single Target cannot honestly represent both).
+func singleOperand(args []string) (string, bool) {
+	operands := operandsOnly(args)
+	if len(operands) != 1 {
+		return "", false
+	}
+	return cleanPath(operands[0])
+}
+
+// lastOperand returns the final non-flag operand — the destination for mv/cp.
+// It requires at least two operands (a source and a destination); a single
+// operand means the command is incomplete and not worth classifying.
+func lastOperand(args []string) (string, bool) {
+	operands := operandsOnly(args)
+	if len(operands) < 2 {
+		return "", false
+	}
+	return cleanPath(operands[len(operands)-1])
+}
+
+// operandsOnly drops flag tokens (leading "-"). A bare "--" ends option
+// parsing; everything after it is an operand. "-" alone (stdin/stdout) is
+// treated as a flag-like token and dropped.
+func operandsOnly(args []string) []string {
+	var out []string
+	endOpts := false
+	for _, a := range args {
+		if !endOpts {
+			if a == "--" {
+				endOpts = true
+				continue
+			}
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// cleanPath unquotes a single literal operand and rejects it when the value is
+// still shell-dependent (glob/tilde, or it expanded to empty). ok=false signals
+// the caller to skip extraction.
+func cleanPath(tok string) (string, bool) {
+	p := unquote(tok)
+	if p == "" {
+		return "", false
+	}
+	if strings.ContainsAny(p, pathExpansionChars) {
+		return "", false
+	}
+	return p, true
+}
+
+// splitFields splits a command into whitespace-separated tokens, honouring
+// single and double quotes so a quoted path with spaces stays one token. It is
+// a minimal shell-word splitter, not a full parser: the metacharacter scan in
+// extractBashTarget has already excluded the inputs it could not handle.
+func splitFields(s string) []string {
+	var fields []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	started := false
+	flush := func() {
+		if started {
+			fields = append(fields, cur.String())
+			cur.Reset()
+			started = false
+		}
+	}
+	for _, r := range s {
+		switch {
+		case inSingle:
+			if r == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteRune(r)
+			}
+		case inDouble:
+			if r == '"' {
+				inDouble = false
+			} else {
+				cur.WriteRune(r)
+			}
+		case r == '\'':
+			inSingle = true
+			started = true
+		case r == '"':
+			inDouble = true
+			started = true
+		case r == ' ' || r == '\t':
+			flush()
+		default:
+			cur.WriteRune(r)
+			started = true
+		}
+	}
+	flush()
+	return fields
+}
+
+// unquote strips a single matched pair of surrounding quotes from a token that
+// splitFields kept whole. splitFields already removes interior quotes, so this
+// is a defensive no-op for tokens it produced; it stays for callers passing raw
+// operands (e.g. a redirect operand lifted before field splitting).
+func unquote(tok string) string {
+	if len(tok) >= 2 {
+		if (tok[0] == '\'' && tok[len(tok)-1] == '\'') ||
+			(tok[0] == '"' && tok[len(tok)-1] == '"') {
+			return tok[1 : len(tok)-1]
+		}
+	}
+	return tok
+}

--- a/hook/cmd/obsigna-hook/shell_target_test.go
+++ b/hook/cmd/obsigna-hook/shell_target_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestExtractBashTarget covers the common filesystem-mutating shapes the parser
+// must classify, plus the non-extractable cases that must fall back cleanly
+// (empty system/resource/action), preserving coverage-fraction honesty.
+func TestExtractBashTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantSys    string
+		wantRes    string
+		wantAction string
+	}{
+		// --- deletes ---
+		{
+			name:       "rm single file → delete/high",
+			command:    "rm notes.txt",
+			wantSys:    "filesystem",
+			wantRes:    "notes.txt",
+			wantAction: actionFileDelete,
+		},
+		{
+			name:       "rm -rf dir → delete/high",
+			command:    "rm -rf build",
+			wantSys:    "filesystem",
+			wantRes:    "build",
+			wantAction: actionFileDelete,
+		},
+		{
+			name:       "rm with -- before operand",
+			command:    "rm -- -weird-name",
+			wantSys:    "filesystem",
+			wantRes:    "-weird-name",
+			wantAction: actionFileDelete,
+		},
+		{
+			name:    "rm of multiple files is not a single honest target",
+			command: "rm a.txt b.txt",
+		},
+		{
+			name:    "rm with no operand",
+			command: "rm -rf",
+		},
+		// --- moves ---
+		{
+			name:       "mv a b → move/target is dest",
+			command:    "mv old.txt new.txt",
+			wantSys:    "filesystem",
+			wantRes:    "new.txt",
+			wantAction: actionFileMove,
+		},
+		{
+			name:       "mv with flag",
+			command:    "mv -f src/app dst/app",
+			wantSys:    "filesystem",
+			wantRes:    "dst/app",
+			wantAction: actionFileMove,
+		},
+		{
+			name:    "mv with only one operand",
+			command: "mv solo.txt",
+		},
+		// --- copies ---
+		{
+			name:       "cp a b → create/target is dest",
+			command:    "cp src.txt dst.txt",
+			wantSys:    "filesystem",
+			wantRes:    "dst.txt",
+			wantAction: actionFileCreate,
+		},
+		{
+			name:       "cp -r dir dest",
+			command:    "cp -r ./srcdir ./destdir",
+			wantSys:    "filesystem",
+			wantRes:    "./destdir",
+			wantAction: actionFileCreate,
+		},
+		// --- redirects ---
+		{
+			name:       "echo > file → create",
+			command:    "echo hello > out.txt",
+			wantSys:    "filesystem",
+			wantRes:    "out.txt",
+			wantAction: actionFileCreate,
+		},
+		{
+			name:       "append >> file → create",
+			command:    "printf x >> log.txt",
+			wantSys:    "filesystem",
+			wantRes:    "log.txt",
+			wantAction: actionFileCreate,
+		},
+		{
+			name:    "fd-prefixed redirect is not classified",
+			command: "cmd 2> err.txt",
+		},
+		{
+			name:    "redirect chained with a destructive sibling is not claimed",
+			command: "echo x > out.txt; rm secret",
+		},
+		{
+			name:    "redirect to fd duplication is not classified",
+			command: "cmd >&2",
+		},
+		// --- quoted paths ---
+		{
+			name:       "rm of quoted path with spaces",
+			command:    `rm "my file.txt"`,
+			wantSys:    "filesystem",
+			wantRes:    "my file.txt",
+			wantAction: actionFileDelete,
+		},
+		{
+			name:       "redirect to quoted path",
+			command:    `echo x > "a b.txt"`,
+			wantSys:    "filesystem",
+			wantRes:    "a b.txt",
+			wantAction: actionFileCreate,
+		},
+		// --- non-extractable: fall back cleanly ---
+		{
+			name:    "glob target not claimed",
+			command: "rm *.log",
+		},
+		{
+			name:    "tilde expansion not claimed",
+			command: "rm ~/cache",
+		},
+		{
+			name:    "variable expansion not claimed",
+			command: "rm $TARGET",
+		},
+		{
+			name:    "command substitution not claimed",
+			command: "rm $(find . -name '*.tmp')",
+		},
+		{
+			name:    "pipe not claimed",
+			command: "cat x | rm y",
+		},
+		{
+			name:    "chained command not claimed",
+			command: "cd /tmp && rm junk",
+		},
+		{
+			name:    "semicolon chain not claimed",
+			command: "echo hi; rm a",
+		},
+		{
+			name:    "non-mutating command ignored",
+			command: "go test ./...",
+		},
+		{
+			name:    "ls is not a mutation",
+			command: "ls -la /tmp",
+		},
+		{
+			name:    "empty command",
+			command: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := json.Marshal(map[string]string{"command": tc.command})
+			if err != nil {
+				t.Fatalf("marshal input: %v", err)
+			}
+			sys, res, action := extractBashTarget(json.RawMessage(input))
+			if sys != tc.wantSys {
+				t.Errorf("system = %q; want %q", sys, tc.wantSys)
+			}
+			if res != tc.wantRes {
+				t.Errorf("resource = %q; want %q", res, tc.wantRes)
+			}
+			if action != tc.wantAction {
+				t.Errorf("actionType = %q; want %q", action, tc.wantAction)
+			}
+		})
+	}
+}
+
+// TestExtractBashTarget_MalformedInput verifies malformed or missing input
+// falls back silently rather than panicking or claiming a target.
+func TestExtractBashTarget_MalformedInput(t *testing.T) {
+	cases := []json.RawMessage{
+		json.RawMessage(``),
+		json.RawMessage(`{bad json`),
+		json.RawMessage(`{"command": 123}`),
+		json.RawMessage(`{"not_command": "rm x"}`),
+		json.RawMessage(`{}`),
+	}
+	for _, in := range cases {
+		sys, res, action := extractBashTarget(in)
+		if sys != "" || res != "" || action != "" {
+			t.Errorf("extractBashTarget(%s) = (%q,%q,%q); want all empty", in, sys, res, action)
+		}
+	}
+}
+
+// TestExtractBashTarget_RiskMapping documents that the action types returned
+// are the ones the taxonomy maps to non-default risk. The hook returns the
+// taxonomy type; the daemon resolves risk from it. Asserting the constants here
+// guards against an accidental rename that would silently drop the call back to
+// UnknownAction (medium) risk.
+func TestExtractBashTarget_RiskMapping(t *testing.T) {
+	if actionFileDelete != "filesystem.file.delete" {
+		t.Errorf("delete action type drifted: %q", actionFileDelete)
+	}
+	if actionFileMove != "filesystem.file.move" {
+		t.Errorf("move action type drifted: %q", actionFileMove)
+	}
+	if actionFileCreate != "filesystem.file.create" {
+		t.Errorf("create action type drifted: %q", actionFileCreate)
+	}
+}

--- a/hook/cmd/obsigna-hook/shell_target_test.go
+++ b/hook/cmd/obsigna-hook/shell_target_test.go
@@ -122,6 +122,41 @@ func TestExtractBashTarget(t *testing.T) {
 			wantRes:    "a b.txt",
 			wantAction: actionFileCreate,
 		},
+		// --- quoted metacharacters must NOT read as operators ---
+		{
+			name:    "redirect arrow inside a quoted commit message is not a redirect",
+			command: `git commit -m "rename foo -> bar"`,
+		},
+		{
+			name:    "gt inside a quoted grep pattern is not a redirect",
+			command: `grep "a>b" file.txt`,
+		},
+		{
+			name:    "quoted semicolon is not a chain operator",
+			command: `git commit -m "first; second"`,
+		},
+		{
+			name:       "rm of a filename literally containing gt stays a delete",
+			command:    `rm "weird>name.txt"`,
+			wantSys:    "filesystem",
+			wantRes:    "weird>name.txt",
+			wantAction: actionFileDelete,
+		},
+		// --- destructive verb wins over a redirect (no risk downgrade) ---
+		{
+			name:       "rm with output redirect is still a delete, not a create",
+			command:    "rm -v foo > log.txt",
+			wantSys:    "filesystem",
+			wantRes:    "foo",
+			wantAction: actionFileDelete,
+		},
+		{
+			name:       "mv with output redirect is still a move",
+			command:    "mv -v a.txt b.txt > log.txt",
+			wantSys:    "filesystem",
+			wantRes:    "b.txt",
+			wantAction: actionFileMove,
+		},
 		// --- non-extractable: fall back cleanly ---
 		{
 			name:    "glob target not claimed",

--- a/hook/cmd/obsigna-hook/shell_target_test.go
+++ b/hook/cmd/obsigna-hook/shell_target_test.go
@@ -157,6 +157,26 @@ func TestExtractBashTarget(t *testing.T) {
 			wantRes:    "b.txt",
 			wantAction: actionFileMove,
 		},
+		// --- double quotes do not suppress expansion; single quotes do ---
+		{
+			name:    "variable expansion inside double quotes not claimed",
+			command: `rm "$TARGET"`,
+		},
+		{
+			name:    "command substitution inside double quotes not claimed",
+			command: `rm "$(find . -name '*.tmp')"`,
+		},
+		{
+			name:    "backtick substitution inside double quotes not claimed",
+			command: "rm \"`echo x`\"",
+		},
+		{
+			name:       "single-quoted dollar is a literal filename",
+			command:    `rm '$TARGET'`,
+			wantSys:    "filesystem",
+			wantRes:    "$TARGET",
+			wantAction: actionFileDelete,
+		},
 		// --- non-extractable: fall back cleanly ---
 		{
 			name:    "glob target not claimed",

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -133,6 +133,16 @@ type Event struct {
 	Error    string
 	Decision string
 
+	// ActionType, when set, is the taxonomic action type the emitter has
+	// already resolved for this call (e.g. "filesystem.file.delete"). The
+	// daemon uses it verbatim as action.type and derives risk_level from it via
+	// the taxonomy, so a known-destructive call carries its real risk instead of
+	// the UnknownAction medium a synthetic "<channel>.<tool>" type would yield.
+	// The daemon resolves risk itself rather than trusting an emitter-supplied
+	// risk, so an emitter cannot downgrade risk by setting this. Optional;
+	// omitted from the frame when empty.
+	ActionType string
+
 	// optional issuer/operator identity fields — forwarded to the daemon so
 	// it can stamp receipt.Issuer.Name, receipt.Issuer.Model, and
 	// receipt.Issuer.Operator. When empty, the Emitter's Defaults are used.
@@ -337,6 +347,7 @@ type frame struct {
 	SessionID      string          `json:"session_id"`
 	Channel        string          `json:"channel"`
 	Tool           frameTool       `json:"tool"`
+	ActionType     string          `json:"action_type,omitempty"`
 	Input          json.RawMessage `json:"input,omitempty"`
 	Output         json.RawMessage `json:"output,omitempty"`
 	Error          string          `json:"error,omitempty"`
@@ -475,7 +486,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 	}
 	// Mirror the daemon's per-field length cap so oversized values are caught
 	// at the emitter rather than silently rejected by the daemon after the write.
-	for _, f := range [9]struct{ name, val string }{
+	for _, f := range [10]struct{ name, val string }{
 		{"issuer_name", issuerName},
 		{"issuer_model", issuerModel},
 		{"operator_id", operatorID},
@@ -485,6 +496,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		{"agent_id", ev.AgentID},
 		{"model", ev.Model},
 		{"capture_method", ev.CaptureMethod},
+		{"action_type", ev.ActionType},
 	} {
 		if len(f.val) > MaxIdentityFieldLen {
 			e.dropCount.Add(pendingDrops)
@@ -498,6 +510,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		SessionID:      e.sessionID,
 		Channel:        ev.Channel,
 		Tool:           frameTool{Server: ev.Tool.Server, Name: ev.Tool.Name},
+		ActionType:     ev.ActionType,
 		Input:          ev.Input,
 		Output:         ev.Output,
 		Error:          ev.Error,

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -138,9 +138,10 @@ type Event struct {
 	// daemon uses it verbatim as action.type and derives risk_level from it via
 	// the taxonomy, so a known-destructive call carries its real risk instead of
 	// the UnknownAction medium a synthetic "<channel>.<tool>" type would yield.
-	// The daemon resolves risk itself rather than trusting an emitter-supplied
-	// risk, so an emitter cannot downgrade risk by setting this. Optional;
-	// omitted from the frame when empty.
+	// The daemon derives risk only from this type and never accepts a separate
+	// emitter-supplied risk level — but risk follows the type, so a mislabeled
+	// type yields that type's risk. Emitters must send the true action type, not
+	// a lower-risk one. Optional; omitted from the frame when empty.
 	ActionType string
 
 	// optional issuer/operator identity fields — forwarded to the daemon so

--- a/sdk/go/emitter/parity_test.go
+++ b/sdk/go/emitter/parity_test.go
@@ -11,11 +11,12 @@ import (
 // exactly match the expected list. The expected list is the contract:
 // updating it forces a deliberate review of the wire format change.
 //
-// frame mirrors daemon/internal/pipeline.EmitterFrame field-for-field
-// (minus EmitterFrame's extra "action_type" field). A divergence here
-// means a daemon that reads fields the emitter never writes, or vice versa.
+// frame mirrors daemon/internal/pipeline.EmitterFrame field-for-field.
+// A divergence here means a daemon that reads fields the emitter never
+// writes, or vice versa.
 func TestFrameParityKnownFields(t *testing.T) {
 	expected := []string{
+		"action_type",
 		"agent_id",
 		"agent_type",
 		"capture_method",


### PR DESCRIPTION
Closes #851

## Problem

A shell `rm` was recorded as `claude-code.Bash` with no `action.target.resource` and the default **medium** risk — indistinguishable from a harmless `echo`. The hook skipped Bash entirely for target extraction, so a destructive delete was invisible to the file-identity index (no blast-radius edge) and looked like a no-op by risk.

## What this does

A conservative, best-effort shell parser (`hook/cmd/obsigna-hook/shell_target.go`) classifies the common, unambiguous filesystem-mutating shapes and resolves a real risk via the existing taxonomy:

| Command shape | action.type | risk | target |
|---|---|---|---|
| `rm FILE` / `rm -rf DIR` | `filesystem.file.delete` | **high** | the path |
| `mv SRC DST` | `filesystem.file.move` | medium | `DST` |
| `cp SRC DST` | `filesystem.file.create` | low | `DST` |
| `CMD > FILE` / `CMD >> FILE` | `filesystem.file.create` | low | `FILE` |

The target is reported as `action.target.resource` with `system=filesystem`, matching the existing file-identity shape (Read/Write/Edit).

## Risk mapping mechanism

The daemon already reads an `action_type` frame field and resolves `risk_level` from the taxonomy (delete → high), but the **emitter SDK never sent it**. This PR adds `Event.ActionType` to `sdk/go/emitter`, plumbs it through `Emit` with a length cap, and emits the `action_type` frame field. The daemon resolves risk itself, so an emitter cannot downgrade risk by setting this field. Both frame-parity tests (`sdk/go/emitter`, `daemon/internal/pipeline`) are updated; the daemon parity comment that called `action_type` "emitter-omitted" is corrected.

## Coverage-honesty fallback

The parser never claims a target it did not parse. It declines (returns nothing → current behaviour: no target, default risk) whenever the effective target is shell-decided rather than a literal token:

- chain operators / pipes / sequences (`|`, `;`, `&&`, `&`), command substitution (`` ` ``, `$(...)`), here-docs/braces
- variable expansion (`$VAR`), globs (`*?[`), tilde (`~`)
- fd-prefixed (`2>`) and fd-duplication (`>&2`) redirects, multiple redirects
- a redirect chained with a destructive sibling (`echo x > out.txt; rm secret`) — declines rather than report the harmless write and mask the delete
- multi-operand `rm a b` — a single `Target` cannot honestly represent two paths

Quoted paths with spaces (`rm "my file.txt"`) are handled by a minimal shell-word splitter.

## Tests

- `shell_target_test.go`: every covered shape + non-extractable cases (globs, pipes, vars, substitution, chains, fd redirects) asserting clean fallback; malformed-input cases; action-type/risk constant-drift guard.
- `main_test.go`: end-to-end through `readClaudeCode` asserting `ev.Target` and `ev.ActionType`.

## Verification

`go test ./...`, `go vet ./...`, `go build ./...` pass in `hook/`, `sdk/go/`, and `daemon/internal/pipeline/`.