### PR TITLE
feat(opencode-plugin): emit action.target.resource for file tools

### DIFF
--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **File-identity metadata on receipts.** The plugin now emits `action.target.resource` for native file tools. When a tool call carries a `filePath` (OpenCode's `read`, `write`, `edit`, `patch`, `apply_patch`), the recorder attaches `{ system: "filesystem", resource: <filePath> }` to the frame; the daemon maps it onto `action.target.{system,resource}`. The extraction is opportunistic and tool-agnostic — tools without a `filePath` (`bash`, `glob`, `grep`, `list`, `webfetch`) yield no target — mirroring the Claude Code hook's `file_path` extraction. Like the action map, this is honest-operator metadata the agent supplies. Shell-command target parsing (`bash` redirects) is a possible follow-up. ([#939](https://github.com/agent-receipts/obsigna/issues/939))
+
 ### Changed
 
+- **Bumped `@obsigna/sdk-ts` to `^0.16.0`** (was `^0.14.1`) for the `EmitEvent.target` / `EmitTarget` surface that carries the file-identity metadata above.
 - **Docs**: refer to the current binary names in `README.md` and `AGENTS.md` — `obsigna-daemon` (was `agent-receipts-daemon`), `obsigna-hook` (was `agent-receipts-hook`), and `obsigna verify` (was `agent-receipts verify`). Documentation-only; no code or behaviour changes.
 
 ## [0.1.0] - 2026-06-16

--- a/integrations/opencode-plugin/package.json
+++ b/integrations/opencode-plugin/package.json
@@ -38,7 +38,7 @@
 	},
 	"packageManager": "pnpm@10.33.0",
 	"dependencies": {
-		"@obsigna/sdk-ts": "^0.14.1"
+		"@obsigna/sdk-ts": "^0.16.0"
 	},
 	"peerDependencies": {
 		"@opencode-ai/plugin": ">=0.1.0"

--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@obsigna/sdk-ts':
-        specifier: ^0.14.1
-        version: 0.14.1
+        specifier: ^0.16.0
+        version: 0.16.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.9
@@ -135,8 +135,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@obsigna/sdk-ts@0.14.1':
-    resolution: {integrity: sha512-J2GkZMwD9CGcAv88iAC8r0SfHSAmyk1Hr+HjiI2hm663tOpMxMxqa6N2RCzNUWCMq9IBVk504JNTig7xHw4o1Q==}
+  '@obsigna/sdk-ts@0.16.0':
+    resolution: {integrity: sha512-j7OBZzsfzm86hLIIA7b2RqNSPz+zZJ/79g+x92iMD7NOLOttdVjdTXoiZio4rPFn1TQWeP4sqaxB5KGVZCXYHA==}
     engines: {node: '>=22.11.0'}
 
   '@opencode-ai/plugin@1.16.2':
@@ -737,7 +737,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@obsigna/sdk-ts@0.14.1':
+  '@obsigna/sdk-ts@0.16.0':
     dependencies:
       undici: 8.5.0
       zod: 4.4.3

--- a/integrations/opencode-plugin/src/recorder.test.ts
+++ b/integrations/opencode-plugin/src/recorder.test.ts
@@ -96,6 +96,92 @@ describe("ReceiptRecorder — one receipt per native tool call", () => {
 	});
 });
 
+describe("ReceiptRecorder — file-identity target", () => {
+	it.each([
+		"edit",
+		"write",
+		"read",
+	])("sets a filesystem target from filePath for %s", async (tool) => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool,
+			sessionID: "s1",
+			callID: "c1",
+			args: { filePath: "src/recorder.ts" },
+		});
+		expect(emitters.get("s1")?.events[0]?.target).toEqual({
+			system: "filesystem",
+			resource: "src/recorder.ts",
+		});
+	});
+
+	it("trims surrounding whitespace from the resource path", async () => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool: "write",
+			sessionID: "s1",
+			callID: "c1",
+			args: { filePath: "  a.ts  " },
+		});
+		expect(emitters.get("s1")?.events[0]?.target).toEqual({
+			system: "filesystem",
+			resource: "a.ts",
+		});
+	});
+
+	it("leaves target unset for a tool with no filePath (bash command)", async () => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool: "bash",
+			sessionID: "s1",
+			callID: "c1",
+			args: { command: "go test ./..." },
+		});
+		expect(emitters.get("s1")?.events[0]?.target).toBeUndefined();
+	});
+
+	it("leaves target unset for grep (pattern arg, no filePath)", async () => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool: "grep",
+			sessionID: "s1",
+			callID: "c1",
+			args: { pattern: "TODO" },
+		});
+		expect(emitters.get("s1")?.events[0]?.target).toBeUndefined();
+	});
+
+	it("leaves target unset for an empty or whitespace filePath", async () => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool: "write",
+			sessionID: "s1",
+			callID: "c1",
+			args: { filePath: "   " },
+		});
+		await recorder.recordResult({
+			tool: "write",
+			sessionID: "s1",
+			callID: "c2",
+			args: { filePath: "" },
+		});
+		const events = emitters.get("s1")?.events ?? [];
+		expect(events[0]?.target).toBeUndefined();
+		expect(events[1]?.target).toBeUndefined();
+	});
+
+	it("leaves target unset for a non-string filePath", async () => {
+		const { recorder, emitters } = harness();
+		await recorder.recordResult({
+			tool: "write",
+			sessionID: "s1",
+			callID: "c1",
+			args: { filePath: 42 },
+		});
+		expect(emitters.get("s1")?.events[0]?.target).toBeUndefined();
+	});
+});
+
 describe("ReceiptRecorder — intent/params bridging", () => {
 	it("falls back to before-hook args when the after-hook omits them", async () => {
 		const { recorder, emitters } = harness();

--- a/integrations/opencode-plugin/src/recorder.ts
+++ b/integrations/opencode-plugin/src/recorder.ts
@@ -24,7 +24,11 @@
  * guessing.
  */
 
-import { DaemonEmitter, type EmitEvent } from "@obsigna/sdk-ts/emitter";
+import {
+	DaemonEmitter,
+	type EmitEvent,
+	type EmitTarget,
+} from "@obsigna/sdk-ts/emitter";
 import { resolveActionType } from "./actions.js";
 import { type ResolvedConfig, shouldEmit } from "./config.js";
 
@@ -184,6 +188,16 @@ export class ReceiptRecorder {
 		if (result.error) {
 			ev.error = result.error;
 		}
+		// Opportunistic, honest-operator file-identity metadata: when the args
+		// carry a `filePath`, surface it as the action's target. The daemon maps
+		// it onto `action.target.{system,resource}` on the receipt. Like the
+		// action map, this is emitter-supplied advisory metadata — a compromised
+		// OpenCode could omit or misreport it (see the trust-boundary note above).
+		// Only set it when fully populated; the SDK rejects a half-populated target.
+		const target = extractTarget(args);
+		if (target) {
+			ev.target = target;
+		}
 		return ev;
 	}
 
@@ -228,6 +242,33 @@ export class ReceiptRecorder {
 			},
 		);
 	}
+}
+
+/**
+ * Opportunistically derive a filesystem target from a tool call's args. Native
+ * OpenCode file tools (`read`, `write`, `edit`, `patch`, `apply_patch`) carry a
+ * camelCase `filePath`; non-file tools (`bash`, `glob`, `grep`, `list`,
+ * `webfetch`) do not, so they naturally yield no target. This mirrors the Claude
+ * Code hook's opportunistic `file_path` extraction (`extractFileTarget`).
+ *
+ * Returns a fully-populated `{ system: "filesystem", resource }` only when
+ * `filePath` is a non-empty (after trimming) string; otherwise `undefined`, so
+ * the caller never assigns a half-populated target (which the SDK rejects).
+ * Shell-command target extraction (parsing `bash` redirects) is out of scope.
+ */
+function extractTarget(args: unknown): EmitTarget | undefined {
+	if (typeof args !== "object" || args === null) {
+		return undefined;
+	}
+	const filePath = (args as { filePath?: unknown }).filePath;
+	if (typeof filePath !== "string") {
+		return undefined;
+	}
+	const resource = filePath.trim();
+	if (resource === "") {
+		return undefined;
+	}
+	return { system: "filesystem", resource };
 }
 
 /** Assemble the receipt output payload from the after-hook fields, dropping empties. */

--- a/integrations/opencode-plugin/src/roundtrip.test.ts
+++ b/integrations/opencode-plugin/src/roundtrip.test.ts
@@ -186,6 +186,29 @@ describe("round-trip against a fake daemon socket", () => {
 		expect(bySession.get("subagent")).toEqual(["filesystem.file.modify"]);
 	});
 
+	it("delivers a filesystem target on the frame for file tools", async () => {
+		await recorder.recordResult({
+			tool: "write",
+			sessionID: "root",
+			callID: "c1",
+			args: { filePath: "out.txt" },
+		});
+		await recorder.recordResult({
+			tool: "bash",
+			sessionID: "root",
+			callID: "c2",
+			args: { command: "ls" },
+		});
+
+		await waitForFrames(server, 2);
+		const frames = server.frames().map((f) => JSON.parse(f));
+		expect(frames[0]?.target_system).toBe("filesystem");
+		expect(frames[0]?.target_resource).toBe("out.txt");
+		// bash carries no filePath, so no target fields reach the frame.
+		expect(frames[1]?.target_system).toBeUndefined();
+		expect(frames[1]?.target_resource).toBeUndefined();
+	});
+
 	it("preserves input bytes verbatim for the daemon to hash", async () => {
 		// Whitespace and key order are preserved exactly so the daemon's
 		// RFC 8785 canonicalisation hashes the bytes the plugin produced.


### PR DESCRIPTION
## Summary

Phase 2 of #939: wires the OpenCode plugin to populate the receipt's file-identity metadata (`action.target.resource`) for native file tools, now that `@obsigna/sdk-ts@0.16.0` (which adds `EmitEvent.target` / `EmitTarget`) is live on npm. Plugin-only — no SDK, daemon, or spec changes.

## What changed

- **`src/recorder.ts`** — new `extractTarget(args)` helper and a call in `buildEvent`. When a tool call's args carry a camelCase `filePath` that is a non-empty (trimmed) string, the recorder attaches `{ system: "filesystem", resource: <filePath> }` to the `EmitEvent`; the daemon maps it onto `action.target.{system,resource}`. Imports `EmitTarget` from `@obsigna/sdk-ts/emitter`.
- **`package.json` + `pnpm-lock.yaml`** — bumped `@obsigna/sdk-ts` `^0.14.1` → `^0.16.0` for the `target` surface. Lockfile change is scoped to that package.
- **`src/recorder.test.ts`** — new "file-identity target" suite: `edit`/`write`/`read` with `filePath` produce the target; `bash` (command) and `grep` (pattern) produce none; empty/whitespace `filePath` and non-string `filePath` produce none; whitespace is trimmed.
- **`src/roundtrip.test.ts`** — added an assertion that `target_system`/`target_resource` reach the daemon wire frame for a file tool and are absent for `bash` (fit the existing echo-server harness cleanly).
- **`CHANGELOG.md`** — Unreleased entry.

## The `filePath` heuristic

The extraction is opportunistic and tool-agnostic, mirroring the Claude Code hook's `file_path` extraction (`hook/cmd/obsigna-hook/claude_code.go` `extractFileTarget`). It naturally covers `read`/`write`/`edit`/`patch`/`apply_patch` (which carry `filePath`) and naturally skips `glob`/`grep`/`list`/`bash`/`webfetch` (which don't). This is honest-operator metadata the agent supplies — emitter-only, not adversary-resistant — consistent with the recorder's existing trust-boundary placement. The helper never returns a half-populated target (the SDK rejects those).

**Out of scope / follow-up:** `bash` shell-command target extraction (parsing redirects, as the hook does in `shell_target.go`) is deliberately not included here.

## Verification (from `integrations/opencode-plugin`)

- `pnpm install` — resolves sdk-ts 0.16.0
- `pnpm test` — 40 passed
- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean (exit 0; only a pre-existing biome.json `$schema` patch-version info note, unrelated to this change)

## Dependencies

Depends on the now-released `@obsigna/sdk-ts@0.16.0`.

Closes #939.