### PR TITLE
fix(release): pin sdk/go v0.21.0-alpha.1 in daemon, hook, mcp-proxy

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -11,9 +11,10 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
+	modernc.org/sqlite v1.52.0
 )
 
 require (
@@ -27,5 +28,4 @@ require (
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.52.0 // indirect
 )

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1 h1:ty9GWmGRPYEU3o7SZjFoXMSLxDYU9Qoj3r4M/IlT6f8=
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1 h1:tpH1h9UDjyNF7f/HQ7p1oSVoY/FuizYMI/DtaNPAMM8=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -2,6 +2,6 @@ module github.com/agent-receipts/ar/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.19.0
+require github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/hook/go.sum
+++ b/hook/go.sum
@@ -1,11 +1,9 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
-github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1 h1:8bf6sLLq+ST5A4wZzgTC2dI9CpbTC02fw3Av+yWgggM=
-github.com/agent-receipts/ar/sdk/go v0.19.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
-github.com/agent-receipts/ar/sdk/go v0.19.0 h1:4N5qohfN8B9n3ygimCuw2nLMV9LK8W39U6YC7TVtauA=
-github.com/agent-receipts/ar/sdk/go v0.19.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/daemon v0.23.0 h1:2YWpa6yhSMePBQgUDPdKOnwEOnwrppHqfieMEnlxK+w=
+github.com/agent-receipts/ar/daemon v0.23.0/go.mod h1:MHymb7QucpV9Z2RaHjj7x5TtHWaPphTB6Zez5xZN+TY=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1 h1:tpH1h9UDjyNF7f/HQ7p1oSVoY/FuizYMI/DtaNPAMM8=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -3,8 +3,8 @@ module github.com/agent-receipts/ar/mcp-proxy
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/daemon v0.16.0
-	github.com/agent-receipts/ar/sdk/go v0.17.0
+	github.com/agent-receipts/ar/daemon v0.23.0
+	github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 	github.com/google/uuid v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/mcp-proxy/go.sum
+++ b/mcp-proxy/go.sum
@@ -1,9 +1,9 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/agent-receipts/ar/daemon v0.16.0 h1:IWEBHiC1HuG3+VTEKpmSX2V0+4IgOPTMzI/5UaW7Fp4=
-github.com/agent-receipts/ar/daemon v0.16.0/go.mod h1:vScXF225vmt3RXn8N33Bt39nLu6HGCjR7Faq9c+/C2I=
-github.com/agent-receipts/ar/sdk/go v0.17.0 h1:BEeBwF0Opn/AERZUJ3+pxT1nWDSs/qxjw/FjOmKqXEY=
-github.com/agent-receipts/ar/sdk/go v0.17.0/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/daemon v0.23.0 h1:2YWpa6yhSMePBQgUDPdKOnwEOnwrppHqfieMEnlxK+w=
+github.com/agent-receipts/ar/daemon v0.23.0/go.mod h1:MHymb7QucpV9Z2RaHjj7x5TtHWaPphTB6Zez5xZN+TY=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1 h1:tpH1h9UDjyNF7f/HQ7p1oSVoY/FuizYMI/DtaNPAMM8=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Release builds run with `GOWORK=off`, so each module resolves `sdk/go` from the published registry. `hook/go.mod` and `mcp-proxy/go.mod` were pinned to old versions that pre-date the `ActionType` and `PromptPreview` fields added in v0.21.0-alpha.1, causing the `obsigna/v0.28.0-alpha.1` release build to fail ([run 27858408497](https://github.com/agent-receipts/obsigna/actions/runs/27858408497)).

## Changes

- `daemon/go.mod`: v0.20.0-alpha.1 → v0.21.0-alpha.1 (also: `modernc.org/sqlite` moves from indirect to direct — `tests_checkpoint_truncation_test.go` blank-imports it)
- `hook/go.mod`: v0.19.0 → v0.21.0-alpha.1
- `mcp-proxy/go.mod`: v0.17.0 → v0.21.0-alpha.1 (also: daemon v0.16.0 → v0.23.0, last published daemon module version)

After merge, delete and recreate the `obsigna/v0.28.0-alpha.1` tag at the merge commit so the release CI retries with the correct go.mod.