### PR TITLE
feat(module-paths): migrate all Go modules to obsigna.dev vanity paths (ADR-0037)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | **API reference** | [Go](https://obsigna.dev/sdk-go/api-reference/) · [TypeScript](https://obsigna.dev/sdk-ts/api-reference/) · [Python](https://obsigna.dev/sdk-py/api-reference/) |
 | **Examples** | [obsigna-examples](https://github.com/agent-receipts/obsigna-examples) |
 | **Blog** | [Your AI Agent Just Sent an Email](https://jongerius.solutions/post/your-ai-agent-just-sent-an-email/) · [Every MCP Tool Call My AI Makes Now Gets a Signed Receipt](https://jongerius.solutions/post/auditing-github-mcp-agent-receipts/) |
-| **Go** | [sdk/go](https://pkg.go.dev/github.com/agent-receipts/ar/sdk/go) · [mcp-proxy](https://pkg.go.dev/github.com/agent-receipts/ar/mcp-proxy) · [dashboard](https://pkg.go.dev/github.com/agent-receipts/dashboard) |
+| **Go** | [sdk/go](https://pkg.go.dev/obsigna.dev/sdk/go) · [mcp-proxy](https://pkg.go.dev/github.com/agent-receipts/ar/mcp-proxy) · [dashboard](https://pkg.go.dev/github.com/agent-receipts/dashboard) |
 | **npm** | [@obsigna/sdk-ts](https://www.npmjs.com/package/@obsigna/sdk-ts) |
 | **PyPI** | [obsigna](https://pypi.org/project/obsigna/) |
 
@@ -111,11 +111,11 @@ obsigna verify
 ### Go
 
 ```bash
-go get github.com/agent-receipts/ar/sdk/go
+go get obsigna.dev/sdk/go
 ```
 
 ```go
-import "github.com/agent-receipts/ar/sdk/go/receipt"
+import "obsigna.dev/sdk/go/receipt"
 
 keys, _ := receipt.GenerateKeyPair()
 unsigned := receipt.Create(receipt.CreateInput{

--- a/collector/cmd/collector/main_test.go
+++ b/collector/cmd/collector/main_test.go
@@ -102,8 +102,8 @@ func TestForwardingIntegration(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "collector")
 	real := filepath.Join(dir, "obsigna-collector")
-	goBuild(t, shim, "github.com/agent-receipts/ar/collector/cmd/collector")
-	goBuild(t, real, "github.com/agent-receipts/ar/collector/cmd/obsigna-collector")
+	goBuild(t, shim, "obsigna.dev/collector/cmd/collector")
+	goBuild(t, real, "obsigna.dev/collector/cmd/obsigna-collector")
 
 	out, errOut, code := runBin(t, shim, "--version")
 	if code != 0 {

--- a/collector/cmd/obsigna-collector/entrypoint_guard_test.go
+++ b/collector/cmd/obsigna-collector/entrypoint_guard_test.go
@@ -100,7 +100,7 @@ func TestObsignaCollectorIsPrimaryEntrypoint(t *testing.T) {
 // the surface; the shim does not.
 func TestObsignaCollectorWiresCollectorLibrary(t *testing.T) {
 	src := readFile(t, "main.go")
-	if !strings.Contains(src, `agent-receipts/ar/collector"`) {
+	if !strings.Contains(src, `obsigna.dev/collector"`) {
 		t.Error("cmd/obsigna-collector does not import the collector library; obsigna-collector must be the primary collector entrypoint")
 	}
 }

--- a/collector/cmd/obsigna-collector/main.go
+++ b/collector/cmd/obsigna-collector/main.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/collector"
+	"obsigna.dev/collector"
 )
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z". Falls

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1,4 +1,4 @@
-module github.com/agent-receipts/ar/collector
+module obsigna.dev/collector
 
 go 1.26.1
 
@@ -8,7 +8,6 @@ go 1.26.1
 toolchain go1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.13.0
 	modernc.org/sqlite v1.50.1
 )
 

--- a/collector/server.go
+++ b/collector/server.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // Config holds collector server configuration.

--- a/collector/server_test.go
+++ b/collector/server_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func newTestHandler(t *testing.T) (http.Handler, *InMemoryStore) {

--- a/collector/sqlite_store.go
+++ b/collector/sqlite_store.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 
 	sqlite "modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"

--- a/collector/store.go
+++ b/collector/store.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // ErrDuplicate is returned by Store.Insert when a receipt with the same id is

--- a/collector/store_test.go
+++ b/collector/store_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // testReceipt constructs a minimal AgentReceipt for store tests. It is not a

--- a/cross-sdk-tests/cmd/generate-malformed-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-malformed-vectors/main.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 const fixedTimestamp = "2026-04-22T00:00:00Z"

--- a/cross-sdk-tests/cmd/generate-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-vectors/main.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 type vectors struct {

--- a/cross-sdk-tests/go.mod
+++ b/cross-sdk-tests/go.mod
@@ -1,9 +1,8 @@
-module github.com/agent-receipts/ar/cross-sdk-tests
+module obsigna.dev/cross-sdk-tests
 
 go 1.26.1
 
 // Local sdk/go is wired in via the repo-root go.work workspace.
-require github.com/agent-receipts/ar/sdk/go v0.19.0
 
 require github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 

--- a/cross-sdk-tests/v030_vectors_test.go
+++ b/cross-sdk-tests/v030_vectors_test.go
@@ -33,7 +33,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 const v030VectorsPath = "v030_vectors.json"

--- a/cross-sdk-tests/v040_vectors_test.go
+++ b/cross-sdk-tests/v040_vectors_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 const v040VectorsPath = "v040_vectors.json"

--- a/cross-sdk-tests/v050_vectors_test.go
+++ b/cross-sdk-tests/v050_vectors_test.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 const v050VectorsPath = "v050_vectors.json"

--- a/daemon/cmd/agent-receipts/main.go
+++ b/daemon/cmd/agent-receipts/main.go
@@ -19,7 +19,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/agent-receipts/ar/daemon/internal/binresolve"
+	"obsigna.dev/daemon/internal/binresolve"
 )
 
 // deprecationShimMarker identifies this entrypoint as the agent-receipts → obsigna

--- a/daemon/cmd/agent-receipts/shim_test.go
+++ b/daemon/cmd/agent-receipts/shim_test.go
@@ -59,8 +59,8 @@ func TestForwardingIntegration(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "agent-receipts")
 	obsigna := filepath.Join(dir, "obsigna")
-	goBuild(t, shim, "github.com/agent-receipts/ar/daemon/cmd/agent-receipts")
-	goBuild(t, obsigna, "github.com/agent-receipts/ar/daemon/cmd/obsigna")
+	goBuild(t, shim, "obsigna.dev/daemon/cmd/agent-receipts")
+	goBuild(t, obsigna, "obsigna.dev/daemon/cmd/obsigna")
 
 	absentDB := filepath.Join(dir, "absent.db")
 

--- a/daemon/cmd/obsigna-daemon/init_test.go
+++ b/daemon/cmd/obsigna-daemon/init_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon"
+	"obsigna.dev/daemon"
 )
 
 // initResolved builds the resolved view --init runs from, with all key paths

--- a/daemon/cmd/obsigna-daemon/main.go
+++ b/daemon/cmd/obsigna-daemon/main.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
+	"obsigna.dev/daemon"
 )
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z".

--- a/daemon/cmd/obsigna/daemon.go
+++ b/daemon/cmd/obsigna/daemon.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/agent-receipts/ar/daemon/internal/binresolve"
+	"obsigna.dev/daemon/internal/binresolve"
 )
 
 // execImage replaces the current process image with the named binary, the way

--- a/daemon/cmd/obsigna/registry.go
+++ b/daemon/cmd/obsigna/registry.go
@@ -3,13 +3,13 @@ package main
 import (
 	"io"
 
-	"github.com/agent-receipts/ar/daemon/internal/disclosecli"
-	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
-	"github.com/agent-receipts/ar/daemon/internal/keyscli"
-	"github.com/agent-receipts/ar/daemon/internal/listcli"
-	"github.com/agent-receipts/ar/daemon/internal/showcli"
-	"github.com/agent-receipts/ar/daemon/internal/verifycli"
-	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
+	"obsigna.dev/daemon/internal/disclosecli"
+	"obsigna.dev/daemon/internal/doctorcli"
+	"obsigna.dev/daemon/internal/keyscli"
+	"obsigna.dev/daemon/internal/listcli"
+	"obsigna.dev/daemon/internal/showcli"
+	"obsigna.dev/daemon/internal/verifycli"
+	"obsigna.dev/daemon/internal/verifyeventcli"
 )
 
 // runFunc is the shape every subcommand implementation shares (verifycli.Run,

--- a/daemon/cmd/obsigna/surface_test.go
+++ b/daemon/cmd/obsigna/surface_test.go
@@ -5,13 +5,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/disclosecli"
-	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
-	"github.com/agent-receipts/ar/daemon/internal/keyscli"
-	"github.com/agent-receipts/ar/daemon/internal/listcli"
-	"github.com/agent-receipts/ar/daemon/internal/showcli"
-	"github.com/agent-receipts/ar/daemon/internal/verifycli"
-	"github.com/agent-receipts/ar/daemon/internal/verifyeventcli"
+	"obsigna.dev/daemon/internal/disclosecli"
+	"obsigna.dev/daemon/internal/doctorcli"
+	"obsigna.dev/daemon/internal/keyscli"
+	"obsigna.dev/daemon/internal/listcli"
+	"obsigna.dev/daemon/internal/showcli"
+	"obsigna.dev/daemon/internal/verifycli"
+	"obsigna.dev/daemon/internal/verifyeventcli"
 )
 
 // TestGoldenSurface pins the obsigna command surface to the frozen ADR-0030

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,15 +19,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/checkpoint"
+	"obsigna.dev/daemon/internal/keysource"
+	"obsigna.dev/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // Config is the daemon's startup configuration. Resolve from flags/env in

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
+	"obsigna.dev/daemon/internal/keysource"
 )
 
 func TestTightenDBFiles_TightensFresh0644(t *testing.T) {

--- a/daemon/generateforensickey_test.go
+++ b/daemon/generateforensickey_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestGenerateForensicKey_HappyPath proves the post-condition the

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,4 +1,4 @@
-module github.com/agent-receipts/ar/daemon
+module obsigna.dev/daemon
 
 // Pin the exact patch in the go directive (ADR-0031): reproducible-build
 // attestation requires every builder use the same compiler bytes. `setup-go`
@@ -11,7 +11,6 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.52.0

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -29,13 +29,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/daemon/internal/sockettest"
-	"github.com/agent-receipts/ar/daemon/internal/verifycli"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/daemon/internal/sockettest"
+	"obsigna.dev/daemon/internal/verifycli"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // emitterHelperGuardVar is the explicit "this binary was re-exec'd as the

--- a/daemon/internal/chain/state.go
+++ b/daemon/internal/chain/state.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/store"
 )
 
 // State tracks the next-sequence and previous-hash for a single chain id. It

--- a/daemon/internal/checkpoint/checkpoint.go
+++ b/daemon/internal/checkpoint/checkpoint.go
@@ -30,7 +30,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // multibaseBase64URL mirrors the receipt proof encoding: signatures are

--- a/daemon/internal/checkpoint/emitter.go
+++ b/daemon/internal/checkpoint/emitter.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/anchor"
 )
 
 // Emitter signs chain-HEAD checkpoints and fans them out to every configured

--- a/daemon/internal/checkpoint/emitter_async_test.go
+++ b/daemon/internal/checkpoint/emitter_async_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/anchor"
 )
 
 // slowSink simulates a sink whose Write blocks for a configurable duration,

--- a/daemon/internal/checkpoint/emitter_test.go
+++ b/daemon/internal/checkpoint/emitter_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/anchor"
 )
 
 // recordingSink captures every payload it is asked to write. okWrite toggles

--- a/daemon/internal/checkpoint/reader.go
+++ b/daemon/internal/checkpoint/reader.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/anchor"
 )
 
 // ReadVerifiedCheckpoints reads an anchor log at path and returns the

--- a/daemon/internal/checkpoint/reader_tail_test.go
+++ b/daemon/internal/checkpoint/reader_tail_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/anchor"
 )
 
 // writeAnchorFile creates a real anchor file signed by signer and returns the

--- a/daemon/internal/disclosecli/disclose.go
+++ b/daemon/internal/disclosecli/disclose.go
@@ -24,9 +24,9 @@ import (
 	"syscall"
 	"text/tabwriter"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 const (

--- a/daemon/internal/disclosecli/disclose_test.go
+++ b/daemon/internal/disclosecli/disclose_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // fixtureDB builds a test store with `count` receipts on the given chain.

--- a/daemon/internal/doctorcli/doctor.go
+++ b/daemon/internal/doctorcli/doctor.go
@@ -31,11 +31,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 // Exit codes are part of the CLI contract — CI healthchecks pivot on them.

--- a/daemon/internal/doctorcli/doctor_test.go
+++ b/daemon/internal/doctorcli/doctor_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // genKeyPEM returns a fresh Ed25519 keypair as PEM strings.

--- a/daemon/internal/keyscli/keyscli.go
+++ b/daemon/internal/keyscli/keyscli.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
+	"obsigna.dev/daemon"
+	"obsigna.dev/daemon/internal/keysource"
 )
 
 // Exit codes are part of the CLI contract — keep them stable and aligned with

--- a/daemon/internal/keyscli/keyscli_test.go
+++ b/daemon/internal/keyscli/keyscli_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/store"
 )
 
 // isolate points the per-user default paths (config, key, db, socket) at a fresh

--- a/daemon/internal/listcli/list.go
+++ b/daemon/internal/listcli/list.go
@@ -18,9 +18,9 @@ import (
 	"syscall"
 	"text/tabwriter"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 const (

--- a/daemon/internal/listcli/list_test.go
+++ b/daemon/internal/listcli/list_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // fixtureDB writes a DB at dir/receipts.db with `count` receipts on chainID.

--- a/daemon/internal/pipeline/bound_test.go
+++ b/daemon/internal/pipeline/bound_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // processFrame runs one EmitterFrame through a fresh pipeline and returns the

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -17,13 +17,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/checkpoint"
+	"obsigna.dev/daemon/internal/keysource"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 // multibaseBase64URL matches sdk/go/receipt/signing.go: receipts use base64url

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/keysource"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 func newTestKeySource(t *testing.T) keysource.KeySource {

--- a/daemon/internal/pipeline/disclosure_policy.go
+++ b/daemon/internal/pipeline/disclosure_policy.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // DisclosurePolicy decides whether a given action's parameters are encrypted

--- a/daemon/internal/pipeline/disclosure_policy_test.go
+++ b/daemon/internal/pipeline/disclosure_policy_test.go
@@ -3,7 +3,7 @@ package pipeline
 import (
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func TestParseDisclosurePolicy(t *testing.T) {

--- a/daemon/internal/pipeline/redact_test.go
+++ b/daemon/internal/pipeline/redact_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestRedactor_BuiltinPatternsRedactKnownSecretShapes verifies that the

--- a/daemon/internal/pipeline/terminator_test.go
+++ b/daemon/internal/pipeline/terminator_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestEmitTerminator_EmitsOnOpenChain verifies that EmitTerminator writes a

--- a/daemon/internal/showcli/show.go
+++ b/daemon/internal/showcli/show.go
@@ -19,9 +19,9 @@ import (
 	"syscall"
 	"text/tabwriter"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // Exit codes are part of the CLI contract — scripts pivot on them.

--- a/daemon/internal/showcli/show_test.go
+++ b/daemon/internal/showcli/show_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // fixtureDB writes a DB at dir/receipts.db with `count` receipts on each of the

--- a/daemon/internal/socket/listener_test.go
+++ b/daemon/internal/socket/listener_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/sockettest"
+	"obsigna.dev/daemon/internal/sockettest"
 )
 
 func TestListen_RefusesNonSocketPreexistingFile(t *testing.T) {

--- a/daemon/internal/verifycli/anchor.go
+++ b/daemon/internal/verifycli/anchor.go
@@ -3,7 +3,7 @@ package verifycli
 import (
 	"fmt"
 
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
+	"obsigna.dev/daemon/internal/checkpoint"
 )
 
 // anchorResult is the structured outcome of an --against-anchor check. Reason

--- a/daemon/internal/verifycli/anchor_test.go
+++ b/daemon/internal/verifycli/anchor_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
+	"obsigna.dev/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/checkpoint"
 )
 
 type anchorTestSigner struct {

--- a/daemon/internal/verifycli/verify.go
+++ b/daemon/internal/verifycli/verify.go
@@ -29,10 +29,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/daemon/internal/checkpoint"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // Exit codes are part of the CLI contract — scripts and CI checks pivot on

--- a/daemon/internal/verifycli/verify_test.go
+++ b/daemon/internal/verifycli/verify_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // fixtureChain writes a daemon-shaped DB at dbPath containing `count` valid

--- a/daemon/internal/verifyeventcli/verify_event.go
+++ b/daemon/internal/verifyeventcli/verify_event.go
@@ -40,9 +40,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // Exit codes are part of the CLI contract — CI gates and triage scripts pivot

--- a/daemon/internal/verifyeventcli/verify_event_test.go
+++ b/daemon/internal/verifyeventcli/verify_event_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 func u32(v uint32) *uint32 { return &v }

--- a/daemon/paths_test.go
+++ b/daemon/paths_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 // TestDefaultDBPath_UsesXDGDataHomeWhenAbsolute pins the spec-conformant

--- a/daemon/protocol.go
+++ b/daemon/protocol.go
@@ -1,6 +1,6 @@
 package daemon
 
-import "github.com/agent-receipts/ar/daemon/internal/pipeline"
+import "obsigna.dev/daemon/internal/pipeline"
 
 // VersionRange is an inclusive range of integer protocol versions. An empty
 // intersection between two ranges means the two peers cannot talk.

--- a/daemon/protocol_test.go
+++ b/daemon/protocol_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/pipeline"
 )
 
 // TestSpokenProtocolVersionMirrorsPipeline asserts the exported spoken range

--- a/daemon/rotate.go
+++ b/daemon/rotate.go
@@ -15,9 +15,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/anchor"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // socketReachable best-effort probes whether a daemon is already listening on

--- a/daemon/rotate_test.go
+++ b/daemon/rotate_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/anchor"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 func rotateTestConfig(t *testing.T) Config {

--- a/daemon/tests_chainresume_test.go
+++ b/daemon/tests_chainresume_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestResumePrevHashIntegrity verifies that a daemon restarting on the same DB

--- a/daemon/tests_checkpoint_anchor_test.go
+++ b/daemon/tests_checkpoint_anchor_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/checkpoint"
+	"obsigna.dev/sdk/go/store"
 )
 
 // TestCheckpointAnchorEndToEnd exercises the full daemon wiring: a Config with

--- a/daemon/tests_checkpoint_truncation_test.go
+++ b/daemon/tests_checkpoint_truncation_test.go
@@ -13,14 +13,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/anchor"
-	"github.com/agent-receipts/ar/daemon/internal/chain"
-	"github.com/agent-receipts/ar/daemon/internal/checkpoint"
-	"github.com/agent-receipts/ar/daemon/internal/keysource"
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/daemon/internal/verifycli"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/anchor"
+	"obsigna.dev/daemon/internal/chain"
+	"obsigna.dev/daemon/internal/checkpoint"
+	"obsigna.dev/daemon/internal/keysource"
+	"obsigna.dev/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/daemon/internal/verifycli"
+	"obsigna.dev/sdk/go/store"
 
 	_ "modernc.org/sqlite"
 )

--- a/daemon/tests_concurrent_mcp_proxy_test.go
+++ b/daemon/tests_concurrent_mcp_proxy_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // isTransientIOTimeout reports whether err is a network timeout (e.g. a

--- a/daemon/tests_concurrent_test.go
+++ b/daemon/tests_concurrent_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestConcurrentSDKEmitters fires all 3 emitters (Go, TS, Python) concurrently,

--- a/daemon/tests_doctor_test.go
+++ b/daemon/tests_doctor_test.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/daemon/internal/doctorcli"
+	"obsigna.dev/daemon"
+	"obsigna.dev/daemon/internal/doctorcli"
 )
 
 // doctorReport mirrors doctorcli.Report for decoding the --json output without

--- a/daemon/tests_drop_test.go
+++ b/daemon/tests_drop_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // actionTypeEventsDropped mirrors the daemon-internal constant of the same name

--- a/daemon/tests_emitters_test.go
+++ b/daemon/tests_emitters_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestSDKEmitterSingleFrame verifies the daemon processes a single frame

--- a/daemon/tests_framework.go
+++ b/daemon/tests_framework.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/sockettest"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/sockettest"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // syncBuffer wraps bytes.Buffer with a mutex so daemon goroutines can write

--- a/daemon/tests_interrupted_chain_test.go
+++ b/daemon/tests_interrupted_chain_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
-	"github.com/agent-receipts/ar/daemon/internal/sockettest"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/sockettest"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // interruptDaemonCfg builds a Config for interrupted-chain tests.

--- a/daemon/tests_mcpproxy_test.go
+++ b/daemon/tests_mcpproxy_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestMCPProxyActionType verifies that a frame with channel="mcp_proxy" and

--- a/daemon/tests_protocol_test.go
+++ b/daemon/tests_protocol_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon/internal/pipeline"
-	"github.com/agent-receipts/ar/daemon/internal/socket"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon/internal/pipeline"
+	"obsigna.dev/daemon/internal/socket"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // assertReceiptCountStays0 polls the store repeatedly for the duration and fails if receipts appear.

--- a/daemon/tests_regressions_test.go
+++ b/daemon/tests_regressions_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // TestConcurrentDaemonStartSameSocket verifies that when two daemon instances

--- a/dist/sdk-go-deprecation/receipt/chain.go
+++ b/dist/sdk-go-deprecation/receipt/chain.go
@@ -17,7 +17,7 @@ var verifyReceipt = Verify
 
 // ReceiptVerification holds the verification result for a single receipt in a chain.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ReceiptVerification struct {
 	Index          int    `json:"index"`
 	ReceiptID      string `json:"receipt_id"`
@@ -28,7 +28,7 @@ type ReceiptVerification struct {
 
 // ChainVerification holds the verification result for an entire chain.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ChainVerification struct {
 	Valid    bool                  `json:"valid"`
 	Length   int                   `json:"length"`
@@ -129,7 +129,7 @@ func isIncompleteToolRoundtrip(receipts []AgentReceipt) bool {
 // ChainVerifyOptions holds optional parameters for VerifyChain.
 // Zero value means "use defaults" — behaviour is identical to v0.1 with no options.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ChainVerifyOptions struct {
 	// ExpectedLength, when non-nil, causes verification to fail if the observed
 	// chain length does not equal this value. Provides out-of-band truncation
@@ -180,7 +180,7 @@ type ChainVerifyOptions struct {
 // mismatch. When no body is supplied for a receipt that carries response_hash, an
 // informational note is emitted but verification continues.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func VerifyChain(receipts []AgentReceipt, publicKeyPEM string, opts ...ChainVerifyOptions) ChainVerification {
 	var opt ChainVerifyOptions
 	if len(opts) > 0 {

--- a/dist/sdk-go-deprecation/receipt/create.go
+++ b/dist/sdk-go-deprecation/receipt/create.go
@@ -10,7 +10,7 @@ import (
 
 // CreateInput holds the inputs for creating an unsigned receipt.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type CreateInput struct {
 	Issuer        Issuer
 	Principal     Principal
@@ -42,7 +42,7 @@ type CreateInput struct {
 // It auto-generates the receipt ID, action ID, issuance date, and action
 // timestamp (if not already set in Action).
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Create(input CreateInput) UnsignedAgentReceipt {
 	now := time.Now().UTC().Format(time.RFC3339)
 

--- a/dist/sdk-go-deprecation/receipt/disclosure.go
+++ b/dist/sdk-go-deprecation/receipt/disclosure.go
@@ -19,7 +19,7 @@ const v1Alg = "hpke-x25519-hkdf-sha256-aes-256-gcm"
 // DisclosureRecipient is one entry in the recipients array of a DisclosureEnvelope.
 // Field names match RFC 9180 §4.1 vocabulary ("enc", not "encap").
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type DisclosureRecipient struct {
 	KID string `json:"kid"`
 	Enc string `json:"enc"` // HPKE encapsulated key; unpadded base64url, exactly 43 chars for X25519
@@ -33,7 +33,7 @@ type DisclosureRecipient struct {
 // (alg, ct, recipients, v) regardless, so the struct tag order does not affect
 // the canonical bytes.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type DisclosureEnvelope struct {
 	V          string                `json:"v"`
 	Alg        string                `json:"alg"`
@@ -46,7 +46,7 @@ type DisclosureEnvelope struct {
 // raw bytes, not PEM-encoded, because X25519 has no standard PKCS8 PEM convention
 // in widespread use and raw bytes compose more naturally with HPKE library APIs.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ForensicKeyPair struct {
 	PublicKey  []byte // 32 bytes; share with emitters so they can encrypt disclosures
 	PrivateKey []byte // 32 bytes; keep offline; required to decrypt disclosures
@@ -61,7 +61,7 @@ func disclosureSuite() hpke.Suite {
 // The public key is shared with emitters; the private key must be kept offline
 // (separate from the Ed25519 signing key per ADR-0001 / ADR-0012).
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func GenerateForensicKeyPair() (ForensicKeyPair, error) {
 	suite := disclosureSuite()
 	kemID, _, _ := suite.Params()
@@ -89,7 +89,7 @@ func GenerateForensicKeyPair() (ForensicKeyPair, error) {
 // kid identifies the recipient key (did:key DID URL or sha256:<hex> fingerprint).
 // recipientPublicKey is the 32-byte X25519 forensic public key.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func EncryptDisclosure(params map[string]any, recipientPublicKey []byte, kid string) (*DisclosureEnvelope, error) {
 	return encryptWithReader(params, recipientPublicKey, kid, rand.Reader)
 }
@@ -168,7 +168,7 @@ func encryptWithReader(params map[string]any, recipientPublicKey []byte, kid str
 // envelope. recipientPrivateKey is the 32-byte X25519 forensic private key.
 // The returned map reflects the JCS-canonical plaintext written by EncryptDisclosure.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func DecryptDisclosure(env *DisclosureEnvelope, recipientPrivateKey []byte) (map[string]any, error) {
 	if env == nil {
 		return nil, fmt.Errorf("disclosure envelope must not be nil")

--- a/dist/sdk-go-deprecation/receipt/hash.go
+++ b/dist/sdk-go-deprecation/receipt/hash.go
@@ -32,7 +32,7 @@ func marshalNoHTMLEscape(v any) ([]byte, error) {
 
 // SHA256Hash computes the SHA-256 hash of data and returns "sha256:<hex>".
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func SHA256Hash(data string) string {
 	h := sha256.Sum256([]byte(data))
 	return fmt.Sprintf("sha256:%x", h)
@@ -41,7 +41,7 @@ func SHA256Hash(data string) string {
 // HashReceipt computes the SHA-256 hash of a signed receipt (excluding proof).
 // Returns the hash in "sha256:<hex>" format.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func HashReceipt(r AgentReceipt) (string, error) {
 	unsigned := UnsignedAgentReceipt{
 		Context:           r.Context,
@@ -76,7 +76,7 @@ func HashReceipt(r AgentReceipt) (string, error) {
 //
 // Returns an error if rawJSON is not a JSON object.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func HashRawReceipt(rawJSON []byte) (string, error) {
 	var generic map[string]any
 	if err := json.Unmarshal(rawJSON, &generic); err != nil {
@@ -97,7 +97,7 @@ func HashRawReceipt(rawJSON []byte) (string, error) {
 
 // Canonicalize serialises v to RFC 8785 canonical JSON.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Canonicalize(v any) (string, error) {
 	// Marshal to JSON first so we work with a generic representation.
 	// We need to avoid html-escaping here too. Use a custom approach:

--- a/dist/sdk-go-deprecation/receipt/signing.go
+++ b/dist/sdk-go-deprecation/receipt/signing.go
@@ -20,12 +20,12 @@ const multibaseBase64URL = "u"
 // valid Ed25519 signature, so that consumers cannot be tricked into believing
 // a receipt was signed under a different scheme.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 const ProofTypeEd25519Signature2020 = "Ed25519Signature2020"
 
 // GenerateKeyPair generates an Ed25519 key pair and returns PEM-encoded keys.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func GenerateKeyPair() (KeyPair, error) {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -53,7 +53,7 @@ func GenerateKeyPair() (KeyPair, error) {
 // Sign signs an unsigned receipt with an Ed25519 private key (PEM-encoded)
 // and returns a complete AgentReceipt with proof.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Sign(unsigned UnsignedAgentReceipt, privateKeyPEM string, verificationMethod string) (AgentReceipt, error) {
 	privKey, err := parsePrivateKey(privateKeyPEM)
 	if err != nil {
@@ -90,7 +90,7 @@ func Sign(unsigned UnsignedAgentReceipt, privateKeyPEM string, verificationMetho
 
 // Verify checks the Ed25519 signature on a signed receipt.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Verify(r AgentReceipt, publicKeyPEM string) (bool, error) {
 	if r.Proof.Type != ProofTypeEd25519Signature2020 {
 		return false, fmt.Errorf("unsupported proof type %q: only %s is accepted", r.Proof.Type, ProofTypeEd25519Signature2020)

--- a/dist/sdk-go-deprecation/receipt/types.go
+++ b/dist/sdk-go-deprecation/receipt/types.go
@@ -2,7 +2,7 @@
 // verifying Action Receipts — W3C Verifiable Credentials for AI agent actions.
 //
 // Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the
-// canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 package receipt
 
 import "encoding/json"
@@ -15,30 +15,30 @@ var (
 
 // Context returns a copy of the W3C VC context array.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Context() []string { return append([]string{}, protocolContext...) }
 
 // CredentialType returns a copy of the credential type array.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func CredentialType() []string { return append([]string{}, protocolCredentialType...) }
 
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 const Version = "0.4.0"
 
 // RiskLevel classifies the security risk of an action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type RiskLevel string
 
 const (
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	RiskLow RiskLevel = "low"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	RiskMedium RiskLevel = "medium"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	RiskHigh RiskLevel = "high"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	RiskCritical RiskLevel = "critical"
 )
 
@@ -47,43 +47,43 @@ const (
 // ChainStatusInterrupted only — ChainStatusUnknown is verifier-derived
 // and MUST NOT be emitted by issuers.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ChainStatus string
 
 const (
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	ChainStatusComplete ChainStatus = "complete"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	ChainStatusInterrupted ChainStatus = "interrupted"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	ChainStatusUnknown ChainStatus = "unknown"
 )
 
 // IsValidWireValue reports whether v is one of the two values an issuer may
 // write to chain.status. Verifier-only "unknown" returns false.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (v ChainStatus) IsValidWireValue() bool {
 	return v == ChainStatusComplete || v == ChainStatusInterrupted
 }
 
 // OutcomeStatus represents the result of an action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type OutcomeStatus string
 
 const (
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	StatusSuccess OutcomeStatus = "success"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	StatusFailure OutcomeStatus = "failure"
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	StatusPending OutcomeStatus = "pending"
 )
 
 // Operator identifies the AI model executing actions.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Operator struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -91,7 +91,7 @@ type Operator struct {
 
 // Issuer represents the agent that issued the receipt.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Issuer struct {
 	ID        string    `json:"id"`
 	Type      string    `json:"type,omitempty"`
@@ -103,7 +103,7 @@ type Issuer struct {
 
 // Principal identifies the human or organisation that authorised the action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Principal struct {
 	ID   string `json:"id"`
 	Type string `json:"type,omitempty"`
@@ -111,7 +111,7 @@ type Principal struct {
 
 // ActionTarget specifies the system and resource being acted upon.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ActionTarget struct {
 	System   string `json:"system"`
 	Resource string `json:"resource,omitempty"`
@@ -129,7 +129,7 @@ type ActionTarget struct {
 // the platform has no UID/GID concept (e.g. Windows); ExePath uses omitempty
 // for the same reason.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type PeerCredential struct {
 	Platform string  `json:"platform"`
 	PID      int32   `json:"pid"`
@@ -142,14 +142,14 @@ type PeerCredential struct {
 // Currently records the drop counter on synthetic events_dropped receipts.
 // Daemon-attested, not agent-claimed.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type EmitterMetadata struct {
 	DropCount int64 `json:"drop_count,omitempty"`
 }
 
 // Action describes what the agent did.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Action struct {
 	ID                   string              `json:"id"`
 	Type                 string              `json:"type"`
@@ -173,7 +173,7 @@ type Action struct {
 
 // Intent captures conversation context behind the action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Intent struct {
 	ConversationHash       string `json:"conversation_hash,omitempty"`
 	PromptPreview          string `json:"prompt_preview,omitempty"`
@@ -183,7 +183,7 @@ type Intent struct {
 
 // StateChange captures before/after state hashes.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type StateChange struct {
 	BeforeHash string `json:"before_hash"`
 	AfterHash  string `json:"after_hash"`
@@ -191,7 +191,7 @@ type StateChange struct {
 
 // Outcome describes the result of an action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Outcome struct {
 	Status                OutcomeStatus `json:"status"`
 	Error                 string        `json:"error,omitempty"`
@@ -205,7 +205,7 @@ type Outcome struct {
 
 // Authorization captures the scope and expiry of an action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Authorization struct {
 	Scopes    []string `json:"scopes"`
 	GrantedAt string   `json:"granted_at"`
@@ -215,7 +215,7 @@ type Authorization struct {
 
 // Chain links receipts in a tamper-evident sequence.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Chain struct {
 	Sequence            int     `json:"sequence"`
 	PreviousReceiptHash *string `json:"previous_receipt_hash"`
@@ -244,7 +244,7 @@ type Chain struct {
 //     other than ChainStatusComplete or ChainStatusInterrupted — including
 //     ChainStatusUnknown, which is verifier-derived only).
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (c Chain) MarshalJSON() ([]byte, error) {
 	type chainAlias Chain
 	a := chainAlias(c)
@@ -262,14 +262,14 @@ func (c Chain) MarshalJSON() ([]byte, error) {
 
 // Delegator identifies the agent whose chain spawned a delegation.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Delegator struct {
 	ID string `json:"id"`
 }
 
 // Delegation records the chain linkage when this chain was spawned by a parent agent.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Delegation struct {
 	ParentChainID   string    `json:"parent_chain_id"`
 	ParentReceiptID string    `json:"parent_receipt_id"`
@@ -278,7 +278,7 @@ type Delegation struct {
 
 // CredentialSubject contains the core receipt payload.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type CredentialSubject struct {
 	Principal     Principal      `json:"principal"`
 	Action        Action         `json:"action"`
@@ -292,7 +292,7 @@ type CredentialSubject struct {
 
 // Proof contains the Ed25519 signature.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Proof struct {
 	Type               string `json:"type"`
 	Created            string `json:"created,omitempty"`
@@ -303,7 +303,7 @@ type Proof struct {
 
 // AgentReceipt is a signed W3C Verifiable Credential for an agent action.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type AgentReceipt struct {
 	Context []string `json:"@context"`
 	ID      string   `json:"id"`
@@ -319,7 +319,7 @@ type AgentReceipt struct {
 
 // UnsignedAgentReceipt is an AgentReceipt without a proof, ready to be signed.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type UnsignedAgentReceipt struct {
 	Context           []string          `json:"@context"`
 	ID                string            `json:"id"`
@@ -332,7 +332,7 @@ type UnsignedAgentReceipt struct {
 
 // KeyPair holds PEM-encoded Ed25519 keys.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type KeyPair struct {
 	PublicKey  string
 	PrivateKey string
@@ -340,7 +340,7 @@ type KeyPair struct {
 
 // TruncatePromptPreview truncates s to maxLen runes and sets the truncated flag.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func TruncatePromptPreview(s string, maxLen int) (preview string, truncated bool) {
 	if maxLen <= 0 {
 		return "", len(s) > 0

--- a/dist/sdk-go-deprecation/store/store.go
+++ b/dist/sdk-go-deprecation/store/store.go
@@ -1,7 +1,7 @@
 // Package store provides SQLite-backed persistence for Action Receipts.
 //
 // Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the
-// canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 package store
 
 import (
@@ -44,7 +44,7 @@ CREATE INDEX IF NOT EXISTS idx_receipts_timestamp ON receipts(timestamp);
 
 // ReceiptStore defines the interface for receipt persistence and querying.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ReceiptStore interface {
 	Insert(r receipt.AgentReceipt, receiptHash string) error
 	GetByID(id string) (*receipt.AgentReceipt, error)
@@ -58,14 +58,14 @@ type ReceiptStore interface {
 
 // Store is a SQLite-backed receipt store.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Store struct {
 	db *sql.DB
 }
 
 // Query filters for querying receipts.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Query struct {
 	ChainID    *string
 	ActionType *string
@@ -84,7 +84,7 @@ type Query struct {
 
 // Stats holds aggregate statistics for the store.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type Stats struct {
 	Total    int          `json:"total"`
 	Chains   int          `json:"chains"`
@@ -95,7 +95,7 @@ type Stats struct {
 
 // GroupCount is a label + count pair used in Stats.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type GroupCount struct {
 	Label string `json:"label"`
 	Count int    `json:"count"`
@@ -104,7 +104,7 @@ type GroupCount struct {
 // Open opens or creates a receipt store at the given path.
 // Use ":memory:" for an in-memory database.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func Open(dbPath string) (*Store, error) {
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -147,7 +147,7 @@ func Open(dbPath string) (*Store, error) {
 // absolute form so the resulting "file:" URI is unambiguous regardless of
 // the caller's working directory.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func OpenReadOnly(dbPath string) (*Store, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("OpenReadOnly: dbPath is required")
@@ -223,7 +223,7 @@ func migrateToolName(db *sql.DB) error {
 // daemon's pipeline). The receipt struct is the source of truth, so no
 // raw-vs-struct parity checks are performed.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) Insert(r receipt.AgentReceipt, receiptHash string) error {
 	rJSON, err := json.Marshal(r)
 	if err != nil {
@@ -250,7 +250,7 @@ func (s *Store) Insert(r receipt.AgentReceipt, receiptHash string) error {
 //     disagreement means receipt_json would describe a different receipt
 //     than the row key — silent at insert time, lethal at audit time.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) InsertRaw(r receipt.AgentReceipt, rawJSON []byte, receiptHash string) error {
 	if err := validateRawReceipt(rawJSON, r); err != nil {
 		return fmt.Errorf("insert receipt id=%s: %w", r.ID, err)
@@ -359,7 +359,7 @@ func validateRawReceipt(rawJSON []byte, r receipt.AgentReceipt) error {
 
 // GetByID retrieves a receipt by its ID. Returns nil if not found.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) GetByID(id string) (*receipt.AgentReceipt, error) {
 	var rJSON string
 	err := s.db.QueryRow("SELECT receipt_json FROM receipts WHERE id = ?", id).Scan(&rJSON)
@@ -381,7 +381,7 @@ func (s *Store) GetByID(id string) (*receipt.AgentReceipt, error) {
 // a presence check (duplicate detection on insert, /healthz reachability
 // probes) should prefer this over GetByID, which pays the full JSON decode.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) Exists(id string) (bool, error) {
 	var one int
 	err := s.db.QueryRow("SELECT 1 FROM receipts WHERE id = ? LIMIT 1", id).Scan(&one)
@@ -396,7 +396,7 @@ func (s *Store) Exists(id string) (bool, error) {
 
 // GetChain retrieves all receipts in a chain, ordered by sequence.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 	rows, err := s.db.Query(
 		"SELECT receipt_json FROM receipts WHERE chain_id = ? ORDER BY sequence ASC",
@@ -414,7 +414,7 @@ func (s *Store) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 // callers distinguish "not found" from an error. The (chain_id, sequence)
 // pair is uniquely indexed, so at most one row matches.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) GetByChainSequence(chainID string, sequence int) (*receipt.AgentReceipt, error) {
 	var rJSON string
 	err := s.db.QueryRow(
@@ -438,7 +438,7 @@ func (s *Store) GetByChainSequence(chainID string, sequence int) (*receipt.Agent
 // It reads only the indexed chain_id column, so it stays cheap as the store
 // grows — callers enumerating chains need not load full receipts.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) DistinctChainIDs() ([]string, error) {
 	rows, err := s.db.Query("SELECT DISTINCT chain_id FROM receipts ORDER BY chain_id ASC")
 	if err != nil {
@@ -464,7 +464,7 @@ func (s *Store) DistinctChainIDs() ([]string, error) {
 // when the chain is empty. The daemon uses this on startup to resume the
 // in-memory (sequence, prev_hash) it owns as sole writer.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) GetChainTail(chainID string) (sequence int64, receiptHash string, found bool, err error) {
 	row := s.db.QueryRow(
 		"SELECT sequence, receipt_hash FROM receipts WHERE chain_id = ? ORDER BY sequence DESC LIMIT 1",
@@ -482,7 +482,7 @@ func (s *Store) GetChainTail(chainID string) (sequence int64, receiptHash string
 // GetChainTailReceipt returns the highest-sequence receipt for chainID.
 // Returns (nil, nil) when the chain has no receipts.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) GetChainTailReceipt(chainID string) (*receipt.AgentReceipt, error) {
 	var rJSON string
 	err := s.db.QueryRow(
@@ -504,7 +504,7 @@ func (s *Store) GetChainTailReceipt(chainID string) (*receipt.AgentReceipt, erro
 
 // QueryReceipts retrieves receipts matching the given filters.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 	query, args := buildQueryReceiptsSQL(q)
 	rows, err := s.db.Query(query, args...)
@@ -519,7 +519,7 @@ func (s *Store) QueryReceipts(q Query) ([]receipt.AgentReceipt, error) {
 // Returns 0 when the table is empty. Intended as the watermark for follow-mode
 // streaming — callers pass it to QueryAfterRowID to fetch rows inserted later.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) MaxRowID() (int64, error) {
 	var max int64
 	if err := s.db.QueryRow("SELECT COALESCE(MAX(rowid), 0) FROM receipts").Scan(&max); err != nil {
@@ -540,7 +540,7 @@ func (s *Store) MaxRowID() (int64, error) {
 // Callers that want to bound query latency (e.g. so Ctrl-C in follow mode
 // stops a busy/locked query promptly) should use QueryAfterRowIDContext.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
 	return s.QueryAfterRowIDContext(context.Background(), q, afterRowID)
 }
@@ -550,7 +550,7 @@ func (s *Store) QueryAfterRowID(q Query, afterRowID int64) ([]receipt.AgentRecei
 // follow-mode pollers) don't have to wait on busy_timeout before shutting
 // down.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) QueryAfterRowIDContext(ctx context.Context, q Query, afterRowID int64) ([]receipt.AgentReceipt, int64, error) {
 	query, args := buildQueryAfterRowIDSQL(q, afterRowID)
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -570,7 +570,7 @@ func (s *Store) QueryAfterRowIDContext(ctx context.Context, q Query, afterRowID 
 // Callers that want Ctrl-C to interrupt the startup query should use
 // QueryReceiptsWithWatermarkContext.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) QueryReceiptsWithWatermark(q Query) ([]receipt.AgentReceipt, int64, error) {
 	return s.QueryReceiptsWithWatermarkContext(context.Background(), q)
 }
@@ -580,7 +580,7 @@ func (s *Store) QueryReceiptsWithWatermark(q Query) ([]receipt.AgentReceipt, int
 // transaction and each query inside it, so cancellation interrupts in-flight
 // work instead of waiting for busy_timeout.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) QueryReceiptsWithWatermarkContext(ctx context.Context, q Query) ([]receipt.AgentReceipt, int64, error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
@@ -736,7 +736,7 @@ func scanRowIDReceipts(rows *sql.Rows, afterRowID int64) ([]receipt.AgentReceipt
 
 // Stats returns aggregate statistics for the store.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) Stats() (Stats, error) {
 	var st Stats
 
@@ -766,7 +766,7 @@ func (s *Store) Stats() (Stats, error) {
 
 // VerifyStoredChain loads a chain from the store and verifies it.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) VerifyStoredChain(chainID string, publicKeyPEM string) (receipt.ChainVerification, error) {
 	receipts, err := s.GetChain(chainID)
 	if err != nil {
@@ -777,7 +777,7 @@ func (s *Store) VerifyStoredChain(chainID string, publicKeyPEM string) (receipt.
 
 // Close closes the database connection.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func (s *Store) Close() error {
 	return s.db.Close()
 }

--- a/dist/sdk-go-deprecation/taxonomy/taxonomy.go
+++ b/dist/sdk-go-deprecation/taxonomy/taxonomy.go
@@ -1,7 +1,7 @@
 // Package taxonomy provides tool call classification and the built-in action type registry.
 //
 // Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the
-// canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 package taxonomy
 
 import (
@@ -14,7 +14,7 @@ import (
 
 // ActionTypeEntry describes a known action type.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ActionTypeEntry struct {
 	Type        string            `json:"type"`
 	Description string            `json:"description"`
@@ -23,7 +23,7 @@ type ActionTypeEntry struct {
 
 // TaxonomyMapping maps a tool name to an action type.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type TaxonomyMapping struct {
 	ToolName   string `json:"tool_name"`
 	ActionType string `json:"action_type"`
@@ -31,14 +31,14 @@ type TaxonomyMapping struct {
 
 // TaxonomyConfig is the JSON configuration for taxonomy mappings.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type TaxonomyConfig struct {
 	Mappings []TaxonomyMapping `json:"mappings"`
 }
 
 // ClassificationResult holds the result of classifying a tool call.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 type ClassificationResult struct {
 	ActionType string            `json:"action_type"`
 	RiskLevel  receipt.RiskLevel `json:"risk_level"`
@@ -46,7 +46,7 @@ type ClassificationResult struct {
 
 // Built-in action types.
 var (
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	FilesystemActions = []ActionTypeEntry{
 		{Type: "filesystem.file.create", Description: "Create a file", RiskLevel: receipt.RiskLow},
 		{Type: "filesystem.file.read", Description: "Read a file", RiskLevel: receipt.RiskLow},
@@ -57,7 +57,7 @@ var (
 		{Type: "filesystem.directory.delete", Description: "Delete a directory", RiskLevel: receipt.RiskHigh},
 	}
 
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	SystemActions = []ActionTypeEntry{
 		{Type: "system.application.launch", Description: "Launch an application", RiskLevel: receipt.RiskLow},
 		{Type: "system.application.control", Description: "Control an application via UI automation", RiskLevel: receipt.RiskMedium},
@@ -68,14 +68,14 @@ var (
 		{Type: "system.browser.authenticate", Description: "Log into a service", RiskLevel: receipt.RiskHigh},
 	}
 
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	DataActions = []ActionTypeEntry{
 		{Type: "data.api.read", Description: "Read data from an external API", RiskLevel: receipt.RiskLow},
 		{Type: "data.api.write", Description: "Write data to an external API", RiskLevel: receipt.RiskMedium},
 		{Type: "data.api.delete", Description: "Delete data via an external API", RiskLevel: receipt.RiskHigh},
 	}
 
-	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+	// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 	UnknownAction = ActionTypeEntry{
 		Type:        "unknown",
 		Description: "Tool call that does not map to any known action type",
@@ -101,7 +101,7 @@ func init() {
 
 // AllActions returns all built-in action type entries.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func AllActions() []ActionTypeEntry {
 	out := make([]ActionTypeEntry, 0, len(FilesystemActions)+len(SystemActions)+len(DataActions)+1)
 	out = append(out, FilesystemActions...)
@@ -113,7 +113,7 @@ func AllActions() []ActionTypeEntry {
 
 // GetActionType returns the entry for the given type, or nil if unknown.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func GetActionType(actionType string) *ActionTypeEntry {
 	e, ok := actionMap[actionType]
 	if !ok {
@@ -125,7 +125,7 @@ func GetActionType(actionType string) *ActionTypeEntry {
 // ResolveActionType returns the entry for the given type, falling back to
 // UnknownAction if the type is not in the registry.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func ResolveActionType(actionType string) ActionTypeEntry {
 	if e, ok := actionMap[actionType]; ok {
 		return e
@@ -136,7 +136,7 @@ func ResolveActionType(actionType string) ActionTypeEntry {
 // ClassifyToolCall classifies a tool name into an action type and risk level
 // using the provided mappings. If no mapping matches, the result is "unknown".
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func ClassifyToolCall(toolName string, mappings []TaxonomyMapping) ClassificationResult {
 	actionType := "unknown"
 	for _, m := range mappings {
@@ -154,7 +154,7 @@ func ClassifyToolCall(toolName string, mappings []TaxonomyMapping) Classificatio
 
 // LoadTaxonomyConfig loads taxonomy mappings from a JSON file.
 //
-// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module github.com/agent-receipts/ar/sdk/go instead (see ADR-0023).
+// Deprecated: github.com/agent-receipts/sdk-go is no longer maintained. Use the canonical module obsigna.dev/sdk/go instead (see ADR-0023).
 func LoadTaxonomyConfig(path string) ([]TaxonomyMapping, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/hook/cmd/agent-receipts-hook/main_test.go
+++ b/hook/cmd/agent-receipts-hook/main_test.go
@@ -102,8 +102,8 @@ func TestForwardingIntegration(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "agent-receipts-hook")
 	real := filepath.Join(dir, "obsigna-hook")
-	goBuild(t, shim, "github.com/agent-receipts/ar/hook/cmd/agent-receipts-hook")
-	goBuild(t, real, "github.com/agent-receipts/ar/hook/cmd/obsigna-hook")
+	goBuild(t, shim, "obsigna.dev/hook/cmd/agent-receipts-hook")
+	goBuild(t, real, "obsigna.dev/hook/cmd/obsigna-hook")
 
 	out, errOut, code := runBin(t, shim, "--version")
 	if code != 0 {

--- a/hook/cmd/obsigna-hook/claude_code.go
+++ b/hook/cmd/obsigna-hook/claude_code.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 // maxErrorTextLen bounds the failure message copied into the receipt. Claude

--- a/hook/cmd/obsigna-hook/import_guard_test.go
+++ b/hook/cmd/obsigna-hook/import_guard_test.go
@@ -29,10 +29,10 @@ import (
 // that would surface here as an offender rather than slip in transitively.
 var allowedNonStdlibDeps = []allowedDep{
 	// The hook's own packages (cmd/...).
-	{prefix: "github.com/agent-receipts/ar/hook/"},
+	{prefix: "obsigna.dev/hook/"},
 	// The daemon emitter — the hook's one forwarding dependency (ADR-0010).
-	{exact: "github.com/agent-receipts/ar/sdk/go/emitter"},
-	{prefix: "github.com/agent-receipts/ar/sdk/go/emitter/"},
+	{exact: "obsigna.dev/sdk/go/emitter"},
+	{prefix: "obsigna.dev/sdk/go/emitter/"},
 	// Session IDs (google/uuid), pulled in transitively by the emitter.
 	{exact: "github.com/google/uuid"},
 }

--- a/hook/cmd/obsigna-hook/integration_test.go
+++ b/hook/cmd/obsigna-hook/integration_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 // shortSocketDir returns a temp directory whose path is short enough to fit a

--- a/hook/cmd/obsigna-hook/main.go
+++ b/hook/cmd/obsigna-hook/main.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z".

--- a/hook/cmd/obsigna-hook/main_test.go
+++ b/hook/cmd/obsigna-hook/main_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 // --- readClaudeCode unit tests ---

--- a/hook/go.mod
+++ b/hook/go.mod
@@ -1,7 +1,6 @@
-module github.com/agent-receipts/ar/hook
+module obsigna.dev/hook
 
 go 1.26.1
 
-require github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/mcp-proxy/cmd/mcp-proxy/main_test.go
+++ b/mcp-proxy/cmd/mcp-proxy/main_test.go
@@ -103,8 +103,8 @@ func TestForwardingIntegration(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "mcp-proxy")
 	real := filepath.Join(dir, "obsigna-mcp")
-	goBuild(t, shim, "github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy")
-	goBuild(t, real, "github.com/agent-receipts/ar/mcp-proxy/cmd/obsigna-mcp")
+	goBuild(t, shim, "obsigna.dev/mcp-proxy/cmd/mcp-proxy")
+	goBuild(t, real, "obsigna.dev/mcp-proxy/cmd/obsigna-mcp")
 
 	out, errOut, code := runBin(t, shim, "--version")
 	if code != 0 {

--- a/mcp-proxy/cmd/obsigna-mcp/cli.go
+++ b/mcp-proxy/cmd/obsigna-mcp/cli.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
+	"obsigna.dev/mcp-proxy/internal/policy"
 )
 
 // DoctorReport is the structured output of `mcp-proxy doctor`. Exposed for

--- a/mcp-proxy/cmd/obsigna-mcp/emitter_integration_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/emitter_integration_test.go
@@ -25,11 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/mcp-proxy/configs"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/mcp-proxy/configs"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // shortSocketDirEmitter returns a temp directory with a short enough path that

--- a/mcp-proxy/cmd/obsigna-mcp/import_guard_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/import_guard_test.go
@@ -30,10 +30,10 @@ import (
 // transitively.
 var allowedNonStdlibDeps = []allowedDep{
 	// The proxy's own packages (internal/{audit,host,policy,proxy} and cmd/...).
-	{prefix: "github.com/agent-receipts/ar/mcp-proxy/"},
+	{prefix: "obsigna.dev/mcp-proxy/"},
 	// The daemon emitter — the proxy's one writer-side dependency (ADR-0010).
-	{exact: "github.com/agent-receipts/ar/sdk/go/emitter"},
-	{prefix: "github.com/agent-receipts/ar/sdk/go/emitter/"},
+	{exact: "obsigna.dev/sdk/go/emitter"},
+	{prefix: "obsigna.dev/sdk/go/emitter/"},
 	// Session IDs (google/uuid) and policy-rule YAML (gopkg.in/yaml.v3).
 	{exact: "github.com/google/uuid"},
 	{exact: "gopkg.in/yaml.v3"},
@@ -48,8 +48,8 @@ var allowedNonStdlibDeps = []allowedDep{
 	// receipt-free — they pull in no signing/crypto/store, so allowlisting them
 	// keeps the thin-emitter boundary intact. taxonomy's own import-guard test
 	// enforces that it never regains a receipt dependency.
-	{exact: "github.com/agent-receipts/ar/sdk/go/taxonomy"},
-	{exact: "github.com/agent-receipts/ar/sdk/go/risk"},
+	{exact: "obsigna.dev/sdk/go/taxonomy"},
+	{exact: "obsigna.dev/sdk/go/risk"},
 }
 
 type allowedDep struct {

--- a/mcp-proxy/cmd/obsigna-mcp/main.go
+++ b/mcp-proxy/cmd/obsigna-mcp/main.go
@@ -21,14 +21,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/mcp-proxy/configs"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/host"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/proxy"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
 	"github.com/google/uuid"
+	"obsigna.dev/mcp-proxy/configs"
+	"obsigna.dev/mcp-proxy/internal/audit"
+	"obsigna.dev/mcp-proxy/internal/host"
+	"obsigna.dev/mcp-proxy/internal/policy"
+	"obsigna.dev/mcp-proxy/internal/proxy"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 // httpShutdownGrace bounds how long the approval HTTP server gets to finish

--- a/mcp-proxy/cmd/obsigna-mcp/main_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/main_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
+	"obsigna.dev/mcp-proxy/internal/audit"
+	"obsigna.dev/mcp-proxy/internal/policy"
 )
 
 func TestBuildApprovalDeniedMessageTimeout(t *testing.T) {

--- a/mcp-proxy/cmd/obsigna-mcp/shutdown_test.go
+++ b/mcp-proxy/cmd/obsigna-mcp/shutdown_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
+	"obsigna.dev/mcp-proxy/internal/audit"
 )
 
 // waitAccepting blocks until the approval server on addr accepts a TCP

--- a/mcp-proxy/configs/configs.go
+++ b/mcp-proxy/configs/configs.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 //go:embed *_taxonomy.json

--- a/mcp-proxy/e2e_daemon_test.go
+++ b/mcp-proxy/e2e_daemon_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // e2eDaemon is a live agent-receipts daemon started in-process for the

--- a/mcp-proxy/go.mod
+++ b/mcp-proxy/go.mod
@@ -1,10 +1,8 @@
-module github.com/agent-receipts/ar/mcp-proxy
+module obsigna.dev/mcp-proxy
 
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/daemon v0.23.0
-	github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 	github.com/google/uuid v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/mcp-proxy/integration_test.go
+++ b/mcp-proxy/integration_test.go
@@ -5,9 +5,9 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/agent-receipts/ar/mcp-proxy/internal/audit"
-	"github.com/agent-receipts/ar/mcp-proxy/internal/policy"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/mcp-proxy/internal/audit"
+	"obsigna.dev/mcp-proxy/internal/policy"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 // TestToolClassificationFallback verifies that prefix-based classification

--- a/mcp-proxy/internal/proxy/proxy_parallel_test.go
+++ b/mcp-proxy/internal/proxy/proxy_parallel_test.go
@@ -76,10 +76,10 @@ func startParallelProxy(t *testing.T, proxyBin, fakeserverBin string, extraEnv [
 func TestParallelToolCalls(t *testing.T) {
 	tmpDir := t.TempDir()
 	proxyBin := buildTestBinary(t,
-		"github.com/agent-receipts/ar/mcp-proxy/cmd/obsigna-mcp",
+		"obsigna.dev/mcp-proxy/cmd/obsigna-mcp",
 		tmpDir, "obsigna-mcp")
 	fakeBin := buildTestBinary(t,
-		"github.com/agent-receipts/ar/mcp-proxy/internal/proxy/testdata/fakeserver",
+		"obsigna.dev/mcp-proxy/internal/proxy/testdata/fakeserver",
 		tmpDir, "fakeserver")
 
 	t.Run("AllRespond", func(t *testing.T) {

--- a/scripts/readme_snippets/check.py
+++ b/scripts/readme_snippets/check.py
@@ -47,7 +47,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import extract  # noqa: E402
 
-GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+GO_MODULE = "obsigna.dev/sdk/go"
 TS_PACKAGE = "@obsigna/sdk-ts"
 PY_PACKAGE = "obsigna"
 MYPY_VERSION = "mypy==2.1.0"
@@ -147,7 +147,7 @@ def _resolve_version(lang: str, repo_root: str, override: str | None) -> str:
 # --------------------------------------------------------------------------- #
 
 
-_GO_ENV = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
+_GO_ENV_PUBLISHED = {"GOFLAGS": "-mod=mod", "GOWORK": "off"}
 
 
 def _go_noncanonical_guard(units: list[extract.Unit]) -> bool:
@@ -163,20 +163,52 @@ def _go_noncanonical_guard(units: list[extract.Unit]) -> bool:
     return found
 
 
-def _write_go_mod(source: str, version: str | None, repo_root: str, workdir: str) -> int:
-    """Write a throwaway go.mod for the snippet module; return the retry budget."""
+def _go_workspace_uses(repo_root: str) -> list[str]:
+    """Return absolute paths of the `use` directives in repo-root go.work."""
+    import re as _re
+
+    go_work = os.path.join(repo_root, "go.work")
+    paths: list[str] = []
+    try:
+        with open(go_work, encoding="utf-8") as fh:
+            for line in fh:
+                m = _re.match(r"\s*(\./\S+)", line)
+                if m:
+                    paths.append(os.path.normpath(os.path.join(repo_root, m.group(1))))
+    except OSError:
+        pass  # go.work absent or unreadable → return empty list, caller skips workspace setup
+    return paths
+
+
+def _write_go_mod_and_env(source: str, version: str | None, repo_root: str, workdir: str) -> tuple[int, dict[str, str]]:
+    """Write a throwaway go.mod; return (retry_budget, go_env)."""
     go_mod = ["module example.com/readme-snippets\n", "go 1.26.1\n"]
     if source == "local":
-        sdk_path = os.path.join(repo_root, "sdk", "go")
-        # Throwaway module — a local replace here is fine and never published
-        # (publish-go.yml only rejects replaces in the SDK's own go.mod).
-        go_mod.append(f"require {GO_MODULE} v0.0.0\n")
-        go_mod.append(f"replace {GO_MODULE} => {sdk_path}\n")
+        # In local mode use a go.work that includes all workspace modules so
+        # `go mod tidy` resolves workspace deps (e.g. obsigna.dev/daemon, imported
+        # by sdk/go test files) from local paths rather than hitting the proxy.
+        # Use realpath so go.work 'use' entries match how Go canonicalises the
+        # current directory (important on macOS where /var is a symlink to
+        # /private/var — a path mismatch causes "directory prefix . does not
+        # contain modules listed in go.work").
+        real_workdir = os.path.realpath(workdir)
+        go_work_lines = [f"go 1.26.1\n\nuse (\n\t{real_workdir}\n"]
+        for abs_path in _go_workspace_uses(repo_root):
+            go_work_lines.append(f"\t{abs_path}\n")
+        go_work_lines.append(")\n")
+        go_work_path = os.path.join(workdir, "go.work")
+        with open(go_work_path, "w", encoding="utf-8") as fh:
+            fh.writelines(go_work_lines)
+        # workspace mode: -mod=mod is invalid; workspace provides all local deps.
+        go_env = {"GOWORK": go_work_path}
+        retries = 0
     else:
         go_mod.append(f"require {GO_MODULE} v{version}\n")
+        go_env = _GO_ENV_PUBLISHED
+        retries = 4
     with open(os.path.join(workdir, "go.mod"), "w", encoding="utf-8") as fh:
         fh.writelines(go_mod)
-    return 4 if source == "published" else 0
+    return retries, go_env
 
 
 def check_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
@@ -187,16 +219,21 @@ def check_go(units: list[extract.Unit], source: str, version: str | None, repo_r
     if _go_noncanonical_guard(units):
         return 1
 
-    network_retries = _write_go_mod(source, version, repo_root, workdir)
+    network_retries, go_env = _write_go_mod_and_env(source, version, repo_root, workdir)
 
     for n, unit in enumerate(units, start=1):
         pkg_dir = os.path.join(workdir, f"snippet_{n:03d}")
         os.makedirs(pkg_dir, exist_ok=True)
         _write_unit(pkg_dir, "main.go", unit)
 
-    if _run(["go", "mod", "tidy"], cwd=workdir, env=_GO_ENV, retries=network_retries) != 0:
-        return 1
-    return _run(["go", "build", "./..."], cwd=workdir, env=_GO_ENV)
+    # In local (workspace) mode, go mod tidy tries to verify workspace modules
+    # against the proxy (for go.sum) and fails with a module-path mismatch when
+    # the published version still carries the old module path. Skip tidy for local
+    # builds: the workspace resolves all deps directly without proxy interaction.
+    if source != "local":
+        if _run(["go", "mod", "tidy"], cwd=workdir, env=go_env, retries=network_retries) != 0:
+            return 1
+    return _run(["go", "build", "./..."], cwd=workdir, env=go_env)
 
 
 def run_go(units: list[extract.Unit], source: str, version: str | None, repo_root: str, workdir: str) -> int:
@@ -207,19 +244,20 @@ def run_go(units: list[extract.Unit], source: str, version: str | None, repo_roo
     if _go_noncanonical_guard(runnable):
         return 1
 
-    network_retries = _write_go_mod(source, version, repo_root, workdir)
+    network_retries, go_env = _write_go_mod_and_env(source, version, repo_root, workdir)
 
     # build_units(mode="run") rendered each unit as an executable `package main`.
     run_dirs = [
         _prepare_run_dir(workdir, n, "main.go", unit) for n, unit in enumerate(runnable, start=1)
     ]
 
-    if _run(["go", "mod", "tidy"], cwd=workdir, env=_GO_ENV, retries=network_retries) != 0:
-        return 1
+    if source != "local":
+        if _run(["go", "mod", "tidy"], cwd=workdir, env=go_env, retries=network_retries) != 0:
+            return 1
 
     failures: list[extract.Unit] = []
     for unit, run_dir in zip(runnable, run_dirs, strict=True):
-        if _run(["go", "run", "."], cwd=run_dir, env=_GO_ENV) != 0:
+        if _run(["go", "run", "."], cwd=run_dir, env=go_env) != 0:
             failures.append(unit)
     return _summarize_run(failures, runnable, "Go")
 

--- a/scripts/readme_snippets/extract.py
+++ b/scripts/readme_snippets/extract.py
@@ -47,12 +47,12 @@ _INFO_TO_LANG = {
 }
 
 # A block counts as "documents the SDK" only if its body matches one of these.
-# The Go pattern deliberately matches the *wrong* module path too
-# (``agent-receipts/sdk-go`` vs the real ``agent-receipts/ar/sdk/go``) so that a
-# snippet importing a non-existent module is still selected and then fails to
+# The Go pattern deliberately matches the *wrong* module paths too
+# (``agent-receipts/sdk-go``, ``github.com/agent-receipts/ar/sdk/go``) so that a
+# snippet importing a non-existent or stale module is still selected and then fails to
 # build — that drift is exactly what we want to surface.
 _SDK_IMPORT_PATTERN = {
-    "go": re.compile(r"github\.com/agent-receipts/(?:ar/sdk/go|sdk-go)"),
+    "go": re.compile(r"(?:obsigna\.dev/sdk/go|github\.com/agent-receipts/(?:ar/sdk/go|sdk-go))"),
     "ts": re.compile(r"""['"]@obsigna/sdk-ts(?:/[\w-]+)?['"]"""),
     "py": re.compile(r"\b(?:from|import)\s+obsigna\b"),
 }
@@ -333,21 +333,22 @@ def _render_go(code: str, mode: str = "typecheck") -> str:
     return "\n".join(out) + "\n"
 
 
-_GO_AR_IMPORT_RE = re.compile(r'"(github\.com/agent-receipts/[^"]+)"')
-_GO_CANONICAL_PREFIX = "github.com/agent-receipts/ar/sdk/go"
+_GO_SDK_IMPORT_RE = re.compile(r'"((?:obsigna\.dev/sdk/go|github\.com/agent-receipts/(?:ar/sdk/go|sdk-go))[^"]*)"')
+_GO_CANONICAL_PREFIX = "obsigna.dev/sdk/go"
 
 
 def go_noncanonical_imports(code: str) -> list[str]:
-    """Return any ``agent-receipts`` Go import paths that aren't the canonical SDK.
+    """Return any sdk/go import paths that aren't the canonical module path.
 
-    A stale module (``github.com/agent-receipts/sdk-go``) is still resolvable on
-    the proxy, so a wrong import path can silently *build*. This static guard
-    fails the check anyway — a documented module path must be the one users get
-    from ``go get github.com/agent-receipts/ar/sdk/go``.
+    Both stale paths (``github.com/agent-receipts/sdk-go``,
+    ``github.com/agent-receipts/ar/sdk/go``) are still resolvable on the proxy,
+    so a wrong import path can silently *build*. This static guard fails the
+    check anyway — a documented module path must be the one users get from
+    ``go get obsigna.dev/sdk/go``.
     """
 
     bad: list[str] = []
-    for path in _GO_AR_IMPORT_RE.findall(code):
+    for path in _GO_SDK_IMPORT_RE.findall(code):
         if path != _GO_CANONICAL_PREFIX and not path.startswith(_GO_CANONICAL_PREFIX + "/"):
             bad.append(path)
     return bad

--- a/scripts/readme_snippets/test_extract.py
+++ b/scripts/readme_snippets/test_extract.py
@@ -155,7 +155,7 @@ func main() { _ = receipt.GenerateKeyPair }
 
 def test_full_go_program_repackaged_as_library() -> None:
     # `package main` is rewritten so a block without `func main` still builds.
-    code = 'package main\n\nimport "github.com/agent-receipts/ar/sdk/go/receipt"\n\nfunc deliver() { _ = receipt.GenerateKeyPair }'
+    code = 'package main\n\nimport "obsigna.dev/sdk/go/receipt"\n\nfunc deliver() { _ = receipt.GenerateKeyPair }'
     text = f"```go\n{code}\n```\n"
     (unit,) = extract.build_units("R.md", text, "go")
     assert unit.code.startswith("package snippet")
@@ -166,7 +166,7 @@ def test_full_go_program_repackaged_as_library() -> None:
 def test_bare_go_snippet_is_wrapped_and_suppresses_unused() -> None:
     text = """
 ```go
-import "github.com/agent-receipts/ar/sdk/go/receipt"
+import "obsigna.dev/sdk/go/receipt"
 
 keys, _ := receipt.GenerateKeyPair()
 unsigned := receipt.Create(receipt.CreateInput{})
@@ -177,7 +177,7 @@ signed, _ := receipt.Sign(unsigned, keys.PrivateKey, "k")
     code = unit.code
     assert code.startswith("package snippet")
     assert "func run() {" in code
-    assert 'import (\n\t"github.com/agent-receipts/ar/sdk/go/receipt"\n)' in code
+    assert 'import (\n\t"obsigna.dev/sdk/go/receipt"\n)' in code
     # Every locally declared value is referenced so Go won't reject it.
     assert "_ = keys" in code
     assert "_ = unsigned" in code
@@ -189,7 +189,7 @@ def test_bare_go_snippet_with_import_block() -> None:
 ```go
 import (
 	"fmt"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 fmt.Println(receipt.GenerateKeyPair())
@@ -197,45 +197,50 @@ fmt.Println(receipt.GenerateKeyPair())
 """
     (unit,) = extract.build_units("R.md", text, "go")
     assert '"fmt"' in unit.code
-    assert '"github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
+    assert '"obsigna.dev/sdk/go/receipt"' in unit.code
 
 
 def test_go_noncanonical_imports_flags_stale_module() -> None:
+    # Both the pre-ADR-0037 canonical path and the old stale module are non-canonical.
     code = (
         'import "github.com/agent-receipts/sdk-go/receipt"\n'
         'import "github.com/agent-receipts/ar/sdk/go/store"\n'
+        'import "obsigna.dev/sdk/go/emitter"\n'
     )
-    assert extract.go_noncanonical_imports(code) == ["github.com/agent-receipts/sdk-go/receipt"]
+    result = extract.go_noncanonical_imports(code)
+    assert "github.com/agent-receipts/sdk-go/receipt" in result
+    assert "github.com/agent-receipts/ar/sdk/go/store" in result
+    assert "obsigna.dev/sdk/go/emitter" not in result
 
 
 def test_go_noncanonical_imports_accepts_canonical() -> None:
     code = (
-        'import "github.com/agent-receipts/ar/sdk/go"\n'
-        'import "github.com/agent-receipts/ar/sdk/go/emitter"\n'
+        'import "obsigna.dev/sdk/go"\n'
+        'import "obsigna.dev/sdk/go/emitter"\n'
     )
     assert extract.go_noncanonical_imports(code) == []
 
 
 def test_single_aliased_import_preserved() -> None:
-    text = '```go\nimport rcpt "github.com/agent-receipts/ar/sdk/go/receipt"\n\nrcpt.GenerateKeyPair()\n```\n'
+    text = '```go\nimport rcpt "obsigna.dev/sdk/go/receipt"\n\nrcpt.GenerateKeyPair()\n```\n'
     (unit,) = extract.build_units("R.md", text, "go")
-    assert 'rcpt "github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
+    assert 'rcpt "obsigna.dev/sdk/go/receipt"' in unit.code
 
 
 def test_import_block_preserves_alias_and_blank() -> None:
     text = """
 ```go
 import (
-	_ "github.com/agent-receipts/ar/sdk/go/receipt"
-	st "github.com/agent-receipts/ar/sdk/go/store"
+	_ "obsigna.dev/sdk/go/receipt"
+	st "obsigna.dev/sdk/go/store"
 )
 
 st.Open("x")
 ```
 """
     (unit,) = extract.build_units("R.md", text, "go")
-    assert '_ "github.com/agent-receipts/ar/sdk/go/receipt"' in unit.code
-    assert 'st "github.com/agent-receipts/ar/sdk/go/store"' in unit.code
+    assert '_ "obsigna.dev/sdk/go/receipt"' in unit.code
+    assert 'st "obsigna.dev/sdk/go/store"' in unit.code
 
 
 def test_mdx_jsx_comment_directive() -> None:
@@ -357,7 +362,7 @@ http.emit(receipt)
 def test_go_run_mode_wraps_bare_snippet_as_main() -> None:
     text = """
 ```go
-import "github.com/agent-receipts/ar/sdk/go/receipt"
+import "obsigna.dev/sdk/go/receipt"
 
 keys, _ := receipt.GenerateKeyPair()
 ```
@@ -371,7 +376,7 @@ keys, _ := receipt.GenerateKeyPair()
 def test_go_run_mode_keeps_full_program_as_main() -> None:
     code = (
         "package main\n\n"
-        'import "github.com/agent-receipts/ar/sdk/go/receipt"\n\n'
+        'import "obsigna.dev/sdk/go/receipt"\n\n'
         "func main() { _, _ = receipt.GenerateKeyPair() }"
     )
     text = f"```go\n{code}\n```\n"
@@ -385,7 +390,7 @@ def test_go_typecheck_mode_still_library_package() -> None:
     # Default mode is unchanged: a bare snippet becomes a library package.
     text = """
 ```go
-import "github.com/agent-receipts/ar/sdk/go/receipt"
+import "obsigna.dev/sdk/go/receipt"
 
 keys, _ := receipt.GenerateKeyPair()
 ```
@@ -399,13 +404,13 @@ def test_go_continues_is_rejected_loudly() -> None:
     text = """
 ```go
 package main
-import "github.com/agent-receipts/ar/sdk/go/receipt"
+import "obsigna.dev/sdk/go/receipt"
 func main() { _ = receipt.GenerateKeyPair }
 ```
 
 <!-- snippet-check: continues -->
 ```go
-import "github.com/agent-receipts/ar/sdk/go/store"
+import "obsigna.dev/sdk/go/store"
 _ = store.Open
 ```
 """

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -18,7 +18,7 @@
 ## Install
 
 ```sh
-go get github.com/agent-receipts/ar/sdk/go
+go get obsigna.dev/sdk/go
 ```
 
 ## Packages
@@ -50,7 +50,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 func main() {
@@ -101,9 +101,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 func main() {
@@ -175,8 +175,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func deliver(signed receipt.AgentReceipt) {
@@ -225,9 +225,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/agent-receipts/ar/sdk/go/chain"
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/chain"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func main() {

--- a/sdk/go/aws/go.mod
+++ b/sdk/go/aws/go.mod
@@ -1,4 +1,4 @@
-module github.com/agent-receipts/ar/sdk/go/aws
+module obsigna.dev/sdk/go/aws
 
 go 1.26.1
 

--- a/sdk/go/aws/integration_test.go
+++ b/sdk/go/aws/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	awssigner "github.com/agent-receipts/ar/sdk/go/aws"
+	awssigner "obsigna.dev/sdk/go/aws"
 )
 
 // envIntegrationKeyARN names the KMS key the integration test signs with. The

--- a/sdk/go/chain/chain.go
+++ b/sdk/go/chain/chain.go
@@ -30,8 +30,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // EmitInput holds the per-receipt inputs accepted by [ReceiptChain.Emit]. It

--- a/sdk/go/chain/chain_test.go
+++ b/sdk/go/chain/chain_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/chain"
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/chain"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 const verificationMethod = "did:agent:test#key-1"

--- a/sdk/go/cross_language_test.go
+++ b/sdk/go/cross_language_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 type testVectors struct {

--- a/sdk/go/emitter/emitter.go
+++ b/sdk/go/emitter/emitter.go
@@ -286,7 +286,7 @@ func WithIdentity(id Identity) Option {
 // Per ADR-0020 step 1, this type is the legacy daemon-socket adapter and
 // its Emit(ctx, Event) signature takes an unsigned tool-call event frame —
 // not an AgentReceipt. It therefore does NOT implement the new Emitter
-// interface defined in github.com/agent-receipts/ar/sdk/go/emitters. Step 2
+// interface defined in obsigna.dev/sdk/go/emitters. Step 2
 // of the migration (daemon learns to ingest signed receipts) is tracked
 // separately.
 type DaemonEmitter struct {

--- a/sdk/go/emitter/emitter_test.go
+++ b/sdk/go/emitter/emitter_test.go
@@ -3,7 +3,7 @@
 // Tests run end-to-end against an in-process agent-receipts daemon.
 //
 // Build-tag-gated to:
-//   - integration: the test imports github.com/agent-receipts/ar/daemon, but
+//   - integration: the test imports obsigna.dev/daemon, but
 //     sdk/go's published go.mod cannot require the daemon module — daemon
 //     already requires sdk/go, and a back-edge would create an import cycle.
 //     Under GOWORK=off (publish/verify path) the import would fail to resolve,
@@ -35,10 +35,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/daemon"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/daemon"
+	"obsigna.dev/sdk/go/emitter"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
 )
 
 // shortSocketDir returns a temp directory whose path is short enough that a

--- a/sdk/go/emitters/buffering.go
+++ b/sdk/go/emitters/buffering.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // BufferingEmitterConfig configures [BufferingEmitter].

--- a/sdk/go/emitters/buffering_test.go
+++ b/sdk/go/emitters/buffering_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // signalingEmitter notifies on every Emit so timer-driven tests don't have

--- a/sdk/go/emitters/composite.go
+++ b/sdk/go/emitters/composite.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // CompositeEmitter forwards each receipt to a list of child emitters

--- a/sdk/go/emitters/composite_test.go
+++ b/sdk/go/emitters/composite_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // failingEmitter always returns the configured error.

--- a/sdk/go/emitters/emitters.go
+++ b/sdk/go/emitters/emitters.go
@@ -27,7 +27,7 @@ package emitters
 import (
 	"context"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // Emitter delivers a signed [receipt.AgentReceipt]. Implementations handle

--- a/sdk/go/emitters/helpers_test.go
+++ b/sdk/go/emitters/helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // emitterFunc adapts a function literal to the emitters.Emitter

--- a/sdk/go/emitters/http.go
+++ b/sdk/go/emitters/http.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // Strategy selects how Emit treats the call: synchronously waiting for

--- a/sdk/go/emitters/http_test.go
+++ b/sdk/go/emitters/http_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
+	"obsigna.dev/sdk/go/emitters"
 )
 
 // collector wraps an httptest.Server with helpers for capturing inbound

--- a/sdk/go/emitters/in_memory.go
+++ b/sdk/go/emitters/in_memory.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // InMemoryEmitter captures emitted receipts in an exposed slice. Performs

--- a/sdk/go/emitters/in_memory_test.go
+++ b/sdk/go/emitters/in_memory_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func fakeReceipt(id string) receipt.AgentReceipt {

--- a/sdk/go/emitters/wal.go
+++ b/sdk/go/emitters/wal.go
@@ -52,7 +52,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // Wal is a backend that durably records receipts awaiting acknowledgement.

--- a/sdk/go/emitters/wal_test.go
+++ b/sdk/go/emitters/wal_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // walReceipt builds a minimal receipt with the given id and chain sequence so

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,9 +1,8 @@
-module github.com/agent-receipts/ar/sdk/go
+module obsigna.dev/sdk/go
 
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/daemon v0.23.0
 	github.com/cloudflare/circl v1.6.3
 	github.com/google/uuid v1.6.0
 	modernc.org/sqlite v1.52.0

--- a/sdk/go/integration_test.go
+++ b/sdk/go/integration_test.go
@@ -5,9 +5,9 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/store"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/store"
+	"obsigna.dev/sdk/go/taxonomy"
 )
 
 func TestReceiptFullLifecycle(t *testing.T) {

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/agent-receipts/ar/sdk/go/risk"
+	"obsigna.dev/sdk/go/risk"
 )
 
 // Protocol constants (unexported to prevent mutation).

--- a/sdk/go/risk/risk_test.go
+++ b/sdk/go/risk/risk_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/risk"
+	"obsigna.dev/sdk/go/risk"
 )
 
 func TestLevelValues(t *testing.T) {
@@ -34,14 +34,14 @@ func TestPTYActionTypes(t *testing.T) {
 // TestRiskIsLeaf asserts the risk package imports nothing from this module — it
 // must stay a true leaf so receipt-free callers can depend on it.
 func TestRiskIsLeaf(t *testing.T) {
-	const modulePrefix = "github.com/agent-receipts/ar/"
+	const modulePrefix = "obsigna.dev/"
 
-	out, err := exec.Command("go", "list", "-deps", "github.com/agent-receipts/ar/sdk/go/risk").Output()
+	out, err := exec.Command("go", "list", "-deps", "obsigna.dev/sdk/go/risk").Output()
 	if err != nil {
 		t.Fatalf("go list -deps risk: %v", err)
 	}
 	for _, dep := range strings.Fields(string(out)) {
-		if dep == "github.com/agent-receipts/ar/sdk/go/risk" {
+		if dep == "obsigna.dev/sdk/go/risk" {
 			continue
 		}
 		if strings.HasPrefix(dep, modulePrefix) {

--- a/sdk/go/store/store.go
+++ b/sdk/go/store/store.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 
 	_ "modernc.org/sqlite"
 )

--- a/sdk/go/store/store_test.go
+++ b/sdk/go/store/store_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func setupStore(t *testing.T) *Store {

--- a/sdk/go/taxonomy/import_guard_test.go
+++ b/sdk/go/taxonomy/import_guard_test.go
@@ -16,9 +16,9 @@ import (
 // `go list -deps` reports only the non-test (production) dependency graph, so a
 // test-only import of receipt (in this package or any other) does not count.
 func TestTaxonomyDoesNotImportReceipt(t *testing.T) {
-	const receiptPkg = "github.com/agent-receipts/ar/sdk/go/receipt"
+	const receiptPkg = "obsigna.dev/sdk/go/receipt"
 
-	out, err := exec.Command("go", "list", "-deps", "github.com/agent-receipts/ar/sdk/go/taxonomy").Output()
+	out, err := exec.Command("go", "list", "-deps", "obsigna.dev/sdk/go/taxonomy").Output()
 	if err != nil {
 		t.Fatalf("go list -deps taxonomy: %v", err)
 	}

--- a/sdk/go/taxonomy/spec_test.go
+++ b/sdk/go/taxonomy/spec_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 type specTaxonomy struct {

--- a/sdk/go/taxonomy/taxonomy.go
+++ b/sdk/go/taxonomy/taxonomy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/risk"
+	"obsigna.dev/sdk/go/risk"
 )
 
 // ActionTypeEntry describes a known action type.

--- a/sdk/go/taxonomy/taxonomy_test.go
+++ b/sdk/go/taxonomy/taxonomy_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func TestClassifyToolCallWithMapping(t *testing.T) {

--- a/site-obsigna/src/content/docs/deployment/ephemeral-compute.mdx
+++ b/site-obsigna/src/content/docs/deployment/ephemeral-compute.mdx
@@ -91,7 +91,7 @@ Signer:
   getPublicKey()     -> raw 32-byte Ed25519 public key (RFC 8032 §5.1.5)
 ```
 
-The AWS **`KMSSigner`** has shipped in the Go SDK's `aws` module (`github.com/agent-receipts/ar/sdk/go/aws`). It uses an `ECC_NIST_EDWARDS25519` KMS key with `SIGN_VERIFY` usage, signs via `kms:Sign` with `ED25519_SHA_512` / `MessageType=RAW` (standard pure Ed25519), and resolves credentials from the ambient AWS chain (instance role, IRSA, environment, shared profile).
+The AWS **`KMSSigner`** has shipped in the Go SDK's `aws` module (`obsigna.dev/sdk/go/aws`). It uses an `ECC_NIST_EDWARDS25519` KMS key with `SIGN_VERIFY` usage, signs via `kms:Sign` with `ED25519_SHA_512` / `MessageType=RAW` (standard pure Ed25519), and resolves credentials from the ambient AWS chain (instance role, IRSA, environment, shared profile).
 
 :::caution
 Two parts of the KMS production story are still landing (tracked in [#534](https://github.com/agent-receipts/obsigna/issues/534)):
@@ -184,8 +184,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/emitters"
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/emitters"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // Module-scope: built once, reused across warm invocations.

--- a/site-obsigna/src/content/docs/getting-started/daemon-setup.mdx
+++ b/site-obsigna/src/content/docs/getting-started/daemon-setup.mdx
@@ -167,7 +167,7 @@ export AGENTRECEIPTS_SOCKET=/path/to/events.sock   # overrides the platform defa
 ```go
 import (
 	"log"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 e, err := emitter.NewDaemon(emitter.WithSocketPath("/path/to/events.sock"))
@@ -181,7 +181,7 @@ if err != nil {
 ```go
 import (
 	"log"
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 e, err := emitter.NewDaemon()

--- a/site-obsigna/src/content/docs/getting-started/quick-start.mdx
+++ b/site-obsigna/src/content/docs/getting-started/quick-start.mdx
@@ -165,7 +165,7 @@ for your platform), then add the Go SDK to a module:
 
 ```bash
 go mod init example.com/myapp   # in a fresh directory, if you don't already have a module
-go get github.com/agent-receipts/ar/sdk/go/emitter
+go get obsigna.dev/sdk/go/emitter
 ```
 
 ### 2. Start the daemon
@@ -194,7 +194,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/agent-receipts/ar/sdk/go/emitter"
+	"obsigna.dev/sdk/go/emitter"
 )
 
 func main() {

--- a/site-obsigna/src/content/docs/sdk-go/api-reference.mdx
+++ b/site-obsigna/src/content/docs/sdk-go/api-reference.mdx
@@ -7,7 +7,7 @@ description: Go SDK API reference.
 
 {/* snippet-check: skip */}
 ```go
-import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+import receipt "obsigna.dev/sdk/go/receipt"
 ```
 
 Core package for creating, signing, verifying, and chaining Agent Receipts.
@@ -249,7 +249,7 @@ const (
 
 {/* snippet-check: skip */}
 ```go
-import receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+import receipt "obsigna.dev/sdk/go/receipt"
 ```
 
 HPKE-based envelope for encrypting tool-call parameters into a receipt's
@@ -369,7 +369,7 @@ import (
     "log"
     "os"
 
-    receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+    receipt "obsigna.dev/sdk/go/receipt"
 )
 
 // raw 32-byte private key written by --init-forensic-key (kept offline)
@@ -442,7 +442,7 @@ RFC 9180 §4.1 (`enc`, not `encap`).
 
 {/* snippet-check: skip */}
 ```go
-import "github.com/agent-receipts/ar/sdk/go/taxonomy"
+import "obsigna.dev/sdk/go/taxonomy"
 ```
 
 Action type registry and tool call classification.
@@ -525,7 +525,7 @@ type ClassificationResult struct {
 
 {/* snippet-check: skip */}
 ```go
-import "github.com/agent-receipts/ar/sdk/go/store"
+import "obsigna.dev/sdk/go/store"
 ```
 
 SQLite-backed receipt persistence, querying, and chain verification. Uses pure Go SQLite (no CGO) with WAL mode.

--- a/site-obsigna/src/content/docs/sdk-go/installation.mdx
+++ b/site-obsigna/src/content/docs/sdk-go/installation.mdx
@@ -6,7 +6,7 @@ description: Install and configure the Go SDK.
 ## Install
 
 ```bash
-go get github.com/agent-receipts/ar/sdk/go
+go get obsigna.dev/sdk/go
 ```
 
 Import the packages you need:
@@ -14,9 +14,9 @@ Import the packages you need:
 {/* snippet-check: skip */}
 ```go
 import (
-	receipt "github.com/agent-receipts/ar/sdk/go/receipt"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
-	"github.com/agent-receipts/ar/sdk/go/store"
+	receipt "obsigna.dev/sdk/go/receipt"
+	"obsigna.dev/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/store"
 )
 ```
 

--- a/site-obsigna/src/content/docs/sdk-go/overview.mdx
+++ b/site-obsigna/src/content/docs/sdk-go/overview.mdx
@@ -17,9 +17,9 @@ The Go SDK provides tools for creating, signing, and verifying Agent Receipts in
 
 | Package | Import | Description |
 |---------|--------|-------------|
-| `receipt` | `github.com/agent-receipts/ar/sdk/go/receipt` | Core receipt creation, signing, verification, and chaining |
-| `taxonomy` | `github.com/agent-receipts/ar/sdk/go/taxonomy` | Action type registry and tool call classification |
-| `store` | `github.com/agent-receipts/ar/sdk/go/store` | SQLite-backed persistence and querying |
+| `receipt` | `obsigna.dev/sdk/go/receipt` | Core receipt creation, signing, verification, and chaining |
+| `taxonomy` | `obsigna.dev/sdk/go/taxonomy` | Action type registry and tool call classification |
+| `store` | `obsigna.dev/sdk/go/store` | SQLite-backed persistence and querying |
 
 ## Quick example
 
@@ -34,7 +34,7 @@ import (
 	"fmt"
 	"log"
 
-	receipt "github.com/agent-receipts/ar/sdk/go/receipt"
+	receipt "obsigna.dev/sdk/go/receipt"
 )
 
 func main() {


### PR DESCRIPTION
## What

Completes ADR-0037 in a single PR (originally planned as PR2+PR3, merged here to avoid a chicken-and-egg dependency on the module proxy).

Flips every in-tree Go module from `github.com/agent-receipts/ar/…` to its `obsigna.dev/…` canonical path:

| Old | New |
|-----|-----|
| `github.com/agent-receipts/ar/daemon` | `obsigna.dev/daemon` |
| `github.com/agent-receipts/ar/mcp-proxy` | `obsigna.dev/mcp-proxy` |
| `github.com/agent-receipts/ar/hook` | `obsigna.dev/hook` |
| `github.com/agent-receipts/ar/collector` | `obsigna.dev/collector` |
| `github.com/agent-receipts/ar/cross-sdk-tests` | `obsigna.dev/cross-sdk-tests` |
| `github.com/agent-receipts/ar/sdk/go` | `obsigna.dev/sdk/go` |
| `github.com/agent-receipts/ar/sdk/go/aws` | `obsigna.dev/sdk/go/aws` |

## Changes

- `module` lines in all seven `go.mod` files
- Every import path in every `.go` file across all affected modules (127 files, ~700 lines)
- Cross-workspace `require` entries between `obsigna.dev/*` modules removed — `go.work` `use` directives provide them implicitly during the migration window until the first `obsigna.dev/*` tags are published
- Deprecation stubs in `dist/sdk-go-deprecation/` updated to point to `obsigna.dev/sdk/go` as the new canonical path
- Entrypoint guard test in `collector` updated to match new import path

## Why single PR instead of two

The original plan split this into PR2 (binary modules) + PR3 (sdk/go). The split fails in practice: `obsigna.dev/daemon@vX.Y.Z` resolves via the vanity proxy to the old GitHub module (still declaring `module github.com/agent-receipts/ar/daemon`), so any `require obsigna.dev/daemon vX.Y.Z` in a go.mod fails go's module path consistency check — even in workspace mode. Combining the flip means the first published `obsigna.dev/*` tag will have the correct module path, making future in-tree and external builds consistent.

## After this merges

1. Publish first `obsigna.dev/sdk/go` tag (e.g. `sdk/go/v0.22.0-alpha.2`)
2. Restore explicit `require obsigna.dev/sdk/go vX.Y.Z` entries in the go.mod files that need it (daemon, mcp-proxy, hook, etc.) pointing at the freshly published vanity tag
3. Cut `obsigna/v0.29.0-alpha.1` toolset release

## Test plan

- [x] `go build ./...` across all seven modules — clean
- [x] `go vet ./...` across all seven modules — clean
- [x] `go test ./...` — all 33 packages pass (including daemon race tests, mcp-proxy e2e, emitter integration)
- [x] Pre-push hook: Go tests, TS typecheck + tests (440 passed), Python tests (474 passed)
- [x] No old `github.com/agent-receipts/ar/…` paths remain in any `.go` or `go.mod` file