### PR TITLE
chore(sdk-py): normalize alpha version to PEP 440 (0.14.0a1)

### DIFF
--- a/sdk/py/AGENTS.md
+++ b/sdk/py/AGENTS.md
@@ -43,6 +43,16 @@ tests/                 # Mirrors src structure, uses conftest.py fixtures
 - camelCase aliases exported at package level for TypeScript SDK users
 - Output must be byte-identical to the TypeScript SDK (`tests/test_cross_language.py` verifies this)
 
+## Releasing
+
+- Version strings must use **normalized PEP 440** form everywhere they appear —
+  `pyproject.toml`, the `CHANGELOG.md` header, and the `sdk-py-v*` tag. Use
+  `0.14.0a1`, **not** `0.14.0-alpha.1`. PyPI normalizes on upload (`-alpha.1` →
+  `a1`), and the release-verify gate (Gate #2) does a literal string compare of
+  the tag suffix against `pip show` output, so a non-normalized tag publishes
+  successfully but fails verification. The TypeScript SDK uses `-alpha.1`
+  (npm preserves it); do not carry that spelling over to Python.
+
 ## Reference files
 
 - `src/obsigna/receipt/signing.py` — Ed25519 signing with proper type guards, RFC 8785 canonicalization, and cross-SDK compatibility

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,7 +12,7 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
-## [0.14.0-alpha.1] - 2026-06-21
+## [0.14.0a1] - 2026-06-21
 
 ### Added
 

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.14.0-alpha.1"
+version = "0.14.0a1"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

- `pyproject.toml` + CHANGELOG header: `0.14.0-alpha.1` → `0.14.0a1`
- `sdk/py/AGENTS.md`: document that py version strings must use normalized PEP 440 (`a1`), never `-alpha.1`

## Why

`obsigna 0.14.0a1` published successfully, but the `sdk-py-v0.14.0-alpha.1` tag failed the release-verify gate (Gate #2). PyPI normalizes `-alpha.1` → `a1` on upload, and the gate compares the tag suffix *literally* against `pip show`'s resolved version ([failed job](https://github.com/agent-receipts/obsigna/actions/runs/27900613585/job/82560202039)). All other gates passed; the package is published and working.

This is "fix forward": the published artifact stays as-is (`0.14.0a1`), and this aligns the in-repo strings with it plus documents the convention so the next py release uses the normalized form. The repo already followed this (`0.13.0a1`, `0.13.0a2`); the `-alpha.1` spelling leaked over from the TS SDK, where npm preserves it.

## Not changed

- The published PyPI release (immutable) and the existing tag/GitHub release are left as-is.