### PR TITLE
chore(release): stamp CHANGELOG 0.28.0-alpha.1 + sdk/go 0.21.0-alpha.1

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0-alpha.1] - 2026-06-20
+
+### Added
+
+- **Hook classifies shell `rm`, `mv`, and `cp` operations** ([#893](https://github.com/agent-receipts/obsigna/pull/893)) — when `obsigna-hook` intercepts a Claude Code `Bash` tool call running `rm`, `mv`, or `cp`, the hook now resolves the primary path argument as `action.target.resource` and sets `action.type` to `filesystem.file.delete`, `filesystem.file.move`, or `filesystem.file.copy`. Receipts for these destructive operations carry the real taxonomy risk level (`high` for delete and move, `medium` for copy) instead of the generic `UnknownAction` medium assigned to any unclassified shell command. The pre-resolved action type is passed to the daemon via the new `action_type` frame field (sdk/go `emitter.Event.ActionType`); the daemon uses it verbatim and derives `risk_level` from the taxonomy, so a mislabeled type would yield that type's risk — emitters must send the true type.
+
+- **Inline `prompt_preview` and plaintext error fields are bounded** ([#894](https://github.com/agent-receipts/obsigna/pull/894)) — `obsigna-daemon` now caps `intent.prompt_preview` at a configurable rune limit (default 500) and any plaintext error field at the same cap, enforced at the daemon boundary so oversized emitter payloads cannot bloat receipts. When the cap fires, `intent.prompt_preview_truncated: true` is stamped on the receipt. The sdk/go emitter gains the corresponding `Event.PromptPreview` field; the emitter forwards the value verbatim and the daemon owns truncation. The emitter also gains `Event.ActionType` (see above) with matching length validation.
+
 ## [0.27.0] - 2026-06-20
 
 Graduates `0.27.0-alpha.2` after the alpha pass. The out-of-band checkpoint anchor for tail-truncation resistance (see `0.27.0-alpha.1`) is the primary new feature since `0.26.0`. Two additional changes landed after the alpha and ship in this stable:

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,16 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.21.0-alpha.1] - 2026-06-20
+
+### Added
+
+- **`emitter.Event.ActionType`** ([#893](https://github.com/agent-receipts/obsigna/pull/893)) — optional field on `Event` carrying a pre-resolved taxonomic action type (e.g. `"filesystem.file.delete"`). When set, the daemon uses it verbatim as `action.type` and derives `risk_level` from the taxonomy, so a known-destructive call carries its real risk instead of the `UnknownAction` medium a synthetic `<channel>.<tool>` type would yield. The field is validated against `MaxIdentityFieldLen` client-side and omitted from the wire frame when empty, so emitters that do not set it are unchanged.
+
+- **`emitter.Event.PromptPreview`** ([#894](https://github.com/agent-receipts/obsigna/pull/894)) — optional field carrying a plaintext preview of the prompt that triggered the action. The daemon stores it in `intent.prompt_preview`, truncating to a configured rune cap and setting `intent.prompt_preview_truncated: true` when the cut fires. The emitter forwards the value verbatim and the daemon owns truncation. Omitted from the wire frame when empty.
+
+- **`receipt.TruncatePromptPreview`** ([#894](https://github.com/agent-receipts/obsigna/pull/894)) — rune-bounded implementation that walks rune boundaries up to the cap rather than materialising the full string as `[]rune`, so a large untrusted input is bounded in both time and memory. Behaviour is otherwise unchanged.
+
 ## [0.20.0] - 2026-06-20
 
 Graduates `0.20.0-alpha.2` after the alpha pass. No source changes since the alpha; see the `0.20.0-alpha.2` and `0.20.0-alpha.1` entries below for the full surface. Since the last stable `0.19.0`, this line ships `receipt.VerifyRaw` for raw-bytes Ed25519 signature verification and `Store.LatestRootChainID` for active-chain detection.


### PR DESCRIPTION
Cuts the new alpha releases. Stacked on #904 — merge that first, then change the base to `main` before merging this one.

## obsigna v0.28.0-alpha.1

Stamps daemon/CHANGELOG.md with `[0.28.0-alpha.1]`. New features:

- **Hook classifies shell `rm`/`mv`/`cp`** (#893) — destructive shell ops now carry the correct action type and real risk level
- **Inline `prompt_preview` and error fields are bounded** (#894) — daemon caps these at a configurable rune limit; emitter gains `Event.PromptPreview` and `Event.ActionType`

After merge, tag with:
```
git tag obsigna/v0.28.0-alpha.1 <merge-commit>
git push origin obsigna/v0.28.0-alpha.1
```

## sdk/go v0.21.0-alpha.1

Stamps sdk/go/CHANGELOG.md with `[0.21.0-alpha.1]`. New exported surface:

- `emitter.Event.ActionType` — pre-resolved action type forwarded to daemon
- `emitter.Event.PromptPreview` — plaintext prompt preview field
- `receipt.TruncatePromptPreview` — rune-bounded, no `[]rune` materialization

After merge, tag with:
```
git tag sdk/go/v0.21.0-alpha.1 <merge-commit>
git push origin sdk/go/v0.21.0-alpha.1
```