### PR TITLE
docs(site-obsigna): add browser-verifier post to blog navbar

### DIFF
--- a/site-obsigna/astro.config.mjs
+++ b/site-obsigna/astro.config.mjs
@@ -213,6 +213,10 @@ export default defineConfig({
           items: [
             { label: "All Posts", slug: "blog" },
             {
+              label: "Run the check yourself: a browser verifier",
+              slug: "blog/browser-verifier",
+            },
+            {
               label: "Your agents are isolated. Your shared state isn't.",
               slug: "blog/attribution-over-undo",
             },


### PR DESCRIPTION
## What

Adds the `browser-verifier` post to the obsigna.dev blog sidebar nav (`site-obsigna/astro.config.mjs`).

## Why

Blog **post content** auto-syncs from `site/` via `scripts/sync-blog.mjs` (`prebuild`/`predev`) — the `.mdx`, the index listing, and the image all mirror automatically. The **sidebar nav** in `astro.config.mjs` is *not* synced; it's hand-maintained per site.

PR #945 added the post to `site/astro.config.mjs` (agentreceipts.ai) but missed the obsigna.dev mirror, so the post was reachable but absent from the blog navbar at obsigna.dev/blog/. This adds it at the top of the Blog group, matching the order on `site/`.

## Test

`pnpm build` in `site-obsigna` succeeds; the post page, index link, and screenshot all populate via the prebuild sync, and the sidebar now lists the entry.