### PR TITLE
chore(release): bump sdk-py manifest to 0.14.0-alpha.1

### DIFF
--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.13.0"
+version = "0.14.0-alpha.1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Bump `sdk/py/pyproject.toml` from `0.13.0` to `0.14.0-alpha.1`.

## Why

The `sdk-py-v0.14.0-alpha.1` tag and its CHANGELOG entry already landed on main (#917), but `pyproject.toml` was left at `0.13.0`. The release workflow's *Verify release tag matches pyproject.toml version* gate compares the tag suffix against the manifest string and aborted before publish ([failed run](https://github.com/agent-receipts/obsigna/actions/runs/27896153255)). This aligns the manifest with the already-tagged version.

The tagged release covers:
- ADR-0038 grounded-principal conformance tier (#915)
- HPKE `outcome.response_disclosure` envelope (#913)
- emitter forwards taxonomic `action_type` to daemon (#897)

## Notes

- `uv build` accepts `0.14.0-alpha.1` and normalizes the artifact to `obsigna-0.14.0a1` (verified locally).
- **After merge:** re-point the `sdk-py-v0.14.0-alpha.1` tag to the merge commit and force-push so the release re-runs against the bumped manifest.