### PR TITLE
refactor(sdk-go): extract portable checkpoint crypto into sdk/go/checkpoint

### DIFF
--- a/daemon/internal/checkpoint/checkpoint.go
+++ b/daemon/internal/checkpoint/checkpoint.go
@@ -10,9 +10,14 @@
 // daemon-local sink/log machinery.
 package checkpoint
 
-import sdk "obsigna.dev/sdk/go/checkpoint"
+import (
+	"crypto/ed25519"
 
-// Portable checkpoint types and crypto, re-exported from the SDK. See
+	sdk "obsigna.dev/sdk/go/checkpoint"
+)
+
+// Portable checkpoint types, re-exported from the SDK so the daemon's emitter,
+// reader, and callers keep one `checkpoint.*` surface. See
 // obsigna.dev/sdk/go/checkpoint for the design constraints (ADR-0008).
 type (
 	Checkpoint = sdk.Checkpoint
@@ -20,8 +25,14 @@ type (
 	Signer     = sdk.Signer
 )
 
-var (
-	Sign             = sdk.Sign
-	Verify           = sdk.Verify
-	PublicKeyFromPEM = sdk.PublicKeyFromPEM
-)
+// Sign, Verify, and PublicKeyFromPEM delegate to the SDK. They are thin wrapper
+// functions rather than var aliases so the crypto entrypoints stay immutable
+// (a var would let any importer reassign them) and function-shaped for docs and
+// grep.
+func Sign(cp Checkpoint, signer Signer) (Signed, error) { return sdk.Sign(cp, signer) }
+
+func Verify(s Signed, publicKeyPEM string) (bool, error) { return sdk.Verify(s, publicKeyPEM) }
+
+func PublicKeyFromPEM(publicKeyPEM []byte) (ed25519.PublicKey, error) {
+	return sdk.PublicKeyFromPEM(publicKeyPEM)
+}

--- a/daemon/internal/checkpoint/checkpoint.go
+++ b/daemon/internal/checkpoint/checkpoint.go
@@ -1,152 +1,27 @@
-// Package checkpoint defines the daemon's out-of-band, additive truncation
-// anchor (ADR-0008 follow-through; spike per #600).
+// Package checkpoint is the daemon's checkpoint anchor: it emits signed
+// checkpoints to append-only sinks (emitter.go) and reads them back from an
+// anchor log for `verify --against-anchor` (reader.go).
 //
-// A checkpoint is a small Ed25519-signed claim about a chain's HEAD —
-// {chain_id, sequence, receipt_hash, timestamp} — emitted to one or more
-// append-only sinks the agent UID cannot rewrite. Receipts stay a linear
-// verifiable-credential chain; the checkpoint is a SEPARATE signed artifact.
-//
-// IRREVERSIBLE DESIGN CONSTRAINT (ADR-0008): a checkpoint is additive and
-// out-of-band. It does NOT touch the receipt schema, the receipt hash chain,
-// @context, or the issuer DID — nothing cryptographically bound into receipts
-// carries an anchor reference. Anchoring is out-of-band by design, the same
-// rationale as the issuer-DID and /context/v1 freezes. If closing the
-// truncation gap ever appears to require an in-receipt anchor field, the
-// design is wrong — do not move the freeze.
-//
-// The truncation-detection mechanism this realises is exactly Option B of
-// ADR-0008 §3 ("out-of-band commitment"): the verifier obtains the expected
-// head out of band (here, the signed checkpoint) and fails when the observed
-// chain does not match. The checkpoint payload is canonicalised through the
-// EXISTING RFC 8785 JCS path (receipt.Canonicalize) so a checkpoint signs and
-// verifies byte-identically to every other signed artifact in the project.
+// The portable wire types and the sign/verify crypto live in the SDK
+// (obsigna.dev/sdk/go/checkpoint) so the daemon, the verify CLI, and the
+// browser verifier all share one implementation. This package re-exports them
+// under their original names so the daemon's emitter, reader, and callers use a
+// single `checkpoint.*` surface for both the portable crypto and the
+// daemon-local sink/log machinery.
 package checkpoint
 
-import (
-	"crypto/ed25519"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
-	"errors"
-	"fmt"
+import sdk "obsigna.dev/sdk/go/checkpoint"
 
-	"obsigna.dev/sdk/go/receipt"
+// Portable checkpoint types and crypto, re-exported from the SDK. See
+// obsigna.dev/sdk/go/checkpoint for the design constraints (ADR-0008).
+type (
+	Checkpoint = sdk.Checkpoint
+	Signed     = sdk.Signed
+	Signer     = sdk.Signer
 )
 
-// multibaseBase64URL mirrors the receipt proof encoding: signatures are
-// base64url (multibase prefix "u"), not the W3C default base58btc ("z"). A
-// checkpoint signature is therefore decoded the same way a receipt proofValue
-// is, so the two cannot drift.
-const multibaseBase64URL = "u"
-
-// Checkpoint is the signed claim about a chain HEAD. The four fields are the
-// entire signed body; nothing else is canonicalised. Sequence is the head
-// receipt's chain sequence and ReceiptHash is its "sha256:<hex>" hash, so a
-// verifier can compare both the position and the content of the head it
-// observes in the store against the head the daemon last anchored.
-type Checkpoint struct {
-	ChainID     string `json:"chain_id"`
-	Sequence    int64  `json:"sequence"`
-	ReceiptHash string `json:"receipt_hash"`
-	Timestamp   string `json:"timestamp"`
-}
-
-// Signed is a Checkpoint plus its detached signature. It is the artifact
-// written to sinks: the embedded Checkpoint fields are the signed body, and
-// VerificationMethod/Signature let any reader verify it against the daemon's
-// published key without a side channel. The signature covers ONLY the
-// Checkpoint body (re-canonicalised on verify), never the wrapper fields —
-// identical to how a receipt's proof covers the unsigned receipt, not the
-// proof block.
-type Signed struct {
-	Checkpoint
-	VerificationMethod string `json:"verification_method"`
-	Signature          string `json:"signature"`
-}
-
-// Signer is the minimal signing surface a checkpoint needs. keysource.KeySource
-// satisfies it, so checkpoints are signed by the same daemon key as receipts
-// without the checkpoint package depending on the daemon's key plumbing.
-type Signer interface {
-	Sign(message []byte) ([]byte, error)
-	VerificationMethod() string
-}
-
-// Sign canonicalises cp via the RFC 8785 JCS path and signs it, returning the
-// Signed artifact ready to hand to a sink. The signature is the raw 64-byte
-// Ed25519 form, multibase base64url-encoded to match receipt proofValues.
-func Sign(cp Checkpoint, signer Signer) (Signed, error) {
-	canonical, err := receipt.Canonicalize(cp)
-	if err != nil {
-		return Signed{}, fmt.Errorf("canonicalize checkpoint: %w", err)
-	}
-	sig, err := signer.Sign([]byte(canonical))
-	if err != nil {
-		return Signed{}, fmt.Errorf("sign checkpoint: %w", err)
-	}
-	return Signed{
-		Checkpoint:         cp,
-		VerificationMethod: signer.VerificationMethod(),
-		Signature:          multibaseBase64URL + base64.RawURLEncoding.EncodeToString(sig),
-	}, nil
-}
-
-// Verify checks s's signature against the PEM/SPKI Ed25519 public key. It
-// re-canonicalises the embedded Checkpoint body (the wrapper fields are never
-// signed) and validates the detached signature.
-//
-// The two failure modes are distinct, so callers can tell a malformed artifact
-// from a genuine forgery:
-//   - (false, err): the signature, key, or canonical body could not even be
-//     evaluated (bad multibase prefix, wrong length, unparseable key, etc.).
-//   - (false, nil): everything parsed but the signature does not match the body
-//     (a real verification failure / forgery).
-//
-// Only (true, nil) means the checkpoint is authentic. Either failure must be
-// treated as a hard rejection — never swallowed.
-func Verify(s Signed, publicKeyPEM string) (bool, error) {
-	if len(s.Signature) < 2 {
-		return false, errors.New("checkpoint signature too short")
-	}
-	if s.Signature[0] != multibaseBase64URL[0] {
-		return false, fmt.Errorf("unsupported multibase prefix %q (want %q)", s.Signature[0], multibaseBase64URL)
-	}
-	sig, err := base64.RawURLEncoding.DecodeString(s.Signature[1:])
-	if err != nil {
-		return false, fmt.Errorf("decode checkpoint signature: %w", err)
-	}
-	if len(sig) != ed25519.SignatureSize {
-		return false, fmt.Errorf("invalid checkpoint signature length: got %d, want %d", len(sig), ed25519.SignatureSize)
-	}
-	pub, err := PublicKeyFromPEM([]byte(publicKeyPEM))
-	if err != nil {
-		return false, err
-	}
-	canonical, err := receipt.Canonicalize(s.Checkpoint)
-	if err != nil {
-		return false, fmt.Errorf("canonicalize checkpoint: %w", err)
-	}
-	return ed25519.Verify(pub, []byte(canonical), sig), nil
-}
-
-// PublicKeyFromPEM decodes PEM/SPKI bytes into an Ed25519 public key, rejecting
-// any other key type or malformed input. Shared by Verify and the verify CLI's
-// anchor check so the daemon has a single Ed25519 public-key parser.
-func PublicKeyFromPEM(publicKeyPEM []byte) (ed25519.PublicKey, error) {
-	block, _ := pem.Decode(publicKeyPEM)
-	if block == nil {
-		return nil, errors.New("PEM decode failed (no PUBLIC KEY block)")
-	}
-	if block.Type != "PUBLIC KEY" {
-		return nil, fmt.Errorf("PEM block type is %q, want PUBLIC KEY", block.Type)
-	}
-	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parse SPKI public key: %w", err)
-	}
-	pub, ok := parsed.(ed25519.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("public key is %T, want ed25519.PublicKey", parsed)
-	}
-	return pub, nil
-}
+var (
+	Sign             = sdk.Sign
+	Verify           = sdk.Verify
+	PublicKeyFromPEM = sdk.PublicKeyFromPEM
+)

--- a/sdk/go/checkpoint/checkpoint.go
+++ b/sdk/go/checkpoint/checkpoint.go
@@ -1,0 +1,160 @@
+// Package checkpoint defines the protocol's out-of-band, additive truncation
+// anchor (ADR-0008; spike per #600) and the portable crypto for it.
+//
+// A checkpoint is a small Ed25519-signed claim about a chain's HEAD —
+// {chain_id, sequence, receipt_hash, timestamp} — emitted to one or more
+// append-only sinks the agent UID cannot rewrite. Receipts stay a linear
+// verifiable-credential chain; the checkpoint is a SEPARATE signed artifact.
+//
+// This package holds only the portable pieces — the wire types and the
+// sign/verify crypto — so every consumer shares one implementation: the daemon
+// emits checkpoints (daemon/internal/checkpoint), `obsigna receipt verify
+// --against-anchor` reads and verifies them, and the browser verifier
+// (obsigna.dev/verify) verifies a pasted checkpoint against a chain head. The
+// sink emission and on-disk anchor-log reading stay in the daemon, which is the
+// only consumer that touches files and sinks.
+//
+// IRREVERSIBLE DESIGN CONSTRAINT (ADR-0008): a checkpoint is additive and
+// out-of-band. It does NOT touch the receipt schema, the receipt hash chain,
+// @context, or the issuer DID — nothing cryptographically bound into receipts
+// carries an anchor reference. Anchoring is out-of-band by design, the same
+// rationale as the issuer-DID and /context/v1 freezes. If closing the
+// truncation gap ever appears to require an in-receipt anchor field, the
+// design is wrong — do not move the freeze.
+//
+// The truncation-detection mechanism this realises is exactly Option B of
+// ADR-0008 §3 ("out-of-band commitment"): the verifier obtains the expected
+// head out of band (here, the signed checkpoint) and fails when the observed
+// chain does not match. The checkpoint payload is canonicalised through the
+// EXISTING RFC 8785 JCS path (receipt.Canonicalize) so a checkpoint signs and
+// verifies byte-identically to every other signed artifact in the project.
+package checkpoint
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"obsigna.dev/sdk/go/receipt"
+)
+
+// multibaseBase64URL mirrors the receipt proof encoding: signatures are
+// base64url (multibase prefix "u"), not the W3C default base58btc ("z"). A
+// checkpoint signature is therefore decoded the same way a receipt proofValue
+// is, so the two cannot drift.
+const multibaseBase64URL = "u"
+
+// Checkpoint is the signed claim about a chain HEAD. The four fields are the
+// entire signed body; nothing else is canonicalised. Sequence is the head
+// receipt's chain sequence and ReceiptHash is its "sha256:<hex>" hash, so a
+// verifier can compare both the position and the content of the head it
+// observes in the store against the head the daemon last anchored.
+type Checkpoint struct {
+	ChainID     string `json:"chain_id"`
+	Sequence    int64  `json:"sequence"`
+	ReceiptHash string `json:"receipt_hash"`
+	Timestamp   string `json:"timestamp"`
+}
+
+// Signed is a Checkpoint plus its detached signature. It is the artifact
+// written to sinks: the embedded Checkpoint fields are the signed body, and
+// VerificationMethod/Signature let any reader verify it against the daemon's
+// published key without a side channel. The signature covers ONLY the
+// Checkpoint body (re-canonicalised on verify), never the wrapper fields —
+// identical to how a receipt's proof covers the unsigned receipt, not the
+// proof block.
+type Signed struct {
+	Checkpoint
+	VerificationMethod string `json:"verification_method"`
+	Signature          string `json:"signature"`
+}
+
+// Signer is the minimal signing surface a checkpoint needs. keysource.KeySource
+// satisfies it, so checkpoints are signed by the same daemon key as receipts
+// without the checkpoint package depending on the daemon's key plumbing.
+type Signer interface {
+	Sign(message []byte) ([]byte, error)
+	VerificationMethod() string
+}
+
+// Sign canonicalises cp via the RFC 8785 JCS path and signs it, returning the
+// Signed artifact ready to hand to a sink. The signature is the raw 64-byte
+// Ed25519 form, multibase base64url-encoded to match receipt proofValues.
+func Sign(cp Checkpoint, signer Signer) (Signed, error) {
+	canonical, err := receipt.Canonicalize(cp)
+	if err != nil {
+		return Signed{}, fmt.Errorf("canonicalize checkpoint: %w", err)
+	}
+	sig, err := signer.Sign([]byte(canonical))
+	if err != nil {
+		return Signed{}, fmt.Errorf("sign checkpoint: %w", err)
+	}
+	return Signed{
+		Checkpoint:         cp,
+		VerificationMethod: signer.VerificationMethod(),
+		Signature:          multibaseBase64URL + base64.RawURLEncoding.EncodeToString(sig),
+	}, nil
+}
+
+// Verify checks s's signature against the PEM/SPKI Ed25519 public key. It
+// re-canonicalises the embedded Checkpoint body (the wrapper fields are never
+// signed) and validates the detached signature.
+//
+// The two failure modes are distinct, so callers can tell a malformed artifact
+// from a genuine forgery:
+//   - (false, err): the signature, key, or canonical body could not even be
+//     evaluated (bad multibase prefix, wrong length, unparseable key, etc.).
+//   - (false, nil): everything parsed but the signature does not match the body
+//     (a real verification failure / forgery).
+//
+// Only (true, nil) means the checkpoint is authentic. Either failure must be
+// treated as a hard rejection — never swallowed.
+func Verify(s Signed, publicKeyPEM string) (bool, error) {
+	if len(s.Signature) < 2 {
+		return false, errors.New("checkpoint signature too short")
+	}
+	if s.Signature[0] != multibaseBase64URL[0] {
+		return false, fmt.Errorf("unsupported multibase prefix %q (want %q)", s.Signature[0], multibaseBase64URL)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(s.Signature[1:])
+	if err != nil {
+		return false, fmt.Errorf("decode checkpoint signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return false, fmt.Errorf("invalid checkpoint signature length: got %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+	pub, err := PublicKeyFromPEM([]byte(publicKeyPEM))
+	if err != nil {
+		return false, err
+	}
+	canonical, err := receipt.Canonicalize(s.Checkpoint)
+	if err != nil {
+		return false, fmt.Errorf("canonicalize checkpoint: %w", err)
+	}
+	return ed25519.Verify(pub, []byte(canonical), sig), nil
+}
+
+// PublicKeyFromPEM decodes PEM/SPKI bytes into an Ed25519 public key, rejecting
+// any other key type or malformed input. Shared by Verify and the verify CLI's
+// anchor check so checkpoint verification has a single Ed25519 public-key parser.
+func PublicKeyFromPEM(publicKeyPEM []byte) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode(publicKeyPEM)
+	if block == nil {
+		return nil, errors.New("PEM decode failed (no PUBLIC KEY block)")
+	}
+	if block.Type != "PUBLIC KEY" {
+		return nil, fmt.Errorf("PEM block type is %q, want PUBLIC KEY", block.Type)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse SPKI public key: %w", err)
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is %T, want ed25519.PublicKey", parsed)
+	}
+	return pub, nil
+}

--- a/sdk/go/checkpoint/checkpoint_test.go
+++ b/sdk/go/checkpoint/checkpoint_test.go
@@ -1,0 +1,151 @@
+package checkpoint
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+// testSigner is the minimal Signer the package needs, backed by a freshly
+// generated test key. Never a real key (AGENTS.md security rule).
+type testSigner struct{ priv ed25519.PrivateKey }
+
+func (s testSigner) Sign(msg []byte) ([]byte, error) { return ed25519.Sign(s.priv, msg), nil }
+func (s testSigner) VerificationMethod() string      { return "did:test#k1" }
+
+func newSigner(t *testing.T) (testSigner, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testSigner{priv: priv}, string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func sampleCheckpoint() Checkpoint {
+	return Checkpoint{ChainID: "c", Sequence: 3, ReceiptHash: "sha256:head", Timestamp: "2026-06-16T00:00:00Z"}
+}
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	signer, pub := newSigner(t)
+	signed, err := Sign(sampleCheckpoint(), signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if signed.VerificationMethod != "did:test#k1" {
+		t.Errorf("VerificationMethod = %q, want did:test#k1", signed.VerificationMethod)
+	}
+	if signed.Signature == "" || signed.Signature[0] != multibaseBase64URL[0] {
+		t.Errorf("signature %q not multibase base64url (prefix %q)", signed.Signature, multibaseBase64URL)
+	}
+	ok, err := Verify(signed, pub)
+	if err != nil {
+		t.Fatalf("Verify returned error on authentic checkpoint: %v", err)
+	}
+	if !ok {
+		t.Fatal("authentic checkpoint did not verify")
+	}
+}
+
+func TestVerifyRejectsTamperedBody(t *testing.T) {
+	signer, pub := newSigner(t)
+	signed, err := Sign(sampleCheckpoint(), signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mutate a signed field after signing: the wrapper still parses, but the
+	// re-canonicalised body no longer matches the signature → (false, nil).
+	signed.ReceiptHash = "sha256:forged"
+	ok, err := Verify(signed, pub)
+	if err != nil {
+		t.Fatalf("tampered body should be a clean (false, nil), got err: %v", err)
+	}
+	if ok {
+		t.Fatal("tampered checkpoint verified as authentic")
+	}
+}
+
+func TestVerifyRejectsWrongKey(t *testing.T) {
+	signer, _ := newSigner(t)
+	_, otherPub := newSigner(t) // verify against a DIFFERENT key
+	signed, err := Sign(sampleCheckpoint(), signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := Verify(signed, otherPub)
+	if err != nil {
+		t.Fatalf("wrong key should be a clean (false, nil), got err: %v", err)
+	}
+	if ok {
+		t.Fatal("checkpoint verified under the wrong key")
+	}
+}
+
+func TestVerifyRejectsMalformedSignature(t *testing.T) {
+	signer, pub := newSigner(t)
+	signed, err := Sign(sampleCheckpoint(), signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		"empty":                  "",
+		"single char":            "u",
+		"wrong multibase prefix": "z" + signed.Signature[1:],
+		"not base64url":          "u!!!not-base64!!!",
+		"too short for ed25519":  "u" + signed.Signature[1:5],
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			bad := signed
+			bad.Signature = sig
+			ok, err := Verify(bad, pub)
+			if ok {
+				t.Fatal("malformed signature verified as authentic")
+			}
+			if err == nil {
+				t.Fatal("malformed signature should return a non-nil error (could not be evaluated), got (false, nil)")
+			}
+		})
+	}
+}
+
+func TestPublicKeyFromPEM(t *testing.T) {
+	_, pub := newSigner(t)
+	if _, err := PublicKeyFromPEM([]byte(pub)); err != nil {
+		t.Fatalf("valid SPKI key rejected: %v", err)
+	}
+	for name, in := range map[string]string{
+		"garbage":          "not a pem block",
+		"wrong block type": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+		"empty":            "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := PublicKeyFromPEM([]byte(in)); err == nil {
+				t.Fatalf("expected error for %s key", name)
+			}
+		})
+	}
+}
+
+func TestVerifyReportsBadKey(t *testing.T) {
+	signer, _ := newSigner(t)
+	signed, err := Sign(sampleCheckpoint(), signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A signature that parses but a key that does not → error (could not evaluate),
+	// distinct from a clean signature-mismatch failure.
+	ok, err := Verify(signed, "not-a-key")
+	if ok || err == nil {
+		t.Fatalf("bad key should return (false, err), got ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(err.Error(), "PEM") {
+		t.Errorf("error %q does not point at the key parse failure", err)
+	}
+}


### PR DESCRIPTION
## What

Extracts the portable checkpoint wire types and sign/verify crypto out of the daemon's internal package into a new public SDK package, **`obsigna.dev/sdk/go/checkpoint`**. Behaviour-preserving move; no functional change.

## Why

This is the **prerequisite** for wiring external-anchor verification into the browser verifier shipped in #924. That verifier wraps `obsigna.dev/sdk/go/receipt`, but checkpoint verification currently lives in `daemon/internal/checkpoint` — an *internal* package of a different module, so neither the SDK nor the web verifier can import it. Promoting the crypto to the SDK lets the daemon emitter, `obsigna receipt verify --against-anchor`, and the browser verifier all share **one** implementation. The follow-up (Step C) that consumes this is stacked on top.

## What moved

- `Checkpoint`, `Signed`, `Signer` types
- `Sign`, `Verify`, `PublicKeyFromPEM`

These depend only on `receipt.Canonicalize` + stdlib, so the move is self-contained (no new module dependency — `daemon` already requires `sdk/go`).

## What stayed

`daemon/internal/checkpoint` keeps the anchor-coupled, file/sink side — `emitter.go` (sink emission) and `reader.go` (anchor-log reading, depends on `daemon/internal/anchor`). It re-exports the moved symbols via type/var aliases, so the emitter, reader, and **all** daemon callers are untouched. The only daemon edit is replacing `checkpoint.go`'s body with the alias bridge.

## Tests

- New focused crypto unit test in the SDK package: sign/verify round-trip, tampered body (clean `false,nil`), wrong key, malformed signatures (empty / bad prefix / non-base64 / short → `false,err`), bad PEM, and the error-vs-mismatch distinction. The code previously had only daemon-level integration coverage.
- Full `sdk/go` and `daemon` suites pass; `go vet` clean on both.

## Follow-up (not in this PR)

- **Step C** (stacked): wire `checkpoint.Verify` + head-binding into the web verifier so a chain can finally reach the `FULL` verdict.
- `checkpoint.PublicKeyFromPEM` overlaps with `receipt.ParsePublicKey` (exported in #924); they differ only in a stricter `PUBLIC KEY` block-type check and error strings. Left as-is here to keep this a pure move — worth deduping separately.