### PR TITLE
refactor(sdk/go): extract risk primitives into receipt-free leaf package

### DIFF
--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -5,6 +5,8 @@ package receipt
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/agent-receipts/ar/sdk/go/risk"
 )
 
 // Protocol constants (unexported to prevent mutation).
@@ -21,14 +23,16 @@ func CredentialType() []string { return append([]string{}, protocolCredentialTyp
 
 const Version = "0.5.0"
 
-// RiskLevel classifies the security risk of an action.
-type RiskLevel string
+// RiskLevel classifies the security risk of an action. It aliases risk.Level
+// (the receipt-free leaf type) so callers that must classify tool calls without
+// importing receipt can share the same type — see package risk.
+type RiskLevel = risk.Level
 
 const (
-	RiskLow      RiskLevel = "low"
-	RiskMedium   RiskLevel = "medium"
-	RiskHigh     RiskLevel = "high"
-	RiskCritical RiskLevel = "critical"
+	RiskLow      = risk.Low
+	RiskMedium   = risk.Medium
+	RiskHigh     = risk.High
+	RiskCritical = risk.Critical
 )
 
 // ChainStatus is the issuer-asserted termination reason carried in
@@ -59,11 +63,12 @@ const (
 )
 
 // ActionTypePTYOpen and ActionTypePTYClose are the action.type values for PTY
-// lifecycle events (ADR-0027 §/pty). Defined here so chain.go can reference
-// them without importing the taxonomy package (which imports receipt).
+// lifecycle events (ADR-0027 §/pty). They re-export the risk leaf constants so
+// chain.go can reference them without importing the taxonomy package, and so the
+// taxonomy registry can reference them without importing receipt.
 const (
-	ActionTypePTYOpen  = "system.pty.open"
-	ActionTypePTYClose = "system.pty.close"
+	ActionTypePTYOpen  = risk.ActionTypePTYOpen
+	ActionTypePTYClose = risk.ActionTypePTYClose
 )
 
 // Operator identifies the AI model executing actions.

--- a/sdk/go/risk/risk.go
+++ b/sdk/go/risk/risk.go
@@ -1,0 +1,30 @@
+// Package risk holds the receipt-free primitives shared between the receipt
+// taxonomy and any classifier that must run without importing receipt — the
+// risk levels and the action.type string constants that carry no crypto.
+//
+// It is a leaf package: it imports nothing from this module (and no crypto), so
+// callers that classify tool calls (e.g. the thin MCP proxy, ADR-0033) can
+// depend on it without pulling in the receipt writer surface ADR-0010 reserves
+// for the daemon. The receipt package re-exports these as type aliases and const
+// re-exports, so receipt.RiskLevel / receipt.RiskLow / receipt.ActionTypePTYOpen
+// remain interchangeable with their risk counterparts everywhere.
+package risk
+
+// Level classifies the security risk of an action.
+type Level string
+
+const (
+	Low      Level = "low"
+	Medium   Level = "medium"
+	High     Level = "high"
+	Critical Level = "critical"
+)
+
+// ActionTypePTYOpen and ActionTypePTYClose are the action.type values for PTY
+// lifecycle events (ADR-0027 §/pty). They live here, free of crypto and the
+// receipt package, so the taxonomy registry can reference them without importing
+// receipt.
+const (
+	ActionTypePTYOpen  = "system.pty.open"
+	ActionTypePTYClose = "system.pty.close"
+)

--- a/sdk/go/risk/risk_test.go
+++ b/sdk/go/risk/risk_test.go
@@ -1,0 +1,51 @@
+package risk_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/risk"
+)
+
+func TestLevelValues(t *testing.T) {
+	cases := map[risk.Level]string{
+		risk.Low:      "low",
+		risk.Medium:   "medium",
+		risk.High:     "high",
+		risk.Critical: "critical",
+	}
+	for level, want := range cases {
+		if string(level) != want {
+			t.Errorf("risk.Level %q = %q, want %q", want, string(level), want)
+		}
+	}
+}
+
+func TestPTYActionTypes(t *testing.T) {
+	if risk.ActionTypePTYOpen != "system.pty.open" {
+		t.Errorf("ActionTypePTYOpen = %q, want system.pty.open", risk.ActionTypePTYOpen)
+	}
+	if risk.ActionTypePTYClose != "system.pty.close" {
+		t.Errorf("ActionTypePTYClose = %q, want system.pty.close", risk.ActionTypePTYClose)
+	}
+}
+
+// TestRiskIsLeaf asserts the risk package imports nothing from this module — it
+// must stay a true leaf so receipt-free callers can depend on it.
+func TestRiskIsLeaf(t *testing.T) {
+	const modulePrefix = "github.com/agent-receipts/ar/"
+
+	out, err := exec.Command("go", "list", "-deps", "github.com/agent-receipts/ar/sdk/go/risk").Output()
+	if err != nil {
+		t.Fatalf("go list -deps risk: %v", err)
+	}
+	for _, dep := range strings.Fields(string(out)) {
+		if dep == "github.com/agent-receipts/ar/sdk/go/risk" {
+			continue
+		}
+		if strings.HasPrefix(dep, modulePrefix) {
+			t.Errorf("risk must be a leaf but reaches in-module package %s", dep)
+		}
+	}
+}

--- a/sdk/go/risk/risk_test.go
+++ b/sdk/go/risk/risk_test.go
@@ -17,7 +17,7 @@ func TestLevelValues(t *testing.T) {
 	}
 	for level, want := range cases {
 		if string(level) != want {
-			t.Errorf("risk.Level %q = %q, want %q", want, string(level), want)
+			t.Errorf("risk.Level = %q, want %q", string(level), want)
 		}
 	}
 }

--- a/sdk/go/taxonomy/import_guard_test.go
+++ b/sdk/go/taxonomy/import_guard_test.go
@@ -13,8 +13,8 @@ import (
 // proxy, ADR-0033) can depend on taxonomy without pulling in the receipt writer
 // surface ADR-0010 reserves for the daemon.
 //
-// `go list -deps` reports the non-test (production) dependency graph, so the
-// fact that this test file's package imports receipt elsewhere does not count.
+// `go list -deps` reports only the non-test (production) dependency graph, so a
+// test-only import of receipt (in this package or any other) does not count.
 func TestTaxonomyDoesNotImportReceipt(t *testing.T) {
 	const receiptPkg = "github.com/agent-receipts/ar/sdk/go/receipt"
 

--- a/sdk/go/taxonomy/import_guard_test.go
+++ b/sdk/go/taxonomy/import_guard_test.go
@@ -1,0 +1,33 @@
+package taxonomy_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestTaxonomyDoesNotImportReceipt locks in the receipt-free invariant: the
+// taxonomy package's production import graph must not transitively reach
+// sdk/go/receipt. The risk/action-type primitives taxonomy needs live in the
+// receipt-free leaf package sdk/go/risk, so a classifier (e.g. the thin MCP
+// proxy, ADR-0033) can depend on taxonomy without pulling in the receipt writer
+// surface ADR-0010 reserves for the daemon.
+//
+// `go list -deps` reports the non-test (production) dependency graph, so the
+// fact that this test file's package imports receipt elsewhere does not count.
+func TestTaxonomyDoesNotImportReceipt(t *testing.T) {
+	const receiptPkg = "github.com/agent-receipts/ar/sdk/go/receipt"
+
+	out, err := exec.Command("go", "list", "-deps", "github.com/agent-receipts/ar/sdk/go/taxonomy").Output()
+	if err != nil {
+		t.Fatalf("go list -deps taxonomy: %v", err)
+	}
+
+	for _, dep := range strings.Fields(string(out)) {
+		if dep == receiptPkg {
+			t.Fatalf("taxonomy transitively imports %s; the risk/action-type primitives "+
+				"must come from the receipt-free leaf sdk/go/risk so classifiers can depend "+
+				"on taxonomy without the receipt writer surface (ADR-0010, ADR-0033)", receiptPkg)
+		}
+	}
+}

--- a/sdk/go/taxonomy/taxonomy.go
+++ b/sdk/go/taxonomy/taxonomy.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"github.com/agent-receipts/ar/sdk/go/risk"
 )
 
 // ActionTypeEntry describes a known action type.
 type ActionTypeEntry struct {
-	Type        string            `json:"type"`
-	Description string            `json:"description"`
-	RiskLevel   receipt.RiskLevel `json:"risk_level"`
+	Type        string     `json:"type"`
+	Description string     `json:"description"`
+	RiskLevel   risk.Level `json:"risk_level"`
 }
 
 // TaxonomyMapping maps a tool name to an action type.
@@ -29,44 +29,44 @@ type TaxonomyConfig struct {
 
 // ClassificationResult holds the result of classifying a tool call.
 type ClassificationResult struct {
-	ActionType string            `json:"action_type"`
-	RiskLevel  receipt.RiskLevel `json:"risk_level"`
+	ActionType string     `json:"action_type"`
+	RiskLevel  risk.Level `json:"risk_level"`
 }
 
 // Built-in action types.
 var (
 	FilesystemActions = []ActionTypeEntry{
-		{Type: "filesystem.file.create", Description: "Create a file", RiskLevel: receipt.RiskLow},
-		{Type: "filesystem.file.read", Description: "Read a file", RiskLevel: receipt.RiskLow},
-		{Type: "filesystem.file.modify", Description: "Modify a file", RiskLevel: receipt.RiskMedium},
-		{Type: "filesystem.file.delete", Description: "Delete a file", RiskLevel: receipt.RiskHigh},
-		{Type: "filesystem.file.move", Description: "Move or rename a file", RiskLevel: receipt.RiskMedium},
-		{Type: "filesystem.directory.create", Description: "Create a directory", RiskLevel: receipt.RiskLow},
-		{Type: "filesystem.directory.delete", Description: "Delete a directory", RiskLevel: receipt.RiskHigh},
-		{Type: "filesystem.directory.list", Description: "List directory contents", RiskLevel: receipt.RiskLow},
+		{Type: "filesystem.file.create", Description: "Create a file", RiskLevel: risk.Low},
+		{Type: "filesystem.file.read", Description: "Read a file", RiskLevel: risk.Low},
+		{Type: "filesystem.file.modify", Description: "Modify a file", RiskLevel: risk.Medium},
+		{Type: "filesystem.file.delete", Description: "Delete a file", RiskLevel: risk.High},
+		{Type: "filesystem.file.move", Description: "Move or rename a file", RiskLevel: risk.Medium},
+		{Type: "filesystem.directory.create", Description: "Create a directory", RiskLevel: risk.Low},
+		{Type: "filesystem.directory.delete", Description: "Delete a directory", RiskLevel: risk.High},
+		{Type: "filesystem.directory.list", Description: "List directory contents", RiskLevel: risk.Low},
 	}
 
 	SystemActions = []ActionTypeEntry{
-		{Type: "system.application.launch", Description: "Launch an application", RiskLevel: receipt.RiskLow},
-		{Type: "system.application.control", Description: "Control an application via UI automation", RiskLevel: receipt.RiskMedium},
-		{Type: "system.settings.modify", Description: "Modify system or app settings", RiskLevel: receipt.RiskHigh},
-		{Type: "system.command.execute", Description: "Execute a shell command", RiskLevel: receipt.RiskHigh},
-		{Type: "system.code.execute", Description: "Execute code in a sandbox code interpreter", RiskLevel: receipt.RiskHigh},
-		{Type: receipt.ActionTypePTYOpen, Description: "Open an interactive PTY session", RiskLevel: receipt.RiskCritical},
-		{Type: receipt.ActionTypePTYClose, Description: "Close a PTY session", RiskLevel: receipt.RiskHigh},
-		{Type: "system.browser.navigate", Description: "Navigate to a URL", RiskLevel: receipt.RiskLow},
-		{Type: "system.browser.form_submit", Description: "Submit a web form", RiskLevel: receipt.RiskMedium},
-		{Type: "system.browser.authenticate", Description: "Log into a service", RiskLevel: receipt.RiskHigh},
+		{Type: "system.application.launch", Description: "Launch an application", RiskLevel: risk.Low},
+		{Type: "system.application.control", Description: "Control an application via UI automation", RiskLevel: risk.Medium},
+		{Type: "system.settings.modify", Description: "Modify system or app settings", RiskLevel: risk.High},
+		{Type: "system.command.execute", Description: "Execute a shell command", RiskLevel: risk.High},
+		{Type: "system.code.execute", Description: "Execute code in a sandbox code interpreter", RiskLevel: risk.High},
+		{Type: risk.ActionTypePTYOpen, Description: "Open an interactive PTY session", RiskLevel: risk.Critical},
+		{Type: risk.ActionTypePTYClose, Description: "Close a PTY session", RiskLevel: risk.High},
+		{Type: "system.browser.navigate", Description: "Navigate to a URL", RiskLevel: risk.Low},
+		{Type: "system.browser.form_submit", Description: "Submit a web form", RiskLevel: risk.Medium},
+		{Type: "system.browser.authenticate", Description: "Log into a service", RiskLevel: risk.High},
 	}
 
 	DataActions = []ActionTypeEntry{
-		{Type: "data.api.read", Description: "Read data from an external API", RiskLevel: receipt.RiskLow},
-		{Type: "data.api.write", Description: "Write data to an external API", RiskLevel: receipt.RiskMedium},
-		{Type: "data.api.delete", Description: "Delete data via an external API", RiskLevel: receipt.RiskHigh},
+		{Type: "data.api.read", Description: "Read data from an external API", RiskLevel: risk.Low},
+		{Type: "data.api.write", Description: "Write data to an external API", RiskLevel: risk.Medium},
+		{Type: "data.api.delete", Description: "Delete data via an external API", RiskLevel: risk.High},
 	}
 
 	NetworkActions = []ActionTypeEntry{
-		{Type: "network.egress.observed", Description: "Observed outbound network connection crossing a sandbox boundary", RiskLevel: receipt.RiskMedium},
+		{Type: "network.egress.observed", Description: "Observed outbound network connection crossing a sandbox boundary", RiskLevel: risk.Medium},
 	}
 
 	// DiagnosticActions classify daemon/CLI self-checks rather than agent tool
@@ -74,13 +74,13 @@ var (
 	// agent — but they land in the real chain like any other event so operators
 	// can see (and filter) them.
 	DiagnosticActions = []ActionTypeEntry{
-		{Type: DiagnosticRoundtripActionType, Description: "agent-receipts doctor synthetic round-trip probe (diagnostic.roundtrip)", RiskLevel: receipt.RiskLow},
+		{Type: DiagnosticRoundtripActionType, Description: "agent-receipts doctor synthetic round-trip probe (diagnostic.roundtrip)", RiskLevel: risk.Low},
 	}
 
 	UnknownAction = ActionTypeEntry{
 		Type:        "unknown",
 		Description: "Tool call that does not map to any known action type",
-		RiskLevel:   receipt.RiskMedium,
+		RiskLevel:   risk.Medium,
 	}
 )
 


### PR DESCRIPTION
## What

Extract the shared risk / action-type primitives out of `sdk/go/receipt` into a new **receipt-free leaf package, `sdk/go/risk`**, and repoint `sdk/go/taxonomy` to import the leaf instead of `receipt`. After this, `taxonomy`'s production import graph no longer transitively reaches `receipt`.

Moved into `sdk/go/risk` (imports nothing from this module, no crypto):
- `type Level string` + `Low` / `Medium` / `High` / `Critical` constants (was `receipt.RiskLevel` + `Risk*`).
- `ActionTypePTYOpen` / `ActionTypePTYClose` action.type string constants.

## Why

Prerequisite for #721 (and the stacked proxy/hook work). It lets the MCP proxy import `taxonomy` to classify tool calls **without** pulling in the receipt writer surface that would trip the thin-emitter import-graph guard (`TestImportGraphIsThinEmitter`, ADR-0033 Gate A — the daemon is the sole receipt writer, ADR-0010). This PR does **not** touch `mcp-proxy` or any import allowlist; it only makes `taxonomy` receipt-free so a later PR can wire the proxy in.

## API preservation (zero call-site churn)

`receipt` keeps its full public API via a **type alias** and **const re-exports**:

```go
type RiskLevel = risk.Level            // alias — interchangeable everywhere
const RiskLow = risk.Low               // (+ Medium/High/Critical)
const ActionTypePTYOpen = risk.ActionTypePTYOpen   // (+ PTYClose)
```

So every existing `receipt.RiskLevel`, `receipt.RiskHigh`, `receipt.ActionTypePTYOpen`, … reference across the repo compiles unchanged, and downstream code comparing `taxonomy` results against `receipt.RiskHigh` still works. The only `receipt`→leaf edge is new; no import cycles.

**Behaviour-preserving:** no JSON tag, wire/serialization, or risk-value changes.

## Tests

- `sdk/go/risk/risk_test.go` — asserts the leaf values and that `risk` stays a true leaf (imports nothing in-module).
- `sdk/go/taxonomy/import_guard_test.go` — `go list -deps` guard asserting `taxonomy`'s production graph does **not** transitively import `sdk/go/receipt`, locking the invariant in.

## Verification (all green)

- `sdk/go`: `go build ./... && go vet ./... && go test ./...`
- `daemon`: `go build ./... && go test ./...`
- `hook`: `go build ./... && go test ./...`
- `mcp-proxy`: `go build ./... && go test ./...` — including `TestImportGraphIsThinEmitter` (unaffected, still passes)
- `cross-sdk-tests`: `go test ./...`

Refs #721