### PR TITLE
chore(release): stamp CHANGELOG 0.29.0-alpha.1 + sdk/go 0.22.0-alpha.1 + sdk-ts 0.15.0-alpha.1 + sdk-py 0.14.0-alpha.1

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0-alpha.1] - 2026-06-21
+
+### Fixed
+
+- **Checkpoint anchor nil-guard on closed sinks** ([#914](https://github.com/agent-receipts/obsigna/pull/914)) — `FileLog.Write` and `SyslogLog.Write` now return an error when called after `Close` rather than panicking on a nil pointer or writing to a closed handle. An `atomic.Bool` in the checkpoint emitter tracks its closed state and increments the `dropped` metric for enqueue attempts after `Close` instead of blocking or crashing. Hardening for the checkpoint anchor subsystem introduced in `0.27.0-alpha.1`.
+
 ## [0.28.0] - 2026-06-21
 
 Graduates `0.28.0-alpha.1` after the alpha pass. Primary new surface since `0.27.0`: `action.target` population on MCP non-file tool calls, `PostToolUseFailure` receipting in the hook, taxonomic `action_type` forwarding across hook/mcp-proxy/Python SDK, bounded `inline_plaintext` error and `prompt_preview` fields, and hook classification of shell `rm`/`mv`/`cp` as high/critical deletes. Both changes below were included in the alpha and are formally documented here:

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,12 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.22.0-alpha.1] - 2026-06-21
+
+### Added
+
+- **Grounded-principal conformance tier (ADR-0038, spec §7.9)** ([#915](https://github.com/agent-receipts/obsigna/pull/915)) — `receipt.GrantResolver` is a pluggable interface for resolving an externally-minted authorization grant to a `GrantInfo` (subject, scopes, issued-at, expiry, issuer). `receipt.VerifyGroundedPrincipalTier(receipts, resolver)` applies ADR-0038 D1–D3: every `high`/`critical` receipt must carry a resolvable `authorization.grant_ref` whose resolved subject matches `credentialSubject.principal.id`. Violations are returned as `[]GroundedPrincipalViolation`; a `nil` or typed-nil resolver is a valid base-tier stance (ADR-0038 D3). `GroundedOutcome` enumerates `UNGROUNDED_PRINCIPAL` and `PRINCIPAL_GRANT_MISMATCH`.
+
 ## [0.21.0] - 2026-06-21
 
 Graduates `0.21.0-alpha.1` after the alpha pass. Ships `risk` as a receipt-free leaf package extracted from `receipt`, exposing `IsHighRisk` and the risk-level constants so downstream tools can import risk semantics without the full receipt dependency graph.

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,12 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0-alpha.1] - 2026-06-21
+
+### Added
+
+- **Grounded-principal conformance tier (ADR-0038, spec §7.9)** ([#915](https://github.com/agent-receipts/obsigna/pull/915)) — `GrantResolver` abstract base class and `verify_grounded_principal_tier(receipts, resolver)` with the same D1–D3 semantics as the Go and TypeScript SDKs. `None` resolver is the base-tier no-op (ADR-0038 D3). Returns `list[GroundedPrincipalViolation]` covering `UNGROUNDED_PRINCIPAL` and `PRINCIPAL_GRANT_MISMATCH`. Exported from the package root as `verify_grounded_principal_tier` and `verifyGroundedPrincipalTier` (camelCase alias).
+
 ## [0.13.0] - 2026-06-12
 
 Graduates `0.13.0a2` after the alpha pass. No source changes since the alpha; see the `0.13.0a2` and `0.13.0a1` entries below for the full surface (`obsigna` rename, `KeyRotation` dataclass and chain-verifier traversal).

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,14 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.15.0-alpha.1] - 2026-06-21
+
+### Added
+
+- **Grounded-principal conformance tier (ADR-0038, spec §7.9)** ([#915](https://github.com/agent-receipts/obsigna/pull/915)) — `GrantResolver` interface and `verifyGroundedPrincipalTier(receipts, resolver)` with the same D1–D3 semantics as the Go and Python SDKs. `null`/`undefined` resolver is the base-tier no-op (ADR-0038 D3). Returns `GrantInfo`, `GroundedPrincipalViolation[]`, and `GroundedOutcome` (`UNGROUNDED_PRINCIPAL` / `PRINCIPAL_GRANT_MISMATCH`). All types exported from the package root.
+
+- **`outcome.response_disclosure` HPKE envelope (spec v0.6.0)** ([#913](https://github.com/agent-receipts/obsigna/pull/913)) — `encryptResponse`/`decryptResponse` seal and unseal `credentialSubject.outcome.response_disclosure` using the same X25519 + AES-128-GCM HPKE scheme as parameter disclosure. Response disclosure is controlled independently of parameter disclosure, so issuers may seal outputs without sealing inputs (or vice versa).
+
 ## [0.14.1] - 2026-06-16
 
 ### Added


### PR DESCRIPTION
Stamps the CHANGELOG entries for the first alpha of the next release cycle, covering the changes from PRs #912–#915.

## Changes

- `daemon/CHANGELOG.md`: `[0.29.0-alpha.1]` — checkpoint anchor nil-guard hardening (#914)
- `sdk/go/CHANGELOG.md`: `[0.22.0-alpha.1]` — grounded-principal conformance tier (#915)
- `sdk/ts/CHANGELOG.md`: `[0.15.0-alpha.1]` — grounded-principal tier (#915) + `outcome.response_disclosure` HPKE envelope (#913)
- `sdk/py/CHANGELOG.md`: `[0.14.0-alpha.1]` — grounded-principal tier (#915)

## After merging

Push tags to trigger release workflows:
- `sdk/go/v0.22.0-alpha.1`
- `sdk-ts-v0.15.0-alpha.1`
- `sdk-py-v0.14.0-alpha.1`

Then pin `sdk/go v0.22.0-alpha.1` in daemon/hook/mcp-proxy `go.mod` and push `obsigna/v0.29.0-alpha.1`.