### PR TITLE
build(deps): bump undici 8.4.1 -> 8.5.0 in opencode-plugin

### DIFF
--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -544,8 +544,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.4.1:
-    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   uuid@14.0.0:
@@ -739,7 +739,7 @@ snapshots:
 
   '@obsigna/sdk-ts@0.14.1':
     dependencies:
-      undici: 8.4.1
+      undici: 8.5.0
       zod: 4.4.3
 
   '@opencode-ai/plugin@1.16.2':
@@ -1071,7 +1071,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.4.1: {}
+  undici@8.5.0: {}
 
   uuid@14.0.0: {}
 


### PR DESCRIPTION
Clears Dependabot alerts **#37–#43** (3 high, 2 medium, 2 low) against undici `>= 8.0.0, < 8.5.0`:

- **#41 / #37** (high): WebSocket client DoS via fragment count / cumulative fragment bypass
- **#39** (high): TLS certificate validation bypass via dropped `requestTls` in SOCKS5 `ProxyAgent`
- **#42** (medium): HTTP header injection via `Set-Cookie` percent-decoding
- **#38** (medium): cross-user information disclosure via shared-cache whitespace bypass
- **#40 / #43** (low): response queue poisoning via keep-alive socket reuse; `Set-Cookie` SameSite downgrade

## What changed
- `integrations/opencode-plugin/pnpm-lock.yaml`: undici `8.4.1` → `8.5.0`.

undici is transitive via `@obsigna/sdk-ts`; 8.5.0 satisfies the existing range, so only the resolved lockfile entry changes — no `package.json` edits. `sdk/ts` already pins `^8.3.0` and resolves 8.5.0, so the **published SDK is unaffected** and needs no change. `pnpm install --frozen-lockfile` passes.