### PR TITLE
docs(opencode): rename stale agent-receipts CLI to obsigna

### DIFF
--- a/site-obsigna/src/content/docs/opencode/installation.mdx
+++ b/site-obsigna/src/content/docs/opencode/installation.mdx
@@ -7,16 +7,16 @@ The `@obsigna/opencode-plugin` package (Tier B) emits one daemon-signed receipt 
 
 ## Prerequisites
 
-- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- [`obsigna-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - OpenCode installed (`npm install -g opencode-ai` or see the [OpenCode docs](https://opencode.ai/docs/))
 
 ## Start the daemon
 
-The plugin holds no key of its own — `agent-receipts-daemon` owns the key and signs every receipt ([ADR-0010](https://github.com/agent-receipts/obsigna/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise it once and start it before launching OpenCode:
+The plugin holds no key of its own — `obsigna-daemon` owns the key and signs every receipt ([ADR-0010](https://github.com/agent-receipts/obsigna/blob/main/docs/adr/0010-daemon-process-separation.md)). Initialise it once and start it before launching OpenCode:
 
 ```bash
-agent-receipts-daemon --init   # one-time: generates the Ed25519 signing key pair
-agent-receipts-daemon          # start the daemon (listens on a Unix socket)
+obsigna-daemon --init   # one-time: generates the Ed25519 signing key pair
+obsigna-daemon          # start the daemon (listens on a Unix socket)
 ```
 
 The plugin reaches the daemon over its default platform socket automatically — no extra flag needed.
@@ -40,7 +40,7 @@ OpenCode also loads plugins from `.opencode/plugin/`. To configure the plugin pr
 
 {/* snippet-check: no-run */}
 ```ts
-// .opencode/plugin/agent-receipts.ts
+// .opencode/plugin/obsigna.ts
 import { createObsignaPlugin } from "@obsigna/opencode-plugin";
 
 export const ObsignaPlugin = createObsignaPlugin({
@@ -65,7 +65,7 @@ Configure via environment variables (read when the plugin loads):
 
 ## Failure posture
 
-Default is **catch-and-warn** (ADR-0025): a tool call is never aborted because the daemon is unreachable; the drop is logged loudly via the configured logger. Because emission is best-effort, a daemon outage produces a **chain gap** — `agent-receipts verify` will report it — rather than silently passing. This is honest-operator-grade auditing, not a completeness guarantee.
+Default is **catch-and-warn** (ADR-0025): a tool call is never aborted because the daemon is unreachable; the drop is logged loudly via the configured logger. Because emission is best-effort, a daemon outage produces a **chain gap** — `obsigna receipt verify` will report it — rather than silently passing. This is honest-operator-grade auditing, not a completeness guarantee.
 
 Set `AGENT_RECEIPTS_STRICT=1` to re-throw emit failures from the `tool.execute.after` hook so OpenCode surfaces a broken audit pipeline.
 
@@ -78,9 +78,9 @@ The plugin is emitter-only and never signs, so it cannot use the SDK's `WalEmitt
 After running a few OpenCode tool calls (e.g. ask it to run a shell command and edit a file), inspect and verify the receipts:
 
 ```bash
-agent-receipts list            # recent receipts — look for channel: opencode
-agent-receipts show 1          # full fields of receipt #1 by sequence
-agent-receipts verify          # walk the hash chain and check every signature
+obsigna receipt list           # recent receipts — look for channel: opencode
+obsigna receipt show 1         # full fields of receipt #1 by sequence
+obsigna receipt verify         # walk the hash chain and check every signature
 ```
 
 A healthy chain prints an `OK` summary. If the daemon was down for some calls, `verify` reports the gap — exactly the honest-operator signal the default posture is designed to surface.

--- a/site-obsigna/src/content/docs/opencode/mcp-proxy.mdx
+++ b/site-obsigna/src/content/docs/opencode/mcp-proxy.mdx
@@ -8,7 +8,7 @@ OpenCode loads MCP servers from `opencode.json`. Wrapping a server with [`mcp-pr
 ## Prerequisites
 
 - [mcp-proxy installed](/mcp-proxy/installation/)
-- [`agent-receipts-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
+- [`obsigna-daemon` installed, initialised, and running](/getting-started/daemon-setup/) — it holds the signing key and writes every receipt
 - The MCP server you want to audit. The example below wraps GitHub's official server:
 
   ```bash
@@ -39,7 +39,7 @@ OpenCode launches local MCP servers as subprocesses. Point the `command` at `mcp
 }
 ```
 
-The proxy reaches `agent-receipts-daemon` over its default platform socket automatically — no extra flag needed.
+The proxy reaches `obsigna-daemon` over its default platform socket automatically — no extra flag needed.
 
 :::danger[Never put secrets in opencode.json]
 `opencode.json` is plaintext on disk. Do **not** put real tokens or API keys in an `environment` block. Wrap the proxy command in a secret-manager launcher (`op run`, `aws-vault exec`) or an OS-keychain script — the same pattern documented for [Codex](/mcp-proxy/codex/#recommended-secret-manager-op-run) and [Claude Desktop](/mcp-proxy/claude-desktop/#fallback-os-keychain-launcher-script) works here. One launcher script works across clients.
@@ -54,8 +54,8 @@ The default policy includes a `pause_high_risk` rule. To enable the approval lis
 Run an MCP tool in OpenCode (e.g. a GitHub query), then:
 
 ```bash
-agent-receipts list     # receipts with channel: mcp from the proxy
-agent-receipts verify   # walk the chain and check signatures
+obsigna receipt list     # receipts with channel: mcp from the proxy
+obsigna receipt verify   # walk the chain and check signatures
 ```
 
 Receipts from the proxy carry `channel: mcp`; native-tool receipts from the [plugin](/opencode/installation/) carry `channel: opencode`. Both land in the same daemon chain, giving you a complete picture across both channels.

--- a/site-obsigna/src/content/docs/opencode/overview.mdx
+++ b/site-obsigna/src/content/docs/opencode/overview.mdx
@@ -14,14 +14,14 @@ graph LR
     T1[Native tools — bash, edit, write…] -- "tool.execute.after" --> PL[opencode-plugin]
     T2[MCP tools — GitHub, Atlassian…] -- "stdio / JSON-RPC" --> P[mcp-proxy]
   end
-  PL -- "Unix socket (emit only)" --> D[agent-receipts-daemon]
+  PL -- "Unix socket (emit only)" --> D[obsigna-daemon]
   P -- "Unix socket" --> D
   D --> DB[(receipts.db)]
 ```
 
 ## Trust model — read this first
 
-The plugin runs **inside** the OpenCode process, so it is an **emitter only**. It forwards each tool call to `agent-receipts-daemon`, which holds the key, canonicalises (RFC 8785), signs (Ed25519), and chains the receipt ([ADR-0010](https://github.com/agent-receipts/obsigna/blob/main/docs/adr/0010-daemon-process-separation.md)). The plugin **never signs and never holds a key**.
+The plugin runs **inside** the OpenCode process, so it is an **emitter only**. It forwards each tool call to `obsigna-daemon`, which holds the key, canonicalises (RFC 8785), signs (Ed25519), and chains the receipt ([ADR-0010](https://github.com/agent-receipts/obsigna/blob/main/docs/adr/0010-daemon-process-separation.md)). The plugin **never signs and never holds a key**.
 
 This placement is **honest-operator-grade**, not adversary-resistant. The agent controls the plugin, so a compromised OpenCode can omit or misreport a native tool call. If you need a placement that holds against the agent itself, route those tools through MCP and the proxy (Tier A). The two tiers are complementary: Tier A is adversary-resistant for the MCP channel; Tier B maximises coverage of the native channel.
 


### PR DESCRIPTION
## What

The OpenCode integration pages on obsigna.dev still referenced the pre-rename binary names:

- `agent-receipts-daemon` → `obsigna-daemon`
- bare `agent-receipts verify/list/show` → `obsigna receipt verify/list/show` (the CLI is now `obsigna receipt <subcommand>`)
- example plugin file `.opencode/plugin/agent-receipts.ts` → `.opencode/plugin/obsigna.ts`

Affects `site-obsigna/src/content/docs/opencode/{installation,mcp-proxy,overview}.mdx` — the rest of the site already uses the current names.

## Not changed

`did:agent-receipts-daemon:local` is left as-is: it's the daemon's actual default issuer DID (`daemon/daemon.go:230`), a value rather than a binary name. Rebranding that identifier would be a separate code change.