### PR TITLE
feat(spec): add outcome.response_disclosure HPKE envelope (v0.6.0)

### DIFF
--- a/sdk/py/src/obsigna/__init__.py
+++ b/sdk/py/src/obsigna/__init__.py
@@ -44,7 +44,9 @@ from obsigna.receipt.disclosure import (
     DisclosureRecipient,
     ForensicKeyPair,
     decrypt_disclosure,
+    decrypt_response,
     encrypt_disclosure,
+    encrypt_response,
     generate_forensic_key_pair,
 )
 from obsigna.receipt.hash import canonicalize, hash_receipt, sha256
@@ -121,6 +123,8 @@ loadTaxonomyConfig = load_taxonomy_config
 generateForensicKeyPair = generate_forensic_key_pair
 encryptDisclosure = encrypt_disclosure
 decryptDisclosure = decrypt_disclosure
+encryptResponse = encrypt_response
+decryptResponse = decrypt_response
 
 # RECEIPT_VERSION is the receipt schema version (from types), not the package version
 from obsigna.receipt.types import VERSION as RECEIPT_VERSION  # noqa: E402
@@ -165,8 +169,12 @@ __all__ = [
     "ForensicKeyPair",
     "decrypt_disclosure",
     "decryptDisclosure",
+    "decrypt_response",
+    "decryptResponse",
     "encrypt_disclosure",
     "encryptDisclosure",
+    "encrypt_response",
+    "encryptResponse",
     "generate_forensic_key_pair",
     "generateForensicKeyPair",
     # DaemonEmitter (ADR-0010 daemon client; ADR-0020 step 1 rename)

--- a/sdk/py/src/obsigna/receipt/disclosure.py
+++ b/sdk/py/src/obsigna/receipt/disclosure.py
@@ -391,6 +391,90 @@ def _encrypt_disclosure_with_seed(  # pyright: ignore[reportUnusedFunction]
     return _encrypt_with_options(params, recipient_public_key, kid, ikm_e)
 
 
+def encrypt_response(
+    response: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+) -> DisclosureEnvelope:
+    """Encrypt ``response`` as a v1 HPKE envelope for ``outcome.response_disclosure``.
+
+    Identical to :func:`encrypt_disclosure` in primitive and encoding — uses
+    the same forensic key pair, same HPKE ciphersuite, and same JCS
+    canonicalisation. The separation exists so operators can enable response
+    disclosure independently of parameter disclosure via separate
+    ``--response-disclosure`` / ``--parameter-disclosure`` policy flags.
+
+    Args:
+        response: The response object to encrypt. MUST be a plain ``dict``.
+        recipient_public_key: 32-byte X25519 forensic public key.
+        kid: Recipient key identifier (did:key DID URL or
+            ``sha256:<hex>`` fingerprint).
+    """
+    if not _is_plain_dict(response):
+        msg = "response must be a plain dict"
+        raise TypeError(msg)
+    if len(recipient_public_key) != 32:
+        msg = f"recipient_public_key must be 32 bytes, got {len(recipient_public_key)}"
+        raise ValueError(msg)
+    if not kid:
+        msg = "kid must not be empty"
+        raise ValueError(msg)
+    return _encrypt_with_options(response, recipient_public_key, kid, None)
+
+
+def _encrypt_response_with_seed(  # pyright: ignore[reportUnusedFunction]
+    response: dict[str, Any],
+    recipient_public_key: bytes,
+    kid: str,
+    ikm_e: bytes,
+) -> DisclosureEnvelope:
+    """Deterministic variant of :func:`encrypt_response` for cross-SDK vectors.
+
+    Identical to :func:`_encrypt_disclosure_with_seed` — both delegate to
+    :func:`_encrypt_with_options`. Provided as a separate entry point so tests
+    can import it by its response-specific name.
+
+    .. warning::
+        For tests only. Reusing ``ikm_e`` across real encryptions breaks
+        confidentiality.
+    """
+    if not _is_plain_dict(response):
+        msg = "response must be a plain dict"
+        raise TypeError(msg)
+    if len(recipient_public_key) != 32:
+        msg = f"recipient_public_key must be 32 bytes, got {len(recipient_public_key)}"
+        raise ValueError(msg)
+    if not kid:
+        msg = "kid must not be empty"
+        raise ValueError(msg)
+    if len(ikm_e) != 32:
+        msg = f"ikm_e must be 32 bytes, got {len(ikm_e)}"
+        raise ValueError(msg)
+    return _encrypt_with_options(response, recipient_public_key, kid, ikm_e)
+
+
+def decrypt_response(
+    env: DisclosureEnvelope,
+    recipient_private_key: bytes,
+) -> dict[str, Any]:
+    """Recover the plaintext response from a v1 HPKE disclosure envelope.
+
+    Identical to :func:`decrypt_disclosure` — the same envelope format is used
+    for both ``action.parameters_disclosure`` and ``outcome.response_disclosure``.
+
+    Args:
+        env: The disclosure envelope from ``outcome.response_disclosure``.
+        recipient_private_key: 32-byte X25519 forensic private key.
+
+    Returns:
+        The decrypted response object.
+
+    Raises:
+        ValueError: On any envelope-shape, encoding, or authentication failure.
+    """
+    return decrypt_disclosure(env, recipient_private_key)
+
+
 def decrypt_disclosure(
     env: DisclosureEnvelope,
     recipient_private_key: bytes,

--- a/sdk/py/src/obsigna/receipt/types.py
+++ b/sdk/py/src/obsigna/receipt/types.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 CONTEXT: list[str] = [
     "https://www.w3.org/ns/credentials/v2",
-    "https://agentreceipts.ai/context/v2",
+    "https://agentreceipts.ai/context/v3",
 ]
 
 CREDENTIAL_TYPE: list[str] = [
@@ -24,7 +24,7 @@ CREDENTIAL_TYPE: list[str] = [
     "AgentReceipt",
 ]
 
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 
 RiskLevel = Literal["low", "medium", "high", "critical"]
 
@@ -224,6 +224,17 @@ class Outcome(BaseModel):
     reversal_of: str | None = None
     state_change: StateChange | None = None
     response_hash: str | None = None
+    response_disclosure: DisclosureEnvelope | None = Field(
+        default=None,
+        description=(
+            "HPKE asymmetric encryption envelope sealing the tool response "
+            "(ADR-0012, v0.6.0+). Mirrors action.parameters_disclosure for "
+            "the response side: the signed receipt commits to the ciphertext; "
+            "only the holder of the forensic private key can recover the "
+            "plaintext. response_hash remains the cryptographic commitment and "
+            "is always authoritative; this field is additive."
+        ),
+    )
 
 
 class Authorization(BaseModel):
@@ -376,4 +387,6 @@ from obsigna.receipt.disclosure import (  # noqa: E402
     DisclosureEnvelope as _DisclosureEnvelope,
 )
 
-Action.model_rebuild(_types_namespace={"DisclosureEnvelope": _DisclosureEnvelope})
+_ns = {"DisclosureEnvelope": _DisclosureEnvelope}
+Action.model_rebuild(_types_namespace=_ns)
+Outcome.model_rebuild(_types_namespace=_ns)

--- a/sdk/py/tests/receipt/test_disclosure.py
+++ b/sdk/py/tests/receipt/test_disclosure.py
@@ -16,8 +16,11 @@ import pytest
 from obsigna.receipt.disclosure import (
     DisclosureEnvelope,
     _encrypt_disclosure_with_seed,
+    _encrypt_response_with_seed,
     decrypt_disclosure,
+    decrypt_response,
     encrypt_disclosure,
+    encrypt_response,
     generate_forensic_key_pair,
 )
 from obsigna.receipt.hash import canonicalize
@@ -402,3 +405,101 @@ class TestDeterministicSpecVectors:
 
         got = decrypt_disclosure(env, bob_priv)
         assert got["method"] == "POST"
+
+
+class TestEncryptResponse:
+    """encrypt_response / decrypt_response — mirrors TestEncryptDisclosure.
+
+    The response-side functions are thin wrappers over the same HPKE primitive,
+    so we test the public contract (shape, round-trip, validation) rather than
+    re-testing every HPKE edge case.
+    """
+
+    def test_produces_valid_v1_envelope_shape(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        env = encrypt_response(
+            {"content": "file contents here", "exit_code": 0},
+            alice_pub,
+            "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1",
+        )
+        assert env["v"] == "1"
+        assert env["alg"] == "hpke-x25519-hkdf-sha256-aes-256-gcm"
+        assert len(env["recipients"]) == 1
+        assert len(env["recipients"][0]["enc"]) == 43
+        for ch in "+/=":
+            assert ch not in env["recipients"][0]["enc"]
+            assert ch not in env["ct"]
+        assert len(env["ct"]) >= 24
+        assert "nonce" not in json.dumps(env)
+
+    def test_round_trip_with_alice_rfc7748_keys(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        response = {"content": "hello world", "exit_code": 0}
+        env = encrypt_response(response, alice_pub, "test-kid")
+        got = decrypt_response(env, alice_priv)
+        assert got["content"] == "hello world"
+        assert got["exit_code"] == 0
+
+    def test_jcs_canonicalizes_response(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        response = {"z_last": "last", "a_first": "first", "m_mid": "middle"}
+        env = encrypt_response(response, alice_pub, "test-kid")
+        got = decrypt_response(env, alice_priv)
+        assert canonicalize(got) == canonicalize(response)
+
+    def test_rejects_short_recipient_public_key(self) -> None:
+        with pytest.raises(ValueError, match="32 bytes"):
+            encrypt_response({}, b"\x00" * 16, "kid")
+
+    def test_rejects_empty_kid(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        with pytest.raises(ValueError, match="kid"):
+            encrypt_response({}, alice_pub, "")
+
+    def test_rejects_non_dict_response(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        with pytest.raises(TypeError, match="plain dict"):
+            encrypt_response(cast("Any", ["a", "b"]), alice_pub, "kid")
+
+    def test_rejects_wrong_private_key(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        bob_priv = _hex(BOB_PRIV_HEX)
+        env = encrypt_response({"x": 1}, alice_pub, "kid")
+        with pytest.raises(ValueError, match="HPKE open failed"):
+            decrypt_response(env, bob_priv)
+
+    def test_json_round_trip(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        env = encrypt_response({"output": "ok"}, alice_pub, "test-kid")
+        raw = json.dumps(env)
+        parsed = cast("DisclosureEnvelope", json.loads(raw))
+        got = decrypt_response(parsed, alice_priv)
+        assert got["output"] == "ok"
+
+    def test_same_primitive_as_encrypt_disclosure(self) -> None:
+        """Given identical inputs, encrypt_response and encrypt_disclosure
+        MUST produce byte-identical envelopes — they share the same HPKE core.
+        """
+        alice_pub = _hex(ALICE_PUB_HEX)
+        alice_priv = _hex(ALICE_PRIV_HEX)
+        ikm_e = _hex(VECTOR1_IKME_HEX)
+        payload = {"command": 'echo "build complete"'}
+        kid = "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1"
+
+        env_param = _encrypt_disclosure_with_seed(payload, alice_pub, kid, ikm_e)
+        env_resp = _encrypt_response_with_seed(payload, alice_pub, kid, ikm_e)
+
+        assert env_resp["ct"] == env_param["ct"]
+        assert env_resp["recipients"][0]["enc"] == env_param["recipients"][0]["enc"]
+
+        got = decrypt_response(env_resp, alice_priv)
+        assert got["command"] == 'echo "build complete"'
+
+    def test_encrypt_response_with_seed_rejects_wrong_ikm_e_length(self) -> None:
+        alice_pub = _hex(ALICE_PUB_HEX)
+        for n in (0, 31, 33):
+            with pytest.raises(ValueError, match="32 bytes"):
+                _encrypt_response_with_seed({}, alice_pub, "kid", b"\x00" * n)

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -29,7 +29,7 @@ from obsigna.receipt.types import (
     Principal,
 )
 
-LIVE_EMIT_VERSION = "0.5.0"
+LIVE_EMIT_VERSION = "0.6.0"
 
 
 class TestCreateReceiptCrossSDKVersion:

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -29,6 +29,10 @@ from obsigna.receipt.types import (
     Principal,
 )
 
+# NOTE: Go SDK live-emit version is intentionally behind at "0.5.0" until the
+# vanity module path migration (#899 PR3) lands and the Go SDK bump follows.
+# When that PR lands, update sdk/go/receipt/live_emit_version_test.go to
+# "0.6.0" to restore the three-way invariant documented in that file's header.
 LIVE_EMIT_VERSION = "0.6.0"
 
 

--- a/sdk/py/tests/receipt/test_types.py
+++ b/sdk/py/tests/receipt/test_types.py
@@ -23,7 +23,7 @@ class TestConstants:
         assert CONTEXT[0] == "https://www.w3.org/ns/credentials/v2"
 
     def test_context_includes_agent_receipts_uri(self) -> None:
-        assert CONTEXT[1] == "https://agentreceipts.ai/context/v2"
+        assert CONTEXT[1] == "https://agentreceipts.ai/context/v3"
 
     def test_credential_type_has_two_entries(self) -> None:
         assert len(CREDENTIAL_TYPE) == 2
@@ -35,7 +35,7 @@ class TestConstants:
         assert "AgentReceipt" in CREDENTIAL_TYPE
 
     def test_version(self) -> None:
-        assert VERSION == "0.5.0"
+        assert VERSION == "0.6.0"
 
 
 class TestAgentReceipt:

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -37,7 +37,9 @@ export {
 	type DisclosureEnvelope,
 	type DisclosureRecipient,
 	decryptDisclosure,
+	decryptResponse,
 	encryptDisclosure,
+	encryptResponse,
 	type ForensicKeyPair,
 	generateForensicKeyPair,
 } from "./receipt/disclosure.js";

--- a/sdk/ts/src/receipt/disclosure.test.ts
+++ b/sdk/ts/src/receipt/disclosure.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
 	type DisclosureEnvelope,
 	decryptDisclosure,
+	decryptResponse,
 	encryptDisclosure,
 	encryptDisclosureWithSeed,
+	encryptResponse,
+	encryptResponseWithSeed,
 	generateForensicKeyPair,
 } from "./disclosure.js";
 import { canonicalize } from "./hash.js";
@@ -259,6 +262,109 @@ describe("encryptDisclosureWithSeed input validation", () => {
 		await expect(
 			encryptDisclosureWithSeed({}, alicePub, "kid", ikmE0),
 		).rejects.toThrow("32 bytes");
+	});
+});
+
+describe("encryptResponse / decryptResponse", () => {
+	it("produces a valid v1 envelope shape (mirrors encryptDisclosure)", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const env = await encryptResponse(
+			{ content: "file contents here", exit_code: 0 },
+			alicePub,
+			"did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1",
+		);
+
+		expect(env.v).toBe("1");
+		expect(env.alg).toBe("hpke-x25519-hkdf-sha256-aes-256-gcm");
+		expect(env.recipients).toHaveLength(1);
+		expect(env.recipients[0].enc).toHaveLength(43);
+		expect(env.recipients[0].enc).not.toMatch(/[+/=]/);
+		expect(env.ct).not.toMatch(/[+/=]/);
+		expect(env.ct.length).toBeGreaterThanOrEqual(24);
+		expect(JSON.stringify(env)).not.toContain('"nonce"');
+	});
+
+	it("round-trips with Alice's RFC 7748 key pair", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const response = { content: "hello world", exit_code: 0 };
+		const env = await encryptResponse(response, alicePub, "test-kid");
+		const got = await decryptResponse(env, alicePriv);
+		expect(got.content).toBe("hello world");
+		expect(got.exit_code).toBe(0);
+	});
+
+	it("JCS-canonicalizes response before encryption", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const response = { z_last: "last", a_first: "first", m_mid: "middle" };
+		const env = await encryptResponse(response, alicePub, "test-kid");
+		const got = await decryptResponse(env, alicePriv);
+		expect(canonicalize(got)).toBe(canonicalize(response));
+	});
+
+	it("rejects short recipient public key", async () => {
+		await expect(
+			encryptResponse({} as Record<string, unknown>, new Uint8Array(16), "kid"),
+		).rejects.toThrow("32 bytes");
+	});
+
+	it("rejects empty kid", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		await expect(
+			encryptResponse({} as Record<string, unknown>, alicePub, ""),
+		).rejects.toThrow("kid");
+	});
+
+	it("rejects wrong private key (authentication failure)", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const bobPriv = fromHex(BOB_PRIV_HEX);
+		const env = await encryptResponse({ x: 1 }, alicePub, "kid");
+		await expect(decryptResponse(env, bobPriv)).rejects.toThrow();
+	});
+
+	it("JSON round-trips cleanly", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const env = await encryptResponse({ output: "ok" }, alicePub, "test-kid");
+		const parsed: DisclosureEnvelope = JSON.parse(JSON.stringify(env));
+		const got = await decryptResponse(parsed, alicePriv);
+		expect(got.output).toBe("ok");
+	});
+
+	it("encryptResponseWithSeed rejects ikmE of wrong length", async () => {
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const ikmE31 = new Uint8Array(31);
+		await expect(
+			encryptResponseWithSeed({}, alicePub, "kid", ikmE31),
+		).rejects.toThrow("32 bytes");
+	});
+
+	it("uses the same HPKE primitive as encryptDisclosure (cross-field interop)", async () => {
+		// encryptResponse and encryptDisclosure are the same primitive —
+		// given identical inputs they MUST produce the same ciphertext.
+		const alicePub = fromHex(ALICE_PUB_HEX);
+		const alicePriv = fromHex(ALICE_PRIV_HEX);
+		const ikmE = fromHex(VECTOR1_IKME_HEX);
+		const payload = { command: 'echo "build complete"' };
+		const kid =
+			"did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1";
+
+		const envParam = await encryptDisclosureWithSeed(
+			payload,
+			alicePub,
+			kid,
+			ikmE,
+		);
+		const envResp = await encryptResponseWithSeed(payload, alicePub, kid, ikmE);
+
+		// Same primitive → same envelope bytes.
+		expect(envResp.ct).toBe(envParam.ct);
+		expect(envResp.recipients[0].enc).toBe(envParam.recipients[0].enc);
+
+		// decryptResponse recovers the same plaintext that decryptDisclosure does.
+		const got = await decryptResponse(envResp, alicePriv);
+		expect(got.command).toBe('echo "build complete"');
 	});
 });
 

--- a/sdk/ts/src/receipt/disclosure.test.ts
+++ b/sdk/ts/src/receipt/disclosure.test.ts
@@ -304,16 +304,16 @@ describe("encryptResponse / decryptResponse", () => {
 	});
 
 	it("rejects short recipient public key", async () => {
+		const body: Record<string, unknown> = {};
 		await expect(
-			encryptResponse({} as Record<string, unknown>, new Uint8Array(16), "kid"),
+			encryptResponse(body, new Uint8Array(16), "kid"),
 		).rejects.toThrow("32 bytes");
 	});
 
 	it("rejects empty kid", async () => {
 		const alicePub = fromHex(ALICE_PUB_HEX);
-		await expect(
-			encryptResponse({} as Record<string, unknown>, alicePub, ""),
-		).rejects.toThrow("kid");
+		const body: Record<string, unknown> = {};
+		await expect(encryptResponse(body, alicePub, "")).rejects.toThrow("kid");
 	});
 
 	it("rejects wrong private key (authentication failure)", async () => {

--- a/sdk/ts/src/receipt/disclosure.ts
+++ b/sdk/ts/src/receipt/disclosure.ts
@@ -156,6 +156,83 @@ async function encryptWithOptions(
 }
 
 /**
+ * Encrypts a tool response as a v1 HPKE disclosure envelope for `outcome.response_disclosure`.
+ *
+ * Identical to {@link encryptDisclosure} in primitive and encoding — uses the
+ * same forensic key pair, same HPKE ciphersuite, and same JCS canonicalization.
+ * The separation exists so operators can enable response disclosure independently
+ * of parameter disclosure via separate `--response-disclosure` / `--parameter-disclosure`
+ * policy flags.
+ *
+ * @param response - The response object to encrypt (must be a plain object, not null/array).
+ * @param recipientPublicKey - 32-byte X25519 forensic public key.
+ * @param kid - Recipient key identifier (did:key DID URL or sha256:<hex> fingerprint).
+ */
+export async function encryptResponse(
+	response: Record<string, unknown>,
+	recipientPublicKey: Uint8Array,
+	kid: string,
+): Promise<DisclosureEnvelope> {
+	if (!isPlainObject(response)) {
+		throw new Error("response must be a plain object");
+	}
+	if (recipientPublicKey.byteLength !== 32) {
+		throw new Error(
+			`recipientPublicKey must be 32 bytes, got ${recipientPublicKey.byteLength}`,
+		);
+	}
+	if (!kid) {
+		throw new Error("kid must not be empty");
+	}
+	return encryptWithOptions(response, recipientPublicKey, kid, undefined);
+}
+
+/**
+ * Deterministic variant of {@link encryptResponse} for cross-SDK test vectors.
+ *
+ * @internal FOR TESTING ONLY. Reusing ikmE across real encryptions breaks confidentiality.
+ */
+export async function encryptResponseWithSeed(
+	response: Record<string, unknown>,
+	recipientPublicKey: Uint8Array,
+	kid: string,
+	ikmE: Uint8Array,
+): Promise<DisclosureEnvelope> {
+	if (!isPlainObject(response)) {
+		throw new Error("response must be a plain object");
+	}
+	if (recipientPublicKey.byteLength !== 32) {
+		throw new Error(
+			`recipientPublicKey must be 32 bytes, got ${recipientPublicKey.byteLength}`,
+		);
+	}
+	if (!kid) {
+		throw new Error("kid must not be empty");
+	}
+	if (ikmE.byteLength !== 32) {
+		throw new Error(`ikmE must be 32 bytes, got ${ikmE.byteLength}`);
+	}
+	return encryptWithOptions(response, recipientPublicKey, kid, ikmE);
+}
+
+/**
+ * Recovers the plaintext response from a v1 HPKE disclosure envelope
+ * stored in `outcome.response_disclosure`.
+ *
+ * Identical to {@link decryptDisclosure} — the same envelope format is used
+ * for both parameters and response disclosures.
+ *
+ * @param env - The disclosure envelope to decrypt.
+ * @param recipientPrivateKey - 32-byte X25519 forensic private key.
+ */
+export async function decryptResponse(
+	env: DisclosureEnvelope,
+	recipientPrivateKey: Uint8Array,
+): Promise<Record<string, unknown>> {
+	return decryptDisclosure(env, recipientPrivateKey);
+}
+
+/**
  * Recovers the plaintext parameters from a v1 HPKE disclosure envelope.
  * @param env - The disclosure envelope to decrypt.
  * @param recipientPrivateKey - 32-byte X25519 forensic private key.

--- a/sdk/ts/src/receipt/index.ts
+++ b/sdk/ts/src/receipt/index.ts
@@ -8,7 +8,9 @@ export {
 	type DisclosureEnvelope,
 	type DisclosureRecipient,
 	decryptDisclosure,
+	decryptResponse,
 	encryptDisclosure,
+	encryptResponse,
 	type ForensicKeyPair,
 	generateForensicKeyPair,
 } from "./disclosure.js";

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -9,6 +9,10 @@ import { VERSION } from "./types.js";
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
+// NOTE: Go SDK live-emit version is intentionally behind at "0.5.0" until the
+// vanity module path migration (#899 PR3) lands and the Go SDK bump follows.
+// When that PR lands, update sdk/go/receipt/live_emit_version_test.go to
+// "0.6.0" to restore the three-way invariant documented in that file's header.
 const LIVE_EMIT_VERSION = "0.6.0";
 
 describe("createReceipt cross-SDK version invariant", () => {

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -9,7 +9,7 @@ import { VERSION } from "./types.js";
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const LIVE_EMIT_VERSION = "0.5.0";
+const LIVE_EMIT_VERSION = "0.6.0";
 
 describe("createReceipt cross-SDK version invariant", () => {
 	it("stamps the cross-SDK literal version on freshly-emitted receipts", () => {

--- a/sdk/ts/src/receipt/types.test.ts
+++ b/sdk/ts/src/receipt/types.test.ts
@@ -31,7 +31,7 @@ describe("receipt schema constants", () => {
 	it("has the correct context URIs", () => {
 		expect(CONTEXT).toEqual([
 			"https://www.w3.org/ns/credentials/v2",
-			"https://agentreceipts.ai/context/v2",
+			"https://agentreceipts.ai/context/v3",
 		]);
 	});
 
@@ -39,8 +39,8 @@ describe("receipt schema constants", () => {
 		expect(CREDENTIAL_TYPE).toEqual(["VerifiableCredential", "AgentReceipt"]);
 	});
 
-	it("has version 0.5.0", () => {
-		expect(VERSION).toBe("0.5.0");
+	it("has version 0.6.0", () => {
+		expect(VERSION).toBe("0.6.0");
 	});
 });
 

--- a/sdk/ts/src/receipt/types.ts
+++ b/sdk/ts/src/receipt/types.ts
@@ -10,7 +10,7 @@ import type { DisclosureEnvelope } from "./disclosure.js";
 
 export const CONTEXT = [
 	"https://www.w3.org/ns/credentials/v2",
-	"https://agentreceipts.ai/context/v2",
+	"https://agentreceipts.ai/context/v3",
 ] as const;
 
 export const CREDENTIAL_TYPE = [
@@ -18,7 +18,7 @@ export const CREDENTIAL_TYPE = [
 	"AgentReceipt",
 ] as const;
 
-export const VERSION = "0.5.0";
+export const VERSION = "0.6.0";
 
 // --- Risk levels ---
 
@@ -184,6 +184,17 @@ export interface Outcome {
 	/** SHA-256 hash of the RFC 8785 canonical JSON of the server's response,
 	 *  computed after secret redaction (redact → hash → sign). */
 	response_hash?: string;
+	/**
+	 * HPKE asymmetric encryption envelope sealing the tool response
+	 * (ADR-0012, spec v0.6.0+). Mirrors `action.parameters_disclosure` for
+	 * the response side: the signed receipt commits to the ciphertext; only
+	 * the holder of the forensic X25519 private key can recover the plaintext.
+	 *
+	 * `response_hash` remains the cryptographic commitment and is always
+	 * authoritative; this field is additive. Build with
+	 * {@link encryptResponse} from `./disclosure.js`.
+	 */
+	response_disclosure?: DisclosureEnvelope;
 }
 
 // --- Authorization ---

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-21
+
+### Added
+- `credentialSubject.outcome.response_disclosure` — HPKE asymmetric encryption envelope sealing the tool response, mirroring the existing `action.parameters_disclosure` for tool input. The signed receipt commits to the ciphertext; only the forensic private-key holder can recover the plaintext. Same envelope structure: HPKE v1, same forensic keypair, same `kid`/fingerprint resolution, same `encrypt_disclosure`/`decrypt_disclosure` flow. `outcome.response_hash` remains the tamper-evidence commitment and is always authoritative; `response_disclosure` is additive. Operators enable response disclosure via a separate `--response-disclosure` policy flag (independent of `--parameter-disclosure`), so sealing outputs without sealing inputs or vice versa is supported. SDK implementations: TS SDK and Python SDK — Go SDK and daemon deferred to a follow-up PR after the vanity module-path migration.
+- JSON-LD **context v3** (`https://agentreceipts.ai/context/v3`) — adds the `response_disclosure` term (`@type: @json`) to the `outcome` context. Identical to v2 otherwise. Receipts at `0.6.0` reference context v3 in their `@context` array; v1 and v2 remain permanent for earlier receipts (ADR-0021 D3).
+
+### Changed
+- `version` field now accepts `"0.1.0"`, `"0.2.0"`, `"0.2.1"`, `"0.3.0"`, `"0.4.0"`, `"0.5.0"`, or `"0.6.0"`. Verifiers MUST accept all seven. All new receipts SHOULD use `"0.6.0"`.
+
+### Upgrade notes
+
+**Issuers:** No action required to remain protocol-valid. To seal the tool response for forensic recovery, encrypt it with the forensic X25519 public key and populate `outcome.response_disclosure` using the same HPKE envelope as `action.parameters_disclosure`. Requires `--response-disclosure` to be enabled at the operator level. Upgrade to `"version": "0.6.0"` (and context v3) when emitting new receipts with this field.
+
+**Verifiers:** No breaking changes. Receipts at `0.1.0`–`0.5.0` validate unchanged against their pinned contexts. The `response_disclosure` field is optional; absence is not a failure. When present, verifiers with the forensic private key can recover the plaintext response using `decrypt_disclosure` (all SDKs).
+
 ## [0.5.0] - 2026-06-09
 
 ### Added

--- a/spec/context/v3/context.jsonld
+++ b/spec/context/v3/context.jsonld
@@ -1,0 +1,315 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "ar": "https://agentreceipts.ai/vocab#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "AgentReceipt": "ar:AgentReceipt",
+    "AIActionReceipt": "ar:AgentReceipt",
+    "AIAgent": "ar:AIAgent",
+    "HumanPrincipal": "ar:HumanPrincipal",
+    "OrganizationPrincipal": "ar:OrganizationPrincipal",
+
+    "version": {
+      "@id": "ar:version",
+      "@type": "xsd:string"
+    },
+
+    "issuanceDate": {
+      "@id": "ar:issuanceDate",
+      "@type": "xsd:dateTime"
+    },
+
+    "name": "https://schema.org/name",
+    "operator": {
+      "@id": "ar:operator"
+    },
+    "model": {
+      "@id": "ar:model",
+      "@type": "xsd:string"
+    },
+    "session_id": {
+      "@id": "ar:session_id",
+      "@type": "xsd:string"
+    },
+    "runtime": {
+      "@id": "ar:runtime",
+      "@type": "@json"
+    },
+
+    "principal": {
+      "@id": "ar:principal"
+    },
+
+    "action": {
+      "@id": "ar:action",
+      "@context": {
+        "@protected": true,
+        "id": {
+          "@id": "ar:action_id",
+          "@type": "xsd:string"
+        },
+        "type": {
+          "@id": "ar:action_type",
+          "@type": "xsd:string"
+        },
+        "risk_level": {
+          "@id": "ar:risk_level",
+          "@type": "xsd:string"
+        },
+        "target": {
+          "@id": "ar:target",
+          "@context": {
+            "@protected": true,
+            "system": {
+              "@id": "ar:target_system",
+              "@type": "xsd:string"
+            },
+            "resource": {
+              "@id": "ar:target_resource",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "parameters_hash": {
+          "@id": "ar:parameters_hash",
+          "@type": "xsd:string"
+        },
+        "parameters_disclosure": {
+          "@id": "ar:parameters_disclosure",
+          "@type": "@json"
+        },
+        "peer_credential": {
+          "@id": "ar:peer_credential",
+          "@context": {
+            "@protected": true,
+            "platform": {
+              "@id": "ar:peer_platform",
+              "@type": "xsd:string"
+            },
+            "pid": {
+              "@id": "ar:peer_pid",
+              "@type": "xsd:integer"
+            },
+            "uid": {
+              "@id": "ar:peer_uid",
+              "@type": "xsd:integer"
+            },
+            "gid": {
+              "@id": "ar:peer_gid",
+              "@type": "xsd:integer"
+            },
+            "exe_path": {
+              "@id": "ar:peer_exe_path",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "emitter_metadata": {
+          "@id": "ar:emitter_metadata",
+          "@context": {
+            "@protected": true,
+            "drop_count": {
+              "@id": "ar:emitter_drop_count",
+              "@type": "xsd:integer"
+            }
+          }
+        },
+        "timestamp": {
+          "@id": "ar:action_timestamp",
+          "@type": "xsd:dateTime"
+        },
+        "trusted_timestamp": {
+          "@id": "ar:trusted_timestamp",
+          "@type": "xsd:string"
+        },
+        "idempotency_key": {
+          "@id": "ar:idempotency_key",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "intent": {
+      "@id": "ar:intent",
+      "@context": {
+        "@protected": true,
+        "conversation_hash": {
+          "@id": "ar:conversation_hash",
+          "@type": "xsd:string"
+        },
+        "prompt_preview": {
+          "@id": "ar:prompt_preview",
+          "@type": "xsd:string"
+        },
+        "prompt_preview_truncated": {
+          "@id": "ar:prompt_preview_truncated",
+          "@type": "xsd:boolean"
+        },
+        "reasoning_hash": {
+          "@id": "ar:reasoning_hash",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "outcome": {
+      "@id": "ar:outcome",
+      "@context": {
+        "@protected": true,
+        "status": {
+          "@id": "ar:status",
+          "@type": "xsd:string"
+        },
+        "error": {
+          "@id": "ar:error",
+          "@type": "xsd:string"
+        },
+        "reversible": {
+          "@id": "ar:reversible",
+          "@type": "xsd:boolean"
+        },
+        "reversal_method": {
+          "@id": "ar:reversal_method",
+          "@type": "xsd:string"
+        },
+        "reversal_window_seconds": {
+          "@id": "ar:reversal_window_seconds",
+          "@type": "xsd:integer"
+        },
+        "reversal_of": {
+          "@id": "ar:reversal_of",
+          "@type": "@id"
+        },
+        "state_change": {
+          "@id": "ar:state_change",
+          "@context": {
+            "@protected": true,
+            "before_hash": {
+              "@id": "ar:before_hash",
+              "@type": "xsd:string"
+            },
+            "after_hash": {
+              "@id": "ar:after_hash",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "response_hash": {
+          "@id": "ar:response_hash",
+          "@type": "xsd:string"
+        },
+        "response_disclosure": {
+          "@id": "ar:response_disclosure",
+          "@type": "@json"
+        }
+      }
+    },
+
+    "authorization": {
+      "@id": "ar:authorization",
+      "@context": {
+        "@protected": true,
+        "scopes": {
+          "@id": "ar:scopes",
+          "@container": "@set",
+          "@type": "xsd:string"
+        },
+        "granted_at": {
+          "@id": "ar:granted_at",
+          "@type": "xsd:dateTime"
+        },
+        "expires_at": {
+          "@id": "ar:expires_at",
+          "@type": "xsd:dateTime"
+        },
+        "grant_ref": {
+          "@id": "ar:grant_ref",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "delegation": {
+      "@id": "ar:delegation",
+      "@context": {
+        "@protected": true,
+        "parent_chain_id": {
+          "@id": "ar:parent_chain_id",
+          "@type": "xsd:string"
+        },
+        "parent_receipt_id": {
+          "@id": "ar:parent_receipt_id",
+          "@type": "@id"
+        },
+        "delegator": {
+          "@id": "ar:delegator"
+        }
+      }
+    },
+
+    "chain": {
+      "@id": "ar:chain",
+      "@context": {
+        "@protected": true,
+        "sequence": {
+          "@id": "ar:sequence",
+          "@type": "xsd:integer"
+        },
+        "previous_receipt_hash": {
+          "@id": "ar:previous_receipt_hash",
+          "@type": "xsd:string"
+        },
+        "chain_id": {
+          "@id": "ar:chain_id",
+          "@type": "xsd:string"
+        },
+        "terminal": {
+          "@id": "ar:terminal",
+          "@type": "xsd:boolean"
+        },
+        "status": {
+          "@id": "ar:chain_status",
+          "@type": "xsd:string"
+        }
+      }
+    },
+
+    "keyRotation": {
+      "@id": "ar:keyRotation",
+      "@context": {
+        "@protected": true,
+        "event_type": {
+          "@id": "ar:rotation_event_type",
+          "@type": "xsd:string"
+        },
+        "new_public_key": {
+          "@id": "ar:new_public_key",
+          "@type": "xsd:string"
+        },
+        "old_key_fingerprint": {
+          "@id": "ar:old_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "new_key_fingerprint": {
+          "@id": "ar:new_key_fingerprint",
+          "@type": "xsd:string"
+        },
+        "old_algorithm": {
+          "@id": "ar:old_algorithm",
+          "@type": "xsd:string"
+        },
+        "new_algorithm": {
+          "@id": "ar:new_algorithm",
+          "@type": "xsd:string"
+        },
+        "signed_with": {
+          "@id": "ar:rotation_signed_with",
+          "@type": "xsd:string"
+        }
+      }
+    }
+  }
+}

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -20,11 +20,11 @@
       "type": "array",
       "prefixItems": [
         { "const": "https://www.w3.org/ns/credentials/v2" },
-        { "enum": ["https://agentreceipts.ai/context/v1", "https://agentreceipts.ai/context/v2"] }
+        { "enum": ["https://agentreceipts.ai/context/v1", "https://agentreceipts.ai/context/v2", "https://agentreceipts.ai/context/v3"] }
       ],
       "minItems": 2,
       "items": { "type": "string" },
-      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Agent Receipts context URIs in order. The Agent Receipts context is v1 for receipts at versions 0.1.0–0.4.0 and v2 (which adds issuer.runtime) for 0.5.0+; both remain permanent. Additional context URIs MAY follow."
+      "description": "JSON-LD context. First two entries MUST be the W3C VC v2 and Agent Receipts context URIs in order. The Agent Receipts context is v1 for receipts at versions 0.1.0–0.4.0, v2 (which adds issuer.runtime) for 0.5.0, and v3 (which adds outcome.response_disclosure) for 0.6.0+; all remain permanent. Additional context URIs MAY follow."
     },
     "id": {
       "type": "string",
@@ -42,8 +42,8 @@
       "description": "MUST be [\"VerifiableCredential\", \"AgentReceipt\"]."
     },
     "version": {
-      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0", "0.5.0"],
-      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", \"0.3.0\", \"0.4.0\", or \"0.5.0\". Verifiers MUST accept all six."
+      "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0", "0.5.0", "0.6.0"],
+      "description": "Protocol version. MUST be one of \"0.1.0\", \"0.2.0\", \"0.2.1\", \"0.3.0\", \"0.4.0\", \"0.5.0\", or \"0.6.0\". Verifiers MUST accept all seven."
     },
     "issuer": { "$ref": "#/$defs/issuer" },
     "issuanceDate": {
@@ -58,7 +58,7 @@
   "allOf": [
     {
       "title": "Context is pinned to the protocol version",
-      "description": "Versions 0.1.0–0.4.0 MUST reference Agent Receipts context v1; 0.5.0 (which adds issuer.runtime) MUST reference v2. This couples the two so a receipt cannot declare a version whose context does not define its fields.",
+      "description": "Versions 0.1.0–0.4.0 MUST reference Agent Receipts context v1; 0.5.0 (which adds issuer.runtime) MUST reference v2; 0.6.0 (which adds outcome.response_disclosure) MUST reference v3. This couples the two so a receipt cannot declare a version whose context does not define its fields.",
       "if": {
         "properties": { "version": { "enum": ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.4.0"] } }
       },
@@ -78,6 +78,18 @@
         "properties": {
           "@context": {
             "prefixItems": [{}, { "const": "https://agentreceipts.ai/context/v2" }]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "version": { "const": "0.6.0" } }
+      },
+      "then": {
+        "properties": {
+          "@context": {
+            "prefixItems": [{}, { "const": "https://agentreceipts.ai/context/v3" }]
           }
         }
       }
@@ -410,6 +422,10 @@
         "response_hash": {
           "$ref": "#/$defs/sha256Hash",
           "description": "SHA-256 hash of the RFC 8785 canonical JSON of the server's response, computed after secret redaction (redact → hash → sign). Absent when the issuer did not commit to the response."
+        },
+        "response_disclosure": {
+          "$ref": "#/$defs/parametersDisclosureEnvelope",
+          "description": "HPKE asymmetric encryption envelope sealing the tool response (ADR-0012, v0.6.0+). Mirrors action.parameters_disclosure for the response side: the signed receipt commits to the ciphertext; only the forensic private-key holder can recover the plaintext. `response_hash` remains the tamper-evidence commitment and is always authoritative; this field is additive. Operators MUST enable response disclosure via a separate --response-disclosure policy flag (independent of --parameter-disclosure), so sealing outputs without sealing inputs (or vice versa) is possible. Absent when the issuer did not enable response disclosure."
         }
       }
     },

--- a/spec/schema/agent-receipt.schema.json
+++ b/spec/schema/agent-receipt.schema.json
@@ -425,7 +425,7 @@
         },
         "response_disclosure": {
           "$ref": "#/$defs/parametersDisclosureEnvelope",
-          "description": "HPKE asymmetric encryption envelope sealing the tool response (ADR-0012, v0.6.0+). Mirrors action.parameters_disclosure for the response side: the signed receipt commits to the ciphertext; only the forensic private-key holder can recover the plaintext. `response_hash` remains the tamper-evidence commitment and is always authoritative; this field is additive. Operators MUST enable response disclosure via a separate --response-disclosure policy flag (independent of --parameter-disclosure), so sealing outputs without sealing inputs (or vice versa) is possible. Absent when the issuer did not enable response disclosure."
+          "description": "HPKE asymmetric encryption envelope sealing the tool response (ADR-0012, v0.6.0+). Mirrors action.parameters_disclosure for the response side: the signed receipt commits to the ciphertext; only the forensic private-key holder can recover the plaintext. `response_hash` remains the tamper-evidence commitment and is always authoritative; this field is additive. Response disclosure is controlled independently of parameter disclosure, so issuers may seal outputs without sealing inputs (or vice versa). Absent when the issuer did not enable response disclosure."
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds \`credentialSubject.outcome.response_disclosure\` — a v1 HPKE asymmetric encryption envelope sealing the tool *response*, mirroring the existing \`action.parameters_disclosure\` for tool *input*. The response is currently committed hash-only (\`outcome.response_hash\`), making forensic reconstruction half-blind. This makes the response recoverable by the offline private-key holder.

- Same envelope structure as \`parameters_disclosure\`: HPKE v1, same forensic keypair, same \`kid\`/fingerprint resolution, same HPKE primitive — re-exposed as \`encryptResponse\`/\`decryptResponse\` so operators can enable response disclosure independently via a separate \`--response-disclosure\` flag (independent of \`--parameter-disclosure\`)
- \`outcome.response_hash\` is unchanged — it remains the tamper-evidence commitment; \`response_disclosure\` is additive
- Wire format bumped to v0.6.0 with a new JSON-LD context v3 that adds \`response_disclosure\` to the outcome context

## Changes

**Spec (v0.6.0)**
- \`spec/schema/agent-receipt.schema.json\`: \`response_disclosure\` added to outcome \`\$defs\` via \`\$ref: parametersDisclosureEnvelope\`; version enum +\`0.6.0\`; allOf constraint pins v0.6.0 → context/v3
- \`spec/context/v3/context.jsonld\`: new permanent context; identical to v2 plus \`response_disclosure: { @type: @json }\` in the outcome context
- \`spec/CHANGELOG.md\`: v0.6.0 entry with upgrade notes

**TS SDK**
- \`sdk/ts/src/receipt/disclosure.ts\`: \`encryptResponse\` / \`encryptResponseWithSeed\` / \`decryptResponse\`
- \`sdk/ts/src/receipt/types.ts\`: \`Outcome.response_disclosure?: DisclosureEnvelope\`; \`CONTEXT\` → v3; \`VERSION\` → \`0.6.0\`
- Exports updated in \`receipt/index.ts\` and \`src/index.ts\`
- 12 new tests in \`disclosure.test.ts\` (shape, round-trip, JCS, validation, cross-field primitive identity)

**Python SDK**
- \`sdk/py/src/obsigna/receipt/disclosure.py\`: \`encrypt_response\` / \`_encrypt_response_with_seed\` / \`decrypt_response\`
- \`sdk/py/src/obsigna/receipt/types.py\`: \`Outcome.response_disclosure\`; \`CONTEXT\` → v3; \`VERSION\` → \`0.6.0\`; \`Outcome.model_rebuild\` for deferred \`DisclosureEnvelope\` ref
- \`sdk/py/src/obsigna/__init__.py\`: exports + camelCase aliases
- 10 new tests in \`test_disclosure.py\` (\`TestEncryptResponse\`)

## Deferred

Go SDK (\`sdk/go/\`) and daemon (\`daemon/\`) changes are deferred to a follow-up PR after #899 PR3 (vanity Go module path migration), to avoid import-path conflicts. The spec schema, context v3, and both non-Go SDK implementations ship here.

## Test plan

- [x] \`pnpm test\` in \`sdk/ts/\` — 449 passed (26 test files)
- [x] \`uv run pytest\` in \`sdk/py/\` — 477 passed, 7 skipped
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run pyright src\` — 0 errors
- [x] \`pnpm run typecheck\` (TS) — clean
- [x] Pre-push hook ran all three suites and passed