### PR TITLE
feat(hook): emit taxonomic action_type for native file tools

### DIFF
--- a/hook/cmd/obsigna-hook/claude_code.go
+++ b/hook/cmd/obsigna-hook/claude_code.go
@@ -83,6 +83,11 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 		default:
 			if sys, res, warn := extractFileTarget(f.ToolName, f.ToolInput); res != "" {
 				ev.Target = emitter.Target{System: sys, Resource: res}
+				// Set the taxonomic action type only for native tools whose verb we
+				// can name honestly (Read → read, Write/Edit/MultiEdit → modify).
+				// Opportunistically-captured tools yield a path but no known verb, so
+				// nativeToolActionType returns "" and ActionType stays empty.
+				ev.ActionType = nativeToolActionType(f.ToolName)
 			} else if warn != "" {
 				fmt.Fprintln(os.Stderr, warn)
 			}
@@ -123,6 +128,28 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 // schema drift without failing the hook.
 var fileTools = map[string]bool{
 	"Read": true, "Write": true, "Edit": true, "MultiEdit": true,
+}
+
+// nativeActionTypes maps a native Claude Code tool name to its taxonomic
+// filesystem action type. Only tools whose effect is unambiguous are listed:
+// Read reads, while Write/Edit/MultiEdit all modify an existing path (Write
+// clobbers it in place). Tools absent from the map have no honestly-derivable
+// verb, so nativeToolActionType returns "" and the daemon falls back to its
+// UnknownAction default. The action types are the shared consts from
+// shell_target.go so there is one source of truth across both classifiers.
+var nativeActionTypes = map[string]string{
+	"Read":      actionFileRead,
+	"Write":     actionFileModify,
+	"Edit":      actionFileModify,
+	"MultiEdit": actionFileModify,
+}
+
+// nativeToolActionType returns the taxonomic action type for a native Claude
+// Code tool, or "" when the tool's verb is not known. Callers should only set
+// ev.ActionType when a file target was resolved; an empty string leaves it
+// unset so the daemon does not over-claim a verb we cannot derive.
+func nativeToolActionType(toolName string) string {
+	return nativeActionTypes[toolName]
 }
 
 // skipTools is the set of non-filesystem tools excluded from file_path

--- a/hook/cmd/obsigna-hook/main_test.go
+++ b/hook/cmd/obsigna-hook/main_test.go
@@ -703,7 +703,11 @@ func TestNativeToolActionType(t *testing.T) {
 		{"", ""},
 	}
 	for _, tc := range cases {
-		t.Run(tc.toolName, func(t *testing.T) {
+		name := tc.toolName
+		if name == "" {
+			name = "<empty>"
+		}
+		t.Run(name, func(t *testing.T) {
 			if got := nativeToolActionType(tc.toolName); got != tc.want {
 				t.Errorf("nativeToolActionType(%q) = %q; want %q", tc.toolName, got, tc.want)
 			}

--- a/hook/cmd/obsigna-hook/main_test.go
+++ b/hook/cmd/obsigna-hook/main_test.go
@@ -685,6 +685,103 @@ func TestReadClaudeCode_BashTarget(t *testing.T) {
 	}
 }
 
+// TestNativeToolActionType verifies the native-tool → taxonomy mapping: Read
+// reads, Write/Edit/MultiEdit modify, and any tool we cannot map honestly
+// (MCP-namespaced, Bash, or an unknown opportunistic tool) returns "".
+func TestNativeToolActionType(t *testing.T) {
+	cases := []struct {
+		toolName string
+		want     string
+	}{
+		{"Read", "filesystem.file.read"},
+		{"Write", "filesystem.file.modify"},
+		{"Edit", "filesystem.file.modify"},
+		{"MultiEdit", "filesystem.file.modify"},
+		{"Bash", ""},
+		{"Move", ""},
+		{"mcp__github-audited__create_or_update_file", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.toolName, func(t *testing.T) {
+			if got := nativeToolActionType(tc.toolName); got != tc.want {
+				t.Errorf("nativeToolActionType(%q) = %q; want %q", tc.toolName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadClaudeCode_NativeActionType verifies that readClaudeCode stamps the
+// taxonomic action_type on native file tools (so the daemon resolves real risk),
+// while leaving it empty for opportunistically-captured tools and MCP tools whose
+// verb the hook cannot honestly name.
+func TestReadClaudeCode_NativeActionType(t *testing.T) {
+	cases := []struct {
+		name       string
+		stdin      string
+		wantRes    string
+		wantAction string
+	}{
+		{
+			name: "Read carries read action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Read",` +
+				`"tool_input":{"file_path":"/etc/hosts"},"tool_response":{"content":"127.0.0.1"}}`,
+			wantRes:    "/etc/hosts",
+			wantAction: "filesystem.file.read",
+		},
+		{
+			name: "Write carries modify action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Write",` +
+				`"tool_input":{"file_path":"out.go","content":"package main"}}`,
+			wantRes:    "out.go",
+			wantAction: "filesystem.file.modify",
+		},
+		{
+			name: "Edit carries modify action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Edit",` +
+				`"tool_input":{"file_path":"x.go","old_string":"a","new_string":"b"}}`,
+			wantRes:    "x.go",
+			wantAction: "filesystem.file.modify",
+		},
+		{
+			name: "MultiEdit carries modify action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"MultiEdit",` +
+				`"tool_input":{"file_path":"z.go","edits":[]}}`,
+			wantRes:    "z.go",
+			wantAction: "filesystem.file.modify",
+		},
+		{
+			name: "opportunistic non-file tool with file_path carries empty action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Move",` +
+				`"tool_input":{"file_path":"old.go","destination":"new.go"}}`,
+			wantRes:    "old.go",
+			wantAction: "",
+		},
+		{
+			name: "MCP tool carries empty action",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s",` +
+				`"tool_name":"mcp__github-audited__list_issues","tool_input":{"owner":"foo"}}`,
+			wantRes:    "",
+			wantAction: "",
+		},
+	}
+	noEnv := func(string) string { return "" }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, _, err := readClaudeCode([]byte(tc.stdin), noEnv)
+			if err != nil {
+				t.Fatalf("readClaudeCode: %v", err)
+			}
+			if ev.Target.Resource != tc.wantRes {
+				t.Errorf("Target.Resource = %q; want %q", ev.Target.Resource, tc.wantRes)
+			}
+			if ev.ActionType != tc.wantAction {
+				t.Errorf("ActionType = %q; want %q", ev.ActionType, tc.wantAction)
+			}
+		})
+	}
+}
+
 // --- resolveVersion unit tests ---
 
 // TestResolveVersion_PrefersLDFlagInjection pins the precedence the

--- a/hook/cmd/obsigna-hook/shell_target.go
+++ b/hook/cmd/obsigna-hook/shell_target.go
@@ -5,14 +5,18 @@ import (
 	"strings"
 )
 
-// Taxonomy action types for filesystem mutations. These mirror the entries in
+// Taxonomy action types for filesystem operations. These mirror the entries in
 // sdk/go/taxonomy so the daemon resolves a real risk level from action.type
-// (delete → high, move/copy/create → medium/low) instead of defaulting to the
-// UnknownAction medium risk a synthetic "claude-code.Bash" type would yield.
+// (delete → high, modify/move/copy → medium, create/read → low) instead of
+// defaulting to the UnknownAction medium risk a synthetic "claude-code.<tool>"
+// type would yield. Shared across the Bash-command classifier (extractBashTarget)
+// and the native-tool classifier (nativeToolActionType).
 const (
 	actionFileDelete = "filesystem.file.delete"
 	actionFileMove   = "filesystem.file.move"
 	actionFileCreate = "filesystem.file.create"
+	actionFileRead   = "filesystem.file.read"
+	actionFileModify = "filesystem.file.modify"
 )
 
 // forbiddenOps are unquoted shell metacharacters that make a command line

--- a/hook/cmd/obsigna-hook/shell_target.go
+++ b/hook/cmd/obsigna-hook/shell_target.go
@@ -7,7 +7,7 @@ import (
 
 // Taxonomy action types for filesystem operations. These mirror the entries in
 // sdk/go/taxonomy so the daemon resolves a real risk level from action.type
-// (delete → high, modify/move/copy → medium, create/read → low) instead of
+// (delete → high; modify/move → medium; create/read → low) instead of
 // defaulting to the UnknownAction medium risk a synthetic "claude-code.<tool>"
 // type would yield. Shared across the Bash-command classifier (extractBashTarget)
 // and the native-tool classifier (nativeToolActionType).


### PR DESCRIPTION
## What

Extend the Claude Code hook to emit a taxonomic `action_type` for native file tools (Read/Write/Edit/MultiEdit), not just Bash.

PR #893 added `Event.ActionType` and set it for Bash filesystem-mutating commands via `extractBashTarget`. The native-tool path (`default:` arm of `readClaudeCode`) set `ev.Target` via `extractFileTarget` but left `ev.ActionType` empty, so these tools reached the daemon with a synthetic `claude-code.<tool>` type that resolves to `UnknownAction` (medium). A risk-based `high` parameter-disclosure policy therefore never fired for them.

## Change

- Add `nativeToolActionType(toolName string) string` — a small lookup mapping native tool names to taxonomy action types, only where the verb is honestly derivable:
  - `Read` → `filesystem.file.read` (low)
  - `Write` / `Edit` / `MultiEdit` → `filesystem.file.modify` (medium; Write clobbers in place, so modify is consistent with Edit)
- Wire it into the `default:` switch arm where `extractFileTarget` succeeds, mirroring `extractBashTarget`.
- Opportunistically-captured tools (a non-file tool that still yields a `file_path`) and MCP-namespaced tools have no known verb, so `ActionType` stays empty and the daemon's `UnknownAction` fallback handles them — we don't guess.

### Papercut

Promoted the filesystem action-type strings to shared consts in `shell_target.go` (added `actionFileRead` / `actionFileModify`) so the Bash classifier and the native classifier share one source of truth.

### Not included

`NotebookEdit` was considered but skipped: its input uses `notebook_path`, not `file_path`, so `extractFileTarget` resolves no target and the action-type branch never runs. Wiring it honestly would require extending path extraction — out of scope for this PR.

## Tests

- `TestNativeToolActionType` — Read/Write/Edit/MultiEdit map to the expected types; Bash, an unknown opportunistic tool, an MCP tool, and the empty name all return `""`.
- `TestReadClaudeCode_NativeActionType` — end-to-end frames: native file tools carry the expected `action_type`; an opportunistic non-file tool and an MCP tool carry empty `action_type`.

Verified taxonomy strings (`filesystem.file.read`, `filesystem.file.modify`) exist in `sdk/go/taxonomy/taxonomy.go`.

## Verify

From `hook/`: `go build ./cmd/...`, `go vet ./...`, `go test ./...` all pass. `sdk/go` was not touched.

Part of #721 (one of three emitter PRs — MCP proxy and SDK emitters are separate). Does not close the issue.