### PR TITLE
feat(site-obsigna): go-import vanity meta tags + post-deploy liveness check

### DIFF
--- a/.github/workflows/go-import-liveness.yml
+++ b/.github/workflows/go-import-liveness.yml
@@ -1,0 +1,53 @@
+name: go-import liveness
+
+# Runs after the obsigna.dev site deploy completes (main-branch pushes only).
+# Asserts that the live site returns the go-import meta tag on the paths the
+# Go toolchain will fetch with ?go-get=1.  A failure here means the vanity
+# import redirect is broken and PR2 / PR3 must not land until it is fixed.
+on:
+  workflow_run:
+    workflows: ["Site (obsigna.dev)"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    # Only run when the triggering deploy actually succeeded.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check go-import meta — sdk/go subpath
+        run: |
+          # Use -sL (no -f) so curl succeeds even on 404; the Go toolchain
+          # accepts meta tags from non-200 responses, and static hosts serve
+          # 404.html for unrecognised subpaths such as /sdk/go.
+          body=$(curl -sL "https://obsigna.dev/sdk/go?go-get=1")
+          if ! echo "$body" | grep -q 'name="go-import"'; then
+            echo "ERROR: go-import meta tag missing from https://obsigna.dev/sdk/go?go-get=1"
+            exit 1
+          fi
+          if ! echo "$body" | grep -q 'obsigna.dev git https://github.com/agent-receipts/obsigna'; then
+            echo "ERROR: go-import content mismatch on https://obsigna.dev/sdk/go?go-get=1"
+            echo "--- body ---"
+            echo "$body" | grep -i 'go-import' || true
+            exit 1
+          fi
+          echo "OK: go-import present on /sdk/go"
+
+      - name: Check go-import meta — daemon subpath
+        run: |
+          body=$(curl -sL "https://obsigna.dev/daemon?go-get=1")
+          if ! echo "$body" | grep -q 'name="go-import"'; then
+            echo "ERROR: go-import meta tag missing from https://obsigna.dev/daemon?go-get=1"
+            exit 1
+          fi
+          if ! echo "$body" | grep -q 'obsigna.dev git https://github.com/agent-receipts/obsigna'; then
+            echo "ERROR: go-import content mismatch on https://obsigna.dev/daemon?go-get=1"
+            echo "--- body ---"
+            echo "$body" | grep -i 'go-import' || true
+            exit 1
+          fi
+          echo "OK: go-import present on /daemon"

--- a/.github/workflows/go-import-liveness.yml
+++ b/.github/workflows/go-import-liveness.yml
@@ -6,7 +6,7 @@ name: go-import liveness
 # import redirect is broken and PR2 / PR3 must not land until it is fixed.
 on:
   workflow_run:
-    workflows: ["Site (obsigna.dev)"]
+    workflows: ["Site (obsigna.dev)"] # triggers after .github/workflows/site-obsigna.yml completes
     types: [completed]
     branches: [main]
 
@@ -24,9 +24,13 @@ jobs:
           # Use -sL (no -f) so curl succeeds even on 404; the Go toolchain
           # accepts meta tags from non-200 responses, and static hosts serve
           # 404.html for unrecognised subpaths such as /sdk/go.
-          body=$(curl -sL "https://obsigna.dev/sdk/go?go-get=1")
+          body=$(curl -sL --max-time 30 --connect-timeout 10 "https://obsigna.dev/sdk/go?go-get=1")
           if ! echo "$body" | grep -q 'name="go-import"'; then
             echo "ERROR: go-import meta tag missing from https://obsigna.dev/sdk/go?go-get=1"
+            exit 1
+          fi
+          if ! echo "$body" | grep -q 'name="go-source"'; then
+            echo "ERROR: go-source meta tag missing from https://obsigna.dev/sdk/go?go-get=1"
             exit 1
           fi
           if ! echo "$body" | grep -q 'obsigna.dev git https://github.com/agent-receipts/obsigna'; then
@@ -39,9 +43,13 @@ jobs:
 
       - name: Check go-import meta — daemon subpath
         run: |
-          body=$(curl -sL "https://obsigna.dev/daemon?go-get=1")
+          body=$(curl -sL --max-time 30 --connect-timeout 10 "https://obsigna.dev/daemon?go-get=1")
           if ! echo "$body" | grep -q 'name="go-import"'; then
             echo "ERROR: go-import meta tag missing from https://obsigna.dev/daemon?go-get=1"
+            exit 1
+          fi
+          if ! echo "$body" | grep -q 'name="go-source"'; then
+            echo "ERROR: go-source meta tag missing from https://obsigna.dev/daemon?go-get=1"
             exit 1
           fi
           if ! echo "$body" | grep -q 'obsigna.dev git https://github.com/agent-receipts/obsigna'; then

--- a/site-obsigna/astro.config.mjs
+++ b/site-obsigna/astro.config.mjs
@@ -22,6 +22,26 @@ export default defineConfig({
       favicon: "/favicon.svg",
       plugins: [starlightThemeFlexoki({ accentColor: "orange" })],
       head: [
+        // Go vanity import path — resolves obsigna.dev/{sdk/go,daemon,...} for `go get`.
+        // Must be present on every page (including 404) so the Go toolchain can fetch
+        // any subpath with ?go-get=1 and find the redirect. Starlight's head config
+        // injects into all generated pages including the 404 route.
+        {
+          tag: "meta",
+          attrs: {
+            name: "go-import",
+            content:
+              "obsigna.dev git https://github.com/agent-receipts/obsigna",
+          },
+        },
+        {
+          tag: "meta",
+          attrs: {
+            name: "go-source",
+            content:
+              "obsigna.dev https://github.com/agent-receipts/obsigna https://github.com/agent-receipts/obsigna/tree/main{/dir} https://github.com/agent-receipts/obsigna/blob/main{/dir}/{file}#L{line}",
+          },
+        },
         {
           tag: "link",
           attrs: { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },


### PR DESCRIPTION
## What

Injects `go-import` and `go-source` meta tags into every obsigna.dev page, and adds a post-deploy CI job that asserts the tags are live before PR2/PR3 can land.

**Site change** (`site-obsigna/astro.config.mjs`): two entries added to the Starlight `head` array:

```html
<meta name="go-import" content="obsigna.dev git https://github.com/agent-receipts/obsigna">
<meta name="go-source" content="obsigna.dev https://github.com/agent-receipts/obsigna https://github.com/agent-receipts/obsigna/tree/main{/dir} https://github.com/agent-receipts/obsigna/blob/main{/dir}/{file}#L{line}">
```

Starlight's `head` config injects into all generated pages including the 404 route. Static hosts serve `404.html` for unrecognised paths (e.g. `/sdk/go`); the Go toolchain accepts meta tags from non-200 responses, so the 404 page is sufficient coverage for subpaths that have no doc page.

**Liveness CI** (`.github/workflows/go-import-liveness.yml`): triggers on `workflow_run` after `Site (obsigna.dev)` completes on `main`. Fetches `https://obsigna.dev/sdk/go?go-get=1` and `https://obsigna.dev/daemon?go-get=1` and asserts `go-import` with the correct content is present. Uses `curl -sL` (not `-f`) so a 404 response body is still inspected rather than errored on. Only runs when the deploy concluded `success`.

## Why

ADR-0037 decision 3 requires these meta tags before Go module paths can be flipped to `obsigna.dev/...`. ADR-0037 decision 4 requires the claim to be enforced by CI, not trusted.

This is **PR1 of 3**. PR2 (flip internal Go modules: daemon, hook, mcp-proxy) and PR3 (flip sdk/go) are blocked until this is deployed and the liveness check is green.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, skip remaining items