### PR TITLE
feat(sdk-py): emitter forwards taxonomic action_type to daemon

### DIFF
--- a/sdk/py/src/obsigna/daemon_emitter.py
+++ b/sdk/py/src/obsigna/daemon_emitter.py
@@ -227,6 +227,7 @@ class DaemonEmitter:
         tool_name: str,
         decision: str,
         tool_server: str = "",
+        action_type: str = "",
         input: bytes | str | None = None,
         output: bytes | str | None = None,
         error: str = "",
@@ -251,6 +252,18 @@ class DaemonEmitter:
             Required. One of ``"allowed"``, ``"denied"``, or ``"pending"``.
         tool_server:
             Optional server qualifier for the tool.
+        action_type:
+            Optional taxonomic action type the emitter has already resolved
+            (e.g. ``"filesystem.file.delete"``). The daemon uses it verbatim as
+            ``action.type`` and resolves ``risk_level`` from it via the
+            taxonomy. When omitted (empty), the daemon falls back to a synthetic
+            ``"<channel>.<tool>"`` type that rarely matches the taxonomy, so
+            risk defaults to medium. Emitters that know the real action type
+            SHOULD set it — that is what makes risk-based controls (e.g.
+            parameter-disclosure ``"high"``) effective. Send the *type*, never a
+            risk level: the daemon always resolves risk itself rather than
+            trusting an emitter-supplied value, so this field cannot be used to
+            downgrade risk and evade a disclosure policy.
         input:
             Optional raw JSON bytes or string. Passed verbatim to the daemon —
             NOT re-serialised. Must be valid JSON when non-empty.
@@ -293,6 +306,11 @@ class DaemonEmitter:
                 "emitter: tool_server must be a str,"
                 f" got {type(tool_server).__name__!r}"
             )
+        if not isinstance(action_type, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(
+                "emitter: action_type must be a str,"
+                f" got {type(action_type).__name__!r}"
+            )
         if not isinstance(error, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: error must be a str, got {type(error).__name__!r}"
@@ -312,6 +330,8 @@ class DaemonEmitter:
             "tool": _build_tool(tool_name, tool_server),
             "decision": decision,
         }
+        if action_type:
+            frame["action_type"] = action_type
         if raw_input is not None:
             frame["input"] = _RawJSON(raw_input)
         if raw_output is not None:

--- a/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
+++ b/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
@@ -650,31 +650,37 @@ def _capture_one_frame(emit_kwargs: dict[str, Any]) -> dict[str, Any]:
 
     def _server() -> None:
         srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        srv.bind(sock_path)
-        srv.listen(1)
-        ready.set()
-        conn, _ = srv.accept()
-        hdr = b""
-        while len(hdr) < 4:
-            chunk = conn.recv(4 - len(hdr))
-            if not chunk:
-                break
-            hdr += chunk
-        if len(hdr) == 4:
-            length = struct.unpack(">I", hdr)[0]
-            body = b""
-            while len(body) < length:
-                chunk = conn.recv(length - len(body))
-                if not chunk:
-                    break
-                body += chunk
-            frames.append(body)
-        conn.close()
-        srv.close()
+        srv.settimeout(5)
+        try:
+            srv.bind(sock_path)
+            srv.listen(1)
+            ready.set()
+            conn, _ = srv.accept()
+            try:
+                conn.settimeout(5)
+                hdr = b""
+                while len(hdr) < 4:
+                    chunk = conn.recv(4 - len(hdr))
+                    if not chunk:
+                        break
+                    hdr += chunk
+                if len(hdr) == 4:
+                    length = struct.unpack(">I", hdr)[0]
+                    body = b""
+                    while len(body) < length:
+                        chunk = conn.recv(length - len(body))
+                        if not chunk:
+                            break
+                        body += chunk
+                    frames.append(body)
+            finally:
+                conn.close()
+        finally:
+            srv.close()
 
     t = threading.Thread(target=_server, daemon=True)
     t.start()
-    ready.wait(timeout=2)
+    assert ready.wait(timeout=2), "echo server did not become ready"
     try:
         e = DaemonEmitter(socket_path=sock_path)
         e.emit(**emit_kwargs)

--- a/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
+++ b/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
@@ -333,6 +333,12 @@ class TestDaemonEmitterValidation:
         with pytest.raises(ValueError, match="tool_name must be a str"):
             self.e.emit(channel="sdk", tool_name=42, decision="allowed")  # type: ignore[arg-type]
 
+    def test_non_str_action_type(self) -> None:
+        with pytest.raises(ValueError, match="action_type must be a str"):
+            self.e.emit(  # type: ignore[arg-type]
+                channel="sdk", tool_name="noop", decision="allowed", action_type=42
+            )
+
     def test_non_str_tool_server(self) -> None:
         with pytest.raises(ValueError, match="tool_server must be a str"):
             self.e.emit(  # type: ignore[arg-type]
@@ -628,6 +634,87 @@ class TestRawJSONPassthrough:
             assert b'{ "b":  2 , "a" : 1 }' in raw_frame
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _capture_one_frame(emit_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Emit a single frame through an in-process echo server and return it.
+
+    Spins up a one-shot AF_UNIX server, runs ``emit`` with ``emit_kwargs``
+    against it, and returns the decoded JSON frame the daemon would receive.
+    No real daemon required.
+    """
+    frames: list[bytes] = []
+    ready = threading.Event()
+    tmpdir = _short_tmp()
+    sock_path = os.path.join(tmpdir, "capture.sock")
+
+    def _server() -> None:
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(sock_path)
+        srv.listen(1)
+        ready.set()
+        conn, _ = srv.accept()
+        hdr = b""
+        while len(hdr) < 4:
+            chunk = conn.recv(4 - len(hdr))
+            if not chunk:
+                break
+            hdr += chunk
+        if len(hdr) == 4:
+            length = struct.unpack(">I", hdr)[0]
+            body = b""
+            while len(body) < length:
+                chunk = conn.recv(length - len(body))
+                if not chunk:
+                    break
+                body += chunk
+            frames.append(body)
+        conn.close()
+        srv.close()
+
+    t = threading.Thread(target=_server, daemon=True)
+    t.start()
+    ready.wait(timeout=2)
+    try:
+        e = DaemonEmitter(socket_path=sock_path)
+        e.emit(**emit_kwargs)
+        e.close()
+        t.join(timeout=2)
+        assert frames, "no frame received by echo server"
+        return json.loads(frames[0])
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestActionType:
+    """The emitter forwards a resolved taxonomic action_type to the daemon.
+
+    The daemon uses action_type verbatim as action.type and resolves risk
+    from the taxonomy, so a high-risk type can drive risk-based controls
+    (parameter-disclosure "high"). The field is omitted when empty so the
+    daemon's "<channel>.<tool>" fallback stays in effect (issue #721).
+    """
+
+    def test_action_type_present_in_frame(self) -> None:
+        frame = _capture_one_frame(
+            {
+                "channel": "sdk",
+                "tool_name": "rm",
+                "decision": "allowed",
+                "action_type": "filesystem.file.delete",
+            }
+        )
+        assert frame["action_type"] == "filesystem.file.delete"
+
+    def test_action_type_absent_when_empty(self) -> None:
+        frame = _capture_one_frame(
+            {
+                "channel": "sdk",
+                "tool_name": "rm",
+                "decision": "allowed",
+            }
+        )
+        assert "action_type" not in frame
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #721 — Python SDK piece of the emitter `action_type` pass-through (Go and TS emitters already send it).

## What

The Python daemon emitter (`sdk/py/src/obsigna/daemon_emitter.py`) now accepts an optional `action_type` keyword on `emit()` and serialises it as the `action_type` frame field, omitted when empty. This matches the Go and TypeScript emitters byte-for-byte:

```python
if action_type:
    frame["action_type"] = action_type
```

## Why

The daemon uses the supplied type verbatim as `action.type` and resolves `risk_level` from the taxonomy. An emitter that knows the real taxonomic type (e.g. `filesystem.file.delete`) can therefore drive risk-based controls such as parameter-disclosure `"high"`. When empty, the daemon’s synthetic `<channel>.<tool>` fallback is unchanged, so the change is additive and backward-compatible.

Emitters send the *type*, never a risk level: the daemon always resolves risk itself, so this field cannot be used to downgrade risk and evade a disclosure policy.

## Changes

- Add `action_type: str = ""` kwarg to `DaemonEmitter.emit()`.
- `isinstance(str)` validation mirroring the existing `tool_server` / `error` guards (raises `ValueError`).
- Insert `action_type` into the frame only when non-empty.
- Docstring `Parameters` section documents the contract (mirrors the TS doc comment).

## Tests

- `action_type="filesystem.file.delete"` → captured frame carries `"action_type": "filesystem.file.delete"`.
- emit without `action_type` → key absent from the frame.
- non-`str` `action_type` raises the validation error.

Frame capture uses an in-process AF_UNIX echo server (no daemon binary required), reusing the existing test pattern.

## Verification

From `sdk/py/`: `uv run pytest` (467 passed, 7 skipped — daemon-binary E2E), `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright src` (0 errors) all clean.

## Notes

- There is no second/duplicate emitter to mirror. The `sdk/py/src/agent_receipts/` directories on disk are stale local `__pycache__` artifacts only — untracked by git, no `.py` source, and not part of the wheel (`packages = ["src/obsigna"]`). The sole daemon emitter lives at `sdk/py/src/obsigna/daemon_emitter.py`.
- Does NOT close #721 (one of three PRs: MCP proxy and hook are separate).