### PR TITLE
feat(sdk-py): add target to the daemon emitter

### DIFF
--- a/sdk/py/src/obsigna/daemon_emitter.py
+++ b/sdk/py/src/obsigna/daemon_emitter.py
@@ -39,6 +39,17 @@ logger = logging.getLogger(__name__)
 # MaxFrameSize must agree with the daemon's socket.MaxFrameSize (1 MiB).
 MAX_FRAME_SIZE = 1 << 20
 
+# MAX_IDENTITY_FIELD_LEN caps target_system at 256 UTF-8 bytes, matching the
+# daemon and the Go/TS emitters (Go MaxIdentityFieldLen, TS
+# MAX_IDENTITY_FIELD_LEN). Measured in bytes, not code points.
+MAX_IDENTITY_FIELD_LEN = 256
+
+# MAX_TARGET_RESOURCE_LEN caps target_resource at 4096 UTF-8 bytes. File paths
+# can reach 4096 bytes on Linux (PATH_MAX), so a wider cap than
+# MAX_IDENTITY_FIELD_LEN is used; the daemon and the Go/TS emitters enforce the
+# same limit. Measured in bytes, not code points.
+MAX_TARGET_RESOURCE_LEN = 4096
+
 # SupportedFrameVersion mirrors the daemon's pipeline.SupportedFrameVersion.
 SUPPORTED_FRAME_VERSION = "1"
 
@@ -228,6 +239,8 @@ class DaemonEmitter:
         decision: str,
         tool_server: str = "",
         action_type: str = "",
+        target_system: str = "",
+        target_resource: str = "",
         input: bytes | str | None = None,
         output: bytes | str | None = None,
         error: str = "",
@@ -264,6 +277,15 @@ class DaemonEmitter:
             risk level: the daemon always resolves risk itself rather than
             trusting an emitter-supplied value, so this field cannot be used to
             downgrade risk and evade a disclosure policy.
+        target_system:
+            Optional resource domain the action operates on, mapped by the
+            daemon to ``action.target.system`` (e.g. ``"filesystem"``). Must be
+            set together with ``target_resource`` — a half-populated target is
+            rejected. Capped at 256 UTF-8 bytes.
+        target_resource:
+            Optional path or identifier within ``target_system``, mapped by the
+            daemon to ``action.target.resource`` (e.g. a file path). Must be set
+            together with ``target_system``. Capped at 4096 UTF-8 bytes.
         input:
             Optional raw JSON bytes or string. Passed verbatim to the daemon —
             NOT re-serialised. Must be valid JSON when non-empty.
@@ -311,6 +333,36 @@ class DaemonEmitter:
                 "emitter: action_type must be a str,"
                 f" got {type(action_type).__name__!r}"
             )
+        if not isinstance(target_system, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(
+                "emitter: target_system must be a str,"
+                f" got {type(target_system).__name__!r}"
+            )
+        if not isinstance(target_resource, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(
+                "emitter: target_resource must be a str,"
+                f" got {type(target_resource).__name__!r}"
+            )
+        # Both set or both empty — a half-populated target would produce an
+        # ActionTarget with an empty system or resource in the signed receipt,
+        # which the daemon's XOR rule rejects.
+        if (target_system != "") != (target_resource != ""):
+            raise ValueError(
+                "emitter: target_system and target_resource must both be set"
+                " or both empty"
+            )
+        target_system_bytes = len(target_system.encode("utf-8"))
+        if target_system_bytes > MAX_IDENTITY_FIELD_LEN:
+            raise ValueError(
+                f"emitter: target_system exceeds {MAX_IDENTITY_FIELD_LEN} bytes"
+                f" (got {target_system_bytes})"
+            )
+        target_resource_bytes = len(target_resource.encode("utf-8"))
+        if target_resource_bytes > MAX_TARGET_RESOURCE_LEN:
+            raise ValueError(
+                f"emitter: target_resource exceeds {MAX_TARGET_RESOURCE_LEN} bytes"
+                f" (got {target_resource_bytes})"
+            )
         if not isinstance(error, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError(
                 f"emitter: error must be a str, got {type(error).__name__!r}"
@@ -332,6 +384,11 @@ class DaemonEmitter:
         }
         if action_type:
             frame["action_type"] = action_type
+        # Both fields are non-empty here (validated above), so an all-empty
+        # target is omitted from the frame entirely.
+        if target_system and target_resource:
+            frame["target_system"] = target_system
+            frame["target_resource"] = target_resource
         if raw_input is not None:
             frame["input"] = _RawJSON(raw_input)
         if raw_output is not None:

--- a/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
+++ b/sdk/py/tests/daemon_emitter/test_daemon_emitter.py
@@ -349,6 +349,69 @@ class TestDaemonEmitterValidation:
         with pytest.raises(ValueError, match="error must be a str"):
             self.e.emit(channel="sdk", tool_name="noop", decision="allowed", error=42)  # type: ignore[arg-type]
 
+    def test_non_str_target_system(self) -> None:
+        with pytest.raises(ValueError, match="target_system must be a str"):
+            self.e.emit(  # type: ignore[arg-type]
+                channel="sdk", tool_name="noop", decision="allowed", target_system=42
+            )
+
+    def test_non_str_target_resource(self) -> None:
+        with pytest.raises(ValueError, match="target_resource must be a str"):
+            self.e.emit(  # type: ignore[arg-type]
+                channel="sdk", tool_name="noop", decision="allowed", target_resource=42
+            )
+
+    def test_half_populated_target_system_only(self) -> None:
+        with pytest.raises(ValueError, match="both be set or both empty"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                target_system="filesystem",
+            )
+
+    def test_half_populated_target_resource_only(self) -> None:
+        with pytest.raises(ValueError, match="both be set or both empty"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                target_resource="/etc/hosts",
+            )
+
+    def test_oversize_target_system(self) -> None:
+        with pytest.raises(ValueError, match="target_system exceeds 256 bytes"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                target_system="a" * 257,
+                target_resource="/etc/hosts",
+            )
+
+    def test_oversize_target_resource(self) -> None:
+        with pytest.raises(ValueError, match="target_resource exceeds 4096 bytes"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                target_system="filesystem",
+                target_resource="/" + "a" * 4096,
+            )
+
+    def test_target_system_byte_length_not_code_points(self) -> None:
+        # 200 code points but each is 2 UTF-8 bytes (400 bytes total), so the
+        # cap is measured in bytes, not characters: char count is under 256 but
+        # byte count exceeds it.
+        with pytest.raises(ValueError, match="target_system exceeds 256 bytes"):
+            self.e.emit(
+                channel="sdk",
+                tool_name="noop",
+                decision="allowed",
+                target_system="é" * 200,
+                target_resource="/etc/hosts",
+            )
+
     def test_invalid_input_json(self) -> None:
         with pytest.raises(ValueError, match="input is not valid JSON"):
             self.e.emit(
@@ -721,6 +784,52 @@ class TestActionType:
             }
         )
         assert "action_type" not in frame
+
+
+class TestTarget:
+    """The emitter forwards a populated target to the daemon.
+
+    target_system / target_resource map to action.target.{system,resource} in
+    the signed receipt. Both fields are required together (the daemon's XOR
+    rule); an all-empty target is omitted so existing callers are unaffected.
+    """
+
+    def test_target_present_in_frame(self) -> None:
+        frame = _capture_one_frame(
+            {
+                "channel": "sdk",
+                "tool_name": "rm",
+                "decision": "allowed",
+                "target_system": "filesystem",
+                "target_resource": "/etc/hosts",
+            }
+        )
+        assert frame["target_system"] == "filesystem"
+        assert frame["target_resource"] == "/etc/hosts"
+
+    def test_target_absent_when_omitted(self) -> None:
+        frame = _capture_one_frame(
+            {
+                "channel": "sdk",
+                "tool_name": "rm",
+                "decision": "allowed",
+            }
+        )
+        assert "target_system" not in frame
+        assert "target_resource" not in frame
+
+    def test_target_absent_when_both_empty(self) -> None:
+        frame = _capture_one_frame(
+            {
+                "channel": "sdk",
+                "tool_name": "rm",
+                "decision": "allowed",
+                "target_system": "",
+                "target_resource": "",
+            }
+        )
+        assert "target_system" not in frame
+        assert "target_resource" not in frame
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `target_system` / `target_resource` keyword-only params to `DaemonEmitter.emit()` in the Python SDK, so the Python emitter can forward file-identity metadata that the daemon maps to `action.target.{system,resource}` in the signed receipt. This is the Python counterpart of the merged TS change (#942); the Go emitter already had it.

## Details

- Two new module-level constants: `MAX_IDENTITY_FIELD_LEN = 256` and `MAX_TARGET_RESOURCE_LEN = 4096` (UTF-8 byte caps matching the daemon, Go, and TS emitters).
- Validation raises `ValueError` (the Python emitter's caller-bug contract — it does not return error objects) with the existing `emitter:`-prefixed message style:
  - both must be `str`
  - both set or both empty (the daemon's XOR rule; a half-populated target is rejected)
  - byte caps measured as UTF-8 bytes (`len(s.encode("utf-8"))`), not code points: `target_system` <= 256, `target_resource` <= 4096
- Serialised into the frame only when both are non-empty, so an omitted or all-empty target is dropped (matches Go's omitempty and the TS fix).

## Compatibility

Additive and backwards-compatible — omitting the params preserves current behaviour.

## Tests

New tests cover: populated target round-trips into the frame; omitted and all-empty targets omit both wire fields; `ValueError` for non-str, half-populated (system-only and resource-only), oversize system (>256 bytes) and resource (>4096 bytes); and a multi-byte UTF-8 case proving byte-length (not code-point) measurement.

`uv run pytest` (500 passed, 7 skipped), `ruff check`, and `ruff format --check` all pass.

Completes cross-SDK emitter `target` parity (Go already had it; TS = #942).

Closes #941