### PR TITLE
chore(release): stamp sdk/go CHANGELOG 0.23.0

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,8 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-23
+
 ### Changed
 
 - **Published `go.mod` no longer lists `github.com/BurntSushi/toml` or `gopkg.in/yaml.v3` as indirect dependencies.** The emitter↔daemon end-to-end integration test moved to the daemon module (which already requires sdk/go, the correct dependency direction), removing sdk/go's test-only import of `obsigna.dev/daemon`. That import was the only thing pulling the daemon's transitive deps into sdk/go's manifest and the reason `go mod tidy` against the published SDK tried — and failed — to resolve `obsigna.dev/daemon` (ADR-0037). `go get obsigna.dev/sdk/go` now resolves a smaller, daemon-free graph, and the post-release README-snippet and daemon-protocol gates run clean.


### PR DESCRIPTION
Promotes the `Unreleased` note (landed in #929) to `[0.23.0]`.

This is the release that publishes the **daemon-free** Go SDK, so its post-release `readme-snippets` and `daemon-protocol` gates run clean — closing out the ADR-0037-completion item. No source change beyond the CHANGELOG.

## After merge
Tag `sdk/go/v0.23.0` at the merge commit and push it alone.