### PR TITLE
chore(release): bump sdk-ts manifest to 0.15.0-alpha.1

### DIFF
--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.14.1",
+	"version": "0.15.0-alpha.1",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## What

Bump `sdk/ts/package.json` from `0.14.1` to `0.15.0-alpha.1`.

## Why

The `sdk-ts-v0.15.0-alpha.1` tag and its CHANGELOG entry already landed on main (#917), but `package.json` was left at `0.14.1`. The release workflow's *Verify release tag matches package.json version* gate compares the tag suffix against the manifest string and aborted before publish ([failed run](https://github.com/agent-receipts/obsigna/actions/runs/27896153173)). This aligns the manifest with the already-tagged version.

The tagged release covers:
- ADR-0038 grounded-principal conformance tier (#915)
- HPKE `outcome.response_disclosure` envelope (#913)

## Notes

- **After merge:** re-point the `sdk-ts-v0.15.0-alpha.1` tag to the merge commit and force-push so the release re-runs against the bumped manifest.