### PR TITLE
docs(roadmap): reconcile v1 statuses + threat-model response-disclosure

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,13 +114,13 @@ across workstreams they can be parallelised.
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Cloud KMS `Signer` adapters (AWS KMS, GCP Cloud KMS, Azure Key Vault) | ADR-0018 | #534 | done |
+| Cloud KMS `Signer` adapter — AWS KMS shipped across all three SDKs (separate module/package/extra). GCP Cloud KMS and Azure Key Vault not built; substitutable by a user `Signer` implementation, and reopen when a deployment needs them. | ADR-0018 | #534 | done |
 
 ### SDK payload handling
 
 | Item | ADR | Issue | Status |
 |---|---|---|---|
-| Bound remaining inline plaintext fields — cap `error` / `prompt_preview` + truncation flag (hash-first model superseded the original `PayloadStrategy` framing; content-addressed/GDPR erasure split to #731, v1.5) | ADR-0019 § S3 | #478 | planned |
+| Bound remaining inline plaintext fields — cap `error` / `prompt_preview` + truncation flag (hash-first model superseded the original `PayloadStrategy` framing; content-addressed/GDPR erasure split to #731, v1.5) | ADR-0019 § S3 | #478 | done |
 | `parameterDisclosure` Phase A — cross-SDK + OpenClaw migration (envelope, Python SDK, OpenClaw rename, cross-SDK tests all shipped) | ADR-0012 | #280 | done |
 
 ### Cross-SDK parity
@@ -128,7 +128,7 @@ across workstreams they can be parallelised.
 | Item | ADR | Issue | Status |
 |---|---|---|---|
 | Python SDK `eventType` naming alignment | ADR-0019 § S1 | (folded into conformance vectors) | done |
-| `KeyProvider` / `Signer` parity across TS, Python, Go | ADR-0018 | tracked per-SDK | planned |
+| `KeyProvider` / `Signer` parity across TS, Python, Go — verified 2026-06-23: all three expose `KeyProvider`, `GeneratingKeyProvider` with the identical `AGENTRECEIPTS_PRODUCTION` guard + error type, a `Signer` interface, and an AWS `KMSSigner` in a separate optional module/package/extra | ADR-0018 | tracked per-SDK | done |
 | `HttpEmitter` parity across TS, Python, Go | ADR-0020 | tracked per-SDK | done |
 
 ---

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -68,7 +68,7 @@ An attacker who compromises the daemon could rewrite the chain's rotation events
 
 Action parameters are committed via `parameters_hash` by default (privacy-preserving, tamper-evident). Operators who need on-demand forensic recovery enable [ADR-0012](adr/0012-payload-disclosure-policy.md) parameter disclosure: the daemon encrypts elected parameters into a separately-keyed HPKE envelope (`action.parameters_disclosure`) inside the signed receipt body, and an offline responder recovers them with the matching private key (SDK `DecryptDisclosure`). **Both the daemon-side sealing and the responder-side decryption are shipped.** The forensic decryption key lives with the responder, not the daemon — so the daemon (and therefore a compromised daemon) cannot decrypt past disclosures.
 
-Tool **output/response is committed via `response_hash` only** — there is no response-disclosure envelope yet, so responses (which often carry the sensitive payload: file contents, query results) cannot be forensically recovered. This input/output asymmetry is tracked in [#819](https://github.com/agent-receipts/obsigna/issues/819).
+Tool **output/response is committed via `response_hash`**, and spec v0.6.0 defines the `outcome.response_disclosure` HPKE envelope that mirrors the parameter-disclosure format. The daemon-side sealing of responses and the SDK-side recovery path are **not yet wired**, so responses (which often carry the sensitive payload: file contents, query results) cannot yet be forensically recovered in practice. Closing this input/output asymmetry is tracked in [#819](https://github.com/agent-receipts/obsigna/issues/819).
 
 Plaintext secrets in receipts are forbidden by policy (see [AGENTS.md security section](../AGENTS.md)).
 


### PR DESCRIPTION
## What

Doc-only reconciliation while scoping the **v1** milestone. ROADMAP and threat-model had drifted behind shipped work.

## Changes

**ROADMAP.md**
- `#478` (bound inline plaintext `error`/`prompt_preview`): `planned` → `done` (shipped #894).
- `KeyProvider`/`Signer` parity across TS/Py/Go: `planned` → `done`. Verified 2026-06-23 — all three SDKs expose `KeyProvider`, `GeneratingKeyProvider` with the identical `AGENTRECEIPTS_PRODUCTION` guard + error type, a `Signer` interface, and an AWS `KMSSigner` in a separate optional module/package/extra.
- `#534` KMS row: clarified AWS KMS shipped across all three; GCP Cloud KMS and Azure Key Vault are **not built and demand-driven** (substitutable via a user `Signer` implementation), reopen if a deployment asks.

**docs/threat-model.md**
- Spec v0.6.0 (#913) added the `outcome.response_disclosure` HPKE envelope. Corrected the stale 'no response-disclosure envelope yet' line: the format now exists; daemon-side sealing + SDK recovery (#819) is the remaining work.

## Why

These are the status corrections behind confirming v1 is engineering-complete. No code or CI touched.