### PR TITLE
feat(sdk): grounded-principal conformance tier (ADR-0038, spec §7.9)

### DIFF
--- a/docs/adr/0038-grounded-principal-conformance-tier.md
+++ b/docs/adr/0038-grounded-principal-conformance-tier.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/sdk/go/receipt/grant_resolver.go
+++ b/sdk/go/receipt/grant_resolver.go
@@ -1,0 +1,158 @@
+package receipt
+
+import "time"
+
+// GrantInfo is the resolved representation of an externally-minted
+// authorization grant (e.g. an RFC 8693 OBO token or a Grantex grant token).
+// GrantResolver implementations MUST populate at minimum Subject; the
+// remaining fields are advisory and MAY be zero when the resolver's backend
+// does not expose them.
+type GrantInfo struct {
+	// Subject is the principal on whose behalf the grant was issued.
+	// MUST equal credentialSubject.principal.id for the grounded-principal
+	// tier check to pass.
+	Subject string
+	// Scopes are the authorization scopes active under the grant.
+	Scopes []string
+	// IssuedAt is when the authorization server minted the grant.
+	IssuedAt time.Time
+	// ExpiresAt is when the grant expires. Zero value means no expiry recorded.
+	ExpiresAt time.Time
+	// Issuer identifies the authorization server that minted the grant.
+	Issuer string
+}
+
+// GrantResolver resolves an authorization grant reference to its minted
+// grant, confirming the named principal delegated authority to the agent.
+//
+// Input:
+//   - grantRef is the authorization.grant_ref value from the receipt.
+//   - principalID is the credentialSubject.principal.id from the receipt
+//     (supplied as a hint; resolvers MAY use it to select a cached entry).
+//
+// Output: the resolved GrantInfo, or a non-nil error on resolution failure
+// (network error, token not found, token revoked, etc.).
+//
+// Implementations MAY perform network I/O (token introspection, OIDC
+// userinfo). Caching is an implementation concern. Side-effect freedom is
+// NOT required: a resolver MAY log, meter, or cache resolutions.
+//
+// The SDK ships this interface only. Integrators supply a resolver for their
+// authorization server (RFC 8693 token introspection, OIDC, Grantex). The
+// project does not endorse a single authorization server, mirroring the
+// ADR-0007 stance on DID methods.
+type GrantResolver interface {
+	ResolveGrant(grantRef, principalID string) (GrantInfo, error)
+}
+
+// GroundedOutcome is the result of a grounded-principal tier check on a
+// single receipt (spec §7.9, ADR-0038).
+type GroundedOutcome string
+
+const (
+	// GroundedOutcomeUngrounded is returned when a high/critical receipt lacks
+	// a resolvable grant_ref. Corresponds to UNGROUNDED_PRINCIPAL in spec §7.9.
+	GroundedOutcomeUngrounded GroundedOutcome = "UNGROUNDED_PRINCIPAL"
+	// GroundedOutcomeMismatch is returned when the resolved grant's subject
+	// does not equal the receipt's principal.id. Corresponds to
+	// PRINCIPAL_GRANT_MISMATCH in spec §7.9.
+	GroundedOutcomeMismatch GroundedOutcome = "PRINCIPAL_GRANT_MISMATCH"
+)
+
+// GroundedPrincipalViolation records a grounded-principal tier failure for a
+// single receipt.
+type GroundedPrincipalViolation struct {
+	// Index is the position of the offending receipt in the input slice.
+	Index int
+	// ReceiptID is the receipt's id field.
+	ReceiptID string
+	// PrincipalID is the receipt's credentialSubject.principal.id.
+	PrincipalID string
+	// GrantRef is the authorization.grant_ref value (may be empty for
+	// UNGROUNDED_PRINCIPAL violations where no grant_ref is present).
+	GrantRef string
+	// Outcome is the specific failure: UNGROUNDED_PRINCIPAL or
+	// PRINCIPAL_GRANT_MISMATCH.
+	Outcome GroundedOutcome
+	// Detail carries a human-readable description of the failure, including
+	// resolver error messages for UNGROUNDED_PRINCIPAL resolution failures.
+	Detail string
+}
+
+// VerifyGroundedPrincipalTier applies the grounded-principal conformance tier
+// checks (spec §7.9, ADR-0038 D1–D3) to a set of receipts.
+//
+// For each receipt whose action.risk_level is "high" or "critical":
+//  1. If authorization.grant_ref is absent or empty → UNGROUNDED_PRINCIPAL.
+//  2. If the resolver returns an error → UNGROUNDED_PRINCIPAL.
+//  3. If the resolved grant's Subject ≠ principal.id → PRINCIPAL_GRANT_MISMATCH.
+//
+// Receipts at risk_level "low" or "medium" are not checked.
+//
+// When resolver is nil, no checks are performed and an empty slice is
+// returned — this is the correct behaviour for base-tier verifiers that
+// have not configured a resolver (ADR-0038 D3: "absence of a resolver in
+// the base tier is not a verification failure").
+//
+// All violations are collected and returned; the function does not stop at
+// the first failure so callers get a complete picture of the tier's state.
+func VerifyGroundedPrincipalTier(receipts []AgentReceipt, resolver GrantResolver) []GroundedPrincipalViolation {
+	if resolver == nil {
+		return nil
+	}
+
+	var violations []GroundedPrincipalViolation
+
+	for i, r := range receipts {
+		rl := r.CredentialSubject.Action.RiskLevel
+		if rl != RiskHigh && rl != RiskCritical {
+			continue
+		}
+
+		principalID := r.CredentialSubject.Principal.ID
+		auth := r.CredentialSubject.Authorization
+
+		// Step 1: grant_ref must be present and non-empty.
+		if auth == nil || auth.GrantRef == "" {
+			violations = append(violations, GroundedPrincipalViolation{
+				Index:       i,
+				ReceiptID:   r.ID,
+				PrincipalID: principalID,
+				Outcome:     GroundedOutcomeUngrounded,
+				Detail:      "authorization.grant_ref is absent on a " + string(rl) + " receipt",
+			})
+			continue
+		}
+
+		grantRef := auth.GrantRef
+
+		// Step 2: resolve the grant.
+		grant, err := resolver.ResolveGrant(grantRef, principalID)
+		if err != nil {
+			violations = append(violations, GroundedPrincipalViolation{
+				Index:       i,
+				ReceiptID:   r.ID,
+				PrincipalID: principalID,
+				GrantRef:    grantRef,
+				Outcome:     GroundedOutcomeUngrounded,
+				Detail:      "grant resolution failed: " + err.Error(),
+			})
+			continue
+		}
+
+		// Step 3: subject must equal principal.id.
+		if grant.Subject != principalID {
+			violations = append(violations, GroundedPrincipalViolation{
+				Index:       i,
+				ReceiptID:   r.ID,
+				PrincipalID: principalID,
+				GrantRef:    grantRef,
+				Outcome:     GroundedOutcomeMismatch,
+				Detail: "grant subject " + grant.Subject +
+					" does not match principal.id " + principalID,
+			})
+		}
+	}
+
+	return violations
+}

--- a/sdk/go/receipt/grant_resolver.go
+++ b/sdk/go/receipt/grant_resolver.go
@@ -82,6 +82,21 @@ type GroundedPrincipalViolation struct {
 	Detail string
 }
 
+// isNilResolver reports whether r is nil, handling both untyped nils and
+// typed nils (e.g. (*MyResolver)(nil) wrapped in a GrantResolver interface).
+// Calling IsNil on a non-nilable kind panics, so the kind is checked first.
+func isNilResolver(r GrantResolver) bool {
+	if r == nil {
+		return true
+	}
+	v := reflect.ValueOf(r)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}
+
 // VerifyGroundedPrincipalTier applies the grounded-principal conformance tier
 // checks (spec §7.9, ADR-0038 D1–D3) to a set of receipts.
 //
@@ -99,24 +114,9 @@ type GroundedPrincipalViolation struct {
 //
 // All violations are collected and returned; the function does not stop at
 // the first failure so callers get a complete picture of the tier's state.
-// isNilResolver reports whether r is nil, handling both untyped nils and
-// typed nils (e.g. (*MyResolver)(nil) wrapped in a GrantResolver interface).
-// Calling IsNil on a non-nilable kind panics, so the kind is checked first.
-func isNilResolver(r GrantResolver) bool {
-	if r == nil {
-		return true
-	}
-	v := reflect.ValueOf(r)
-	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
-		return v.IsNil()
-	}
-	return false
-}
-
 func VerifyGroundedPrincipalTier(receipts []AgentReceipt, resolver GrantResolver) []GroundedPrincipalViolation {
 	if isNilResolver(resolver) {
-		return nil
+		return []GroundedPrincipalViolation{}
 	}
 
 	var violations []GroundedPrincipalViolation

--- a/sdk/go/receipt/grant_resolver.go
+++ b/sdk/go/receipt/grant_resolver.go
@@ -1,6 +1,9 @@
 package receipt
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 // GrantInfo is the resolved representation of an externally-minted
 // authorization grant (e.g. an RFC 8693 OBO token or a Grantex grant token).
@@ -96,8 +99,23 @@ type GroundedPrincipalViolation struct {
 //
 // All violations are collected and returned; the function does not stop at
 // the first failure so callers get a complete picture of the tier's state.
+// isNilResolver reports whether r is nil, handling both untyped nils and
+// typed nils (e.g. (*MyResolver)(nil) wrapped in a GrantResolver interface).
+// Calling IsNil on a non-nilable kind panics, so the kind is checked first.
+func isNilResolver(r GrantResolver) bool {
+	if r == nil {
+		return true
+	}
+	v := reflect.ValueOf(r)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}
+
 func VerifyGroundedPrincipalTier(receipts []AgentReceipt, resolver GrantResolver) []GroundedPrincipalViolation {
-	if resolver == nil {
+	if isNilResolver(resolver) {
 		return nil
 	}
 

--- a/sdk/go/receipt/grant_resolver_test.go
+++ b/sdk/go/receipt/grant_resolver_test.go
@@ -226,3 +226,17 @@ func TestVerifyGroundedPrincipalTier_EmptyChain(t *testing.T) {
 		t.Errorf("expected no violations for empty chain, got %d", len(violations))
 	}
 }
+
+// TestVerifyGroundedPrincipalTier_TypedNilResolver confirms that a typed-nil
+// resolver (a non-nil interface value whose concrete pointer is nil) is treated
+// the same as a nil interface — no violations, no panic.
+func TestVerifyGroundedPrincipalTier_TypedNilResolver(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "")
+
+	var typed *stubResolver // typed nil: concrete type known, pointer is nil
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, typed)
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for typed-nil resolver, got %d", len(violations))
+	}
+}

--- a/sdk/go/receipt/grant_resolver_test.go
+++ b/sdk/go/receipt/grant_resolver_test.go
@@ -1,0 +1,228 @@
+package receipt
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// stubResolver is a GrantResolver used in tests. It maps grant_ref to a
+// pre-built GrantInfo (or an error if the key maps to an error sentinel).
+type stubResolver struct {
+	grants map[string]GrantInfo
+	// errorRefs maps grant_ref strings that should return an error.
+	errorRefs map[string]struct{}
+}
+
+func (s *stubResolver) ResolveGrant(grantRef, _ string) (GrantInfo, error) {
+	if _, bad := s.errorRefs[grantRef]; bad {
+		return GrantInfo{}, errors.New("resolver: grant not found")
+	}
+	if g, ok := s.grants[grantRef]; ok {
+		return g, nil
+	}
+	return GrantInfo{}, errors.New("resolver: unknown grant ref")
+}
+
+func makeGroundedReceipt(t *testing.T, kp KeyPair, principalID string, riskLevel RiskLevel, grantRef string) AgentReceipt {
+	t.Helper()
+
+	var auth *Authorization
+	if grantRef != "" {
+		auth = &Authorization{
+			Scopes:    []string{"files:write"},
+			GrantedAt: time.Now().UTC().Format(time.RFC3339),
+			GrantRef:  grantRef,
+		}
+	}
+
+	unsigned := Create(CreateInput{
+		Issuer:        Issuer{ID: "did:key:z6Mk1"},
+		Principal:     Principal{ID: principalID},
+		Action:        Action{Type: "filesystem.file.write", RiskLevel: riskLevel},
+		Outcome:       Outcome{Status: StatusSuccess},
+		Authorization: auth,
+		Chain:         Chain{Sequence: 1, PreviousReceiptHash: nil, ChainID: "chain-grounded-1"},
+	})
+	signed, err := Sign(unsigned, kp.PrivateKey, "did:key:z6Mk1#key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+// TestGrantInfoFields verifies the GrantInfo struct carries the expected fields.
+func TestGrantInfoFields(t *testing.T) {
+	now := time.Now().UTC()
+	g := GrantInfo{
+		Subject:   "did:user:alice",
+		Scopes:    []string{"files:write"},
+		IssuedAt:  now,
+		ExpiresAt: now.Add(time.Hour),
+		Issuer:    "https://auth.example.com",
+	}
+	if g.Subject != "did:user:alice" {
+		t.Errorf("unexpected Subject: %s", g.Subject)
+	}
+	if len(g.Scopes) != 1 || g.Scopes[0] != "files:write" {
+		t.Errorf("unexpected Scopes: %v", g.Scopes)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_NoResolver returns no violations when no
+// resolver is configured (base-tier verifier).
+func TestVerifyGroundedPrincipalTier_NoResolver(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, nil)
+	if len(violations) != 0 {
+		t.Errorf("expected no violations without resolver, got %d", len(violations))
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_LowMediumSkipped confirms low/medium receipts
+// are not checked even when a resolver is configured.
+func TestVerifyGroundedPrincipalTier_LowMediumSkipped(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{grants: map[string]GrantInfo{}}
+	lowR := makeGroundedReceipt(t, kp, "did:user:alice", RiskLow, "")
+	medR := makeGroundedReceipt(t, kp, "did:user:alice", RiskMedium, "")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{lowR, medR}, resolver)
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for low/medium receipts, got %d", len(violations))
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_MissingGrantRef produces UNGROUNDED_PRINCIPAL
+// for a high receipt with no grant_ref.
+func TestVerifyGroundedPrincipalTier_MissingGrantRef(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{grants: map[string]GrantInfo{}}
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, resolver)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].Outcome != GroundedOutcomeUngrounded {
+		t.Errorf("expected UNGROUNDED_PRINCIPAL, got %s", violations[0].Outcome)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_ResolutionFailure produces UNGROUNDED_PRINCIPAL
+// when the resolver cannot resolve the grant_ref.
+func TestVerifyGroundedPrincipalTier_ResolutionFailure(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{
+		grants:    map[string]GrantInfo{},
+		errorRefs: map[string]struct{}{"bad-ref": {}},
+	}
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "bad-ref")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, resolver)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].Outcome != GroundedOutcomeUngrounded {
+		t.Errorf("expected UNGROUNDED_PRINCIPAL, got %s", violations[0].Outcome)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_PrincipalMismatch produces PRINCIPAL_GRANT_MISMATCH
+// when the resolved grant subject does not equal principal.id.
+func TestVerifyGroundedPrincipalTier_PrincipalMismatch(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{
+		grants: map[string]GrantInfo{
+			"grant-abc": {
+				Subject: "did:user:bob", // mismatch: receipt says alice
+				Scopes:  []string{"files:write"},
+			},
+		},
+	}
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "grant-abc")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, resolver)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].Outcome != GroundedOutcomeMismatch {
+		t.Errorf("expected PRINCIPAL_GRANT_MISMATCH, got %s", violations[0].Outcome)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_ValidGrounding produces no violation when
+// grant resolves and subject equals principal.id.
+func TestVerifyGroundedPrincipalTier_ValidGrounding(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{
+		grants: map[string]GrantInfo{
+			"grant-xyz": {
+				Subject: "did:user:alice",
+				Scopes:  []string{"files:write"},
+			},
+		},
+	}
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "grant-xyz")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, resolver)
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for grounded receipt, got %d", len(violations))
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_CriticalAlsoChecked verifies critical receipts
+// are included in the tier checks alongside high receipts.
+func TestVerifyGroundedPrincipalTier_CriticalAlsoChecked(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{grants: map[string]GrantInfo{}}
+	r := makeGroundedReceipt(t, kp, "did:user:alice", RiskCritical, "")
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r}, resolver)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation for critical receipt without grant_ref, got %d", len(violations))
+	}
+	if violations[0].Outcome != GroundedOutcomeUngrounded {
+		t.Errorf("expected UNGROUNDED_PRINCIPAL, got %s", violations[0].Outcome)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_MultipleViolations surfaces all violations,
+// not just the first.
+func TestVerifyGroundedPrincipalTier_MultipleViolations(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{
+		grants: map[string]GrantInfo{
+			"grant-good": {Subject: "did:user:alice"},
+		},
+		errorRefs: map[string]struct{}{"grant-bad": {}},
+	}
+	r1 := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "")              // UNGROUNDED
+	r2 := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "grant-good")    // OK
+	r3 := makeGroundedReceipt(t, kp, "did:user:alice", RiskCritical, "grant-bad") // UNGROUNDED (resolution fails)
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{r1, r2, r3}, resolver)
+	if len(violations) != 2 {
+		t.Errorf("expected 2 violations, got %d", len(violations))
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_ReceiptIndexReported confirms the violation
+// records the correct receipt index.
+func TestVerifyGroundedPrincipalTier_ReceiptIndexReported(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	resolver := &stubResolver{grants: map[string]GrantInfo{}}
+	low := makeGroundedReceipt(t, kp, "did:user:alice", RiskLow, "")   // index 0, skipped
+	high := makeGroundedReceipt(t, kp, "did:user:alice", RiskHigh, "") // index 1, violation
+	violations := VerifyGroundedPrincipalTier([]AgentReceipt{low, high}, resolver)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].Index != 1 {
+		t.Errorf("expected violation at index 1, got %d", violations[0].Index)
+	}
+}
+
+// TestVerifyGroundedPrincipalTier_EmptyChain produces no violations for an
+// empty receipt slice.
+func TestVerifyGroundedPrincipalTier_EmptyChain(t *testing.T) {
+	resolver := &stubResolver{grants: map[string]GrantInfo{}}
+	violations := VerifyGroundedPrincipalTier(nil, resolver)
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for empty chain, got %d", len(violations))
+	}
+}

--- a/sdk/py/src/obsigna/__init__.py
+++ b/sdk/py/src/obsigna/__init__.py
@@ -49,6 +49,13 @@ from obsigna.receipt.disclosure import (
     encrypt_response,
     generate_forensic_key_pair,
 )
+from obsigna.receipt.grant_resolver import (
+    GrantInfo,
+    GrantResolver,
+    GroundedOutcome,
+    GroundedPrincipalViolation,
+    verify_grounded_principal_tier,
+)
 from obsigna.receipt.hash import canonicalize, hash_receipt, sha256
 from obsigna.receipt.key_provider import (
     GeneratingKeyProvider,
@@ -125,6 +132,7 @@ encryptDisclosure = encrypt_disclosure
 decryptDisclosure = decrypt_disclosure
 encryptResponse = encrypt_response
 decryptResponse = decrypt_response
+verifyGroundedPrincipalTier = verify_grounded_principal_tier
 
 # RECEIPT_VERSION is the receipt schema version (from types), not the package version
 from obsigna.receipt.types import VERSION as RECEIPT_VERSION  # noqa: E402
@@ -163,6 +171,13 @@ __all__ = [
     "CreateReceiptInput",
     "create_receipt",
     "createReceipt",
+    # Grounded-principal conformance tier (ADR-0038)
+    "GrantInfo",
+    "GrantResolver",
+    "GroundedOutcome",
+    "GroundedPrincipalViolation",
+    "verify_grounded_principal_tier",
+    "verifyGroundedPrincipalTier",
     # Disclosure (HPKE envelope, ADR-0012)
     "DisclosureEnvelope",
     "DisclosureRecipient",

--- a/sdk/py/src/obsigna/receipt/grant_resolver.py
+++ b/sdk/py/src/obsigna/receipt/grant_resolver.py
@@ -1,0 +1,191 @@
+"""Grounded-principal conformance tier (ADR-0038, spec §7.9).
+
+Provides the GrantResolver interface and VerifyGroundedPrincipalTier gate
+that deployments claiming the grounded-principal tier must wire into their
+verification pipelines.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from obsigna.receipt.types import AgentReceipt
+
+
+@dataclass
+class GrantInfo:
+    """The resolved representation of an externally-minted authorization grant
+    (e.g. an RFC 8693 OBO token or a Grantex grant token).
+
+    ``subject`` MUST be populated by all resolvers. The remaining fields are
+    advisory and MAY be omitted when the resolver's backend does not expose
+    them.
+    """
+
+    # MUST be populated: the principal on whose behalf the grant was issued.
+    # MUST equal credentialSubject.principal.id for the tier check to pass.
+    subject: str
+    # Authorization scopes active under the grant.
+    scopes: list[str] = field(default_factory=list[str])
+    # When the authorization server minted the grant.
+    issued_at: datetime | None = None
+    # When the grant expires.
+    expires_at: datetime | None = None
+    # Identifies the authorization server that minted the grant.
+    issuer: str | None = None
+
+
+class GrantResolver(abc.ABC):
+    """Resolves an authorization grant reference to its minted grant,
+    confirming the named principal delegated authority to the agent.
+
+    Input:
+    - ``grant_ref``: the ``authorization.grant_ref`` value from the receipt.
+    - ``principal_id``: the ``credentialSubject.principal.id`` from the
+      receipt (supplied as a hint; implementations MAY use it to select a
+      cached entry).
+
+    Output: the resolved ``GrantInfo``. Raise any ``Exception`` on resolution
+    failure (network error, token not found, token revoked, etc.).
+
+    Implementations MAY perform network I/O (token introspection, OIDC
+    userinfo). Caching is an implementation concern.
+
+    The SDK ships this interface only. Integrators supply a resolver for their
+    authorization server (RFC 8693 token introspection, OIDC, Grantex). The
+    project does not endorse a single authorization server, mirroring the
+    ADR-0007 stance on DID methods.
+    """
+
+    @abc.abstractmethod
+    def resolve_grant(self, grant_ref: str, principal_id: str) -> GrantInfo:
+        """Resolve *grant_ref* to a GrantInfo, or raise on failure."""
+
+
+class GroundedOutcome(StrEnum):
+    """Outcome of a grounded-principal tier check on a single receipt
+    (spec §7.9, ADR-0038).
+    """
+
+    # A high/critical receipt lacks a resolvable grant_ref.
+    # Corresponds to UNGROUNDED_PRINCIPAL in spec §7.9.
+    UNGROUNDED_PRINCIPAL = "UNGROUNDED_PRINCIPAL"
+    # The resolved grant's subject does not equal the receipt's principal.id.
+    # Corresponds to PRINCIPAL_GRANT_MISMATCH in spec §7.9.
+    PRINCIPAL_GRANT_MISMATCH = "PRINCIPAL_GRANT_MISMATCH"
+
+
+@dataclass
+class GroundedPrincipalViolation:
+    """A grounded-principal tier failure for a single receipt."""
+
+    # Position of the offending receipt in the input list.
+    index: int
+    # The receipt's id field.
+    receipt_id: str
+    # The receipt's credentialSubject.principal.id.
+    principal_id: str
+    # The authorization.grant_ref value (may be empty for UNGROUNDED_PRINCIPAL
+    # violations where no grant_ref is present).
+    grant_ref: str
+    # The specific failure outcome.
+    outcome: GroundedOutcome
+    # Human-readable description, including resolver error messages.
+    detail: str
+
+
+def verify_grounded_principal_tier(
+    receipts: list[AgentReceipt],
+    resolver: GrantResolver | None,
+) -> list[GroundedPrincipalViolation]:
+    """Apply the grounded-principal conformance tier checks (spec §7.9,
+    ADR-0038 D1–D3) to a set of receipts.
+
+    For each receipt whose ``action.risk_level`` is ``"high"`` or
+    ``"critical"``:
+
+    1. If ``authorization.grant_ref`` is absent or empty →
+       ``UNGROUNDED_PRINCIPAL``.
+    2. If the resolver raises → ``UNGROUNDED_PRINCIPAL``.
+    3. If the resolved grant's ``subject`` ≠ ``principal.id`` →
+       ``PRINCIPAL_GRANT_MISMATCH``.
+
+    Receipts at ``risk_level`` ``"low"`` or ``"medium"`` are not checked.
+
+    When *resolver* is ``None``, no checks are performed and an empty list is
+    returned — this is the correct behaviour for base-tier verifiers that have
+    not configured a resolver (ADR-0038 D3: "absence of a resolver in the
+    base tier is not a verification failure").
+
+    All violations are collected and returned; the function does not stop at
+    the first failure so callers get a complete picture of the tier's state.
+    """
+    if resolver is None:
+        return []
+
+    violations: list[GroundedPrincipalViolation] = []
+
+    for i, r in enumerate(receipts):
+        risk_level = r.credentialSubject.action.risk_level
+        if risk_level not in ("high", "critical"):
+            continue
+
+        principal_id = r.credentialSubject.principal.id
+        auth = r.credentialSubject.authorization
+        grant_ref = (auth.grant_ref or "") if auth is not None else ""
+
+        # Step 1: grant_ref must be present and non-empty.
+        if not grant_ref:
+            violations.append(
+                GroundedPrincipalViolation(
+                    index=i,
+                    receipt_id=r.id,
+                    principal_id=principal_id,
+                    grant_ref="",
+                    outcome=GroundedOutcome.UNGROUNDED_PRINCIPAL,
+                    detail=(
+                        f"authorization.grant_ref is absent on a {risk_level} receipt"
+                    ),
+                )
+            )
+            continue
+
+        # Step 2: resolve the grant.
+        try:
+            grant = resolver.resolve_grant(grant_ref, principal_id)
+        except Exception as exc:  # noqa: BLE001
+            violations.append(
+                GroundedPrincipalViolation(
+                    index=i,
+                    receipt_id=r.id,
+                    principal_id=principal_id,
+                    grant_ref=grant_ref,
+                    outcome=GroundedOutcome.UNGROUNDED_PRINCIPAL,
+                    detail=f"grant resolution failed: {exc}",
+                )
+            )
+            continue
+
+        # Step 3: subject must equal principal.id.
+        if grant.subject != principal_id:
+            violations.append(
+                GroundedPrincipalViolation(
+                    index=i,
+                    receipt_id=r.id,
+                    principal_id=principal_id,
+                    grant_ref=grant_ref,
+                    outcome=GroundedOutcome.PRINCIPAL_GRANT_MISMATCH,
+                    detail=(
+                        f"grant subject {grant.subject!r} does not match "
+                        f"principal.id {principal_id!r}"
+                    ),
+                )
+            )
+
+    return violations

--- a/sdk/py/src/obsigna/receipt/grant_resolver.py
+++ b/sdk/py/src/obsigna/receipt/grant_resolver.py
@@ -32,7 +32,7 @@ class GrantInfo:
     # MUST equal credentialSubject.principal.id for the tier check to pass.
     subject: str
     # Authorization scopes active under the grant.
-    scopes: list[str] = field(default_factory=list[str])
+    scopes: list[str] = field(default_factory=list)
     # When the authorization server minted the grant.
     issued_at: datetime | None = None
     # When the grant expires.

--- a/sdk/py/src/obsigna/receipt/grant_resolver.py
+++ b/sdk/py/src/obsigna/receipt/grant_resolver.py
@@ -32,7 +32,7 @@ class GrantInfo:
     # MUST equal credentialSubject.principal.id for the tier check to pass.
     subject: str
     # Authorization scopes active under the grant.
-    scopes: list[str] = field(default_factory=list)
+    scopes: list[str] = field(default_factory=list[str])
     # When the authorization server minted the grant.
     issued_at: datetime | None = None
     # When the grant expires.

--- a/sdk/py/tests/receipt/test_grant_resolver.py
+++ b/sdk/py/tests/receipt/test_grant_resolver.py
@@ -1,0 +1,222 @@
+"""Tests for the grounded-principal conformance tier (ADR-0038)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from obsigna.receipt.grant_resolver import (
+    GrantInfo,
+    GrantResolver,
+    GroundedOutcome,
+    GroundedPrincipalViolation,
+    verify_grounded_principal_tier,
+)
+from obsigna.receipt.signing import generate_key_pair, sign_receipt
+from obsigna.receipt.types import (
+    Action,
+    Authorization,
+    Chain,
+    CredentialSubject,
+    Issuer,
+    Outcome,
+    Principal,
+    UnsignedAgentReceipt,
+)
+
+if TYPE_CHECKING:
+    from obsigna.receipt.types import AgentReceipt, RiskLevel
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_grounded_receipt(
+    principal_id: str,
+    risk_level: RiskLevel,
+    grant_ref: str | None,
+) -> AgentReceipt:
+    kp = generate_key_pair()
+    now = datetime.now(UTC).isoformat()
+    auth: Authorization | None = None
+    if grant_ref is not None:
+        auth = Authorization(
+            scopes=["files:write"],
+            granted_at=now,
+            grant_ref=grant_ref,
+        )
+    unsigned = UnsignedAgentReceipt(
+        **{
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://agentreceipts.ai/context/v2",
+            ],
+            "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+            "type": ["VerifiableCredential", "AgentReceipt"],
+            "version": "0.5.0",
+            "issuer": Issuer(id="did:key:z6Mk1"),
+            "issuanceDate": now,
+            "credentialSubject": CredentialSubject(
+                principal=Principal(id=principal_id),
+                action=Action(
+                    id="act_00000000-0000-0000-0000-000000000001",
+                    type="filesystem.file.write",
+                    risk_level=risk_level,
+                    timestamp=now,
+                ),
+                outcome=Outcome(status="success"),
+                authorization=auth,
+                chain=Chain(
+                    sequence=1,
+                    previous_receipt_hash=None,
+                    chain_id="chain-grounded-1",
+                ),
+            ),
+        }
+    )
+    return sign_receipt(unsigned, kp.private_key, "did:key:z6Mk1#key-1")
+
+
+class StubResolver(GrantResolver):
+    """Test double: returns pre-configured grants or raises on error refs."""
+
+    def __init__(
+        self,
+        grants: dict[str, GrantInfo],
+        error_refs: set[str] | None = None,
+    ) -> None:
+        self._grants = grants
+        self._error_refs: set[str] = error_refs or set()
+
+    def resolve_grant(self, grant_ref: str, _principal_id: str) -> GrantInfo:
+        if grant_ref in self._error_refs:
+            raise ValueError("resolver: grant not found")
+        if grant_ref in self._grants:
+            return self._grants[grant_ref]
+        raise ValueError("resolver: unknown grant ref")
+
+
+# ---------------------------------------------------------------------------
+# GrantInfo field coverage
+# ---------------------------------------------------------------------------
+
+
+def test_grant_info_fields() -> None:
+    now = datetime.now(UTC)
+    g = GrantInfo(
+        subject="did:user:alice",
+        scopes=["files:write"],
+        issued_at=now,
+        expires_at=now,
+        issuer="https://auth.example.com",
+    )
+    assert g.subject == "did:user:alice"
+    assert g.scopes == ["files:write"]
+
+
+# ---------------------------------------------------------------------------
+# verify_grounded_principal_tier
+# ---------------------------------------------------------------------------
+
+
+def test_no_resolver_returns_no_violations() -> None:
+    r = _make_grounded_receipt("did:user:alice", "high", None)
+    assert verify_grounded_principal_tier([r], None) == []
+
+
+def test_low_medium_receipts_skipped() -> None:
+    resolver = StubResolver({})
+    low = _make_grounded_receipt("did:user:alice", "low", None)
+    med = _make_grounded_receipt("did:user:alice", "medium", None)
+    assert verify_grounded_principal_tier([low, med], resolver) == []
+
+
+def test_high_without_grant_ref_is_ungrounded() -> None:
+    resolver = StubResolver({})
+    r = _make_grounded_receipt("did:user:alice", "high", None)
+    violations = verify_grounded_principal_tier([r], resolver)
+    assert len(violations) == 1
+    assert violations[0].outcome == GroundedOutcome.UNGROUNDED_PRINCIPAL
+
+
+def test_high_with_empty_grant_ref_is_ungrounded() -> None:
+    resolver = StubResolver({})
+    r = _make_grounded_receipt("did:user:alice", "high", "")
+    violations = verify_grounded_principal_tier([r], resolver)
+    assert len(violations) == 1
+    assert violations[0].outcome == GroundedOutcome.UNGROUNDED_PRINCIPAL
+
+
+def test_resolution_failure_is_ungrounded() -> None:
+    resolver = StubResolver({}, error_refs={"bad-ref"})
+    r = _make_grounded_receipt("did:user:alice", "high", "bad-ref")
+    violations = verify_grounded_principal_tier([r], resolver)
+    assert len(violations) == 1
+    assert violations[0].outcome == GroundedOutcome.UNGROUNDED_PRINCIPAL
+
+
+def test_subject_mismatch_is_principal_grant_mismatch() -> None:
+    resolver = StubResolver(
+        {"grant-abc": GrantInfo(subject="did:user:bob", scopes=["files:write"])}
+    )
+    r = _make_grounded_receipt("did:user:alice", "high", "grant-abc")
+    violations = verify_grounded_principal_tier([r], resolver)
+    assert len(violations) == 1
+    assert violations[0].outcome == GroundedOutcome.PRINCIPAL_GRANT_MISMATCH
+
+
+def test_valid_grounding_produces_no_violation() -> None:
+    resolver = StubResolver(
+        {"grant-xyz": GrantInfo(subject="did:user:alice", scopes=["files:write"])}
+    )
+    r = _make_grounded_receipt("did:user:alice", "high", "grant-xyz")
+    assert verify_grounded_principal_tier([r], resolver) == []
+
+
+def test_critical_receipts_also_checked() -> None:
+    resolver = StubResolver({})
+    r = _make_grounded_receipt("did:user:alice", "critical", None)
+    violations = verify_grounded_principal_tier([r], resolver)
+    assert len(violations) == 1
+    assert violations[0].outcome == GroundedOutcome.UNGROUNDED_PRINCIPAL
+
+
+def test_all_violations_collected() -> None:
+    resolver = StubResolver(
+        {"grant-good": GrantInfo(subject="did:user:alice", scopes=[])},
+        error_refs={"grant-bad"},
+    )
+    r1 = _make_grounded_receipt("did:user:alice", "high", None)  # UNGROUNDED
+    r2 = _make_grounded_receipt("did:user:alice", "high", "grant-good")  # OK
+    r3 = _make_grounded_receipt("did:user:alice", "critical", "grant-bad")  # UNGROUNDED
+    violations = verify_grounded_principal_tier([r1, r2, r3], resolver)
+    assert len(violations) == 2
+
+
+def test_violation_reports_correct_index() -> None:
+    resolver = StubResolver({})
+    low = _make_grounded_receipt("did:user:alice", "low", None)  # index 0, skipped
+    high = _make_grounded_receipt("did:user:alice", "high", None)  # index 1, violation
+    violations = verify_grounded_principal_tier([low, high], resolver)
+    assert len(violations) == 1
+    assert violations[0].index == 1
+
+
+def test_empty_receipts_returns_no_violations() -> None:
+    resolver = StubResolver({})
+    assert verify_grounded_principal_tier([], resolver) == []
+
+
+def test_grounded_principal_violation_fields() -> None:
+    v = GroundedPrincipalViolation(
+        index=0,
+        receipt_id="urn:receipt:00000000-0000-0000-0000-000000000001",
+        principal_id="did:user:alice",
+        grant_ref="grant-abc",
+        outcome=GroundedOutcome.UNGROUNDED_PRINCIPAL,
+        detail="authorization.grant_ref is absent on a high receipt",
+    )
+    assert v.index == 0
+    assert v.outcome == GroundedOutcome.UNGROUNDED_PRINCIPAL

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -43,6 +43,13 @@ export {
 	type ForensicKeyPair,
 	generateForensicKeyPair,
 } from "./receipt/disclosure.js";
+export {
+	type GrantInfo,
+	type GrantResolver,
+	GroundedOutcome,
+	type GroundedPrincipalViolation,
+	verifyGroundedPrincipalTier,
+} from "./receipt/grant-resolver.js";
 export { canonicalize, hashReceipt, sha256 } from "./receipt/hash.js";
 export {
 	GeneratingKeyProvider,

--- a/sdk/ts/src/receipt/grant-resolver.test.ts
+++ b/sdk/ts/src/receipt/grant-resolver.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+	type GrantInfo,
+	type GrantResolver,
+	GroundedOutcome,
+	type GroundedPrincipalViolation,
+	verifyGroundedPrincipalTier,
+} from "./grant-resolver.js";
+import { generateKeyPair, signReceipt } from "./signing.js";
+import type { AgentReceipt, RiskLevel } from "./types.js";
+
+// --- test helpers ---
+
+function makeGroundedReceipt(
+	principalId: string,
+	riskLevel: RiskLevel,
+	grantRef: string | undefined,
+): AgentReceipt {
+	const unsigned = {
+		"@context": [
+			"https://www.w3.org/ns/credentials/v2",
+			"https://agentreceipts.ai/context/v2",
+		] as const,
+		id: "urn:receipt:00000000-0000-0000-0000-000000000001",
+		type: ["VerifiableCredential", "AgentReceipt"] as const,
+		version: "0.5.0",
+		issuer: { id: "did:key:z6Mk1" },
+		issuanceDate: new Date().toISOString(),
+		credentialSubject: {
+			principal: { id: principalId },
+			action: {
+				id: "act_00000000-0000-0000-0000-000000000001",
+				type: "filesystem.file.write",
+				risk_level: riskLevel,
+				timestamp: new Date().toISOString(),
+			},
+			outcome: { status: "success" as const },
+			chain: {
+				sequence: 1,
+				previous_receipt_hash: null,
+				chain_id: "chain-grounded-1",
+			},
+			...(grantRef !== undefined
+				? {
+						authorization: {
+							scopes: ["files:write"],
+							granted_at: new Date().toISOString(),
+							grant_ref: grantRef,
+						},
+					}
+				: {}),
+		},
+	};
+	const { privateKey } = generateKeyPair();
+	return signReceipt(unsigned, privateKey, "did:key:z6Mk1#key-1");
+}
+
+class StubResolver implements GrantResolver {
+	constructor(
+		private readonly grants: Map<string, GrantInfo>,
+		private readonly errorRefs: Set<string> = new Set(),
+	) {}
+
+	resolveGrant(grantRef: string, _principalId: string): GrantInfo {
+		if (this.errorRefs.has(grantRef)) {
+			throw new Error("resolver: grant not found");
+		}
+		const g = this.grants.get(grantRef);
+		if (g === undefined) {
+			throw new Error("resolver: unknown grant ref");
+		}
+		return g;
+	}
+}
+
+// --- tests ---
+
+describe("verifyGroundedPrincipalTier", () => {
+	it("returns no violations when resolver is null (base-tier verifier)", () => {
+		const r = makeGroundedReceipt("did:user:alice", "high", undefined);
+		const violations = verifyGroundedPrincipalTier([r], null);
+		expect(violations).toHaveLength(0);
+	});
+
+	it("skips low and medium receipts even with a resolver configured", () => {
+		const resolver = new StubResolver(new Map());
+		const low = makeGroundedReceipt("did:user:alice", "low", undefined);
+		const med = makeGroundedReceipt("did:user:alice", "medium", undefined);
+		const violations = verifyGroundedPrincipalTier([low, med], resolver);
+		expect(violations).toHaveLength(0);
+	});
+
+	it("returns UNGROUNDED_PRINCIPAL for a high receipt with no grant_ref", () => {
+		const resolver = new StubResolver(new Map());
+		const r = makeGroundedReceipt("did:user:alice", "high", undefined);
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
+	});
+
+	it("returns UNGROUNDED_PRINCIPAL for a high receipt with empty grant_ref", () => {
+		const resolver = new StubResolver(new Map());
+		const r = makeGroundedReceipt("did:user:alice", "high", "");
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
+	});
+
+	it("returns UNGROUNDED_PRINCIPAL when the resolver throws for the grant_ref", () => {
+		const resolver = new StubResolver(new Map(), new Set(["bad-ref"]));
+		const r = makeGroundedReceipt("did:user:alice", "high", "bad-ref");
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
+	});
+
+	it("returns PRINCIPAL_GRANT_MISMATCH when resolved subject does not equal principal.id", () => {
+		const resolver = new StubResolver(
+			new Map([
+				["grant-abc", { subject: "did:user:bob", scopes: ["files:write"] }],
+			]),
+		);
+		const r = makeGroundedReceipt("did:user:alice", "high", "grant-abc");
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.outcome).toBe(GroundedOutcome.PrincipalGrantMismatch);
+	});
+
+	it("returns no violation when the grant resolves and subject equals principal.id", () => {
+		const resolver = new StubResolver(
+			new Map([
+				["grant-xyz", { subject: "did:user:alice", scopes: ["files:write"] }],
+			]),
+		);
+		const r = makeGroundedReceipt("did:user:alice", "high", "grant-xyz");
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(0);
+	});
+
+	it("checks critical receipts alongside high receipts", () => {
+		const resolver = new StubResolver(new Map());
+		const r = makeGroundedReceipt("did:user:alice", "critical", undefined);
+		const violations = verifyGroundedPrincipalTier([r], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
+	});
+
+	it("collects all violations rather than stopping at the first", () => {
+		const resolver = new StubResolver(
+			new Map([["grant-good", { subject: "did:user:alice", scopes: [] }]]),
+			new Set(["grant-bad"]),
+		);
+		const r1 = makeGroundedReceipt("did:user:alice", "high", undefined); // UNGROUNDED
+		const r2 = makeGroundedReceipt("did:user:alice", "high", "grant-good"); // OK
+		const r3 = makeGroundedReceipt("did:user:alice", "critical", "grant-bad"); // UNGROUNDED (resolve fails)
+		const violations = verifyGroundedPrincipalTier([r1, r2, r3], resolver);
+		expect(violations).toHaveLength(2);
+	});
+
+	it("reports the correct receipt index in the violation", () => {
+		const resolver = new StubResolver(new Map());
+		const low = makeGroundedReceipt("did:user:alice", "low", undefined); // index 0, skipped
+		const high = makeGroundedReceipt("did:user:alice", "high", undefined); // index 1, violation
+		const violations = verifyGroundedPrincipalTier([low, high], resolver);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.index).toBe(1);
+	});
+
+	it("returns no violations for an empty receipt slice", () => {
+		const resolver = new StubResolver(new Map());
+		const violations = verifyGroundedPrincipalTier([], resolver);
+		expect(violations).toHaveLength(0);
+	});
+});
+
+// Type-level smoke test: ensure the exported types satisfy expected shapes.
+const _typeCheck: GroundedPrincipalViolation = {
+	index: 0,
+	receiptId: "urn:receipt:00000000-0000-0000-0000-000000000001",
+	principalId: "did:user:alice",
+	grantRef: "grant-abc",
+	outcome: GroundedOutcome.UngroundedPrincipal,
+	detail: "authorization.grant_ref is absent on a high receipt",
+};
+void _typeCheck;

--- a/sdk/ts/src/receipt/grant-resolver.test.ts
+++ b/sdk/ts/src/receipt/grant-resolver.test.ts
@@ -61,91 +61,91 @@ class StubResolver implements GrantResolver {
 		private readonly errorRefs: Set<string> = new Set(),
 	) {}
 
-	resolveGrant(grantRef: string, _principalId: string): GrantInfo {
+	resolveGrant(grantRef: string, _principalId: string): Promise<GrantInfo> {
 		if (this.errorRefs.has(grantRef)) {
-			throw new Error("resolver: grant not found");
+			return Promise.reject(new Error("resolver: grant not found"));
 		}
 		const g = this.grants.get(grantRef);
 		if (g === undefined) {
-			throw new Error("resolver: unknown grant ref");
+			return Promise.reject(new Error("resolver: unknown grant ref"));
 		}
-		return g;
+		return Promise.resolve(g);
 	}
 }
 
 // --- tests ---
 
 describe("verifyGroundedPrincipalTier", () => {
-	it("returns no violations when resolver is null (base-tier verifier)", () => {
+	it("returns no violations when resolver is null (base-tier verifier)", async () => {
 		const r = makeGroundedReceipt("did:user:alice", "high", undefined);
-		const violations = verifyGroundedPrincipalTier([r], null);
+		const violations = await verifyGroundedPrincipalTier([r], null);
 		expect(violations).toHaveLength(0);
 	});
 
-	it("skips low and medium receipts even with a resolver configured", () => {
+	it("skips low and medium receipts even with a resolver configured", async () => {
 		const resolver = new StubResolver(new Map());
 		const low = makeGroundedReceipt("did:user:alice", "low", undefined);
 		const med = makeGroundedReceipt("did:user:alice", "medium", undefined);
-		const violations = verifyGroundedPrincipalTier([low, med], resolver);
+		const violations = await verifyGroundedPrincipalTier([low, med], resolver);
 		expect(violations).toHaveLength(0);
 	});
 
-	it("returns UNGROUNDED_PRINCIPAL for a high receipt with no grant_ref", () => {
+	it("returns UNGROUNDED_PRINCIPAL for a high receipt with no grant_ref", async () => {
 		const resolver = new StubResolver(new Map());
 		const r = makeGroundedReceipt("did:user:alice", "high", undefined);
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
 	});
 
-	it("returns UNGROUNDED_PRINCIPAL for a high receipt with empty grant_ref", () => {
+	it("returns UNGROUNDED_PRINCIPAL for a high receipt with empty grant_ref", async () => {
 		const resolver = new StubResolver(new Map());
 		const r = makeGroundedReceipt("did:user:alice", "high", "");
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
 	});
 
-	it("returns UNGROUNDED_PRINCIPAL when the resolver throws for the grant_ref", () => {
+	it("returns UNGROUNDED_PRINCIPAL when the resolver rejects for the grant_ref", async () => {
 		const resolver = new StubResolver(new Map(), new Set(["bad-ref"]));
 		const r = makeGroundedReceipt("did:user:alice", "high", "bad-ref");
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
 	});
 
-	it("returns PRINCIPAL_GRANT_MISMATCH when resolved subject does not equal principal.id", () => {
+	it("returns PRINCIPAL_GRANT_MISMATCH when resolved subject does not equal principal.id", async () => {
 		const resolver = new StubResolver(
 			new Map([
 				["grant-abc", { subject: "did:user:bob", scopes: ["files:write"] }],
 			]),
 		);
 		const r = makeGroundedReceipt("did:user:alice", "high", "grant-abc");
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.outcome).toBe(GroundedOutcome.PrincipalGrantMismatch);
 	});
 
-	it("returns no violation when the grant resolves and subject equals principal.id", () => {
+	it("returns no violation when the grant resolves and subject equals principal.id", async () => {
 		const resolver = new StubResolver(
 			new Map([
 				["grant-xyz", { subject: "did:user:alice", scopes: ["files:write"] }],
 			]),
 		);
 		const r = makeGroundedReceipt("did:user:alice", "high", "grant-xyz");
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(0);
 	});
 
-	it("checks critical receipts alongside high receipts", () => {
+	it("checks critical receipts alongside high receipts", async () => {
 		const resolver = new StubResolver(new Map());
 		const r = makeGroundedReceipt("did:user:alice", "critical", undefined);
-		const violations = verifyGroundedPrincipalTier([r], resolver);
+		const violations = await verifyGroundedPrincipalTier([r], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.outcome).toBe(GroundedOutcome.UngroundedPrincipal);
 	});
 
-	it("collects all violations rather than stopping at the first", () => {
+	it("collects all violations rather than stopping at the first", async () => {
 		const resolver = new StubResolver(
 			new Map([["grant-good", { subject: "did:user:alice", scopes: [] }]]),
 			new Set(["grant-bad"]),
@@ -153,22 +153,25 @@ describe("verifyGroundedPrincipalTier", () => {
 		const r1 = makeGroundedReceipt("did:user:alice", "high", undefined); // UNGROUNDED
 		const r2 = makeGroundedReceipt("did:user:alice", "high", "grant-good"); // OK
 		const r3 = makeGroundedReceipt("did:user:alice", "critical", "grant-bad"); // UNGROUNDED (resolve fails)
-		const violations = verifyGroundedPrincipalTier([r1, r2, r3], resolver);
+		const violations = await verifyGroundedPrincipalTier(
+			[r1, r2, r3],
+			resolver,
+		);
 		expect(violations).toHaveLength(2);
 	});
 
-	it("reports the correct receipt index in the violation", () => {
+	it("reports the correct receipt index in the violation", async () => {
 		const resolver = new StubResolver(new Map());
 		const low = makeGroundedReceipt("did:user:alice", "low", undefined); // index 0, skipped
 		const high = makeGroundedReceipt("did:user:alice", "high", undefined); // index 1, violation
-		const violations = verifyGroundedPrincipalTier([low, high], resolver);
+		const violations = await verifyGroundedPrincipalTier([low, high], resolver);
 		expect(violations).toHaveLength(1);
 		expect(violations[0]?.index).toBe(1);
 	});
 
-	it("returns no violations for an empty receipt slice", () => {
+	it("returns no violations for an empty receipt slice", async () => {
 		const resolver = new StubResolver(new Map());
-		const violations = verifyGroundedPrincipalTier([], resolver);
+		const violations = await verifyGroundedPrincipalTier([], resolver);
 		expect(violations).toHaveLength(0);
 	});
 });

--- a/sdk/ts/src/receipt/grant-resolver.ts
+++ b/sdk/ts/src/receipt/grant-resolver.ts
@@ -111,7 +111,7 @@ export async function verifyGroundedPrincipalTier(
 	receipts: AgentReceipt[],
 	resolver: GrantResolver | null,
 ): Promise<GroundedPrincipalViolation[]> {
-	if (resolver === null) {
+	if (resolver == null) {
 		return [];
 	}
 

--- a/sdk/ts/src/receipt/grant-resolver.ts
+++ b/sdk/ts/src/receipt/grant-resolver.ts
@@ -45,7 +45,7 @@ export interface GrantInfo {
  * ADR-0007 stance on DID methods.
  */
 export interface GrantResolver {
-	resolveGrant(grantRef: string, principalId: string): GrantInfo;
+	resolveGrant(grantRef: string, principalId: string): Promise<GrantInfo>;
 }
 
 /**
@@ -107,10 +107,10 @@ export interface GroundedPrincipalViolation {
  * All violations are collected and returned; the function does not stop at
  * the first failure so callers get a complete picture of the tier's state.
  */
-export function verifyGroundedPrincipalTier(
+export async function verifyGroundedPrincipalTier(
 	receipts: AgentReceipt[],
 	resolver: GrantResolver | null,
-): GroundedPrincipalViolation[] {
+): Promise<GroundedPrincipalViolation[]> {
 	if (resolver === null) {
 		return [];
 	}
@@ -146,7 +146,7 @@ export function verifyGroundedPrincipalTier(
 		// Step 2: resolve the grant.
 		let grant: GrantInfo;
 		try {
-			grant = resolver.resolveGrant(grantRef, principalId);
+			grant = await resolver.resolveGrant(grantRef, principalId);
 		} catch (err) {
 			const reason = err instanceof Error ? err.message : String(err);
 			violations.push({

--- a/sdk/ts/src/receipt/grant-resolver.ts
+++ b/sdk/ts/src/receipt/grant-resolver.ts
@@ -1,0 +1,177 @@
+import type { AgentReceipt } from "./types.js";
+
+/**
+ * The resolved representation of an externally-minted authorization grant
+ * (e.g. an RFC 8693 OBO token or a Grantex grant token).
+ *
+ * `subject` MUST be populated by all resolvers. The remaining fields are
+ * advisory and MAY be omitted when the resolver's backend does not expose them.
+ */
+export interface GrantInfo {
+	/**
+	 * The principal on whose behalf the grant was issued. MUST equal
+	 * `credentialSubject.principal.id` for the grounded-principal tier check
+	 * to pass (spec §7.9, ADR-0038 D2).
+	 */
+	subject: string;
+	/** Authorization scopes active under the grant. */
+	scopes?: string[];
+	/** When the authorization server minted the grant. */
+	issuedAt?: Date;
+	/** When the grant expires. */
+	expiresAt?: Date;
+	/** Identifies the authorization server that minted the grant. */
+	issuer?: string;
+}
+
+/**
+ * Resolves an authorization grant reference to its minted grant, confirming
+ * the named principal delegated authority to the agent.
+ *
+ * Input:
+ * - `grantRef` — the `authorization.grant_ref` value from the receipt.
+ * - `principalId` — the `credentialSubject.principal.id` from the receipt
+ *   (supplied as a hint; resolvers MAY use it to select a cached entry).
+ *
+ * Output: the resolved `GrantInfo`. Throw an `Error` on resolution failure
+ * (network error, token not found, token revoked, etc.).
+ *
+ * Implementations MAY perform network I/O (token introspection, OIDC
+ * userinfo). Caching is an implementation concern.
+ *
+ * The SDK ships this interface only. Integrators supply a resolver for their
+ * authorization server (RFC 8693 token introspection, OIDC, Grantex). The
+ * project does not endorse a single authorization server, mirroring the
+ * ADR-0007 stance on DID methods.
+ */
+export interface GrantResolver {
+	resolveGrant(grantRef: string, principalId: string): GrantInfo;
+}
+
+/**
+ * The outcome of a grounded-principal tier check on a single receipt
+ * (spec §7.9, ADR-0038).
+ */
+export const GroundedOutcome = {
+	/**
+	 * A high/critical receipt lacks a resolvable `grant_ref`.
+	 * Corresponds to `UNGROUNDED_PRINCIPAL` in spec §7.9.
+	 */
+	UngroundedPrincipal: "UNGROUNDED_PRINCIPAL",
+	/**
+	 * The resolved grant's subject does not equal the receipt's `principal.id`.
+	 * Corresponds to `PRINCIPAL_GRANT_MISMATCH` in spec §7.9.
+	 */
+	PrincipalGrantMismatch: "PRINCIPAL_GRANT_MISMATCH",
+} as const;
+
+export type GroundedOutcome =
+	(typeof GroundedOutcome)[keyof typeof GroundedOutcome];
+
+/** A grounded-principal tier failure for a single receipt. */
+export interface GroundedPrincipalViolation {
+	/** Position of the offending receipt in the input array. */
+	index: number;
+	/** The receipt's `id` field. */
+	receiptId: string;
+	/** The receipt's `credentialSubject.principal.id`. */
+	principalId: string;
+	/**
+	 * The `authorization.grant_ref` value. May be empty for
+	 * `UNGROUNDED_PRINCIPAL` violations where no `grant_ref` is present.
+	 */
+	grantRef: string;
+	/** The specific failure outcome. */
+	outcome: GroundedOutcome;
+	/** Human-readable description, including resolver error messages. */
+	detail: string;
+}
+
+/**
+ * Apply the grounded-principal conformance tier checks (spec §7.9,
+ * ADR-0038 D1–D3) to a set of receipts.
+ *
+ * For each receipt whose `action.risk_level` is `"high"` or `"critical"`:
+ * 1. If `authorization.grant_ref` is absent or empty → `UNGROUNDED_PRINCIPAL`.
+ * 2. If the resolver throws → `UNGROUNDED_PRINCIPAL`.
+ * 3. If the resolved grant's `subject` ≠ `principal.id` →
+ *    `PRINCIPAL_GRANT_MISMATCH`.
+ *
+ * Receipts at `risk_level` `"low"` or `"medium"` are not checked.
+ *
+ * When `resolver` is `null`, no checks are performed and an empty array is
+ * returned — this is the correct behaviour for base-tier verifiers that have
+ * not configured a resolver (ADR-0038 D3: "absence of a resolver in the base
+ * tier is not a verification failure").
+ *
+ * All violations are collected and returned; the function does not stop at
+ * the first failure so callers get a complete picture of the tier's state.
+ */
+export function verifyGroundedPrincipalTier(
+	receipts: AgentReceipt[],
+	resolver: GrantResolver | null,
+): GroundedPrincipalViolation[] {
+	if (resolver === null) {
+		return [];
+	}
+
+	const violations: GroundedPrincipalViolation[] = [];
+
+	for (let i = 0; i < receipts.length; i++) {
+		const r = receipts[i];
+		if (!r) continue;
+
+		const riskLevel = r.credentialSubject.action.risk_level;
+		if (riskLevel !== "high" && riskLevel !== "critical") {
+			continue;
+		}
+
+		const principalId = r.credentialSubject.principal.id;
+		const auth = r.credentialSubject.authorization;
+		const grantRef = auth?.grant_ref ?? "";
+
+		// Step 1: grant_ref must be present and non-empty.
+		if (!grantRef) {
+			violations.push({
+				index: i,
+				receiptId: r.id,
+				principalId,
+				grantRef: "",
+				outcome: GroundedOutcome.UngroundedPrincipal,
+				detail: `authorization.grant_ref is absent on a ${riskLevel} receipt`,
+			});
+			continue;
+		}
+
+		// Step 2: resolve the grant.
+		let grant: GrantInfo;
+		try {
+			grant = resolver.resolveGrant(grantRef, principalId);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			violations.push({
+				index: i,
+				receiptId: r.id,
+				principalId,
+				grantRef,
+				outcome: GroundedOutcome.UngroundedPrincipal,
+				detail: `grant resolution failed: ${reason}`,
+			});
+			continue;
+		}
+
+		// Step 3: subject must equal principal.id.
+		if (grant.subject !== principalId) {
+			violations.push({
+				index: i,
+				receiptId: r.id,
+				principalId,
+				grantRef,
+				outcome: GroundedOutcome.PrincipalGrantMismatch,
+				detail: `grant subject ${grant.subject} does not match principal.id ${principalId}`,
+			});
+		}
+	}
+
+	return violations;
+}

--- a/sdk/ts/src/receipt/index.ts
+++ b/sdk/ts/src/receipt/index.ts
@@ -14,6 +14,13 @@ export {
 	type ForensicKeyPair,
 	generateForensicKeyPair,
 } from "./disclosure.js";
+export {
+	type GrantInfo,
+	type GrantResolver,
+	GroundedOutcome,
+	type GroundedPrincipalViolation,
+	verifyGroundedPrincipalTier,
+} from "./grant-resolver.js";
 export { canonicalize, hashReceipt, sha256 } from "./hash.js";
 export {
 	GeneratingKeyProvider,

--- a/spec/v0.5.0/spec.md
+++ b/spec/v0.5.0/spec.md
@@ -598,6 +598,37 @@ A receipt that passes steps 1–4 is individually valid. Steps 5–6 provide cha
 
 > **Note:** This algorithm depends on DID resolution (step 2), which is not fully specified in this version. Implementations MUST document their DID resolution strategy. See §9.6.
 
+### 7.9 Grounded-principal tier verification (ADR-0038)
+
+This section defines additional verification steps applied when a verifier operates in the **grounded-principal conformance tier** (ADR-0038). The tier is opt-in: a base-tier verifier that has no grant resolver configured MUST NOT apply these steps, and their absence is never a verification failure in the base tier.
+
+A verifier enters the grounded-principal tier by supplying a **grant resolver** — an external function that, given `(grant_ref, principal_id)`, returns a resolved grant exposing at minimum `{ subject, scopes, issued_at, expires_at, issuer }`, or a resolution failure. The resolver is an implementation concern; the spec defines only the contract it must satisfy.
+
+**Grounded-principal check (applied per receipt, after step 6 of §7.8):**
+
+For any receipt whose `action.risk_level` is `high` or `critical`, when a grant resolver is configured:
+
+1. **Grant presence check.** If `credentialSubject.authorization` is absent or `credentialSubject.authorization.grant_ref` is absent or empty, the receipt outcome is `UNGROUNDED_PRINCIPAL`. This is a hard failure in the grounded-principal tier.
+
+2. **Grant resolution.** Resolve `authorization.grant_ref` via the configured grant resolver, passing the receipt's `credentialSubject.principal.id` as the principal hint. If resolution fails (network error, token not found, token revoked), the receipt outcome is `UNGROUNDED_PRINCIPAL`.
+
+3. **Subject match.** If the resolved grant's `subject` does not equal `credentialSubject.principal.id` (exact string equality), the receipt outcome is `PRINCIPAL_GRANT_MISMATCH`.
+
+A receipt that passes all three steps is **grounded**: an external authorization server confirms the named principal delegated authority under which the action was taken.
+
+**Receipts at `risk_level` `low` or `medium` are not subject to these checks**, even in the grounded-principal tier. D1 of ADR-0038 targets only the action classes where reasonable-oversight regimes apply.
+
+**Absence of a resolver is not a failure.** A verifier without a configured grant resolver behaves as a base-tier verifier for all receipts regardless of risk level. No error is raised. This mirrors the ADR-0008 pattern where `RequireTerminal` is absent by default.
+
+**New verification outcomes (grounded-principal tier only):**
+
+| Outcome | Meaning |
+|---|---|
+| `UNGROUNDED_PRINCIPAL` | A `high`/`critical` receipt lacks a resolvable `grant_ref` in the grounded-principal tier. |
+| `PRINCIPAL_GRANT_MISMATCH` | The resolved grant's subject does not equal `principal.id`. |
+
+These outcomes supplement the base-tier outcomes (`MALFORMED_RECEIPT`, `UNRESOLVABLE_DID`, `INVALID_SIGNATURE`, `INVALID_TIMESTAMP`) defined in §7.8. They are never raised in the base tier.
+
 ---
 
 ## 8. Relationship to Existing Work


### PR DESCRIPTION
## What

Implements ADR-0038: grounded-principal conformance tier across all three SDKs.

- **spec §7.9** — new section describing the three-step principal-to-grant check and two new verification outcomes (`UNGROUNDED_PRINCIPAL`, `PRINCIPAL_GRANT_MISMATCH`)
- **ADR-0038** — status updated from Proposed to Accepted
- **sdk/go** — `GrantResolver` interface, `VerifyGroundedPrincipalTier` gate, 11 tests
- **sdk/ts** — `GrantResolver` interface, `verifyGroundedPrincipalTier` gate, 11 tests; exported from both `receipt/index.ts` and `src/index.ts`
- **sdk/py** — `GrantResolver` ABC, `verify_grounded_principal_tier` gate, 13 tests; exported from `obsigna/__init__.py` with `verifyGroundedPrincipalTier` camelCase alias

D1 (confirm `authorization.grant_ref` in schema): already present, no change needed.
D5 (CI gate): `VerifyGroundedPrincipalTier` / `verifyGroundedPrincipalTier` serves as the gate per ADR-0024 discipline.

## Why

ADR-0038 defines an opt-in tier for deployments that require every high/critical receipt to carry a verifiable authorization grant. Without the SDK gate, the tier assertion in the ADR has no enforcement path. Closes #900.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed)
- [x] AGENTS.md updated (if project structure changed)
- [x] Spec changes have been reviewed by a maintainer (if applicable)

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items)

This PR adds no crypto primitives. It adds a pluggable resolver interface that integrators wire to their authorization server. The resolver contract requires resolution failures to raise exceptions (handled as `UNGROUNDED_PRINCIPAL`), preventing silent pass-through on errors.