### PR TITLE
feat(sdk-ts): add target to the daemon emitter frame

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+### Added
+
+- **`EmitEvent.target`** ([#939](https://github.com/agent-receipts/obsigna/issues/939)) — new optional `{ system, resource }` field on the `DaemonEmitter` frame, forwarded to the daemon as `target_system` / `target_resource` and mapped onto `action.target.{system,resource}` (file-identity metadata). `system` is capped at 256 UTF-8 bytes and `resource` at 4096; both must be set together (a half-populated target is rejected), matching the Go emitter and daemon. Caps are measured in UTF-8 bytes, not JS string length. Exports `EmitTarget`, `MAX_IDENTITY_FIELD_LEN`, and `MAX_TARGET_RESOURCE_LEN`. The daemon already accepted these frame fields; this exposes them through the TS emitter (Phase 1 of #939). Additive and backwards-compatible: omitting `target` preserves the previous behaviour.
+
 ## [0.15.0] - 2026-06-23
 
 Graduates `0.15.0-alpha.1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9) and `outcome.response_disclosure` HPKE envelope (spec v0.6.0).

--- a/sdk/ts/src/daemon-emitter.test.ts
+++ b/sdk/ts/src/daemon-emitter.test.ts
@@ -24,6 +24,8 @@ import {
 	type EmitEvent,
 	EmitTransportError,
 	MAX_FRAME_SIZE,
+	MAX_IDENTITY_FIELD_LEN,
+	MAX_TARGET_RESOURCE_LEN,
 	resolveSocketPath,
 	type SocketPathDeps,
 	SUPPORTED_FRAME_VERSION,
@@ -229,6 +231,95 @@ describe("DaemonEmitter — validation errors (caller bugs)", () => {
 		e.close();
 	});
 
+	it("rejects a target with only system set", async () => {
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: { system: "filesystem", resource: "" },
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/both be set or both empty/);
+		e.close();
+	});
+
+	it("rejects a target with only resource set", async () => {
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: { system: "", resource: "/etc/hosts" },
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/both be set or both empty/);
+		e.close();
+	});
+
+	it("rejects a target.system over the byte cap", async () => {
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: {
+				system: "a".repeat(MAX_IDENTITY_FIELD_LEN + 1),
+				resource: "/etc/hosts",
+			},
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/target_system exceeds 256 bytes/);
+		e.close();
+	});
+
+	it("rejects a target.resource over the byte cap", async () => {
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: {
+				system: "filesystem",
+				resource: "a".repeat(MAX_TARGET_RESOURCE_LEN + 1),
+			},
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/target_resource exceeds 4096 bytes/);
+		e.close();
+	});
+
+	it("measures the target.system cap in UTF-8 bytes, not characters", async () => {
+		// "あ" is 3 UTF-8 bytes but 1 JS char (well within UTF-16 length).
+		// 86 copies = 258 bytes (> 256) yet only 86 .length, so a char-length
+		// check would wrongly accept this.
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const system = "あ".repeat(86);
+		expect(system.length).toBeLessThanOrEqual(MAX_IDENTITY_FIELD_LEN);
+		expect(Buffer.byteLength(system, "utf8")).toBeGreaterThan(
+			MAX_IDENTITY_FIELD_LEN,
+		);
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: { system, resource: "/etc/hosts" },
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/target_system exceeds 256 bytes/);
+		e.close();
+	});
+
+	it("accepts a multi-byte target at the byte boundary", async () => {
+		// A multi-byte resource whose byte length is exactly the cap must pass —
+		// proves the check is inclusive and byte-accurate. Use an echo server so
+		// the emit reaches the write path rather than failing transport.
+		const sockPath = tempSockPath("target-boundary");
+		const server = startEchoServer(sockPath);
+		await server.ready;
+		const e = new DaemonEmitter({ socketPath: sockPath });
+		// "あ" is 3 bytes; 1365 * 3 = 4095, + one ASCII byte = 4096 = cap.
+		const resource = `${"あ".repeat(1365)}a`;
+		expect(Buffer.byteLength(resource, "utf8")).toBe(MAX_TARGET_RESOURCE_LEN);
+		const err = await e.emit({
+			...GOOD_EVENT,
+			target: { system: "filesystem", resource },
+		});
+		expect(err).toBeNull();
+		e.close();
+		await server.stop();
+	});
+
 	it("returns an error after close", async () => {
 		const sockPath = tempSockPath("closed");
 		const server = startEchoServer(sockPath);
@@ -344,6 +435,29 @@ describe("DaemonEmitter — frame round-trip", () => {
 		expect(err).toBeInstanceOf(Error);
 		expect(err?.message).toMatch(/actionType must be a string/);
 		e.close();
+	});
+
+	it("target is forwarded as target_system / target_resource", async () => {
+		await emitter.emit({
+			...GOOD_EVENT,
+			target: { system: "filesystem", resource: "/etc/hosts" },
+		});
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f.target_system).toBe("filesystem");
+		expect(f.target_resource).toBe("/etc/hosts");
+	});
+
+	it("target_system and target_resource are absent when target is omitted", async () => {
+		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f).not.toHaveProperty("target_system");
+		expect(f).not.toHaveProperty("target_resource");
 	});
 
 	it("input and output are forwarded as raw JSON values (not double-encoded)", async () => {

--- a/sdk/ts/src/daemon-emitter.test.ts
+++ b/sdk/ts/src/daemon-emitter.test.ts
@@ -22,6 +22,7 @@ import {
 	DaemonEmitter,
 	defaultSocketPath,
 	type EmitEvent,
+	type EmitTarget,
 	EmitTransportError,
 	MAX_FRAME_SIZE,
 	MAX_IDENTITY_FIELD_LEN,
@@ -253,6 +254,19 @@ describe("DaemonEmitter — validation errors (caller bugs)", () => {
 		e.close();
 	});
 
+	it("returns an Error (does not throw) for a null target from a JS caller", async () => {
+		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
+		const err = await e.emit({
+			...GOOD_EVENT,
+			// A non-TypeScript caller can pass null; emit() must report it as a
+			// caller-bug Error rather than throwing on a null property access.
+			target: null as unknown as EmitTarget,
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err?.message).toMatch(/target must be an object/);
+		e.close();
+	});
+
 	it("rejects a target.system over the byte cap", async () => {
 		const e = new DaemonEmitter({ socketPath: tempSockPath("noop") });
 		const err = await e.emit({
@@ -452,6 +466,16 @@ describe("DaemonEmitter — frame round-trip", () => {
 
 	it("target_system and target_resource are absent when target is omitted", async () => {
 		await emitter.emit(GOOD_EVENT);
+		await waitFor(async () => (await server.frames()).length > 0);
+
+		const frames = await server.frames();
+		const f = JSON.parse(frames[0] ?? "{}");
+		expect(f).not.toHaveProperty("target_system");
+		expect(f).not.toHaveProperty("target_resource");
+	});
+
+	it("omits the wire fields for an all-empty target (matches Go omitempty)", async () => {
+		await emitter.emit({ ...GOOD_EVENT, target: { system: "", resource: "" } });
 		await waitFor(async () => (await server.frames()).length > 0);
 
 		const frames = await server.frames();

--- a/sdk/ts/src/daemon-emitter.ts
+++ b/sdk/ts/src/daemon-emitter.ts
@@ -33,6 +33,21 @@ export const MAX_FRAME_SIZE = 1 << 20;
 export const SUPPORTED_FRAME_VERSION = "1";
 
 /**
+ * Maximum UTF-8 byte length of an identity-style field. Applies to
+ * {@link EmitTarget.system}. The daemon enforces the same limit
+ * (`maxIdentityFieldLen`); validating client-side surfaces violations before
+ * the write rather than as a silent daemon-side rejection.
+ */
+export const MAX_IDENTITY_FIELD_LEN = 256;
+
+/**
+ * Maximum UTF-8 byte length of {@link EmitTarget.resource}. File paths can
+ * reach 4096 bytes on Linux (PATH_MAX), so a wider cap than
+ * {@link MAX_IDENTITY_FIELD_LEN} is used. The daemon enforces the same limit.
+ */
+export const MAX_TARGET_RESOURCE_LEN = 4096;
+
+/**
  * Inclusive range of emitter-frame schema versions this SDK can speak to the
  * daemon — its declared daemon-protocol range in the ADR-0024 Gate #8 sense.
  * Today the SDK emits exactly one version ({@link SUPPORTED_FRAME_VERSION}), so
@@ -75,6 +90,19 @@ export interface EmitTool {
 	name: string;
 }
 
+/**
+ * Identifies the system and resource an action operates on. `system` names a
+ * resource domain (e.g. "filesystem"); `resource` is the path or identifier
+ * within that domain (e.g. a file path). Both must be set together — a
+ * half-populated target is rejected.
+ */
+export interface EmitTarget {
+	/** Resource domain, e.g. "filesystem". */
+	system: string;
+	/** Path or identifier within the domain, e.g. a file path. */
+	resource: string;
+}
+
 /** One tool invocation to forward to the daemon. */
 export interface EmitEvent {
 	/** Stable channel identifier (required, non-empty). */
@@ -112,6 +140,17 @@ export interface EmitEvent {
 	output?: string;
 	/** Human-readable error message when the tool call failed. */
 	error?: string;
+	/**
+	 * Optional target identifying the resource the action operates on (e.g. a
+	 * file path for filesystem tools). When set, the daemon maps it to
+	 * `action.target.{system,resource}` on the receipt — for example
+	 * `{ system: "filesystem", resource: "<file path>" }`. Both `system` and
+	 * `resource` must be set together; a half-populated target is rejected.
+	 * `system` is capped at {@link MAX_IDENTITY_FIELD_LEN} UTF-8 bytes and
+	 * `resource` at {@link MAX_TARGET_RESOURCE_LEN}. Omitted from the frame when
+	 * unset.
+	 */
+	target?: EmitTarget;
 	/** Policy decision for this call. */
 	decision: "allowed" | "denied" | "pending";
 }
@@ -165,6 +204,8 @@ interface WireFrame {
 	input?: string;
 	output?: string;
 	error?: string;
+	target_system?: string;
+	target_resource?: string;
 	decision: string;
 }
 
@@ -397,6 +438,12 @@ export class DaemonEmitter {
 		if (ev.actionType !== undefined && typeof ev.actionType !== "string") {
 			return new Error("emitter: actionType must be a string");
 		}
+		if (ev.target !== undefined) {
+			const targetErr = validateTarget(ev.target);
+			if (targetErr !== null) {
+				return targetErr;
+			}
+		}
 		if (ev.input !== undefined && !isValidJson(ev.input)) {
 			return new Error("emitter: input is not valid JSON");
 		}
@@ -421,6 +468,12 @@ export class DaemonEmitter {
 			...(ev.input !== undefined ? { input: RAW_INPUT_SENTINEL } : {}),
 			...(ev.output !== undefined ? { output: RAW_OUTPUT_SENTINEL } : {}),
 			...(ev.error ? { error: ev.error } : {}),
+			...(ev.target
+				? {
+						target_system: ev.target.system,
+						target_resource: ev.target.resource,
+					}
+				: {}),
 			decision: ev.decision,
 		};
 
@@ -709,6 +762,44 @@ export class DaemonEmitter {
 			// A throwing debugLog must not take down the host process.
 		}
 	}
+}
+
+/**
+ * Validates an {@link EmitTarget} against the daemon's rules, returning a
+ * caller-bug Error on violation or null when valid. Caps are measured in UTF-8
+ * bytes (via Buffer.byteLength), not JS string length, to match the daemon and
+ * the Go emitter, which count bytes — a multi-byte string under the char limit
+ * can still exceed the byte cap.
+ */
+function validateTarget(target: EmitTarget): Error | null {
+	if (
+		typeof target.system !== "string" ||
+		typeof target.resource !== "string"
+	) {
+		return new Error(
+			"emitter: target.system and target.resource must be strings",
+		);
+	}
+	// Both set or both empty — a half-populated target would produce an
+	// ActionTarget with an empty system or resource in the signed receipt.
+	if ((target.system !== "") !== (target.resource !== "")) {
+		return new Error(
+			"emitter: target.system and target.resource must both be set or both empty",
+		);
+	}
+	const systemBytes = Buffer.byteLength(target.system, "utf8");
+	if (systemBytes > MAX_IDENTITY_FIELD_LEN) {
+		return new Error(
+			`emitter: target_system exceeds ${MAX_IDENTITY_FIELD_LEN} bytes (got ${systemBytes})`,
+		);
+	}
+	const resourceBytes = Buffer.byteLength(target.resource, "utf8");
+	if (resourceBytes > MAX_TARGET_RESOURCE_LEN) {
+		return new Error(
+			`emitter: target_resource exceeds ${MAX_TARGET_RESOURCE_LEN} bytes (got ${resourceBytes})`,
+		);
+	}
+	return null;
 }
 
 /**

--- a/sdk/ts/src/daemon-emitter.ts
+++ b/sdk/ts/src/daemon-emitter.ts
@@ -468,7 +468,10 @@ export class DaemonEmitter {
 			...(ev.input !== undefined ? { input: RAW_INPUT_SENTINEL } : {}),
 			...(ev.output !== undefined ? { output: RAW_OUTPUT_SENTINEL } : {}),
 			...(ev.error ? { error: ev.error } : {}),
-			...(ev.target
+			// Both fields are non-empty here (validateTarget enforces both-or-
+			// neither); guarding on `system` omits an all-empty target so the
+			// frame matches the Go emitter's omitempty behaviour.
+			...(ev.target?.system
 				? {
 						target_system: ev.target.system,
 						target_resource: ev.target.resource,
@@ -771,29 +774,32 @@ export class DaemonEmitter {
  * the Go emitter, which count bytes — a multi-byte string under the char limit
  * can still exceed the byte cap.
  */
-function validateTarget(target: EmitTarget): Error | null {
-	if (
-		typeof target.system !== "string" ||
-		typeof target.resource !== "string"
-	) {
+function validateTarget(target: unknown): Error | null {
+	// Guard null and non-objects: callers without TypeScript can pass anything,
+	// and validateTarget must return a caller-bug Error rather than throw.
+	if (typeof target !== "object" || target === null) {
+		return new Error("emitter: target must be an object");
+	}
+	const { system, resource } = target as Partial<EmitTarget>;
+	if (typeof system !== "string" || typeof resource !== "string") {
 		return new Error(
 			"emitter: target.system and target.resource must be strings",
 		);
 	}
 	// Both set or both empty — a half-populated target would produce an
 	// ActionTarget with an empty system or resource in the signed receipt.
-	if ((target.system !== "") !== (target.resource !== "")) {
+	if ((system !== "") !== (resource !== "")) {
 		return new Error(
 			"emitter: target.system and target.resource must both be set or both empty",
 		);
 	}
-	const systemBytes = Buffer.byteLength(target.system, "utf8");
+	const systemBytes = Buffer.byteLength(system, "utf8");
 	if (systemBytes > MAX_IDENTITY_FIELD_LEN) {
 		return new Error(
 			`emitter: target_system exceeds ${MAX_IDENTITY_FIELD_LEN} bytes (got ${systemBytes})`,
 		);
 	}
-	const resourceBytes = Buffer.byteLength(target.resource, "utf8");
+	const resourceBytes = Buffer.byteLength(resource, "utf8");
 	if (resourceBytes > MAX_TARGET_RESOURCE_LEN) {
 		return new Error(
 			`emitter: target_resource exceeds ${MAX_TARGET_RESOURCE_LEN} bytes (got ${resourceBytes})`,

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -4,9 +4,12 @@ export {
 	type DaemonEmitterOptions,
 	defaultSocketPath,
 	type EmitEvent,
+	type EmitTarget,
 	type EmitTool,
 	EmitTransportError,
 	MAX_FRAME_SIZE,
+	MAX_IDENTITY_FIELD_LEN,
+	MAX_TARGET_RESOURCE_LEN,
 	SUPPORTED_FRAME_VERSION,
 } from "./daemon-emitter.js";
 export {


### PR DESCRIPTION
## Summary

Adds an optional `target: { system, resource }` field to `EmitEvent` in the TypeScript daemon emitter (`sdk/ts/src/daemon-emitter.ts`). When set, the emitter serialises it into the daemon frame as `target_system` / `target_resource`, which the daemon maps onto `action.target.{system,resource}` (file-identity metadata, e.g. `{ system: "filesystem", resource: "<file path>" }`).

This is **Phase 1 of #939** — exposing the field through the TS emitter. The daemon and Go emitter already implement these frame fields; this brings the TS emitter to parity.

## Validation (mirrors the Go emitter and daemon)

- `system` capped at **256 UTF-8 bytes** (`MAX_IDENTITY_FIELD_LEN`)
- `resource` capped at **4096 UTF-8 bytes** (`MAX_TARGET_RESOURCE_LEN`) — file paths can reach PATH_MAX
- caps measured in **UTF-8 bytes** via `Buffer.byteLength`, not JS string `.length` (UTF-16 code units)
- `system` and `resource` must be **both set or both empty** — a half-populated target is rejected, matching the daemon's XOR rule

`EmitTarget`, `MAX_IDENTITY_FIELD_LEN`, and `MAX_TARGET_RESOURCE_LEN` are exported from the package root and the `@obsigna/sdk-ts/emitter` subpath alongside `EmitTool` / `EmitEvent`.

## Tests

Added vitest coverage in `daemon-emitter.test.ts`:
- populated `target` round-trips into `target_system` / `target_resource`
- omitting `target` leaves both frame fields absent (current behaviour unchanged)
- rejects oversize `system` / `resource` and half-populated targets (system-only, resource-only)
- a multi-byte UTF-8 case proves byte-length (not char-length) measurement, plus a byte-boundary accept case

All 468 tests pass; `pnpm typecheck` and `pnpm lint` (biome) are clean (the 2 pre-existing warnings/infos are in `chain.ts`, untouched).

## Compatibility

Additive and backwards-compatible — omitting `target` preserves current behaviour. TypeScript-only; no changes to Go, Python, the daemon, or the protocol spec.

## Follow-up

Phase 2 (wiring the OpenCode plugin to populate `target`) lands after sdk-ts is released: the plugin consumes sdk-ts from the npm registry rather than a workspace link, so it can't depend on this until published.

Closes part of #939 (Phase 1).