### PR TITLE
feat(mcp-proxy): forward taxonomic action_type on emit frame

### DIFF
--- a/mcp-proxy/cmd/obsigna-mcp/emitter_integration_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/emitter_integration_test.go
@@ -26,7 +26,9 @@ import (
 	"time"
 
 	"github.com/agent-receipts/ar/daemon"
+	"github.com/agent-receipts/ar/mcp-proxy/configs"
 	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/receipt"
 	"github.com/agent-receipts/ar/sdk/go/store"
 )
 
@@ -198,6 +200,7 @@ func TestEmitToContext_AllowedToolCall(t *testing.T) {
 		"allowed",
 		"jsonrpc-req-42",
 		"",
+		"",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
@@ -236,6 +239,7 @@ func TestEmitToContext_DeniedToolCall(t *testing.T) {
 		"denied",
 		"",
 		"",
+		"",
 	)
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
@@ -260,7 +264,7 @@ func TestEmitToContext_MultipleEvents(t *testing.T) {
 	}
 
 	for _, ev := range events {
-		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision, "", "")
+		emitToContext(em, "multi-server", ev.tool, ev.input, ev.output, "", ev.decision, "", "", "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, len(events), 5*time.Second)
@@ -305,7 +309,7 @@ func TestEmitToContext_FireAndForgetWhenNoDaemon(t *testing.T) {
 
 	start := time.Now()
 	// emitToContext logs the drop via log.Printf — that's fine for tests.
-	emitToContext(em, "srv", "noop", nil, nil, "", "allowed", "", "")
+	emitToContext(em, "srv", "noop", nil, nil, "", "allowed", "", "", "")
 	elapsed := time.Since(start)
 
 	// 25ms dial timeout + 100ms write deadline = 125ms worst-case. We allow
@@ -333,7 +337,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 
 	// nil input and output are valid: the emitter accepts them and the daemon
 	// treats them as absent. No panic, no error returned.
-	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed", "", "")
+	emitToContext(em, "srv", "tool-with-no-io", nil, nil, "", "allowed", "", "", "")
 }
 
 // TestEmitToContext_NilEmitterIsNoOp guards the nil-emitter path in serve():
@@ -343,7 +347,7 @@ func TestEmitToContext_NilInputsAreValid(t *testing.T) {
 // explicit guard at the call sites is kept for clarity.
 func TestEmitToContext_NilEmitterIsNoOp(t *testing.T) {
 	// Must not panic.
-	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed", "", "")
+	emitToContext(nil, "srv", "tool", nil, nil, "", "allowed", "", "", "")
 }
 
 // TestEmitToContext_SessionIDPropagatesToReceipts verifies the ADR-0010 OQ4
@@ -357,7 +361,7 @@ func TestEmitToContext_SessionIDPropagatesToReceipts(t *testing.T) {
 	em := newSilentEmitter(t, d.cfg.SocketPath, sid)
 
 	for i := 0; i < 3; i++ {
-		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed", "", "")
+		emitToContext(em, "srv", "tool", json.RawMessage(`{"i":1}`), nil, "", "allowed", "", "", "")
 	}
 
 	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 3, 5*time.Second)
@@ -375,5 +379,97 @@ func TestEmitToContext_SessionIDPropagatesToReceipts(t *testing.T) {
 		if r.Issuer.SessionID != sid {
 			t.Errorf("receipt[%d]: issuer.session_id = %q; want %q", i, r.Issuer.SessionID, sid)
 		}
+	}
+}
+
+// TestEmitToContext_MappedToolForwardsActionType verifies issue #721 for the
+// proxy: a tool that resolves to a real taxonomic type sends that type on the
+// emitter frame, and the daemon uses it verbatim as action.type and resolves
+// the matching risk_level from the taxonomy. `delete_file` maps to
+// "data.api.delete" in the bundled github taxonomy (a high-risk data type), so
+// the resulting receipt must carry that type and risk_level: high.
+func TestEmitToContext_MappedToolForwardsActionType(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	em := newSilentEmitter(t, d.cfg.SocketPath, "proxy-test-session-mapped")
+
+	mappings, err := configs.BundledTaxonomies()
+	if err != nil {
+		t.Fatalf("BundledTaxonomies: %v", err)
+	}
+	const tool = "delete_file"
+	actionType := resolveActionType(tool, mappings)
+	if actionType != "data.api.delete" {
+		t.Fatalf("resolveActionType(%q) = %q; want %q (check bundled github taxonomy)", tool, actionType, "data.api.delete")
+	}
+
+	emitToContext(em, "github", tool,
+		json.RawMessage(`{"path":"secrets.txt"}`), nil, "", "allowed", "", "", actionType)
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+
+	s, err := store.OpenReadOnly(d.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	receipts, err := s.GetChain(d.cfg.ChainID)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	action := receipts[0].CredentialSubject.Action
+	if action.Type != "data.api.delete" {
+		t.Errorf("action.type = %q; want %q (daemon must use the forwarded action_type verbatim)", action.Type, "data.api.delete")
+	}
+	if action.RiskLevel != receipt.RiskHigh {
+		t.Errorf("action.risk_level = %q; want %q (daemon resolves risk from the taxonomic type)", action.RiskLevel, receipt.RiskHigh)
+	}
+}
+
+// TestEmitToContext_UnknownToolOmitsActionType verifies the issue #721
+// constraint that the proxy sends NO action_type for a tool that does not map
+// to a real taxonomic type. resolveActionType returns "" for the unknown case,
+// the emitter omits the frame field, and the daemon falls back to its synthetic
+// "<channel>.<tool>" type (risk_level: medium).
+func TestEmitToContext_UnknownToolOmitsActionType(t *testing.T) {
+	d := startTestDaemon(t, shortSocketDirEmitter(t))
+
+	em := newSilentEmitter(t, d.cfg.SocketPath, "proxy-test-session-unknown")
+
+	mappings, err := configs.BundledTaxonomies()
+	if err != nil {
+		t.Fatalf("BundledTaxonomies: %v", err)
+	}
+	const tool = "totally_unmapped_tool_xyz"
+	if at := resolveActionType(tool, mappings); at != "" {
+		t.Fatalf("resolveActionType(%q) = %q; want empty (unmapped tool must not send a type)", tool, at)
+	}
+
+	// Mirror the proxy: an unmapped tool forwards an empty action_type.
+	emitToContext(em, "github", tool,
+		json.RawMessage(`{"q":"x"}`), nil, "", "allowed", "", "", resolveActionType(tool, mappings))
+
+	waitForDaemonReceipts(t, d.cfg.DBPath, d.cfg.ChainID, 1, 5*time.Second)
+
+	s, err := store.OpenReadOnly(d.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	receipts, err := s.GetChain(d.cfg.ChainID)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	// With no forwarded action_type the daemon derives the synthetic
+	// "<channel>.<tool>" type — "mcp.github.totally_unmapped_tool_xyz" — never a
+	// guessed taxonomic value.
+	if got := receipts[0].CredentialSubject.Action.Type; got != "mcp.github."+tool {
+		t.Errorf("action.type = %q; want synthetic fallback %q", got, "mcp.github."+tool)
 	}
 }

--- a/mcp-proxy/cmd/obsigna-mcp/import_guard_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/import_guard_test.go
@@ -37,6 +37,19 @@ var allowedNonStdlibDeps = []allowedDep{
 	// Session IDs (google/uuid) and policy-rule YAML (gopkg.in/yaml.v3).
 	{exact: "github.com/google/uuid"},
 	{exact: "gopkg.in/yaml.v3"},
+	// Taxonomic action-type classification (issue #721). The proxy resolves a
+	// tool's taxonomic action_type from the bundled mappings (configs.
+	// BundledTaxonomies) via taxonomy.ClassifyToolCall and forwards it on the
+	// emitter frame so the daemon can resolve risk_level from the type instead of
+	// the synthetic "<channel>.<tool>" fallback. This is read-only classification,
+	// not a writer responsibility: the proxy sends a type STRING; the daemon still
+	// owns risk resolution, redaction, hashing, signing, and persistence
+	// (ADR-0010). taxonomy and its risk-primitive leaf (sdk/go/risk) are
+	// receipt-free — they pull in no signing/crypto/store, so allowlisting them
+	// keeps the thin-emitter boundary intact. taxonomy's own import-guard test
+	// enforces that it never regains a receipt dependency.
+	{exact: "github.com/agent-receipts/ar/sdk/go/taxonomy"},
+	{exact: "github.com/agent-receipts/ar/sdk/go/risk"},
 }
 
 type allowedDep struct {

--- a/mcp-proxy/cmd/obsigna-mcp/main.go
+++ b/mcp-proxy/cmd/obsigna-mcp/main.go
@@ -21,11 +21,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/agent-receipts/ar/mcp-proxy/configs"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/host"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
 	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
 	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"github.com/agent-receipts/ar/sdk/go/taxonomy"
 	"github.com/google/uuid"
 )
 
@@ -210,6 +212,19 @@ func serve() int {
 	}
 	engine := policy.NewEngine(rules)
 
+	// Load the bundled per-server taxonomy mappings so we can forward a
+	// taxonomic action_type to the daemon (issue #721). The daemon resolves
+	// risk_level from that type; without it, the synthetic "<channel>.<tool>"
+	// fallback classifies nearly everything as medium risk. Taxonomy is
+	// best-effort enrichment — never fatal. On error we log and continue with
+	// an empty mapping set, in which case every tool resolves to "unknown" and
+	// the proxy sends no action_type (the daemon's fallback still applies).
+	taxonomyMappings, err := configs.BundledTaxonomies()
+	if err != nil {
+		log.Printf("mcp-proxy: load bundled taxonomies: %v; action_type enrichment disabled", err)
+		taxonomyMappings = nil
+	}
+
 	// Approval channels for pause actions.
 	approvalToken := generateToken(32)
 	approvals := audit.NewApprovalManager()
@@ -226,6 +241,7 @@ func serve() int {
 		argJSON        json.RawMessage
 		idempotencyKey string
 		correlationID  string
+		actionType     string
 	}
 	pendingCalls := make(map[string]*pendingCall)
 	var pendingMu sync.Mutex
@@ -290,6 +306,7 @@ func serve() int {
 			if params != nil {
 				toolName := proxy.StripMCPPrefix(params.Name)
 				opType := audit.ClassifyOperation(toolName)
+				actionType := resolveActionType(toolName, taxonomyMappings)
 				riskScore, _ := audit.ScoreRisk(toolName, params.Arguments)
 
 				decision := engine.Evaluate(policy.EvalContext{
@@ -315,6 +332,7 @@ func serve() int {
 					argJSON:        argJSON,
 					idempotencyKey: jsonrpcID,
 					correlationID:  params.ToolUseID(),
+					actionType:     actionType,
 				}
 				pendingMu.Unlock()
 
@@ -325,7 +343,7 @@ func serve() int {
 					blockedCorrelationID := pendingCalls[jsonrpcID].correlationID
 					delete(pendingCalls, jsonrpcID)
 					pendingMu.Unlock()
-					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID, blockedCorrelationID)
+					emitToContext(em, *serverName, toolName, argJSON, nil, fmt.Sprintf("blocked by policy: %s", decision.Reason), "denied", jsonrpcID, blockedCorrelationID, actionType)
 					return &proxy.HandlerResult{
 						Block:          true,
 						ClientResponse: proxy.MakeErrorResponse(msg.ID, -32001, fmt.Sprintf("blocked by policy: %s", decision.Reason)),
@@ -352,7 +370,7 @@ func serve() int {
 						deniedCorrelationID := pendingCalls[jsonrpcID].correlationID
 						delete(pendingCalls, jsonrpcID)
 						pendingMu.Unlock()
-						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID, deniedCorrelationID)
+						emitToContext(em, *serverName, toolName, argJSON, nil, message, "denied", jsonrpcID, deniedCorrelationID, actionType)
 						return &proxy.HandlerResult{
 							Block: true,
 							ClientResponse: proxy.MakeErrorResponseWithData(
@@ -416,7 +434,7 @@ func serve() int {
 				if resultStr != "" && json.Valid([]byte(resultStr)) {
 					outputRaw = json.RawMessage(resultStr)
 				}
-				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed", pc.idempotencyKey, pc.correlationID)
+				emitToContext(em, *serverName, pc.toolName, pc.argJSON, outputRaw, errorStr, "allowed", pc.idempotencyKey, pc.correlationID, pc.actionType)
 			}
 		}
 
@@ -658,6 +676,22 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 	}
 }
 
+// resolveActionType classifies toolName against the bundled taxonomy mappings
+// and returns the taxonomic action type ONLY on a real match (issue #721).
+// toolName is already StripMCPPrefix'd, matching the bundled JSON keys.
+//
+// On no match ClassifyToolCall yields taxonomy.UnknownAction.Type ("unknown");
+// we return "" in that case (and for any empty result) so the emitter omits
+// action_type and the daemon's synthetic "<channel>.<tool>" fallback applies.
+// The proxy never sends a guessed or synthetic type.
+func resolveActionType(toolName string, mappings []taxonomy.TaxonomyMapping) string {
+	at := taxonomy.ClassifyToolCall(toolName, mappings).ActionType
+	if at == "" || at == taxonomy.UnknownAction.Type {
+		return ""
+	}
+	return at
+}
+
 // emitToContext forwards one tool-call event to the daemon emitter (ADR-0010,
 // fire-and-forget). The emitter returns nil on transient failures (no daemon,
 // broken socket); the only errors emerging here are caller bugs that no retry
@@ -684,13 +718,22 @@ func emitStartupBanner(summary policy.Summary, approvalURL string, approverDisab
 // correlationID is the Claude Code tool_use_id from _meta, used to link this
 // proxy post-action receipt to the hook pre-check receipt for the same
 // logical tool invocation. Empty when not available (non-Claude-Code clients).
-func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision, idempotencyKey, correlationID string) {
+//
+// actionType is the taxonomic action type resolved for this tool call (e.g.
+// "data.api.delete"), forwarded so the daemon resolves risk_level from the
+// taxonomy instead of falling back to the synthetic "<channel>.<tool>" type
+// (issue #721). It is set ONLY when the proxy resolves a real taxonomic match;
+// it is empty for unknown tools, in which case the emitter omits the frame
+// field and the daemon's fallback applies. The daemon always resolves risk
+// itself from the type — the proxy never sends a risk level.
+func emitToContext(em *emitter.DaemonEmitter, serverName, toolName string, input, output json.RawMessage, errStr, decision, idempotencyKey, correlationID, actionType string) {
 	if em == nil {
 		return
 	}
 	if err := em.Emit(context.Background(), emitter.Event{
 		Channel:        "mcp",
 		Tool:           emitter.Tool{Server: serverName, Name: toolName},
+		ActionType:     actionType,
 		Input:          input,
 		Output:         output,
 		Error:          errStr,

--- a/mcp-proxy/cmd/obsigna-mcp/main_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/main_test.go
@@ -839,7 +839,7 @@ func TestDiagnoseConfigNoApproverReturnsNotConfigured(t *testing.T) {
 
 func TestEmitToContextNilEmitterNoOp(t *testing.T) {
 	// Must not panic with nil emitter.
-	emitToContext(nil, "server", "tool", nil, nil, "", "allowed", "", "")
+	emitToContext(nil, "server", "tool", nil, nil, "", "allowed", "", "", "")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Make the MCP proxy resolve a taxonomic `action_type` for each tool call (via `configs.BundledTaxonomies()` + `taxonomy.ClassifyToolCall`) and forward it on the emitter frame. The daemon then uses it verbatim as `action.type` and resolves `risk_level` from the taxonomy — so a known tool (e.g. github `delete_file` → `data.api.delete`) carries its real risk instead of the `UnknownAction` medium that the synthetic `<channel>.<tool>` fallback yields. Part of #721.

The proxy sends the **type** only, never a risk level, and only on a real match: an unmapped/unknown tool leaves `action_type` empty so the daemon's `<channel>.<tool>` fallback stays in effect.

## Stacked on #901

This PR is stacked on #901 (`refactor: receipt-free risk leaf`). That refactor makes `sdk/go/taxonomy` import-free of `sdk/go/receipt`, which is what lets the proxy classify tool calls **without** pulling the receipt-writer surface (and its crypto stack) into its graph.

## Thin-emitter guard (ADR-0033) stays intact

`TestImportGraphIsThinEmitter` is a fail-closed allowlist on the proxy's production import graph. The proxy now reaches two new packages — `sdk/go/taxonomy` and `sdk/go/risk` — both of which are **receipt-free** (no signing/crypto/store), so only those two are added to the allowlist. `sdk/go/receipt` and the crypto stack are **not** allowlisted, and the guard passes with them absent from the graph. `sdk/go/taxonomy`'s own import-guard test (added in #901) enforces that taxonomy never regains a receipt dependency.

## Tests

End-to-end through a real daemon socket:
- mapped tool (`delete_file`) → frame carries `action_type: data.api.delete`; receipt shows `action.type = data.api.delete` and `risk_level: high`.
- unmapped tool → no `action_type`; daemon derives the synthetic `mcp.github.<tool>` fallback (medium).

## Verification

`go build ./cmd/...`, `go vet ./...`, `go test ./...` (mcp-proxy) all pass, including `TestImportGraphIsThinEmitter`.

Part of #721.
