### PR TITLE
fix(ci): prune stale toml/yaml entries from the Go dependency allowlist

### DIFF
--- a/scripts/dependency_manifest/allowlist.json
+++ b/scripts/dependency_manifest/allowlist.json
@@ -35,14 +35,6 @@
     {
       "name": "github.com/remyoudompheng/bigfft",
       "justification": "Transitive dependency of modernc.org/sqlite (declared) via modernc.org/mathutil; big-integer FFT multiplication."
-    },
-    {
-      "name": "gopkg.in/yaml.v3",
-      "justification": "Transitive dependency of github.com/agent-receipts/ar/daemon (declared in-repo module); used by the daemon's config handling."
-    },
-    {
-      "name": "github.com/BurntSushi/toml",
-      "justification": "Transitive dependency of github.com/agent-receipts/ar/daemon (declared in-repo module) via the daemon's TOML config parser; pulled into sdk/go's go.sum through the integration tests that run the in-tree daemon."
     }
   ],
   "py": [


### PR DESCRIPTION
## Why

The `sdk/go/v0.23.0` release was a near-complete success — the two ADR-0037 gates that were red on v0.22.0 (**readme-snippets**, **daemon-protocol**) both passed, and the SDK published. But the **dependency-manifest** (Gate #10) job went red on its unit-test step.

#929 removed sdk/go's test-only import of `obsigna.dev/daemon`, so `go mod tidy` dropped `github.com/BurntSushi/toml` and `gopkg.in/yaml.v3` from sdk/go's go.mod (they were only pulled transitively via the daemon integration test). That left their allowlist entries **orphaned**, and Gate #10's `test_no_stale_allowlist_entries` flags any allow-listed dep no longer installed in any Go manifest. This should have ridden along in #929 — it's the same change's fallout.

## What

Prune the two stale entries. Both are **direct** requires in the daemon/mcp-proxy modules, so they need no allowlist entry there.

## Validation

- `check.py --lang go` → `Gate #10 PASSED` ("all 12 installed deps declared or allow-listed")
- `test_check.py` → full suite passes (0 failures), including `test_no_stale_allowlist_entries`

## Note

`sdk/go v0.23.0` is published and consumable; this only affects the release's post-publish gate run. With this merged, future Go releases run Gate #10 green. (Whether to cut a `v0.23.1` for a fully-green release run on record is your call — the artifact itself is fine.)