### PR TITLE
feat(sdk-go,daemon): forensic response disclosure (#819)

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Forensic response disclosure** ([#819](https://github.com/agent-receipts/obsigna/issues/819)) — a `--response-disclosure` policy flag (env `AGENTRECEIPTS_RESPONSE_DISCLOSURE`, TOML `response_disclosure`) that seals elected tool responses into `outcome.response_disclosure`, mirroring `--parameter-disclosure`. Same value space (`false|true|high|<action types>`), shares the single forensic key, and fires independently of parameter disclosure. `outcome.response_hash` remains the authoritative commitment; sealing is best-effort and falls back to hash-only on error. `obsigna receipt disclose --response` decrypts the response envelope. Receipts now stamp protocol version `0.6.0` / context v3 (sdk/go catch-up).
+
 ## [0.29.0] - 2026-06-23
 
 Graduates `0.29.0-alpha.1` after the alpha pass. No code changes since the alpha; this entry formally promotes the checkpoint anchor nil-guard hardening to stable.

--- a/daemon/cmd/obsigna-daemon/main.go
+++ b/daemon/cmd/obsigna-daemon/main.go
@@ -321,6 +321,7 @@ func resolveConfig(args []string, getenv func(string) string, errOut io.Writer) 
 	fs.StringVar(&cfg.VerificationMethodID, "verification-method", cfg.VerificationMethodID, "proof.verificationMethod (env: AGENTRECEIPTS_VERIFICATION_METHOD)")
 	fs.StringVar(&cfg.AnchorLogPath, "anchor-log", cfg.AnchorLogPath, "Append-only external-witness log for rotation events (ADR-0015). When set, --rotate writes the rotation event here before committing locally; a write failure aborts the rotation. (env: AGENTRECEIPTS_ANCHOR_LOG)")
 	fs.StringVar(&cfg.ParameterDisclosure, "parameter-disclosure", cfg.ParameterDisclosure, "Which actions encrypt their parameters into parameters_disclosure (ADR-0012): false|true|high|<comma-separated action types>. Requires --forensic-public-key. (env: AGENTRECEIPTS_PARAMETER_DISCLOSURE)")
+	fs.StringVar(&cfg.ResponseDisclosure, "response-disclosure", cfg.ResponseDisclosure, "Which actions encrypt their tool response into outcome.response_disclosure (ADR-0012, spec v0.6.0+): false|true|high|<comma-separated action types>. Independent of --parameter-disclosure; requires --forensic-public-key. (env: AGENTRECEIPTS_RESPONSE_DISCLOSURE)")
 	fs.BoolVar(&cfg.UnsafeSocketPath, "unsafe-socket-path", cfg.UnsafeSocketPath, "Permit a --socket/AGENTRECEIPTS_SOCKET path outside the per-platform safe set (logs a warning; does not override TCP rejection) (env: AGENTRECEIPTS_UNSAFE_SOCKET_PATH)")
 	fs.StringVar(&cfg.RedactPatternsPath, "redact-patterns", cfg.RedactPatternsPath, "Path to a YAML file of additional redaction patterns (merged with built-in defaults) (env: AGENTRECEIPTS_REDACT_PATTERNS)")
 	fs.DurationVar(&cfg.ShutdownDeadline, "shutdown-deadline", cfg.ShutdownDeadline, "Best-effort time budget for emitting interrupted-chain terminators on SIGTERM/SIGINT (cannot preempt in-progress SQLite I/O)")
@@ -497,6 +498,9 @@ func applyFileConfig(cfg *daemon.Config, fc *daemon.FileConfig) {
 	if fc.ParameterDisclosure != nil {
 		cfg.ParameterDisclosure = fc.ParameterDisclosure.Value
 	}
+	if fc.ResponseDisclosure != nil {
+		cfg.ResponseDisclosure = fc.ResponseDisclosure.Value
+	}
 	if fc.UnsafeSocketPath != nil {
 		cfg.UnsafeSocketPath = *fc.UnsafeSocketPath
 	}
@@ -557,6 +561,9 @@ func envOverlay(cfg *daemon.Config, getenv func(string) string) error {
 	}
 	if v := getenv("AGENTRECEIPTS_PARAMETER_DISCLOSURE"); v != "" {
 		cfg.ParameterDisclosure = v
+	}
+	if v := getenv("AGENTRECEIPTS_RESPONSE_DISCLOSURE"); v != "" {
+		cfg.ResponseDisclosure = v
 	}
 	if v := getenv("AGENTRECEIPTS_UNSAFE_SOCKET_PATH"); v != "" {
 		b, err := strconv.ParseBool(v)
@@ -621,6 +628,7 @@ func printConfig(w io.Writer, cfg daemon.Config) {
 	fmt.Fprintf(w, "issuer_id = %q\n", cfg.IssuerID)
 	fmt.Fprintf(w, "verification_method = %q\n", cfg.VerificationMethodID)
 	fmt.Fprintf(w, "parameter_disclosure = %q\n", cfg.ParameterDisclosure)
+	fmt.Fprintf(w, "response_disclosure = %q\n", cfg.ResponseDisclosure)
 	fmt.Fprintf(w, "redact_patterns = %q\n", cfg.RedactPatternsPath)
 	fmt.Fprintf(w, "unsafe_socket_path = %t\n", cfg.UnsafeSocketPath)
 	fmt.Fprintf(w, "shutdown_deadline = %q\n", cfg.ShutdownDeadline.String())

--- a/daemon/cmd/obsigna/registry.go
+++ b/daemon/cmd/obsigna/registry.go
@@ -70,7 +70,7 @@ func commandTree() tree {
 					"show":         {"Print the full fields of a single receipt by sequence number.", showcli.Run},
 					"list":         {"List recent receipts from the store.", listcli.Run},
 					"verify-event": {"Verify one historical receipt's end-to-end pipeline provenance.", verifyeventcli.Run},
-					"disclose":     {"Decrypt a receipt's parameters_disclosure with the forensic key.", disclosecli.Run},
+					"disclose":     {"Decrypt a receipt's parameters_disclosure (or, with --response, response_disclosure) using the forensic key.", disclosecli.Run},
 				},
 			},
 			"keys": {

--- a/daemon/configfile.go
+++ b/daemon/configfile.go
@@ -38,6 +38,7 @@ type FileConfig struct {
 	IssuerID            *string           `toml:"issuer_id"`
 	VerificationMethod  *string           `toml:"verification_method"`
 	ParameterDisclosure *DisclosureConfig `toml:"parameter_disclosure"`
+	ResponseDisclosure  *DisclosureConfig `toml:"response_disclosure"`
 	RedactPatterns      *string           `toml:"redact_patterns"`
 	UnsafeSocketPath    *bool             `toml:"unsafe_socket_path"`
 	// ShutdownDeadline accepts a Go duration string, e.g. "200ms" or "1s".

--- a/daemon/configfile_test.go
+++ b/daemon/configfile_test.go
@@ -41,6 +41,7 @@ chain_id = "prod"
 issuer_id = "did:agent-receipts-daemon:host"
 verification_method = "did:agent-receipts-daemon:host#k1"
 parameter_disclosure = "high"
+response_disclosure = ["fs.read", "net.http"]
 redact_patterns = "/etc/agent-receipts/redact.yaml"
 unsafe_socket_path = true
 shutdown_deadline = "500ms"
@@ -70,6 +71,9 @@ shutdown_deadline = "500ms"
 	}
 	if fc.ParameterDisclosure == nil || fc.ParameterDisclosure.Value != "high" {
 		t.Errorf("parameter_disclosure = %v", fc.ParameterDisclosure)
+	}
+	if fc.ResponseDisclosure == nil || fc.ResponseDisclosure.Value != "fs.read,net.http" {
+		t.Errorf("response_disclosure = %v, want fs.read,net.http", fc.ResponseDisclosure)
 	}
 	if fc.UnsafeSocketPath == nil || !*fc.UnsafeSocketPath {
 		t.Errorf("unsafe_socket_path = %v", fc.UnsafeSocketPath)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -426,6 +426,24 @@ func writeNewSecretFile(path string, data []byte, mode os.FileMode) error {
 	return nil
 }
 
+// requireForensicKey validates that an enabled disclosure policy has a forensic
+// public key to encrypt to, and logs its activation. surface is the lowercase
+// policy name ("parameter"/"response") and target is the human phrase for what
+// gets sealed ("parameters"/"tool responses"). It is a no-op when the policy is
+// disabled, and returns an error when the policy is enabled without a key.
+func requireForensicKey(surface, target, policyValue string, policy pipeline.DisclosurePolicy, forensicPublicKey []byte, logger *log.Logger) error {
+	if !policy.Enabled() {
+		return nil
+	}
+	if len(forensicPublicKey) == 0 {
+		return fmt.Errorf("%s disclosure %q requires a forensic public key (--forensic-public-key); without one there is nothing to encrypt to", surface, policyValue)
+	}
+	fp, _ := receipt.ForensicKeyFingerprint(forensicPublicKey)
+	logger.Printf("%s disclosure ACTIVE: policy=%s, forensic key %s — matching %s will be HPKE-encrypted to that key (recoverable only with the private key)",
+		strings.ToUpper(surface[:1])+surface[1:], policy.String(), fp, target)
+	return nil
+}
+
 // Run starts the daemon and blocks until ctx is cancelled. It returns the
 // first fatal error or nil on graceful shutdown.
 func Run(ctx context.Context, cfg Config) error {
@@ -583,22 +601,14 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Parameter and response disclosure share the single forensic key but fire
 	// independently; either policy being on requires a key to encrypt to.
-	switch {
-	case policy.Enabled() && len(forensicPublicKey) == 0:
-		return fmt.Errorf("parameter disclosure %q requires a forensic public key (--forensic-public-key); without one there is nothing to encrypt to", cfg.ParameterDisclosure)
-	case policy.Enabled():
-		fp, _ := receipt.ForensicKeyFingerprint(forensicPublicKey)
-		cfg.Logger.Printf("Parameter disclosure ACTIVE: policy=%s, forensic key %s — matching parameters will be HPKE-encrypted to that key (recoverable only with the private key)", policy.String(), fp)
-	case len(forensicPublicKey) > 0 && !responsePolicy.Enabled():
-		cfg.Logger.Printf("NOTICE: a forensic public key is set but parameter disclosure policy is off; no parameters will be disclosed. Set --parameter-disclosure (true|high|<action-types>) to enable.")
+	if err := requireForensicKey("parameter", "parameters", cfg.ParameterDisclosure, policy, forensicPublicKey, cfg.Logger); err != nil {
+		return err
 	}
-
-	switch {
-	case responsePolicy.Enabled() && len(forensicPublicKey) == 0:
-		return fmt.Errorf("response disclosure %q requires a forensic public key (--forensic-public-key); without one there is nothing to encrypt to", cfg.ResponseDisclosure)
-	case responsePolicy.Enabled():
-		fp, _ := receipt.ForensicKeyFingerprint(forensicPublicKey)
-		cfg.Logger.Printf("Response disclosure ACTIVE: policy=%s, forensic key %s — matching tool responses will be HPKE-encrypted to that key (recoverable only with the private key)", responsePolicy.String(), fp)
+	if err := requireForensicKey("response", "tool responses", cfg.ResponseDisclosure, responsePolicy, forensicPublicKey, cfg.Logger); err != nil {
+		return err
+	}
+	if len(forensicPublicKey) > 0 && !policy.Enabled() && !responsePolicy.Enabled() {
+		cfg.Logger.Printf("NOTICE: a forensic public key is set but no disclosure policy is on; nothing will be disclosed. Set --parameter-disclosure or --response-disclosure (true|high|<action-types>) to enable.")
 	}
 
 	pp := pipeline.New(state, ks, st, cfg.IssuerID)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,6 +97,13 @@ type Config struct {
 	// pipeline.ParseDisclosurePolicy at startup.
 	ParameterDisclosure string
 
+	// ResponseDisclosure selects which actions seal their tool response into the
+	// outcome.response_disclosure envelope (ADR-0012, spec v0.6.0+). Same value
+	// space and parsing as ParameterDisclosure, but independent: an operator may
+	// disclose responses without parameters or vice versa. Shares the single
+	// ForensicPublicKeyPath — when set, response disclosure also requires it.
+	ResponseDisclosure string
+
 	// RedactPatternsPath is an optional path to a YAML file of additional
 	// redaction patterns applied to receipt body fields after hashing. When
 	// empty, only the built-in patterns are used. File format:
@@ -558,6 +565,10 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("parameter disclosure policy: %w", err)
 	}
+	responsePolicy, err := pipeline.ParseDisclosurePolicy(cfg.ResponseDisclosure)
+	if err != nil {
+		return fmt.Errorf("response disclosure policy: %w", err)
+	}
 
 	var forensicPublicKey []byte
 	if cfg.ForensicPublicKeyPath != "" {
@@ -570,20 +581,31 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	}
 
+	// Parameter and response disclosure share the single forensic key but fire
+	// independently; either policy being on requires a key to encrypt to.
 	switch {
 	case policy.Enabled() && len(forensicPublicKey) == 0:
 		return fmt.Errorf("parameter disclosure %q requires a forensic public key (--forensic-public-key); without one there is nothing to encrypt to", cfg.ParameterDisclosure)
 	case policy.Enabled():
 		fp, _ := receipt.ForensicKeyFingerprint(forensicPublicKey)
 		cfg.Logger.Printf("Parameter disclosure ACTIVE: policy=%s, forensic key %s — matching parameters will be HPKE-encrypted to that key (recoverable only with the private key)", policy.String(), fp)
-	case len(forensicPublicKey) > 0:
+	case len(forensicPublicKey) > 0 && !responsePolicy.Enabled():
 		cfg.Logger.Printf("NOTICE: a forensic public key is set but parameter disclosure policy is off; no parameters will be disclosed. Set --parameter-disclosure (true|high|<action-types>) to enable.")
+	}
+
+	switch {
+	case responsePolicy.Enabled() && len(forensicPublicKey) == 0:
+		return fmt.Errorf("response disclosure %q requires a forensic public key (--forensic-public-key); without one there is nothing to encrypt to", cfg.ResponseDisclosure)
+	case responsePolicy.Enabled():
+		fp, _ := receipt.ForensicKeyFingerprint(forensicPublicKey)
+		cfg.Logger.Printf("Response disclosure ACTIVE: policy=%s, forensic key %s — matching tool responses will be HPKE-encrypted to that key (recoverable only with the private key)", responsePolicy.String(), fp)
 	}
 
 	pp := pipeline.New(state, ks, st, cfg.IssuerID)
 	pp.TraceLog = cfg.TraceLog
 	pp.ErrorLog = cfg.Logger.Printf
 	pp.DisclosurePolicy = policy
+	pp.ResponseDisclosurePolicy = responsePolicy
 	pp.ForensicPublicKey = forensicPublicKey
 
 	// Bound the inline plaintext fields (issue #478). New already installed sane

--- a/daemon/internal/disclosecli/disclose.go
+++ b/daemon/internal/disclosecli/disclose.go
@@ -59,7 +59,8 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: obsigna receipt disclose <seq> [flags]")
 		fmt.Fprintln(stderr, "\nDecrypt the parameters_disclosure envelope of a single stored receipt")
-		fmt.Fprintln(stderr, "using the operator's X25519 forensic private key.")
+		fmt.Fprintln(stderr, "using the operator's X25519 forensic private key. Pass --response to")
+		fmt.Fprintln(stderr, "decrypt outcome.response_disclosure (the tool response) instead.")
 		fmt.Fprintln(stderr, "\nThe key may be supplied as a raw 32-byte file, hex (64 chars),")
 		fmt.Fprintln(stderr, "standard or URL-safe base64, or a PKCS#8 PEM-wrapped X25519 key.")
 		fmt.Fprintln(stderr, "\nFlags:")
@@ -72,7 +73,8 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		"Chain id to read from (env: AGENTRECEIPTS_CHAIN_ID); required only when the store holds more than one chain")
 	keyPath := fs.String("key", envOr("AGENTRECEIPTS_FORENSIC_KEY", daemon.DefaultForensicKeyPath()),
 		"Forensic private-key path (raw 32-byte X25519, hex, base64, or PKCS#8 PEM) (env: AGENTRECEIPTS_FORENSIC_KEY)")
-	asJSON := fs.Bool("json", false, "Output decrypted parameters as JSON")
+	asJSON := fs.Bool("json", false, "Output decrypted plaintext as JSON")
+	discloseResponse := fs.Bool("response", false, "Decrypt outcome.response_disclosure (the tool response) instead of action.parameters_disclosure (ADR-0012)")
 
 	var rest []string
 	remaining := args
@@ -151,9 +153,14 @@ func Run(args []string, stdout, stderr io.Writer, envLookup func(string) string)
 		return ExitNotFound
 	}
 
+	field := "parameters_disclosure"
 	env := r.CredentialSubject.Action.ParametersDisclosure
+	if *discloseResponse {
+		field = "response_disclosure"
+		env = r.CredentialSubject.Outcome.ResponseDisclosure
+	}
 	if env == nil {
-		fmt.Fprintf(stderr, "obsigna receipt disclose: receipt at sequence %d has no parameters_disclosure\n", seq)
+		fmt.Fprintf(stderr, "obsigna receipt disclose: receipt at sequence %d has no %s\n", seq, field)
 		return ExitOK
 	}
 

--- a/daemon/internal/disclosecli/disclose_test.go
+++ b/daemon/internal/disclosecli/disclose_test.go
@@ -63,7 +63,10 @@ func fixtureDB(t *testing.T, dir string, count int) (dbPath string, forensicPriv
 			Timestamp: fmt.Sprintf("2024-01-01T%02d:00:00Z", i),
 		}
 
-		// Odd sequences get an encrypted disclosure; even ones do not.
+		outcome := receipt.Outcome{Status: receipt.StatusSuccess}
+
+		// Odd sequences get encrypted disclosures (both parameters and response);
+		// even ones do not.
 		if i%2 == 1 {
 			params := map[string]any{
 				"file_path": fmt.Sprintf("/tmp/file%d.txt", i),
@@ -73,13 +76,22 @@ func fixtureDB(t *testing.T, dir string, count int) (dbPath string, forensicPriv
 				t.Fatal(err)
 			}
 			action.ParametersDisclosure = env
+
+			response := map[string]any{
+				"contents": fmt.Sprintf("body of file%d", i),
+			}
+			respEnv, err := receipt.EncryptResponse(response, forensicKP.PublicKey, kid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			outcome.ResponseDisclosure = respEnv
 		}
 
 		unsigned := receipt.Create(receipt.CreateInput{
 			Issuer:    receipt.Issuer{ID: "did:test"},
 			Principal: receipt.Principal{ID: "did:user:test"},
 			Action:    action,
-			Outcome:   receipt.Outcome{Status: receipt.StatusSuccess},
+			Outcome:   outcome,
 			Chain:     receipt.Chain{Sequence: i, PreviousReceiptHash: prevHash, ChainID: "test-chain"},
 		})
 		signed, err := receipt.Sign(unsigned, sigPrivPEM, "did:test#k1")
@@ -160,6 +172,45 @@ func TestDisclose_JSON(t *testing.T) {
 	}
 	if params["file_path"] != "/tmp/file1.txt" {
 		t.Errorf("wrong file_path: %v", params["file_path"])
+	}
+}
+
+func TestDisclose_Response(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 3)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"1", "--response", "--json", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if resp["contents"] != "body of file1" {
+		t.Errorf("wrong response contents: %v", resp["contents"])
+	}
+}
+
+func TestDisclose_ResponseNoneOnEvenSeq(t *testing.T) {
+	dir := t.TempDir()
+	dbPath, priv := fixtureDB(t, dir, 3)
+	keyPath := writeKeyFile(t, dir, priv)
+
+	var out, errOut bytes.Buffer
+	// Sequence 2 has no disclosure (even-numbered).
+	code := Run([]string{"2", "--response", "--chain-id", "test-chain"},
+		&out, &errOut, env(dbPath, "", keyPath))
+
+	if code != ExitOK {
+		t.Fatalf("want ExitOK, got %d; stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "no response_disclosure") {
+		t.Errorf("expected 'no response_disclosure' message, got stderr: %s", errOut.String())
 	}
 }
 

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -706,17 +706,13 @@ func canonicalSHA256(raw json.RawMessage) (string, error) {
 // It returns nil on any failure (non-object payload, HPKE error) after logging,
 // so the caller falls back to a hash-only receipt rather than dropping the
 // event. The hash is computed independently by the caller and is unaffected.
-func (p *Pipeline) encryptDisclosure(payload json.RawMessage) *receipt.DisclosureEnvelope {
+// kid is the recipient fingerprint, resolved once per receipt by the caller.
+func (p *Pipeline) encryptDisclosure(payload json.RawMessage, kid string) *receipt.DisclosureEnvelope {
 	var params map[string]any
 	if err := json.Unmarshal(payload, &params); err != nil {
 		// Disclosure requires a JSON object (HPKE plaintext is the canonical
 		// object); arrays/primitives cannot be disclosed. Hash-only fallback.
 		p.logError("disclosure skipped (payload is not a JSON object): %v", err)
-		return nil
-	}
-	kid, err := receipt.ForensicKeyFingerprint(p.ForensicPublicKey)
-	if err != nil {
-		p.logError("disclosure skipped (forensic key fingerprint failed): %v", err)
 		return nil
 	}
 	env, err := receipt.EncryptDisclosure(params, p.ForensicPublicKey, kid)
@@ -790,6 +786,23 @@ func (p *Pipeline) buildAndSign(
 	// disclosure ("high") fire correctly.
 	risk := taxonomy.ResolveActionType(actionType).RiskLevel
 
+	// Resolve the forensic recipient fingerprint once per receipt, only when a
+	// disclosure policy could actually fire. It depends only on the static
+	// forensic public key, so computing it here lets both the parameter and
+	// response disclosure paths reuse it instead of each re-hashing the key.
+	// Empty when no key is configured, both policies are off, or the key is
+	// malformed — in every case both paths fall back to hash-only.
+	var forensicKid string
+	if len(p.ForensicPublicKey) == 32 &&
+		(p.DisclosurePolicy.Enabled() || p.ResponseDisclosurePolicy.Enabled()) {
+		kid, err := receipt.ForensicKeyFingerprint(p.ForensicPublicKey)
+		if err != nil {
+			p.logError("disclosure skipped (forensic key fingerprint failed): %v", err)
+		} else {
+			forensicKid = kid
+		}
+	}
+
 	action := receipt.Action{
 		Type:           actionType,
 		ToolName:       f.Tool.Name,
@@ -823,9 +836,9 @@ func (p *Pipeline) buildAndSign(
 		// than dropping the event. A privacy-preserving hash-only receipt keeps
 		// the chain gap-free; refusing the event would punch a hole in the audit
 		// trail, which is the worse outcome for an audit system.
-		if len(p.ForensicPublicKey) == 32 &&
+		if forensicKid != "" &&
 			p.DisclosurePolicy.ShouldDisclose(actionType, risk) {
-			if env := p.encryptDisclosure(f.Input); env != nil {
+			if env := p.encryptDisclosure(f.Input, forensicKid); env != nil {
 				action.ParametersDisclosure = env
 			}
 		}
@@ -868,9 +881,9 @@ func (p *Pipeline) buildAndSign(
 		// canonical bytes, so tamper-evidence is independent of disclosure; the
 		// envelope is additive and recoverable only by the forensic private-key
 		// holder. Best-effort: a failure falls back to hash-only for this receipt.
-		if len(p.ForensicPublicKey) == 32 &&
+		if forensicKid != "" &&
 			p.ResponseDisclosurePolicy.ShouldDisclose(actionType, risk) {
-			if env := p.encryptDisclosure(f.Output); env != nil {
+			if env := p.encryptDisclosure(f.Output, forensicKid); env != nil {
 				outcome.ResponseDisclosure = env
 			}
 		}

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -204,6 +204,13 @@ type Pipeline struct {
 	// ADR-0012). The zero value discloses nothing.
 	DisclosurePolicy DisclosurePolicy
 
+	// ResponseDisclosurePolicy governs which actions seal their tool response
+	// into outcome.response_disclosure (ADR-0012, spec v0.6.0+). It is
+	// independent of DisclosurePolicy — an operator may disclose responses
+	// without parameters or vice versa — but shares the single ForensicPublicKey.
+	// The zero value discloses nothing.
+	ResponseDisclosurePolicy DisclosurePolicy
+
 	// Redactor is applied to text fields before they are persisted in the
 	// receipt body. Today that means outcome.error only; input and output are
 	// never stored as raw text — only their SHA-256 hashes go into
@@ -689,20 +696,22 @@ func canonicalSHA256(raw json.RawMessage) (string, error) {
 	return receipt.SHA256Hash(canonical), nil
 }
 
-// encryptDisclosure encrypts the emitter input into an HPKE disclosure envelope
-// addressed to the configured forensic public key (ADR-0012). The recipient kid
-// is the key's canonical fingerprint (ADR-0015), so a forensic tool holding the
-// matching private key can locate this receipt without a key registry.
+// encryptDisclosure seals a JSON-object payload (action input or tool output)
+// into an HPKE disclosure envelope addressed to the configured forensic public
+// key (ADR-0012). It is shared by parameter and response disclosure — the
+// envelope is identical for both. The recipient kid is the key's canonical
+// fingerprint (ADR-0015), so a forensic tool holding the matching private key
+// can locate this receipt without a key registry.
 //
-// It returns nil on any failure (non-object input, HPKE error) after logging,
+// It returns nil on any failure (non-object payload, HPKE error) after logging,
 // so the caller falls back to a hash-only receipt rather than dropping the
 // event. The hash is computed independently by the caller and is unaffected.
-func (p *Pipeline) encryptDisclosure(input json.RawMessage) *receipt.DisclosureEnvelope {
+func (p *Pipeline) encryptDisclosure(payload json.RawMessage) *receipt.DisclosureEnvelope {
 	var params map[string]any
-	if err := json.Unmarshal(input, &params); err != nil {
+	if err := json.Unmarshal(payload, &params); err != nil {
 		// Disclosure requires a JSON object (HPKE plaintext is the canonical
 		// object); arrays/primitives cannot be disclosed. Hash-only fallback.
-		p.logError("disclosure skipped (input is not a JSON object): %v", err)
+		p.logError("disclosure skipped (payload is not a JSON object): %v", err)
 		return nil
 	}
 	kid, err := receipt.ForensicKeyFingerprint(p.ForensicPublicKey)
@@ -853,6 +862,18 @@ func (p *Pipeline) buildAndSign(
 			return receipt.AgentReceipt{}, "", fmt.Errorf("hash output: %w", err)
 		}
 		outcome.ResponseHash = hash
+
+		// Forensic response disclosure (ADR-0012, spec v0.6.0+): mirrors the
+		// parameter path above. ResponseHash always commits to the original
+		// canonical bytes, so tamper-evidence is independent of disclosure; the
+		// envelope is additive and recoverable only by the forensic private-key
+		// holder. Best-effort: a failure falls back to hash-only for this receipt.
+		if len(p.ForensicPublicKey) == 32 &&
+			p.ResponseDisclosurePolicy.ShouldDisclose(actionType, risk) {
+			if env := p.encryptDisclosure(f.Output); env != nil {
+				outcome.ResponseDisclosure = env
+			}
+		}
 	}
 
 	return p.signAndHash(receipt.CreateInput{

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1219,6 +1219,102 @@ func TestProcess_DisclosurePolicyGatesEncryption(t *testing.T) {
 	}
 }
 
+// TestProcess_ResponseDisclosureGatesAndIsIndependent verifies response
+// disclosure (ADR-0012, spec v0.6.0+): with a forensic key and a response
+// policy of "high", only the high-risk action seals its tool response into
+// outcome.response_disclosure, and it decrypts back to the original output.
+// It also asserts independence — with ONLY the response policy on, parameters
+// are never disclosed — and that response_hash is always present.
+func TestProcess_ResponseDisclosureGatesAndIsIndependent(t *testing.T) {
+	fk, err := receipt.GenerateForensicKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	p := New(chain.New("chain-1"), ks, st, "did:agent-receipts-daemon:test")
+	p.ForensicPublicKey = fk.PublicKey
+	// Only the response policy is enabled; the parameter policy stays at its
+	// zero value (discloses nothing).
+	pol, err := ParseDisclosurePolicy("high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.ResponseDisclosurePolicy = pol
+
+	send := func(channel, toolName string, input, output json.RawMessage) {
+		body, err := json.Marshal(EmitterFrame{
+			Version: "1", TsEmit: "2026-05-03T00:00:00Z", SessionID: "s",
+			Channel: channel, Tool: EmitterTool{Name: toolName},
+			Input: input, Output: output, Decision: "allowed",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := p.Process(socket.Frame{Payload: body}); err != nil {
+			t.Fatalf("Process(%s.%s): %v", channel, toolName, err)
+		}
+	}
+	send("filesystem", "file.delete", json.RawMessage(`{"command":"rm -rf /tmp/x"}`), json.RawMessage(`{"deleted":true,"path":"/tmp/x"}`)) // high risk
+	send("sdk", "noop", json.RawMessage(`{"path":"/tmp/x"}`), json.RawMessage(`{"ok":true}`))                                              // unknown -> medium
+
+	receipts, err := st.GetChain("chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 2 {
+		t.Fatalf("got %d receipts, want 2", len(receipts))
+	}
+
+	var highRec, lowRec *receipt.AgentReceipt
+	for i := range receipts {
+		switch receipts[i].CredentialSubject.Action.Type {
+		case "filesystem.file.delete":
+			highRec = &receipts[i]
+		case "sdk.noop":
+			lowRec = &receipts[i]
+		}
+	}
+	if highRec == nil || lowRec == nil {
+		t.Fatalf("missing expected receipts: high=%v low=%v", highRec != nil, lowRec != nil)
+	}
+
+	// High-risk action seals its response under policy "high".
+	env := highRec.CredentialSubject.Outcome.ResponseDisclosure
+	if env == nil {
+		t.Fatal("high-risk action must have a response_disclosure envelope under policy=high")
+	}
+	wantKID, _ := receipt.ForensicKeyFingerprint(fk.PublicKey)
+	if env.Recipients[0].KID != wantKID {
+		t.Errorf("kid = %q, want %q (ADR-0015 fingerprint)", env.Recipients[0].KID, wantKID)
+	}
+	dec, err := receipt.DecryptResponse(env, fk.PrivateKey)
+	if err != nil {
+		t.Fatalf("DecryptResponse: %v", err)
+	}
+	if dec["deleted"] != true || dec["path"] != "/tmp/x" {
+		t.Errorf("decrypted response = %v, want {deleted:true, path:/tmp/x}", dec)
+	}
+	// response_hash remains the authoritative commitment.
+	if highRec.CredentialSubject.Outcome.ResponseHash == "" {
+		t.Error("response_hash must be present alongside the disclosure envelope")
+	}
+	// Independence: parameter disclosure is off, so no parameters envelope.
+	if highRec.CredentialSubject.Action.ParametersDisclosure != nil {
+		t.Errorf("parameters must not be disclosed when only the response policy is on; got %#v",
+			highRec.CredentialSubject.Action.ParametersDisclosure)
+	}
+
+	// Low-risk action does NOT seal its response under policy "high".
+	if lowRec.CredentialSubject.Outcome.ResponseDisclosure != nil {
+		t.Errorf("low-risk action must not disclose its response under policy=high; got %#v",
+			lowRec.CredentialSubject.Outcome.ResponseDisclosure)
+	}
+	if lowRec.CredentialSubject.Outcome.ResponseHash == "" {
+		t.Error("low-risk action still needs response_hash")
+	}
+}
+
 // TestProcess_DisclosureFallsBackToHashOnNonObjectInput verifies the fail-open
 // behaviour: when disclosure is on but the input is not a JSON object (so it
 // cannot be encrypted as an HPKE parameters object), the receipt is still

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,6 +11,14 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+### Added
+
+- **Forensic response disclosure** ([#819](https://github.com/agent-receipts/obsigna/issues/819)) — `EncryptResponse` / `DecryptResponse` and the `Outcome.ResponseDisclosure` field, mirroring `EncryptDisclosure` / `Action.ParametersDisclosure` for the tool output side (ADR-0012). Same HPKE v1 envelope, forensic keypair, and JCS canonicalization; `Outcome.ResponseHash` remains the authoritative commitment. Catches the Go SDK up to the TS/Python SDKs, which shipped response disclosure in 0.6.0 (PR #913).
+
+### Changed
+
+- **Protocol version bumped to `0.6.0` and JSON-LD context to v3** to match the TS and Python SDKs. New receipts stamp `version: "0.6.0"` and reference `https://agentreceipts.ai/context/v3`, restoring the cross-SDK live-emit version invariant (the Go SDK was intentionally held at `0.5.0`/context v2 pending the vanity module-path migration).
+
 ## [0.23.0] - 2026-06-23
 
 ### Changed

--- a/sdk/go/receipt/disclosure.go
+++ b/sdk/go/receipt/disclosure.go
@@ -203,6 +203,9 @@ func encryptWithReader(params map[string]any, recipientPublicKey []byte, kid str
 // response is JCS-canonicalized before encryption. recipientPublicKey is the
 // 32-byte X25519 forensic public key; kid identifies the recipient key.
 func EncryptResponse(response map[string]any, recipientPublicKey []byte, kid string) (*DisclosureEnvelope, error) {
+	if response == nil {
+		return nil, fmt.Errorf("response must not be nil; pass an empty map for no response")
+	}
 	return encryptWithReader(response, recipientPublicKey, kid, rand.Reader)
 }
 
@@ -210,6 +213,9 @@ func EncryptResponse(response map[string]any, recipientPublicKey []byte, kid str
 // cross-SDK test vectors. Use only in tests — reusing ikmE across real
 // encryptions breaks confidentiality. ikmE MUST be 32 bytes.
 func encryptResponseWithSeed(response map[string]any, recipientPublicKey []byte, kid string, ikmE []byte) (*DisclosureEnvelope, error) {
+	if response == nil {
+		return nil, fmt.Errorf("response must not be nil; pass an empty map for no response")
+	}
 	if len(ikmE) != 32 {
 		return nil, fmt.Errorf("ikmE must be 32 bytes, got %d", len(ikmE))
 	}

--- a/sdk/go/receipt/disclosure.go
+++ b/sdk/go/receipt/disclosure.go
@@ -192,6 +192,38 @@ func encryptWithReader(params map[string]any, recipientPublicKey []byte, kid str
 	}, nil
 }
 
+// EncryptResponse encrypts a tool response as a v1 HPKE disclosure envelope for
+// outcome.response_disclosure (ADR-0012, spec v0.6.0+).
+//
+// Identical to EncryptDisclosure in primitive and encoding — same forensic key
+// pair, same HPKE ciphersuite, same JCS canonicalization. The separation exists
+// so operators can enable response disclosure independently of parameter
+// disclosure via separate --response-disclosure / --parameter-disclosure flags.
+//
+// response is JCS-canonicalized before encryption. recipientPublicKey is the
+// 32-byte X25519 forensic public key; kid identifies the recipient key.
+func EncryptResponse(response map[string]any, recipientPublicKey []byte, kid string) (*DisclosureEnvelope, error) {
+	return encryptWithReader(response, recipientPublicKey, kid, rand.Reader)
+}
+
+// encryptResponseWithSeed is the deterministic variant of EncryptResponse for
+// cross-SDK test vectors. Use only in tests — reusing ikmE across real
+// encryptions breaks confidentiality. ikmE MUST be 32 bytes.
+func encryptResponseWithSeed(response map[string]any, recipientPublicKey []byte, kid string, ikmE []byte) (*DisclosureEnvelope, error) {
+	if len(ikmE) != 32 {
+		return nil, fmt.Errorf("ikmE must be 32 bytes, got %d", len(ikmE))
+	}
+	return encryptWithReader(response, recipientPublicKey, kid, bytes.NewReader(ikmE))
+}
+
+// DecryptResponse recovers the plaintext response from a v1 HPKE disclosure
+// envelope stored in outcome.response_disclosure. It is identical to
+// DecryptDisclosure — the same envelope format serves both parameters and
+// response disclosures — and exists for API symmetry with EncryptResponse.
+func DecryptResponse(env *DisclosureEnvelope, recipientPrivateKey []byte) (map[string]any, error) {
+	return DecryptDisclosure(env, recipientPrivateKey)
+}
+
 // DecryptDisclosure recovers the plaintext parameters from a v1 HPKE disclosure
 // envelope. recipientPrivateKey is the 32-byte X25519 forensic private key.
 // The returned map reflects the JCS-canonical plaintext written by EncryptDisclosure.

--- a/sdk/go/receipt/disclosure_test.go
+++ b/sdk/go/receipt/disclosure_test.go
@@ -657,8 +657,12 @@ func TestEncryptResponseValidation(t *testing.T) {
 	alicePub := mustDecodeHex(t, alicePubHex)
 	kid := "sha256:abc"
 
+	// Error wording is response-specific, not the delegate's "params" text,
+	// matching the TS/Python encryptResponse surface.
 	if _, err := EncryptResponse(nil, alicePub, kid); err == nil {
 		t.Error("EncryptResponse(nil response) should error")
+	} else if !strings.Contains(err.Error(), "response must not be nil") {
+		t.Errorf("nil-response error = %q, want response-specific wording", err)
 	}
 	if _, err := EncryptResponse(map[string]any{}, alicePub[:31], kid); err == nil {
 		t.Error("EncryptResponse(short key) should error")

--- a/sdk/go/receipt/disclosure_test.go
+++ b/sdk/go/receipt/disclosure_test.go
@@ -564,3 +564,109 @@ func hexSHA256(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
 }
+
+// TestEncryptResponseDecryptResponseRoundTrip verifies the response disclosure
+// API (ADR-0012, spec v0.6.0+) round-trips through the public Response functions.
+func TestEncryptResponseDecryptResponseRoundTrip(t *testing.T) {
+	alicePub := mustDecodeHex(t, alicePubHex)
+	alicePriv := mustDecodeHex(t, alicePrivHex)
+
+	response := map[string]any{
+		"stdout":    "build complete\n",
+		"exit_code": float64(0),
+	}
+	env, err := EncryptResponse(response, alicePub, "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1")
+	if err != nil {
+		t.Fatalf("EncryptResponse: %v", err)
+	}
+
+	// Envelope shape invariants — identical envelope to the parameter surface.
+	if env.V != "1" {
+		t.Errorf("v = %q, want \"1\"", env.V)
+	}
+	if env.Alg != v1Alg {
+		t.Errorf("alg = %q, want %q", env.Alg, v1Alg)
+	}
+	if len(env.Recipients) != 1 || len(env.Recipients[0].Enc) != 43 {
+		t.Errorf("recipients shape wrong: %+v", env.Recipients)
+	}
+
+	got, err := DecryptResponse(env, alicePriv)
+	if err != nil {
+		t.Fatalf("DecryptResponse: %v", err)
+	}
+	if got["stdout"] != "build complete\n" || got["exit_code"] != float64(0) {
+		t.Errorf("decrypted response = %v", got)
+	}
+}
+
+// TestResponseEnvelopeMatchesParameterEnvelope is the load-bearing parity check:
+// for the same plaintext, key, kid, and seed, the response surface
+// (encryptResponseWithSeed) MUST produce a byte-identical envelope to the
+// parameter surface (encryptDisclosureWithSeed). This pins the cross-SDK
+// byte-identity property for outcome.response_disclosure against the same
+// vector-1 values the parameter path is pinned to (vectors.json).
+func TestResponseEnvelopeMatchesParameterEnvelope(t *testing.T) {
+	alicePub := mustDecodeHex(t, alicePubHex)
+	alicePriv := mustDecodeHex(t, alicePrivHex)
+	ikmE := mustDecodeHex(t, vector1IkmEHex)
+	kid := "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQUQUaHL9XJ7Z5W#enc-1"
+
+	payload := map[string]any{"command": `echo "build complete"`}
+
+	paramEnv, err := encryptDisclosureWithSeed(payload, alicePub, kid, ikmE)
+	if err != nil {
+		t.Fatalf("encryptDisclosureWithSeed: %v", err)
+	}
+	respEnv, err := encryptResponseWithSeed(payload, alicePub, kid, ikmE)
+	if err != nil {
+		t.Fatalf("encryptResponseWithSeed: %v", err)
+	}
+
+	paramJCS, err := Canonicalize(paramEnv)
+	if err != nil {
+		t.Fatalf("Canonicalize paramEnv: %v", err)
+	}
+	respJCS, err := Canonicalize(respEnv)
+	if err != nil {
+		t.Fatalf("Canonicalize respEnv: %v", err)
+	}
+	if paramJCS != respJCS {
+		t.Errorf("response envelope diverges from parameter envelope:\nparam: %s\nresp:  %s", paramJCS, respJCS)
+	}
+
+	// And it must match the pinned vector-1 ciphertext, so the response surface
+	// is locked to the same cross-SDK bytes.
+	const wantCT1 = "YGn3i4NpiZxHjeZVggTP8lTxb0ZVdLl-2HjW31qsvo28PjQ_Lt_UQgAMidEXjzwhJPHM7OM"
+	if respEnv.CT != wantCT1 {
+		t.Errorf("response ct = %s\nwant %s", respEnv.CT, wantCT1)
+	}
+
+	got, err := DecryptResponse(respEnv, alicePriv)
+	if err != nil {
+		t.Fatalf("DecryptResponse: %v", err)
+	}
+	if got["command"] != `echo "build complete"` {
+		t.Errorf("decrypted = %v", got)
+	}
+}
+
+// TestEncryptResponseValidation verifies EncryptResponse rejects bad inputs the
+// same way EncryptDisclosure does, and the seeded variant enforces ikmE length.
+func TestEncryptResponseValidation(t *testing.T) {
+	alicePub := mustDecodeHex(t, alicePubHex)
+	kid := "sha256:abc"
+
+	if _, err := EncryptResponse(nil, alicePub, kid); err == nil {
+		t.Error("EncryptResponse(nil response) should error")
+	}
+	if _, err := EncryptResponse(map[string]any{}, alicePub[:31], kid); err == nil {
+		t.Error("EncryptResponse(short key) should error")
+	}
+	if _, err := EncryptResponse(map[string]any{}, alicePub, ""); err == nil {
+		t.Error("EncryptResponse(empty kid) should error")
+	}
+	if _, err := encryptResponseWithSeed(map[string]any{}, alicePub, kid, []byte{1, 2, 3}); err == nil {
+		t.Error("encryptResponseWithSeed(short ikmE) should error")
+	}
+}

--- a/sdk/go/receipt/live_emit_version_test.go
+++ b/sdk/go/receipt/live_emit_version_test.go
@@ -9,7 +9,7 @@ import "testing"
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-const liveEmitVersion = "0.5.0"
+const liveEmitVersion = "0.6.0"
 
 // TestCreateStampsCrossSDKVersion asserts that Create() stamps the
 // cross-SDK-agreed literal version string. This pins the SDK's Version

--- a/sdk/go/receipt/types.go
+++ b/sdk/go/receipt/types.go
@@ -11,7 +11,7 @@ import (
 
 // Protocol constants (unexported to prevent mutation).
 var (
-	protocolContext        = []string{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v2"}
+	protocolContext        = []string{"https://www.w3.org/ns/credentials/v2", "https://agentreceipts.ai/context/v3"}
 	protocolCredentialType = []string{"VerifiableCredential", "AgentReceipt"}
 )
 
@@ -21,7 +21,7 @@ func Context() []string { return append([]string{}, protocolContext...) }
 // CredentialType returns a copy of the credential type array.
 func CredentialType() []string { return append([]string{}, protocolCredentialType...) }
 
-const Version = "0.5.0"
+const Version = "0.6.0"
 
 // RiskLevel classifies the security risk of an action. It aliases risk.Level
 // (the receipt-free leaf type) so callers that must classify tool calls without
@@ -310,6 +310,12 @@ type Outcome struct {
 	ReversalOf            string        `json:"reversal_of,omitempty"`
 	StateChange           *StateChange  `json:"state_change,omitempty"`
 	ResponseHash          string        `json:"response_hash,omitempty"`
+	// ResponseDisclosure seals the tool response in a v1 HPKE envelope (ADR-0012,
+	// spec v0.6.0+), mirroring Action.ParametersDisclosure for the output side.
+	// ResponseHash remains the authoritative tamper-evidence commitment; this field
+	// is additive and recoverable only by the forensic private-key holder. Omitted
+	// when the issuer did not enable response disclosure.
+	ResponseDisclosure *DisclosureEnvelope `json:"response_disclosure,omitempty"`
 }
 
 // Authorization captures the scope and expiry of an action.

--- a/sdk/py/tests/receipt/test_live_emit_version.py
+++ b/sdk/py/tests/receipt/test_live_emit_version.py
@@ -29,10 +29,8 @@ from obsigna.receipt.types import (
     Principal,
 )
 
-# NOTE: Go SDK live-emit version is intentionally behind at "0.5.0" until the
-# vanity module path migration (#899 PR3) lands and the Go SDK bump follows.
-# When that PR lands, update sdk/go/receipt/live_emit_version_test.go to
-# "0.6.0" to restore the three-way invariant documented in that file's header.
+# All three SDKs are aligned at "0.6.0" (Go caught up in the response-disclosure
+# follow-up, #819), restoring the three-way invariant documented above.
 LIVE_EMIT_VERSION = "0.6.0"
 
 

--- a/sdk/ts/src/receipt/live-emit-version.test.ts
+++ b/sdk/ts/src/receipt/live-emit-version.test.ts
@@ -9,10 +9,8 @@ import { VERSION } from "./types.js";
 // breaks that SDK's test in isolation, closing the gap surfaced by #512 where
 // the existing v030 cross-SDK byte-identicality tests load a pre-built JSON
 // fixture and never consult the SDK's VERSION constant.
-// NOTE: Go SDK live-emit version is intentionally behind at "0.5.0" until the
-// vanity module path migration (#899 PR3) lands and the Go SDK bump follows.
-// When that PR lands, update sdk/go/receipt/live_emit_version_test.go to
-// "0.6.0" to restore the three-way invariant documented in that file's header.
+// All three SDKs are aligned at "0.6.0" (Go caught up in the response-disclosure
+// follow-up, #819), restoring the three-way invariant documented above.
 const LIVE_EMIT_VERSION = "0.6.0";
 
 describe("createReceipt cross-SDK version invariant", () => {


### PR DESCRIPTION
Closes #819.

## What

Completes ADR-0012 **response disclosure** for the Go SDK and daemon — the deferred half of #819. The spec (v0.6.0), TS SDK, and Python SDK shipped in #913; the Go SDK and daemon were explicitly held back until the vanity module-path migration (ADR-0037, #922) landed. It has, so this catches them up.

Tool responses can now be sealed into `outcome.response_disclosure`, mirroring `action.parameters_disclosure` for the output side. `response_hash` stays the authoritative tamper-evidence commitment; the envelope is additive and recoverable only by the forensic private-key holder (the daemon never holds it).

## sdk/go
- `EncryptResponse` / `DecryptResponse` + `Outcome.ResponseDisclosure` — thin mirrors of `EncryptDisclosure` / `Action.ParametersDisclosure` over the identical HPKE v1 envelope and JCS canonicalization.
- **Protocol version `0.5.0` → `0.6.0`, context v2 → v3**, matching the TS/Python SDKs. This restores the three-way live-emit version invariant (the Go SDK was intentionally behind per the notes in the TS/Py `live-emit-version` tests, now updated). New receipts across the daemon/hook/mcp-proxy now stamp `0.6.0` / context v3.
- A test pins the response envelope to the **same byte-identical vector-1 ciphertext** as the parameter surface, locking cross-SDK byte-identity.

## daemon
- `--response-disclosure` flag (env `AGENTRECEIPTS_RESPONSE_DISCLOSURE`, TOML `response_disclosure`), independent of `--parameter-disclosure` but sharing the single forensic key. Either policy being enabled requires the key.
- Pipeline seals `f.Output` into `outcome.response_disclosure` when the policy elects the action; best-effort, falls back to hash-only on error (never drops the event).
- `obsigna receipt disclose --response` decrypts the response envelope.
- Tests cover policy gating, parameter/response **independence**, and the CLI path.

## Testing
- `sdk/go`, `daemon`, `hook`, `mcp-proxy` full suites pass; `go vet` clean.
- Cross-SDK byte-identity vectors (`-tags integration`) pass — the envelope and canonicalization are shared and already pinned at v0.3.0, so existing vectors are unaffected.
- TS/Python edits are comment-only (the `VERSION`/`LIVE_EMIT_VERSION` constants were already `0.6.0` from #913); their suites are unaffected.

## Follow-ups (not in this PR, to keep it focused)
- `docs/threat-model.md` — the "Sensitive data in storage" section flags the input/output asymmetry as a limitation (#819). It should flip to "shipped" once this lands. That paragraph is also touched by #935 (interim wording); reconcile at merge.
- A dedicated v0.6.0 cross-SDK *receipt* vector exercising `response_disclosure` would be a nice completeness step (mirroring how v0.3.0 pins parameter disclosure), but isn't required for correctness.
- Papercut spotted: `sdk/go/CHANGELOG.md` header still cites the old `agent-receipts/ar/sdk/go` module path (stale post-ADR-0037).