### PR TITLE
feat(daemon): bound inline plaintext error + prompt_preview fields (#478)

### DIFF
--- a/daemon/cmd/obsigna-daemon/main.go
+++ b/daemon/cmd/obsigna-daemon/main.go
@@ -326,6 +326,8 @@ func resolveConfig(args []string, getenv func(string) string, errOut io.Writer) 
 	fs.DurationVar(&cfg.ShutdownDeadline, "shutdown-deadline", cfg.ShutdownDeadline, "Best-effort time budget for emitting interrupted-chain terminators on SIGTERM/SIGINT (cannot preempt in-progress SQLite I/O)")
 	checkpointAnchor := fs.String("checkpoint-anchor", strings.Join(cfg.CheckpointAnchors, ","), "Comma-separated out-of-band checkpoint anchor sinks (ADR-0008 truncation anchor): file:<path>, git:<dir>, syslog:<tag>, or a bare path (=file:). Empty disables checkpointing. (env: AGENTRECEIPTS_CHECKPOINT_ANCHOR)")
 	fs.IntVar(&cfg.CheckpointCadence, "checkpoint-cadence", cfg.CheckpointCadence, "Receipts between checkpoint emissions per chain; 0/1 = every receipt. A graceful shutdown always forces a final checkpoint. (env: AGENTRECEIPTS_CHECKPOINT_CADENCE)")
+	fs.IntVar(&cfg.MaxErrorLen, "max-error-len", cfg.MaxErrorLen, "Rune cap on the inline outcome.error string; oversized values are truncated, not rejected. 0 = default (256); negative disables truncation. (env: AGENTRECEIPTS_MAX_ERROR_LEN)")
+	fs.IntVar(&cfg.MaxPromptPreviewLen, "max-prompt-preview-len", cfg.MaxPromptPreviewLen, "Rune cap on the inline intent.prompt_preview string; oversized values are truncated and prompt_preview_truncated is set. 0 = default (256); negative disables truncation. (env: AGENTRECEIPTS_MAX_PROMPT_PREVIEW_LEN)")
 
 	// scanConfigFlag (via loadConfigLayer) is the source of truth for --config:
 	// it has already consumed the value, so we never read *configPath. The flag
@@ -510,6 +512,12 @@ func applyFileConfig(cfg *daemon.Config, fc *daemon.FileConfig) {
 	if fc.CheckpointCadence != nil {
 		cfg.CheckpointCadence = *fc.CheckpointCadence
 	}
+	if fc.MaxErrorLen != nil {
+		cfg.MaxErrorLen = *fc.MaxErrorLen
+	}
+	if fc.MaxPromptPreviewLen != nil {
+		cfg.MaxPromptPreviewLen = *fc.MaxPromptPreviewLen
+	}
 }
 
 // envOverlay applies AGENTRECEIPTS_* environment variables over cfg. An unset
@@ -570,6 +578,20 @@ func envOverlay(cfg *daemon.Config, getenv func(string) string) error {
 		}
 		cfg.CheckpointCadence = n
 	}
+	if v := getenv("AGENTRECEIPTS_MAX_ERROR_LEN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid AGENTRECEIPTS_MAX_ERROR_LEN %q: want an integer", v)
+		}
+		cfg.MaxErrorLen = n
+	}
+	if v := getenv("AGENTRECEIPTS_MAX_PROMPT_PREVIEW_LEN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid AGENTRECEIPTS_MAX_PROMPT_PREVIEW_LEN %q: want an integer", v)
+		}
+		cfg.MaxPromptPreviewLen = n
+	}
 	return nil
 }
 
@@ -604,4 +626,19 @@ func printConfig(w io.Writer, cfg daemon.Config) {
 	fmt.Fprintf(w, "shutdown_deadline = %q\n", cfg.ShutdownDeadline.String())
 	fmt.Fprintf(w, "checkpoint_anchor = %q\n", strings.Join(cfg.CheckpointAnchors, ","))
 	fmt.Fprintf(w, "checkpoint_cadence = %d\n", cfg.CheckpointCadence)
+	// Resolve 0 (unset) to the effective default so the printed config reflects
+	// the cap the daemon will actually apply, not a confusing 0. A negative value
+	// (truncation disabled) is printed verbatim.
+	fmt.Fprintf(w, "max_error_len = %d\n", resolveCap(cfg.MaxErrorLen, daemon.DefaultMaxErrorLen))
+	fmt.Fprintf(w, "max_prompt_preview_len = %d\n", resolveCap(cfg.MaxPromptPreviewLen, daemon.DefaultMaxPromptPreviewLen))
+}
+
+// resolveCap returns def when v is 0 (unset) and v otherwise, so a printed cap
+// reflects the value the daemon will apply. A negative v (truncation disabled)
+// is returned as-is.
+func resolveCap(v, def int) int {
+	if v == 0 {
+		return def
+	}
+	return v
 }

--- a/daemon/configfile.go
+++ b/daemon/configfile.go
@@ -47,6 +47,11 @@ type FileConfig struct {
 	// mirrors --checkpoint-cadence.
 	CheckpointAnchor  *string `toml:"checkpoint_anchor"`
 	CheckpointCadence *int    `toml:"checkpoint_cadence"`
+	// MaxErrorLen and MaxPromptPreviewLen mirror --max-error-len and
+	// --max-prompt-preview-len: rune caps on the inline outcome.error and
+	// intent.prompt_preview fields (issue #478).
+	MaxErrorLen         *int `toml:"max_error_len"`
+	MaxPromptPreviewLen *int `toml:"max_prompt_preview_len"`
 }
 
 // DisclosureConfig is the parsed `parameter_disclosure` config-file value. It

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -127,6 +127,18 @@ type Config struct {
 	// CheckpointAnchors is non-empty. Set from --checkpoint-cadence
 	// (env: AGENTRECEIPTS_CHECKPOINT_CADENCE).
 	CheckpointCadence int
+
+	// MaxErrorLen and MaxPromptPreviewLen bound, in runes, the two plaintext
+	// fields the daemon still writes inline (issue #478): outcome.error and
+	// intent.prompt_preview. An oversized value is truncated, not rejected — the
+	// descriptive context is worth keeping even clipped, and dropping the whole
+	// receipt would punch a hole in the audit trail. Default to 256 (matching the
+	// identity-field cap's order of magnitude) when zero; a negative value
+	// disables truncation for that field. Set from --max-error-len /
+	// --max-prompt-preview-len (env: AGENTRECEIPTS_MAX_ERROR_LEN /
+	// AGENTRECEIPTS_MAX_PROMPT_PREVIEW_LEN).
+	MaxErrorLen         int
+	MaxPromptPreviewLen int
 }
 
 // DefaultSocketPath returns the per-OS default socket path. Phase 1 resolves
@@ -217,6 +229,15 @@ func DefaultPublicKeyPath(keyPath string) string {
 const (
 	DefaultIssuerID             = "did:agent-receipts-daemon:local"
 	DefaultVerificationMethodID = DefaultIssuerID + "#k1"
+)
+
+// DefaultMaxErrorLen and DefaultMaxPromptPreviewLen are the default rune caps
+// for the inline plaintext fields outcome.error and intent.prompt_preview
+// (issue #478). They re-export the pipeline package's defaults so the config
+// layer (flags, --print-config) shares the pipeline's single source of truth.
+const (
+	DefaultMaxErrorLen         = pipeline.DefaultMaxErrorLen
+	DefaultMaxPromptPreviewLen = pipeline.DefaultMaxPromptPreviewLen
 )
 
 // DefaultForensicKeyPath returns the default forensic private-key path,
@@ -564,6 +585,17 @@ func Run(ctx context.Context, cfg Config) error {
 	pp.ErrorLog = cfg.Logger.Printf
 	pp.DisclosurePolicy = policy
 	pp.ForensicPublicKey = forensicPublicKey
+
+	// Bound the inline plaintext fields (issue #478). New already installed sane
+	// defaults; only override when the operator configured a non-zero cap, so a
+	// zero/unset Config value keeps the default rather than disabling truncation.
+	// A negative value is a deliberate opt-out and is forwarded as-is.
+	if cfg.MaxErrorLen != 0 {
+		pp.MaxErrorLen = cfg.MaxErrorLen
+	}
+	if cfg.MaxPromptPreviewLen != 0 {
+		pp.MaxPromptPreviewLen = cfg.MaxPromptPreviewLen
+	}
 
 	// Always enable redaction with the built-in patterns. If the operator
 	// supplied a patterns file, load and merge the custom patterns.

--- a/daemon/internal/pipeline/bound_test.go
+++ b/daemon/internal/pipeline/bound_test.go
@@ -1,0 +1,203 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/daemon/internal/chain"
+	"github.com/agent-receipts/ar/daemon/internal/socket"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+// processFrame runs one EmitterFrame through a fresh pipeline and returns the
+// single stored receipt. It is the common harness for the bounding tests below.
+func processFrame(t *testing.T, f EmitterFrame, mutate func(*Pipeline)) receipt.AgentReceipt {
+	t.Helper()
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-1")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+	if mutate != nil {
+		mutate(p)
+	}
+	body, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	return receipts[0]
+}
+
+func errorFrame(errText string) EmitterFrame {
+	return EmitterFrame{
+		Version:   "1",
+		TsEmit:    "2026-05-03T00:00:00Z",
+		SessionID: "s",
+		Channel:   "sdk",
+		Tool:      EmitterTool{Name: "t"},
+		Decision:  "allowed",
+		Error:     errText,
+	}
+}
+
+// TestBuildAndSign_CapsOversizedError verifies the daemon truncates an oversized
+// outcome.error to the configured rune cap and records the truncation in-band
+// (the outcome object's schema forbids an extra flag field), so a hostile or
+// runaway error message cannot inflate the receipt.
+func TestBuildAndSign_CapsOversizedError(t *testing.T) {
+	const cap = 64
+	huge := strings.Repeat("e", 5000)
+	r := processFrame(t, errorFrame(huge), func(p *Pipeline) { p.MaxErrorLen = cap })
+
+	got := r.CredentialSubject.Outcome.Error
+	if got == huge {
+		t.Fatal("error was not truncated")
+	}
+	if !strings.HasSuffix(got, errorTruncatedSuffix) {
+		t.Errorf("truncated error %q missing truncation marker %q", got, errorTruncatedSuffix)
+	}
+	// The kept prefix must be exactly the cap, with the marker appended.
+	if want := huge[:cap] + errorTruncatedSuffix; got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+	if r.CredentialSubject.Outcome.Status != receipt.StatusFailure {
+		t.Errorf("status = %q, want failure", r.CredentialSubject.Outcome.Status)
+	}
+}
+
+// TestBuildAndSign_UndersizedErrorUntouched verifies an error within the cap is
+// stored verbatim with no truncation marker.
+func TestBuildAndSign_UndersizedErrorUntouched(t *testing.T) {
+	const cap = 256
+	msg := "permission denied: cannot write /etc/hosts"
+	r := processFrame(t, errorFrame(msg), func(p *Pipeline) { p.MaxErrorLen = cap })
+
+	if got := r.CredentialSubject.Outcome.Error; got != msg {
+		t.Errorf("error = %q, want untouched %q", got, msg)
+	}
+}
+
+// TestBuildAndSign_ErrorAtCapUntouched checks the boundary: an error exactly at
+// the cap must pass through without a truncation marker.
+func TestBuildAndSign_ErrorAtCapUntouched(t *testing.T) {
+	const cap = 64
+	msg := strings.Repeat("x", cap)
+	r := processFrame(t, errorFrame(msg), func(p *Pipeline) { p.MaxErrorLen = cap })
+
+	if got := r.CredentialSubject.Outcome.Error; got != msg {
+		t.Errorf("error at cap = %q, want untouched %q", got, msg)
+	}
+	if strings.Contains(r.CredentialSubject.Outcome.Error, errorTruncatedSuffix) {
+		t.Error("error exactly at cap must not be marked truncated")
+	}
+}
+
+// TestBuildAndSign_ErrorCapIsRuneSafe verifies the cap counts runes, not bytes,
+// so truncating a multi-byte string never splits a UTF-8 sequence.
+func TestBuildAndSign_ErrorCapIsRuneSafe(t *testing.T) {
+	const cap = 3
+	msg := "héllo wörld" // multi-byte runes
+	r := processFrame(t, errorFrame(msg), func(p *Pipeline) { p.MaxErrorLen = cap })
+
+	got := r.CredentialSubject.Outcome.Error
+	if want := string([]rune(msg)[:cap]) + errorTruncatedSuffix; got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+func previewFrame(preview string) EmitterFrame {
+	f := errorFrame("")
+	f.Error = ""
+	f.PromptPreview = preview
+	return f
+}
+
+// TestBuildAndSign_TruncatesPromptPreview verifies the daemon enforces
+// TruncatePromptPreview on an oversized prompt_preview and sets the
+// prompt_preview_truncated flag the schema already defines.
+func TestBuildAndSign_TruncatesPromptPreview(t *testing.T) {
+	const cap = 16
+	huge := strings.Repeat("p", 4096)
+	r := processFrame(t, previewFrame(huge), func(p *Pipeline) { p.MaxPromptPreviewLen = cap })
+
+	intent := r.CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil; daemon must populate intent.prompt_preview")
+	}
+	if got := intent.PromptPreview; got != huge[:cap] {
+		t.Errorf("prompt_preview = %q, want first %d runes", got, cap)
+	}
+	if intent.PromptPreviewTruncated == nil || !*intent.PromptPreviewTruncated {
+		t.Error("prompt_preview_truncated must be true after truncation")
+	}
+}
+
+// TestBuildAndSign_PromptPreviewUntouched verifies a preview within the cap is
+// stored verbatim and the truncated flag is left absent (nil), not false.
+func TestBuildAndSign_PromptPreviewUntouched(t *testing.T) {
+	const cap = 256
+	preview := "Send the Q3 report to the team"
+	r := processFrame(t, previewFrame(preview), func(p *Pipeline) { p.MaxPromptPreviewLen = cap })
+
+	intent := r.CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil; daemon must populate intent.prompt_preview")
+	}
+	if intent.PromptPreview != preview {
+		t.Errorf("prompt_preview = %q, want untouched %q", intent.PromptPreview, preview)
+	}
+	if intent.PromptPreviewTruncated != nil {
+		t.Errorf("prompt_preview_truncated = %v, want absent for an untruncated preview", *intent.PromptPreviewTruncated)
+	}
+}
+
+// TestBuildAndSign_PromptPreviewAtCapUntouched checks the boundary: a preview
+// exactly at the cap must not be flagged truncated.
+func TestBuildAndSign_PromptPreviewAtCapUntouched(t *testing.T) {
+	const cap = 32
+	preview := strings.Repeat("z", cap)
+	r := processFrame(t, previewFrame(preview), func(p *Pipeline) { p.MaxPromptPreviewLen = cap })
+
+	intent := r.CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil")
+	}
+	if intent.PromptPreview != preview {
+		t.Errorf("prompt_preview at cap = %q, want untouched", intent.PromptPreview)
+	}
+	if intent.PromptPreviewTruncated != nil {
+		t.Error("prompt_preview exactly at cap must not be flagged truncated")
+	}
+}
+
+// TestBuildAndSign_NoPromptPreviewNoIntent verifies a frame without a prompt
+// preview produces no intent block at all (omitempty), keeping the receipt
+// byte-identical to today's output for emitters that send no preview.
+func TestBuildAndSign_NoPromptPreviewNoIntent(t *testing.T) {
+	r := processFrame(t, previewFrame(""), nil)
+	if r.CredentialSubject.Intent != nil {
+		t.Errorf("intent = %#v, want nil when no prompt_preview is sent", r.CredentialSubject.Intent)
+	}
+}
+
+// TestNew_DefaultsBoundCaps pins that New installs sane non-zero default caps so
+// a Pipeline built without explicit configuration still bounds both fields.
+func TestNew_DefaultsBoundCaps(t *testing.T) {
+	p := New(chain.New("c"), nil, nil, "did:test")
+	if p.MaxErrorLen != DefaultMaxErrorLen {
+		t.Errorf("MaxErrorLen = %d, want default %d", p.MaxErrorLen, DefaultMaxErrorLen)
+	}
+	if p.MaxPromptPreviewLen != DefaultMaxPromptPreviewLen {
+		t.Errorf("MaxPromptPreviewLen = %d, want default %d", p.MaxPromptPreviewLen, DefaultMaxPromptPreviewLen)
+	}
+}

--- a/daemon/internal/pipeline/bound_test.go
+++ b/daemon/internal/pipeline/bound_test.go
@@ -180,6 +180,27 @@ func TestBuildAndSign_PromptPreviewAtCapUntouched(t *testing.T) {
 	}
 }
 
+// TestBuildAndSign_NegativePromptPreviewCapDisables verifies a non-positive cap
+// disables truncation (the documented "negative disables" contract) rather than
+// dropping the whole preview. The shared TruncatePromptPreview helper treats
+// maxLen <= 0 as "return empty, mark truncated"; intentFromFrame must not.
+func TestBuildAndSign_NegativePromptPreviewCapDisables(t *testing.T) {
+	preview := strings.Repeat("p", 4096)
+	r := processFrame(t, previewFrame(preview), func(p *Pipeline) { p.MaxPromptPreviewLen = -1 })
+
+	intent := r.CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil; a disabled cap must still store the preview")
+	}
+	if intent.PromptPreview != preview {
+		t.Errorf("prompt_preview = %q (len %d), want full preview untruncated (len %d)",
+			intent.PromptPreview, len(intent.PromptPreview), len(preview))
+	}
+	if intent.PromptPreviewTruncated != nil {
+		t.Errorf("prompt_preview_truncated = %v, want absent when truncation is disabled", *intent.PromptPreviewTruncated)
+	}
+}
+
 // TestBuildAndSign_NoPromptPreviewNoIntent verifies a frame without a prompt
 // preview produces no intent block at all (omitempty), keeping the receipt
 // byte-identical to today's output for emitters that send no preview.

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -948,11 +948,14 @@ func truncateError(s string, maxLen int) string {
 	if maxLen <= 0 {
 		return s
 	}
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
+	count := 0
+	for i := range s { // walk only up to the cap; never materialise []rune(s)
+		if count == maxLen {
+			return s[:i] + errorTruncatedSuffix
+		}
+		count++
 	}
-	return string(runes[:maxLen]) + errorTruncatedSuffix
+	return s
 }
 
 // buildAndSignDropReceipt constructs a synthetic events_dropped receipt.

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -922,6 +922,13 @@ func intentFromFrame(f *EmitterFrame, maxPreviewLen int) *receipt.Intent {
 	if f.PromptPreview == "" {
 		return nil
 	}
+	// A non-positive cap disables truncation, matching truncateError and the
+	// flag/env/TOML contract ("negative disables"). The shared
+	// TruncatePromptPreview helper instead treats maxLen <= 0 as "drop the
+	// whole preview", so guard it here rather than route a disable through it.
+	if maxPreviewLen <= 0 {
+		return &receipt.Intent{PromptPreview: f.PromptPreview}
+	}
 	preview, truncated := receipt.TruncatePromptPreview(f.PromptPreview, maxPreviewLen)
 	intent := &receipt.Intent{PromptPreview: preview}
 	if truncated {

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -42,6 +42,29 @@ const maxIdentityFieldLen = 256
 // rather than the identity-field limit.
 const maxTargetResourceLen = 4096
 
+// DefaultMaxErrorLen and DefaultMaxPromptPreviewLen are the default rune caps
+// for the two plaintext-bearing fields the daemon still writes inline (issue
+// #478). Both default to 256 runes — the same order of magnitude as the
+// identity-field byte cap — so a hostile or runaway value cannot inflate the
+// receipt, slow canonicalisation, or degrade audit-trail readability. Unlike
+// the identity fields (which are rejected outright), these two are truncated:
+// an error message or prompt preview is descriptive context, so dropping the
+// whole receipt to punch a hole in the audit trail is the worse outcome. The
+// caps are rune-based so truncation never splits a UTF-8 sequence. Exported so
+// the daemon's config layer shares one source of truth for the default.
+const (
+	DefaultMaxErrorLen         = 256
+	DefaultMaxPromptPreviewLen = 256
+)
+
+// errorTruncatedSuffix is appended to a truncated outcome.error. The outcome
+// object's schema sets additionalProperties:false (spec
+// agent-receipt.schema.json), so there is no room for a dedicated
+// error_truncated flag without a protocol change; the marker keeps the
+// truncation visible in-band, inside the existing error string, the same way
+// prompt_preview signals truncation via its own typed flag.
+const errorTruncatedSuffix = " […error truncated]"
+
 // SupportedFrameVersion is the only emitter-frame schema this daemon accepts.
 // Bumping it requires a migration plan and a daemon-side translator for the
 // old version; until that exists, accepting unknown versions would silently
@@ -133,6 +156,13 @@ type EmitterFrame struct {
 	// Both are optional; omitted when the tool has no addressable resource.
 	TargetSystem   string `json:"target_system,omitempty"`
 	TargetResource string `json:"target_resource,omitempty"`
+	// PromptPreview is a plaintext preview of the prompt that triggered the
+	// action. When set, the daemon stores it (truncated to MaxPromptPreviewLen
+	// runes) in intent.prompt_preview and flags intent.prompt_preview_truncated
+	// when it had to cut. It is the only plaintext intent field carried inline;
+	// conversation/reasoning are hash-only. Optional; omitted when the emitter
+	// has no prompt to preview.
+	PromptPreview string `json:"prompt_preview,omitempty"`
 }
 
 // EmitterTool identifies the tool the agent invoked.
@@ -181,6 +211,15 @@ type Pipeline struct {
 	// original emitter payload. Nil = no redaction.
 	Redactor *Redactor
 
+	// MaxErrorLen and MaxPromptPreviewLen bound, in runes, the two plaintext
+	// fields the daemon writes inline (issue #478): outcome.error and
+	// intent.prompt_preview. New installs the defaults; the daemon overrides them
+	// from config. A non-positive value disables truncation for that field — set
+	// it deliberately, never by leaving the struct zero-valued (New guards
+	// against that).
+	MaxErrorLen         int
+	MaxPromptPreviewLen int
+
 	// Checkpointer, when set, receives the chain HEAD after every committed
 	// receipt and emits an out-of-band signed checkpoint per its cadence
 	// (ADR-0008 follow-through, truncation anchor). Nil = checkpointing
@@ -219,14 +258,16 @@ type Pipeline struct {
 // time.Now.UTC.
 func New(s *chain.State, ks keysource.KeySource, store pipelineStore, issuerID string) *Pipeline {
 	return &Pipeline{
-		State:       s,
-		Keys:        ks,
-		Store:       store,
-		IssuerID:    issuerID,
-		Now:         func() time.Time { return time.Now().UTC() },
-		TraceLog:    nil,
-		rootChainID: s.ChainID(),
-		agentChains: make(map[string]*chain.State),
+		State:               s,
+		Keys:                ks,
+		Store:               store,
+		IssuerID:            issuerID,
+		Now:                 func() time.Time { return time.Now().UTC() },
+		TraceLog:            nil,
+		MaxErrorLen:         DefaultMaxErrorLen,
+		MaxPromptPreviewLen: DefaultMaxPromptPreviewLen,
+		rootChainID:         s.ChainID(),
+		agentChains:         make(map[string]*chain.State),
 	}
 }
 
@@ -785,10 +826,17 @@ func (p *Pipeline) buildAndSign(
 	// canonical bytes; redaction only sanitises the human-readable string
 	// fields written into the receipt body. The error field is not hashed, so
 	// it is redacted unconditionally when a Redactor is set.
+	//
+	// Bound the error AFTER redaction so the cap reflects what is actually
+	// stored: redaction can grow the string (a long match replaced by a longer
+	// placeholder), so capping first could still leave an over-cap value. The
+	// error is plaintext written inline (issue #478); truncating keeps a hostile
+	// or runaway message from inflating the receipt and slowing canonicalisation.
 	errText := f.Error
 	if p.Redactor != nil {
 		errText = p.Redactor.Redact(errText)
 	}
+	errText = truncateError(errText, p.MaxErrorLen)
 
 	outcome := receipt.Outcome{
 		Status: status,
@@ -812,6 +860,7 @@ func (p *Pipeline) buildAndSign(
 		Principal:     principalFromPeer(peer),
 		Action:        action,
 		Outcome:       outcome,
+		Intent:        intentFromFrame(f, p.MaxPromptPreviewLen),
 		CorrelationID: f.CorrelationID,
 		Delegation:    delegation,
 		Chain: receipt.Chain{
@@ -861,6 +910,42 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 		SessionID: f.SessionID,
 		Runtime:   runtime,
 	}
+}
+
+// intentFromFrame builds the receipt Intent from the emitter frame, truncating
+// the plaintext prompt_preview to maxPreviewLen runes (issue #478). It returns
+// nil when the emitter sent no preview, so the receipt omits the intent block
+// entirely rather than emitting an empty object. The conversation/reasoning
+// hashes are not carried on the daemon emit path today — only the one inline
+// plaintext intent field is, which is why it is the only one bounded here.
+func intentFromFrame(f *EmitterFrame, maxPreviewLen int) *receipt.Intent {
+	if f.PromptPreview == "" {
+		return nil
+	}
+	preview, truncated := receipt.TruncatePromptPreview(f.PromptPreview, maxPreviewLen)
+	intent := &receipt.Intent{PromptPreview: preview}
+	if truncated {
+		intent.PromptPreviewTruncated = &truncated
+	}
+	return intent
+}
+
+// truncateError caps an outcome.error to maxLen runes, appending
+// errorTruncatedSuffix when it had to cut. A non-positive maxLen disables the
+// cap (returns s unchanged) — the daemon never passes one, but a library caller
+// can opt out explicitly. The cap is rune-based so it never splits a UTF-8
+// sequence. Unlike prompt_preview, the truncation is recorded in-band: the
+// outcome schema is closed (additionalProperties:false), so there is no field
+// for an error_truncated flag without a protocol change.
+func truncateError(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + errorTruncatedSuffix
 }
 
 // buildAndSignDropReceipt constructs a synthetic events_dropped receipt.

--- a/daemon/internal/pipeline/parity_test.go
+++ b/daemon/internal/pipeline/parity_test.go
@@ -33,6 +33,7 @@ func TestEmitterFrameParityKnownFields(t *testing.T) {
 		"operator_id",
 		"operator_name",
 		"output",
+		"prompt_preview",
 		"session_id",
 		"target_resource",
 		"target_system",

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -199,6 +199,13 @@ type Event struct {
 	// for filesystem tools). Optional; omitted from the frame when System and
 	// Resource are both empty.
 	Target Target
+
+	// PromptPreview is a plaintext preview of the prompt that triggered the
+	// action. The daemon stores it in intent.prompt_preview, truncating it to a
+	// configured rune cap and flagging intent.prompt_preview_truncated when it
+	// cuts. It is the only plaintext intent field carried inline; conversation
+	// and reasoning are hash-only. Optional; omitted from the frame when empty.
+	PromptPreview string
 }
 
 // Option configures an Emitter at construction.
@@ -367,6 +374,7 @@ type frame struct {
 	CaptureMethod  string          `json:"capture_method,omitempty"`
 	TargetSystem   string          `json:"target_system,omitempty"`
 	TargetResource string          `json:"target_resource,omitempty"`
+	PromptPreview  string          `json:"prompt_preview,omitempty"`
 }
 
 type frameTool struct {
@@ -530,6 +538,7 @@ func (e *DaemonEmitter) Emit(ctx context.Context, ev Event) error {
 		CaptureMethod:  ev.CaptureMethod,
 		TargetSystem:   ev.Target.System,
 		TargetResource: ev.Target.Resource,
+		PromptPreview:  ev.PromptPreview,
 	})
 	if err != nil {
 		// Marshal failure is a caller bug, not a transient outage. Restore

--- a/sdk/go/emitter/emitter_unix_test.go
+++ b/sdk/go/emitter/emitter_unix_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1201,5 +1202,78 @@ func TestEmit_ConcurrentCallsAreSerialised(t *testing.T) {
 		if err := json.Unmarshal(f, &got); err != nil {
 			t.Errorf("frame %d: unmarshal: %v (raw: %s)", i, err, f)
 		}
+	}
+}
+
+// TestEmit_PromptPreviewStampedOnFrame verifies the optional PromptPreview
+// event field reaches the wire frame as prompt_preview, so the daemon can store
+// (and bound) intent.prompt_preview. The emitter forwards it verbatim; the
+// daemon owns truncation (issue #478).
+func TestEmit_PromptPreviewStampedOnFrame(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	em, err := NewDaemon(
+		WithSocketPath(rl.path),
+		WithSessionID("preview-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	defer em.Close()
+
+	const preview = "Send the Q3 report to the team"
+	ev := Event{
+		Channel:       "claude-code",
+		Tool:          Tool{Name: "Bash"},
+		Decision:      "allowed",
+		PromptPreview: preview,
+	}
+	if err := em.Emit(context.Background(), ev); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	frames := rl.waitForFrames(t, 1, 2*time.Second)
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames; want 1", len(frames))
+	}
+	var got frame
+	if err := json.Unmarshal(frames[0], &got); err != nil {
+		t.Fatalf("unmarshal frame: %v (raw: %s)", err, frames[0])
+	}
+	if got.PromptPreview != preview {
+		t.Errorf("frame.prompt_preview = %q; want %q", got.PromptPreview, preview)
+	}
+}
+
+// TestEmit_NoPromptPreviewOmitted verifies an empty PromptPreview is omitted
+// from the frame entirely (omitempty), so emitters that send no preview produce
+// the same bytes as before this field existed.
+func TestEmit_NoPromptPreviewOmitted(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	em, err := NewDaemon(
+		WithSocketPath(rl.path),
+		WithSessionID("no-preview-test"),
+		WithLogger(silentLogger()),
+	)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	defer em.Close()
+
+	ev := Event{Channel: "claude-code", Tool: Tool{Name: "Bash"}, Decision: "allowed"}
+	if err := em.Emit(context.Background(), ev); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	frames := rl.waitForFrames(t, 1, 2*time.Second)
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames; want 1", len(frames))
+	}
+	if strings.Contains(string(frames[0]), "prompt_preview") {
+		t.Errorf("frame should omit prompt_preview when unset; got %s", frames[0])
 	}
 }

--- a/sdk/go/emitter/parity_test.go
+++ b/sdk/go/emitter/parity_test.go
@@ -33,6 +33,7 @@ func TestFrameParityKnownFields(t *testing.T) {
 		"operator_id",
 		"operator_name",
 		"output",
+		"prompt_preview",
 		"session_id",
 		"target_resource",
 		"target_system",

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -460,13 +460,18 @@ type KeyPair struct {
 }
 
 // TruncatePromptPreview truncates s to maxLen runes and sets the truncated flag.
+// It walks runes only up to the cap rather than materialising the whole string
+// as []rune, so a large (untrusted) input is bounded in both time and memory.
 func TruncatePromptPreview(s string, maxLen int) (preview string, truncated bool) {
 	if maxLen <= 0 {
 		return "", len(s) > 0
 	}
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s, false
+	count := 0
+	for i := range s { // range yields the byte index at each rune boundary
+		if count == maxLen {
+			return s[:i], true
+		}
+		count++
 	}
-	return string(runes[:maxLen]), true
+	return s, false
 }


### PR DESCRIPTION
## What

Bounds the two plaintext-bearing fields the daemon still writes inline, per #478. The hash-first receipt model already covers `parameters`/`conversation`/`reasoning`/`response`/`before`/`after`; this closes the remaining unbounded inline fields:

- **`outcome.error`** — was unbounded. Now truncated to a configurable rune cap (default **256**), with an in-band truncation marker (` […error truncated]`).
- **`intent.prompt_preview`** — `receipt.TruncatePromptPreview` existed but had **no non-test caller**, so the daemon never enforced it. Now wired into the daemon emit path: truncated to a configurable rune cap (default **256**) and the existing `prompt_preview_truncated` schema flag is set on truncation.

Both caps default to 256 (the identity-field cap's order of magnitude). Unlike the identity fields (rejected outright), these are **truncated, not rejected** — the descriptive context is worth keeping even clipped, and dropping the whole receipt would punch a hole in the audit trail (same philosophy as the disclosure-failure hash-only fallback).

## Truncation flag for `error` — no `error_truncated` field

The issue asked whether `error` needs a new truncation flag. **It cannot get a dedicated boolean flag without a spec change:** `outcome` in `spec/schema/agent-receipt.schema.json` sets `additionalProperties: false`, so an `error_truncated` property would make receipts schema-invalid. Per the agent-safety rule (no spec changes without approval), I kept truncation **in-band** via a suffix marker inside the existing `error` string. If a typed `error_truncated` flag is preferred, that is a deliberate protocol change and a separate decision.

## Spec impact

**None.** `prompt_preview_truncated` already exists in the schema; the error marker stays inside the existing `error` string. No file under `spec/` is touched.

## prompt_preview source

Nothing emitted `prompt_preview` anywhere (the field/helper/flag were latent). To give the daemon a value to bound, a new optional `PromptPreview` field is threaded through the SDK emitter `Event` → wire `frame` → daemon `EmitterFrame`, keeping the emitter↔daemon parity contract intact (both parity tests updated in lockstep).

## Configuration

| Flag | Env | Config-file key |
|------|-----|-----------------|
| `--max-error-len` | `AGENTRECEIPTS_MAX_ERROR_LEN` | `max_error_len` |
| `--max-prompt-preview-len` | `AGENTRECEIPTS_MAX_PROMPT_PREVIEW_LEN` | `max_prompt_preview_len` |

`0` = use default (256); negative = disable truncation. The pipeline default is the single source of truth, re-exported by the daemon config layer; `--print-config` resolves `0`→default so the printed value reflects the effective cap.

## Tests (written first)

- daemon `bound_test.go`: oversized error capped + marked; under-cap and exactly-at-cap untouched; rune-safe truncation (no split UTF-8); oversized preview truncated + flag set; under/at-cap untouched (flag stays absent, not `false`); no preview → no `intent` block; `New` installs defaults.
- emitter: `PromptPreview` reaches the wire frame; omitted when empty.
- both `parity_test.go` updated for the new `prompt_preview` field.

## Verification

`go test ./...`, `go vet ./...`, `go build ./...` all pass for `daemon` and `sdk/go`. `mcp-proxy` and `hook` build clean against the changed SDK.

Closes #478