### PR TITLE
chore(release): stamp CHANGELOG 0.29.0 + sdk/go 0.22.0 + sdk-ts 0.15.0 + sdk-py 0.14.0

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-06-23
+
+Graduates `0.29.0-alpha.1` after the alpha pass. No code changes since the alpha; this entry formally promotes the checkpoint anchor nil-guard hardening to stable.
+
 ## [0.29.0-alpha.1] - 2026-06-21
 
 ### Fixed

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-23
+
+Graduates `0.22.0-alpha.1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9): `GrantResolver` interface, `VerifyGroundedPrincipalTier`, `GroundedPrincipalViolation`, and `GroundedOutcome`.
+
 ## [0.22.0-alpha.1] - 2026-06-21
 
 ### Added

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-23
+
+Graduates `0.14.0a1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9): `GrantResolver` abstract base class and `verify_grounded_principal_tier`.
+
 ## [0.14.0a1] - 2026-06-21
 
 ### Added

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.14.0a1"
+version = "0.14.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "obsigna"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-23
+
+Graduates `0.15.0-alpha.1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9) and `outcome.response_disclosure` HPKE envelope (spec v0.6.0).
+
 ## [0.15.0-alpha.1] - 2026-06-21
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.15.0-alpha.1",
+	"version": "0.15.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
Promotes the current alpha series to stable.

## Changes

- `daemon/CHANGELOG.md` — adds `[0.29.0]` graduation entry
- `sdk/go/CHANGELOG.md` — adds `[0.22.0]` graduation entry
- `sdk/ts/CHANGELOG.md` — adds `[0.15.0]` graduation entry; bumps `package.json` version to `0.15.0`
- `sdk/py/CHANGELOG.md` — adds `[0.14.0]` graduation entry; bumps `pyproject.toml` + `uv.lock` version to `0.14.0`

## After merge, push stable tags

```bash
git tag obsigna/v0.29.0 <merge-commit>
git tag sdk/go/v0.22.0 <merge-commit>
git tag sdk-ts-v0.15.0 <merge-commit>
git tag sdk-py-v0.14.0 <merge-commit>
git push origin obsigna/v0.29.0 sdk/go/v0.22.0 sdk-ts-v0.15.0 sdk-py-v0.14.0
```

Each tag push triggers its release workflow (`release-obsigna.yml`, `release-sdk-go.yml`, `release-sdk-ts.yml`, `release-sdk-py.yml`).