### PR TITLE
fix(release): point Go release gates at obsigna.dev/sdk/go vanity path

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Request pkg.go.dev indexing
         run: |
           VERSION="${GITHUB_REF_NAME#sdk/go/v}"
-          URL="https://proxy.golang.org/github.com/agent-receipts/ar/sdk/go/@v/v${VERSION}.info"
+          URL="https://proxy.golang.org/obsigna.dev/sdk/go/@v/v${VERSION}.info"
           succeeded=false
           for attempt in 1 2 3; do
             if curl -fsS "$URL"; then succeeded=true; break; fi

--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-06-23
+
+Graduates `0.29.0-alpha.1` after the alpha pass. No code changes since the alpha; this entry formally promotes the checkpoint anchor nil-guard hardening to stable.
+
 ## [0.29.0-alpha.1] - 2026-06-21
 
 ### Fixed

--- a/scripts/byte_identity/check.py
+++ b/scripts/byte_identity/check.py
@@ -60,7 +60,7 @@ import time
 # Constants
 # ---------------------------------------------------------------------------
 
-GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+GO_MODULE = "obsigna.dev/sdk/go"
 TS_PACKAGE = "@obsigna/sdk-ts"
 PY_PACKAGE = "obsigna"
 
@@ -312,7 +312,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 type vectorFile struct {

--- a/scripts/daemon_protocol/check.py
+++ b/scripts/daemon_protocol/check.py
@@ -66,8 +66,8 @@ import urllib.request
 # Constants
 # ---------------------------------------------------------------------------
 
-GO_SDK_MODULE = "github.com/agent-receipts/ar/sdk/go"
-GO_DAEMON_MODULE = "github.com/agent-receipts/ar/daemon"
+GO_SDK_MODULE = "obsigna.dev/sdk/go"
+GO_DAEMON_MODULE = "obsigna.dev/daemon"
 TS_PACKAGE = "@obsigna/sdk-ts"
 PY_PACKAGE = "obsigna"
 
@@ -449,7 +449,7 @@ import (
 \t"fmt"
 \t"os"
 
-\t"github.com/agent-receipts/ar/sdk/go/emitter"
+\t"obsigna.dev/sdk/go/emitter"
 )
 
 func fail(err error) {

--- a/scripts/release_verify/check.py
+++ b/scripts/release_verify/check.py
@@ -44,7 +44,7 @@ import time
 # Constants
 # ---------------------------------------------------------------------------
 
-GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+GO_MODULE = "obsigna.dev/sdk/go"
 TS_PACKAGE = "@obsigna/sdk-ts"
 PY_PACKAGE = "obsigna"
 
@@ -191,7 +191,7 @@ def _parse_go_list_version(output: str) -> str | None:
     """Extract the version (without the leading 'v') from `go list -m` output.
 
     `go list -m` prints lines like:
-        github.com/agent-receipts/ar/sdk/go v0.12.0
+        obsigna.dev/sdk/go v0.12.0
 
     Returns the bare semver string (e.g. "0.12.0"), or None if not found.
     """
@@ -200,7 +200,7 @@ def _parse_go_list_version(output: str) -> str | None:
 
 
 def verify_go(version: str, workdir: str) -> int:
-    """Fetch github.com/agent-receipts/ar/sdk/go@vVERSION from the Go proxy
+    """Fetch obsigna.dev/sdk/go@vVERSION from the Go proxy
     and confirm the resolved version."""
     go_mod = [
         "module example.com/release-verify\n",

--- a/scripts/schema_conformance/check.py
+++ b/scripts/schema_conformance/check.py
@@ -50,7 +50,7 @@ import time
 # Constants
 # ---------------------------------------------------------------------------
 
-GO_MODULE = "github.com/agent-receipts/ar/sdk/go"
+GO_MODULE = "obsigna.dev/sdk/go"
 TS_PACKAGE = "@obsigna/sdk-ts"
 PY_PACKAGE = "obsigna"
 
@@ -218,7 +218,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 func main() {

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-23
+
+Graduates `0.22.0-alpha.1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9): `GrantResolver` interface, `VerifyGroundedPrincipalTier`, `GroundedPrincipalViolation`, and `GroundedOutcome`.
+
 ## [0.22.0-alpha.1] - 2026-06-21
 
 ### Added

--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-23
+
+Graduates `0.14.0a1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9): `GrantResolver` abstract base class and `verify_grounded_principal_tier`.
+
 ## [0.14.0a1] - 2026-06-21
 
 ### Added

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.14.0a1"
+version = "0.14.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "obsigna"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-23
+
+Graduates `0.15.0-alpha.1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9) and `outcome.response_disclosure` HPKE envelope (spec v0.6.0).
+
 ## [0.15.0-alpha.1] - 2026-06-21
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.15.0-alpha.1",
+	"version": "0.15.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## Why

Promoting the current alphas to stable (#925) surfaced that the release pipeline can't actually publish the Go SDK.

PR #922 (ADR-0037) migrated every in-tree Go module to its `obsigna.dev/…` canonical path, but **the release-gate scripts were not updated** — they're still pinned to the retired `github.com/agent-receipts/ar/sdk/go` module. Each post-release gate fetches the just-published module from the Go proxy by that constant, so an `sdk/go` release would go red resolving a path that no longer exists.

## What

- `scripts/release_verify/check.py` (Gate #2) — `GO_MODULE` + docstrings
- `scripts/schema_conformance/check.py` (Gate #6) — `GO_MODULE` + generated import
- `scripts/byte_identity/check.py` (Gate #7) — `GO_MODULE` + generated import
- `scripts/daemon_protocol/check.py` (Gate #8) — `GO_SDK_MODULE`/`GO_DAEMON_MODULE` + generated import
- `.github/workflows/publish-go.yml` — pkg.go.dev indexing proxy URL ⚠️ **workflow change, needs human review per AGENTS.md**

All four gate unit-test suites pass locally (`scripts/*/test_check.py`).

Left intentionally unchanged: `readme_snippets/extract.py` + `test_extract.py` (already use `obsigna.dev/sdk/go` as canonical; the old-path refs there are the *non-canonical* examples the stale-import guard flags) and `legacy_name_guard/test_check.py` (asserts the old Go path is out-of-scope for the brand guard).

## Not in this PR — follow-ups before the release train can run

1. **`usage_signal/check.py`** still references the old module path and the pre-rename `agent-receipts/ar` repo — analytics only, not release-blocking; separate cleanup.
2. **`daemon`/`hook`/`mcp-proxy` `go.mod` lack `require obsigna.dev/sdk/go`** — #922 dropped the cross-workspace requires for the migration window. With `GOWORK=off` (the release build) these can't resolve the SDK, so the obsigna train build fails until they're wired to the published `sdk/go` version. That wiring must land *after* `sdk/go` stable is on the proxy.