### PR TITLE
Add clause traceability to MUST-reject corpus vectors

### DIFF
--- a/cross-sdk-tests/cmd/generate-malformed-vectors/main.go
+++ b/cross-sdk-tests/cmd/generate-malformed-vectors/main.go
@@ -24,6 +24,19 @@ import (
 
 const fixedTimestamp = "2026-04-22T00:00:00Z"
 
+// frozenContext and frozenVersion pin the wire form of the base receipts to the
+// spec version the corpus was frozen at (v0.2.0 / context v1). receipt.Create
+// defaults to the current SDK version, which has since advanced; without these
+// overrides a regeneration would rewrite the @context and version of the frozen
+// cases (and therefore their signatures). Pinning them keeps the existing cases
+// byte-identical across regenerations while new cases share the same wire form.
+var frozenContext = []string{
+	"https://www.w3.org/ns/credentials/v2",
+	"https://agentreceipts.ai/context/v1",
+}
+
+const frozenVersion = "0.2.0"
+
 type malformedVectors struct {
 	Description string        `json:"description"`
 	Keys        keysSection   `json:"keys"`
@@ -37,13 +50,18 @@ type keysSection struct {
 }
 
 type receiptCase struct {
-	Name        string          `json:"name"`
+	Name string `json:"name"`
+	// Clause names the normative spec section the case enforces, so a reviewer
+	// can trace each MUST-reject vector to the requirement it guards. Rendered
+	// as the "Enforces" column on the conformance page (via count.py).
+	Clause      string          `json:"clause"`
 	Description string          `json:"description"`
 	Receipt     json.RawMessage `json:"receipt"`
 }
 
 type chainCase struct {
 	Name        string            `json:"name"`
+	Clause      string            `json:"clause"`
 	Description string            `json:"description"`
 	Receipts    []json.RawMessage `json:"receipts"`
 }
@@ -69,34 +87,61 @@ func main() {
 
 	receiptCases := []receiptCase{
 		mustCase("wrong_proof_type",
+			"§4.3.3 proof — type MUST be Ed25519Signature2020",
 			"proof.type changed from Ed25519Signature2020 to RsaSignature2018; verifiers MUST reject any other proof type (the field lives outside the signed bytes, so the Ed25519 signature still checks — this case guards the explicit type check in verify)",
 			mutateProofType(signedBase, "RsaSignature2018")),
 
 		mustCase("mutated_action_type",
+			"§7.8 End-to-end receipt verification — signature over canonical bytes",
 			"action.type changed after signing — canonical bytes no longer match the signature",
 			mutateActionType(signedBase, "filesystem.file.delete")),
 
 		mustCase("mutated_principal_id",
+			"§7.8 End-to-end receipt verification — signature over canonical bytes",
 			"principal.id changed after signing — payload tampering",
 			mutatePrincipalID(signedBase, "did:user:attacker")),
 
 		mustCase("truncated_proof_value",
+			"§7.8 End-to-end receipt verification — signature over canonical bytes",
 			"signature truncated to its multibase prefix only — empty signature bytes",
 			mutateProofValue(signedBase, "u")),
 
 		mustCase("wrong_multibase_prefix",
+			"§4.3.3 proof — proofValue is u-prefixed base64url",
 			"proof.proofValue uses 'z' (base58) instead of 'u' (base64url) — Ed25519Signature2020 mandates base64url",
 			swapMultibasePrefix(signedBase, "z")),
 
 		mustCase("flipped_proof_byte",
+			"§7.8 End-to-end receipt verification — signature over canonical bytes",
 			"single byte of proofValue replaced — Ed25519 verification MUST fail on any single-bit mutation",
 			flipProofByte(signedBase)),
+
+		rawCase("schema_missing_required_field",
+			"§4.3.2 credentialSubject — chain.chain_id is required",
+			"chain.chain_id (a schema-required field) removed from an otherwise-valid signed receipt — a schema-invalid receipt every verifier MUST reject. Verifiers that schema-validate reject it at parse time, before the signature check; removing a signed field also breaks the Ed25519 signature, so a verify-only path rejects it too",
+			removeChainField(signedBase, "chain_id")),
 	}
 
 	chainCases := []chainCase{
 		mustChainCase("missing_previous_receipt_hash_mid_chain",
+			"§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)",
 			"middle receipt is missing chain.previous_receipt_hash, breaking the hash linkage",
 			buildBrokenChain(ts.Keys.PrivateKey)),
+
+		mustChainCase("chain_wrong_previous_receipt_hash",
+			"§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)",
+			"last receipt's chain.previous_receipt_hash is the valid hash of the genesis receipt (a different receipt in the set) instead of its immediate predecessor — well-formed linkage pointing at the wrong predecessor. Distinct from the missing case; each receipt is individually signed and verifiable, so only the chain hash-linkage check fails",
+			buildWrongPrevHashChain(ts.Keys.PrivateKey)),
+
+		mustChainCase("chain_duplicate_sequence",
+			"§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1",
+			"two receipts under one chain_id share sequence 2 (fork / equivocation); each receipt is individually signed and hash-linked, so only the strict-contiguity check fails",
+			buildDuplicateSequenceChain(ts.Keys.PrivateKey)),
+
+		mustChainCase("chain_sequence_gap",
+			"§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1",
+			"sequences run 1, 2, 4 with a gap at 3; each receipt is individually signed and hash-linked, so only the strict-contiguity check fails (spec §7.3.5 mandates contiguity, not merely strictly-increasing)",
+			buildSequenceGapChain(ts.Keys.PrivateKey)),
 	}
 
 	out := malformedVectors{
@@ -137,6 +182,8 @@ func signSample(privateKey string) (receipt.AgentReceipt, error) {
 	r.IssuanceDate = fixedTimestamp
 	r.CredentialSubject.Action.ID = "act_malformed_1"
 	r.CredentialSubject.Action.Timestamp = fixedTimestamp
+	r.Context = frozenContext
+	r.Version = frozenVersion
 
 	signed, err := receipt.Sign(r, privateKey, "did:agent:malformed-test#key-1")
 	if err != nil {
@@ -218,6 +265,8 @@ func buildBrokenChain(privateKey string) []receipt.AgentReceipt {
 		r.IssuanceDate = fixedTimestamp
 		r.CredentialSubject.Action.ID = fmt.Sprintf("act_malformed_chain_%d", i)
 		r.CredentialSubject.Action.Timestamp = fixedTimestamp
+		r.Context = frozenContext
+		r.Version = frozenVersion
 
 		signed, err := receipt.Sign(r, privateKey, "did:agent:malformed-test#key-1")
 		if err != nil {
@@ -242,6 +291,153 @@ func buildBrokenChain(privateKey string) []receipt.AgentReceipt {
 	return chain
 }
 
+// newChainReceipt builds one unsigned chain receipt with the frozen wire form,
+// used by the chain-negative builders below. The defect (wrong prev hash,
+// duplicate/gapped sequence) is baked into the Chain input BEFORE signing so the
+// signature stays valid and only the targeted chain check fails — a stronger
+// test than relying on a broken signature to reject the case.
+func newChainReceipt(seq int, prev *string, chainID, actionID, id string) receipt.UnsignedAgentReceipt {
+	r := receipt.Create(receipt.CreateInput{
+		Issuer:    receipt.Issuer{ID: "did:agent:malformed-test"},
+		Principal: receipt.Principal{ID: "did:user:alice"},
+		Action: receipt.Action{
+			Type:      "filesystem.file.read",
+			RiskLevel: receipt.RiskLow,
+		},
+		Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+		Chain: receipt.Chain{
+			Sequence:            seq,
+			PreviousReceiptHash: prev,
+			ChainID:             chainID,
+		},
+	})
+	r.ID = id
+	r.IssuanceDate = fixedTimestamp
+	r.CredentialSubject.Action.ID = actionID
+	r.CredentialSubject.Action.Timestamp = fixedTimestamp
+	r.Context = frozenContext
+	r.Version = frozenVersion
+	return r
+}
+
+// signChainReceipt signs an unsigned chain receipt with the shared key and
+// stamps the fixed proof timestamp.
+func signChainReceipt(r receipt.UnsignedAgentReceipt, privateKey string) receipt.AgentReceipt {
+	signed, err := receipt.Sign(r, privateKey, "did:agent:malformed-test#key-1")
+	if err != nil {
+		fail("sign chain receipt: %v", err)
+	}
+	signed.Proof.Created = fixedTimestamp
+	return signed
+}
+
+func hashOrFail(r receipt.AgentReceipt) string {
+	h, err := receipt.HashReceipt(r)
+	if err != nil {
+		fail("hash chain receipt: %v", err)
+	}
+	return h
+}
+
+// buildWrongPrevHashChain builds a 3-receipt chain whose last receipt points its
+// chain.previous_receipt_hash at the genesis receipt (index 0) rather than its
+// immediate predecessor (index 1). Every receipt is individually signed and
+// verifiable; only the chain hash-linkage check fails. Distinct from
+// missing_previous_receipt_hash_mid_chain (which nulls the field).
+func buildWrongPrevHashChain(privateKey string) []receipt.AgentReceipt {
+	const chainID = "chain_malformed_wrong_prev"
+	chain := make([]receipt.AgentReceipt, 0, 3)
+	hashes := make([]string, 0, 3)
+	var prev *string
+	for i := 1; i <= 3; i++ {
+		linkTo := prev
+		if i == 3 {
+			// Point at the genesis receipt's hash — a valid hash of a DIFFERENT
+			// receipt in the set — instead of the immediate predecessor's.
+			wrong := hashes[0]
+			linkTo = &wrong
+		}
+		id := fmt.Sprintf("urn:receipt:00000000-0000-4000-8000-00000000001%d", i)
+		r := newChainReceipt(i, linkTo, chainID, fmt.Sprintf("act_wrong_prev_%d", i), id)
+		signed := signChainReceipt(r, privateKey)
+		chain = append(chain, signed)
+		h := hashOrFail(signed)
+		hashes = append(hashes, h)
+		prev = &h
+	}
+	return chain
+}
+
+// buildDuplicateSequenceChain builds a 3-receipt chain in which the third
+// receipt reuses sequence 2 (fork / equivocation under one chain_id). Hash
+// linkage to the immediate predecessor stays correct, so only the strict
+// sequence-contiguity check fails.
+func buildDuplicateSequenceChain(privateKey string) []receipt.AgentReceipt {
+	const chainID = "chain_malformed_dup_seq"
+	sequences := []int{1, 2, 2}
+	return buildSequencedChain(privateKey, chainID, "dup_seq", sequences)
+}
+
+// buildSequenceGapChain builds a 3-receipt chain whose sequences run 1, 2, 4 —
+// a gap at 3. Hash linkage stays correct, so only the strict contiguity check
+// fails. Exercises spec §7.3.5's contiguity mandate (not merely
+// strictly-increasing).
+func buildSequenceGapChain(privateKey string) []receipt.AgentReceipt {
+	const chainID = "chain_malformed_seq_gap"
+	sequences := []int{1, 2, 4}
+	return buildSequencedChain(privateKey, chainID, "seq_gap", sequences)
+}
+
+// buildSequencedChain signs a hash-linked chain whose receipts carry the given
+// sequence numbers verbatim. Each receipt links to the actual hash of its
+// predecessor, so hash linkage is valid regardless of the sequence values —
+// isolating the sequence check as the sole reason a non-contiguous chain fails.
+func buildSequencedChain(privateKey, chainID, actionPrefix string, sequences []int) []receipt.AgentReceipt {
+	chain := make([]receipt.AgentReceipt, 0, len(sequences))
+	var prev *string
+	for i, seq := range sequences {
+		id := fmt.Sprintf("urn:receipt:00000000-0000-4000-8000-00000000002%d", i+1)
+		r := newChainReceipt(seq, prev, chainID, fmt.Sprintf("act_%s_%d", actionPrefix, i+1), id)
+		signed := signChainReceipt(r, privateKey)
+		chain = append(chain, signed)
+		h := hashOrFail(signed)
+		prev = &h
+	}
+	return chain
+}
+
+// removeChainField marshals a signed receipt and deletes one field from its
+// credentialSubject.chain object at the JSON layer, producing a schema-invalid
+// receipt no typed AgentReceipt can express (the Go struct always carries the
+// field). Verifiers MUST reject a receipt missing a schema-required chain field.
+func removeChainField(base receipt.AgentReceipt, field string) json.RawMessage {
+	body, err := json.Marshal(base)
+	if err != nil {
+		fail("marshal for field removal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		fail("unmarshal for field removal: %v", err)
+	}
+	cs, ok := m["credentialSubject"].(map[string]any)
+	if !ok {
+		fail("removeChainField: credentialSubject not an object")
+	}
+	chain, ok := cs["chain"].(map[string]any)
+	if !ok {
+		fail("removeChainField: chain not an object")
+	}
+	if _, present := chain[field]; !present {
+		fail("removeChainField: field %q not present to remove", field)
+	}
+	delete(chain, field)
+	out, err := json.Marshal(m)
+	if err != nil {
+		fail("re-marshal after field removal: %v", err)
+	}
+	return out
+}
+
 func cloneReceipt(in receipt.AgentReceipt) receipt.AgentReceipt {
 	body, err := json.Marshal(in)
 	if err != nil {
@@ -254,15 +450,22 @@ func cloneReceipt(in receipt.AgentReceipt) receipt.AgentReceipt {
 	return out
 }
 
-func mustCase(name, desc string, r receipt.AgentReceipt) receiptCase {
+func mustCase(name, clause, desc string, r receipt.AgentReceipt) receiptCase {
 	body, err := json.Marshal(r)
 	if err != nil {
 		fail("marshal case %s: %v", name, err)
 	}
-	return receiptCase{Name: name, Description: desc, Receipt: body}
+	return receiptCase{Name: name, Clause: clause, Description: desc, Receipt: body}
 }
 
-func mustChainCase(name, desc string, receipts []receipt.AgentReceipt) chainCase {
+// rawCase builds a receipt-level case from an already-serialised body. Used for
+// cases that mutate the receipt at the JSON layer (e.g. removing a required
+// field), where no typed AgentReceipt can express the malformation.
+func rawCase(name, clause, desc string, body json.RawMessage) receiptCase {
+	return receiptCase{Name: name, Clause: clause, Description: desc, Receipt: body}
+}
+
+func mustChainCase(name, clause, desc string, receipts []receipt.AgentReceipt) chainCase {
 	out := make([]json.RawMessage, len(receipts))
 	for i, r := range receipts {
 		body, err := json.Marshal(r)
@@ -271,7 +474,7 @@ func mustChainCase(name, desc string, receipts []receipt.AgentReceipt) chainCase
 		}
 		out[i] = body
 	}
-	return chainCase{Name: name, Description: desc, Receipts: out}
+	return chainCase{Name: name, Clause: clause, Description: desc, Receipts: out}
 }
 
 func fail(format string, args ...any) {

--- a/cross-sdk-tests/conformance_page_test.go
+++ b/cross-sdk-tests/conformance_page_test.go
@@ -48,9 +48,18 @@ type countSet struct {
 	OnPage bool   `json:"onPage"`
 }
 
+// malformedClause is one MUST-reject vector's clause traceability, as emitted by
+// count.py under "malformedCorpus". It backs the page's "Enforces" column.
+type malformedClause struct {
+	Name   string `json:"name"`
+	Kind   string `json:"kind"`
+	Clause string `json:"clause"`
+}
+
 type countPayload struct {
-	Sets  []countSet `json:"sets"`
-	Total int        `json:"total"`
+	Sets            []countSet        `json:"sets"`
+	Total           int               `json:"total"`
+	MalformedCorpus []malformedClause `json:"malformedCorpus"`
 }
 
 // reconcileInputs bundles the once-loaded count.py output and page text so the
@@ -163,6 +172,34 @@ var (
 	proseMalformedRe = regexp.MustCompile(`(\d+)-case MUST-reject corpus`)
 )
 
+// enforcesRowRe matches a clause-traceability row: `| vector_name | receipt |
+// §… clause text |`. The first cell is the snake_case vector name, the second is
+// the layer (receipt|chain), the third is the clause. The header row ("| Vector
+// | Layer | Enforces |") and the separator ("| --- | --- | --- |") do not match,
+// so only data rows are parsed.
+var enforcesRowRe = regexp.MustCompile(`^\|\s*([a-z0-9_]+)\s*\|\s*(receipt|chain)\s*\|\s*(.+?)\s*\|\s*$`)
+
+// parseEnforces extracts {name: clause} for every clause-traceability row in the
+// given section.
+func parseEnforces(t *testing.T, src string) map[string]string {
+	t.Helper()
+	rows := map[string]string{}
+	for _, line := range strings.Split(src, "\n") {
+		m := enforcesRowRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if _, dup := rows[m[1]]; dup {
+			t.Fatalf("duplicate Enforces row for %q", m[1])
+		}
+		rows[m[1]] = m[3]
+	}
+	if len(rows) == 0 {
+		t.Fatal("no Enforces rows parsed from the clause-traceability section")
+	}
+	return rows
+}
+
 func TestConformancePageReconciles(t *testing.T) {
 	in := loadReconcileInputs(t)
 
@@ -195,6 +232,37 @@ func TestConformancePageReconciles(t *testing.T) {
 		for name := range pageRows {
 			if _, ok := expected[name]; !ok {
 				t.Errorf("page matrix row %q has no corresponding on-page set in count.py", name)
+			}
+		}
+	})
+
+	// The page's "Enforces" column (clause traceability for the MUST-reject
+	// corpus) is pinned to count.py's malformedCorpus: every vector appears with
+	// the exact clause count.py reads from the vector file, and no row exists
+	// that count.py does not know about. This is what stops the column from
+	// being hand-typed and drifting from the committed `clause` fields.
+	t.Run("enforces", func(t *testing.T) {
+		if len(in.payload.MalformedCorpus) == 0 {
+			t.Fatal("count.py returned no malformedCorpus entries")
+		}
+		src := section(t, in.page, "## Clause traceability", "## CI enforcement")
+		pageRows := parseEnforces(t, src)
+
+		expected := map[string]bool{}
+		for _, c := range in.payload.MalformedCorpus {
+			expected[c.Name] = true
+			got, present := pageRows[c.Name]
+			if !present {
+				t.Errorf("malformed vector %q is missing from the page Enforces table", c.Name)
+				continue
+			}
+			if got != c.Clause {
+				t.Errorf("clause mismatch for %q:\n  page=%q\n  count.py=%q", c.Name, got, c.Clause)
+			}
+		}
+		for name := range pageRows {
+			if !expected[name] {
+				t.Errorf("page Enforces row %q has no corresponding vector in count.py", name)
 			}
 		}
 	})

--- a/cross-sdk-tests/conformance_page_test.go
+++ b/cross-sdk-tests/conformance_page_test.go
@@ -49,11 +49,13 @@ type countSet struct {
 }
 
 // malformedClause is one MUST-reject vector's clause traceability, as emitted by
-// count.py under "malformedCorpus". It backs the page's "Enforces" column.
+// count.py under "malformedCorpus". It backs the page's "Enforces" column: the
+// clause text is the link label and the anchor is its href.
 type malformedClause struct {
 	Name   string `json:"name"`
 	Kind   string `json:"kind"`
 	Clause string `json:"clause"`
+	Anchor string `json:"anchor"`
 }
 
 type countPayload struct {
@@ -173,17 +175,23 @@ var (
 )
 
 // enforcesRowRe matches a clause-traceability row: `| vector_name | receipt |
-// §… clause text |`. The first cell is the snake_case vector name, the second is
-// the layer (receipt|chain), the third is the clause. The header row ("| Vector
-// | Layer | Enforces |") and the separator ("| --- | --- | --- |") do not match,
-// so only data rows are parsed.
-var enforcesRowRe = regexp.MustCompile(`^\|\s*([a-z0-9_]+)\s*\|\s*(receipt|chain)\s*\|\s*(.+?)\s*\|\s*$`)
+// [§… clause text](/anchor) |`. The first cell is the snake_case vector name, the
+// second is the layer (receipt|chain), the third is a markdown link whose label
+// is the clause and whose href is the anchor. The header row ("| Vector | Layer |
+// Enforces |") and the separator ("| --- | --- | --- |") do not match, so only
+// data rows are parsed.
+var enforcesRowRe = regexp.MustCompile(`^\|\s*([a-z0-9_]+)\s*\|\s*(receipt|chain)\s*\|\s*\[(.+?)\]\((.+?)\)\s*\|\s*$`)
 
-// parseEnforces extracts {name: clause} for every clause-traceability row in the
-// given section.
-func parseEnforces(t *testing.T, src string) map[string]string {
+type enforcesCell struct {
+	clause string
+	anchor string
+}
+
+// parseEnforces extracts {name: {clause, anchor}} for every clause-traceability
+// row in the given section.
+func parseEnforces(t *testing.T, src string) map[string]enforcesCell {
 	t.Helper()
-	rows := map[string]string{}
+	rows := map[string]enforcesCell{}
 	for _, line := range strings.Split(src, "\n") {
 		m := enforcesRowRe.FindStringSubmatch(line)
 		if m == nil {
@@ -192,7 +200,7 @@ func parseEnforces(t *testing.T, src string) map[string]string {
 		if _, dup := rows[m[1]]; dup {
 			t.Fatalf("duplicate Enforces row for %q", m[1])
 		}
-		rows[m[1]] = m[3]
+		rows[m[1]] = enforcesCell{clause: m[3], anchor: m[4]}
 	}
 	if len(rows) == 0 {
 		t.Fatal("no Enforces rows parsed from the clause-traceability section")
@@ -256,8 +264,11 @@ func TestConformancePageReconciles(t *testing.T) {
 				t.Errorf("malformed vector %q is missing from the page Enforces table", c.Name)
 				continue
 			}
-			if got != c.Clause {
-				t.Errorf("clause mismatch for %q:\n  page=%q\n  count.py=%q", c.Name, got, c.Clause)
+			if got.clause != c.Clause {
+				t.Errorf("clause mismatch for %q:\n  page=%q\n  count.py=%q", c.Name, got.clause, c.Clause)
+			}
+			if got.anchor != c.Anchor {
+				t.Errorf("anchor mismatch for %q:\n  page=%q\n  count.py=%q", c.Name, got.anchor, c.Anchor)
 			}
 		}
 		for name := range pageRows {

--- a/cross-sdk-tests/malformed_vectors.json
+++ b/cross-sdk-tests/malformed_vectors.json
@@ -7,6 +7,7 @@
   "receipts": [
     {
       "name": "wrong_proof_type",
+      "clause": "§4.3.3 proof — type MUST be Ed25519Signature2020",
       "description": "proof.type changed from Ed25519Signature2020 to RsaSignature2018; verifiers MUST reject any other proof type (the field lives outside the signed bytes, so the Ed25519 signature still checks — this case guards the explicit type check in verify)",
       "receipt": {
         "@context": [
@@ -53,6 +54,7 @@
     },
     {
       "name": "mutated_action_type",
+      "clause": "§7.8 End-to-end receipt verification — signature over canonical bytes",
       "description": "action.type changed after signing — canonical bytes no longer match the signature",
       "receipt": {
         "@context": [
@@ -99,6 +101,7 @@
     },
     {
       "name": "mutated_principal_id",
+      "clause": "§7.8 End-to-end receipt verification — signature over canonical bytes",
       "description": "principal.id changed after signing — payload tampering",
       "receipt": {
         "@context": [
@@ -145,6 +148,7 @@
     },
     {
       "name": "truncated_proof_value",
+      "clause": "§7.8 End-to-end receipt verification — signature over canonical bytes",
       "description": "signature truncated to its multibase prefix only — empty signature bytes",
       "receipt": {
         "@context": [
@@ -191,6 +195,7 @@
     },
     {
       "name": "wrong_multibase_prefix",
+      "clause": "§4.3.3 proof — proofValue is u-prefixed base64url",
       "description": "proof.proofValue uses 'z' (base58) instead of 'u' (base64url) — Ed25519Signature2020 mandates base64url",
       "receipt": {
         "@context": [
@@ -237,6 +242,7 @@
     },
     {
       "name": "flipped_proof_byte",
+      "clause": "§7.8 End-to-end receipt verification — signature over canonical bytes",
       "description": "single byte of proofValue replaced — Ed25519 verification MUST fail on any single-bit mutation",
       "receipt": {
         "@context": [
@@ -280,11 +286,58 @@
           "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvA1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
         }
       }
+    },
+    {
+      "name": "schema_missing_required_field",
+      "clause": "§4.3.2 credentialSubject — chain.chain_id is required",
+      "description": "chain.chain_id (a schema-required field) removed from an otherwise-valid signed receipt — a schema-invalid receipt every verifier MUST reject. Verifiers that schema-validate reject it at parse time, before the signature check; removing a signed field also breaks the Ed25519 signature, so a verify-only path rejects it too",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "credentialSubject": {
+          "action": {
+            "id": "act_malformed_1",
+            "risk_level": "low",
+            "timestamp": "2026-04-22T00:00:00Z",
+            "type": "filesystem.file.read"
+          },
+          "chain": {
+            "previous_receipt_hash": null,
+            "sequence": 1
+          },
+          "outcome": {
+            "status": "success"
+          },
+          "principal": {
+            "id": "did:user:alice"
+          }
+        },
+        "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "issuer": {
+          "id": "did:agent:malformed-test"
+        },
+        "proof": {
+          "created": "2026-04-22T00:00:00Z",
+          "proofPurpose": "assertionMethod",
+          "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA",
+          "type": "Ed25519Signature2020",
+          "verificationMethod": "did:agent:malformed-test#key-1"
+        },
+        "type": [
+          "VerifiableCredential",
+          "AgentReceipt"
+        ],
+        "version": "0.2.0"
+      }
     }
   ],
   "chains": [
     {
       "name": "missing_previous_receipt_hash_mid_chain",
+      "clause": "§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)",
       "description": "middle receipt is missing chain.previous_receipt_hash, breaking the hash linkage",
       "receipts": [
         {
@@ -411,6 +464,405 @@
             "verificationMethod": "did:agent:malformed-test#key-1",
             "proofPurpose": "assertionMethod",
             "proofValue": "uzbD61QfQxeEN9nd-LJZ6SCtrfCE4tg6Cq1e49mKCBq5wUKa85CnXd1U49mDLL-spdUEPWLouzdO8l_borMqqDA"
+          }
+        }
+      ]
+    },
+    {
+      "name": "chain_wrong_previous_receipt_hash",
+      "clause": "§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)",
+      "description": "last receipt's chain.previous_receipt_hash is the valid hash of the genesis receipt (a different receipt in the set) instead of its immediate predecessor — well-formed linkage pointing at the wrong predecessor. Distinct from the missing case; each receipt is individually signed and verifiable, so only the chain hash-linkage check fails",
+      "receipts": [
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000011",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_wrong_prev_1",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 1,
+              "previous_receipt_hash": null,
+              "chain_id": "chain_malformed_wrong_prev"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "uQVvQARf-31EgkLBu3Y0uvZ7hbeLyZS7k4bLT-uOFBsH7jTqRoB59r67MNMT59H0yTn69o6nF0s9Lfy3C7zFeCg"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000012",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_wrong_prev_2",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 2,
+              "previous_receipt_hash": "sha256:8ea793027b9046ff25d85797ef2a3fcd10fed3aa670b06dd8caca72adecda20a",
+              "chain_id": "chain_malformed_wrong_prev"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "u4s4PU3QqTl5AV23_hRRMYL3EXUsLzweKgZcDcXQp1GS-M2EY0zNOY4wUjnlZ_FLIkHRGRjhM_yripZuZenX4DQ"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000013",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_wrong_prev_3",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 3,
+              "previous_receipt_hash": "sha256:8ea793027b9046ff25d85797ef2a3fcd10fed3aa670b06dd8caca72adecda20a",
+              "chain_id": "chain_malformed_wrong_prev"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "un231nmR3zG_wWyQUAkEUZ4XURNnfSRpO-qHwLl1_XswzuotnHb88eEf0BHE9iavCdvarPGCQxXTw-3pDgA9UBQ"
+          }
+        }
+      ]
+    },
+    {
+      "name": "chain_duplicate_sequence",
+      "clause": "§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1",
+      "description": "two receipts under one chain_id share sequence 2 (fork / equivocation); each receipt is individually signed and hash-linked, so only the strict-contiguity check fails",
+      "receipts": [
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000021",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_dup_seq_1",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 1,
+              "previous_receipt_hash": null,
+              "chain_id": "chain_malformed_dup_seq"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "u3PtS4aYQv0-u1oWE35Jmw0U7DUnPFLL9TOeOfpOUA3kkz9gOBTA6UGJ4VqcLlFqODnwcb4FVsR-EZT0PlFPXDw"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000022",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_dup_seq_2",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 2,
+              "previous_receipt_hash": "sha256:a06b5c730d6e3d667dc8471566c13bd1551c548c4c73a3d65365120f3d5d8231",
+              "chain_id": "chain_malformed_dup_seq"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "uPUPqUr4jXNvHk-hUCnJB10wf1H7bFCC63_2syJoSCN9q3jxrQVhT-nhLifn9xBzKfQhaNDqXzjvQQZ5KCjAZCA"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000023",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_dup_seq_3",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 2,
+              "previous_receipt_hash": "sha256:d6d706e38bd35df81a4276a244f95e5273412fed1bd6176e0452669cd351d1d1",
+              "chain_id": "chain_malformed_dup_seq"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "uoDEQiGHnCEUKqilicI8hNroW0Wj-lLZgoSOQ1v-lEPOqhoPbgJrVnBDBwfO3lx3MfcwrNUqob2eb_X-aYSz5CA"
+          }
+        }
+      ]
+    },
+    {
+      "name": "chain_sequence_gap",
+      "clause": "§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1",
+      "description": "sequences run 1, 2, 4 with a gap at 3; each receipt is individually signed and hash-linked, so only the strict-contiguity check fails (spec §7.3.5 mandates contiguity, not merely strictly-increasing)",
+      "receipts": [
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000021",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_seq_gap_1",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 1,
+              "previous_receipt_hash": null,
+              "chain_id": "chain_malformed_seq_gap"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "uXOo_uK2HoZyH0ASTj9ptSrJF1RfGFX2MRM2XefUnRvqN5MUTQJ9w53sSAPYdE9sLe7bQnZYQPdHVK8ePYoG4CA"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000022",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_seq_gap_2",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 2,
+              "previous_receipt_hash": "sha256:89f93b3eb26d561e49c41d20f0f4565b22ff76127cff8da4e6376c749f5adeb8",
+              "chain_id": "chain_malformed_seq_gap"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "usrsUze49abKMi0qPJsQX17trEeWQrfvY_-YdwO3GjY66EcIGRMqNUtZzxCYtVnN5n4AGwcfUkBgDB36ci7vbCA"
+          }
+        },
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://agentreceipts.ai/context/v1"
+          ],
+          "id": "urn:receipt:00000000-0000-4000-8000-000000000023",
+          "type": [
+            "VerifiableCredential",
+            "AgentReceipt"
+          ],
+          "version": "0.2.0",
+          "issuer": {
+            "id": "did:agent:malformed-test"
+          },
+          "issuanceDate": "2026-04-22T00:00:00Z",
+          "credentialSubject": {
+            "principal": {
+              "id": "did:user:alice"
+            },
+            "action": {
+              "id": "act_seq_gap_3",
+              "type": "filesystem.file.read",
+              "risk_level": "low",
+              "timestamp": "2026-04-22T00:00:00Z"
+            },
+            "outcome": {
+              "status": "success"
+            },
+            "chain": {
+              "sequence": 4,
+              "previous_receipt_hash": "sha256:9db9d821e093b2639e9699182f80072b3789f839357e0f87b23a7e3cf123e38d",
+              "chain_id": "chain_malformed_seq_gap"
+            }
+          },
+          "proof": {
+            "type": "Ed25519Signature2020",
+            "created": "2026-04-22T00:00:00Z",
+            "verificationMethod": "did:agent:malformed-test#key-1",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "uNJIceOLwoeenLgsnHA-2dxA0kZ9lJpYeq2V-hBuA4VZM4lzLca6ppYao4bU1H7zgu3bL5v-12RoLpG0sOxhhBA"
           }
         }
       ]

--- a/scripts/conformance_matrix/count.py
+++ b/scripts/conformance_matrix/count.py
@@ -18,7 +18,9 @@ Usage:
                               # this output's "Consumers" column into separate
                               # Go/Py/TS columns, so paste it in as a reference,
                               # not a drop-in replacement)
-    count.py --format json   # machine-readable counts
+    count.py --format enforces  # Markdown "Enforces" table: per-vector clause
+                              # traceability for the MUST-reject corpus
+    count.py --format json   # machine-readable counts (+ malformedCorpus clauses)
 
 Exit codes:
     0  all vector files read and counted
@@ -203,13 +205,50 @@ def _malformed_set() -> VectorSet:
     raise KeyError("malformed vector set not found in VECTOR_SETS")
 
 
+# Published spec pages the clause sections live on (Starlight slugs). The site's
+# spec is reorganised from the source spec.md, so not every source subsection
+# (e.g. §7.3.5, §7.8) has its own on-page anchor; those map to the nearest
+# containing section that does. The `clause` field stays a plain source-section
+# reference (it is shared across the three SDKs in the vector JSON and must not
+# carry site URLs); the anchor is resolved here, at render time, so the page's
+# "Enforces" links stay generated rather than hand-typed.
+_SPEC_CHAIN = "/specification/receipt-chain-verification/"
+_SPEC_SCHEMA = "/specification/agent-receipt-schema/"
+
+# Map the leading section token of a clause (e.g. "§7.3.5") to its published
+# anchor. A clause whose section token is absent here raises KeyError, so a new
+# vector referencing an unmapped section fails the count rather than shipping an
+# unlinked or dead-linked cell.
+_CLAUSE_ANCHOR: dict[str, str] = {
+    "§4.3.2": _SPEC_SCHEMA + "#chain",  # chain.chain_id is a required chain field
+    "§4.3.3": _SPEC_SCHEMA + "#proof",
+    "§7.3": _SPEC_CHAIN + "#chain-integrity-verification",
+    "§7.3.5": _SPEC_CHAIN + "#chain-integrity-verification",
+    "§7.8": _SPEC_CHAIN + "#chain-integrity-verification",
+}
+
+
+def _clause_anchor(clause: str) -> str:
+    """Resolve a clause string to its published spec anchor via its leading
+    section token (the first whitespace-delimited word, e.g. ``§7.3.5``)."""
+    section = clause.split(None, 1)[0]
+    try:
+        return _CLAUSE_ANCHOR[section]
+    except KeyError:
+        raise KeyError(
+            f"no published anchor mapped for clause section {section!r} "
+            f"(clause: {clause!r}); add it to _CLAUSE_ANCHOR"
+        ) from None
+
+
 def malformed_corpus() -> list[dict[str, str]]:
     """Clause traceability for every vector in the MUST-reject corpus.
 
     Reads the same file the ``malformed (MUST-reject)`` set counts and returns
-    one ``{name, kind, clause}`` entry per vector — receipt-level cases from
-    ``receipts[]`` and chain-level cases from ``chains[]``. The ``clause`` names
-    the normative spec section the vector enforces; it feeds the "Enforces"
+    one ``{name, kind, clause, anchor}`` entry per vector — receipt-level cases
+    from ``receipts[]`` and chain-level cases from ``chains[]``. The ``clause``
+    names the normative spec section the vector enforces and ``anchor`` is the
+    published spec-page anchor it resolves to; together they feed the "Enforces"
     column on the conformance page. A vector missing its ``clause`` raises
     ``KeyError`` here, so an unannotated vector fails the count rather than
     silently shipping a blank cell.
@@ -218,7 +257,15 @@ def malformed_corpus() -> list[dict[str, str]]:
     out: list[dict[str, str]] = []
     for kind, key in (("receipt", "receipts"), ("chain", "chains")):
         for case in doc[key]:
-            out.append({"name": case["name"], "kind": kind, "clause": case["clause"]})
+            clause = case["clause"]
+            out.append(
+                {
+                    "name": case["name"],
+                    "kind": kind,
+                    "clause": clause,
+                    "anchor": _clause_anchor(clause),
+                }
+            )
     return out
 
 
@@ -249,13 +296,20 @@ def _render_md(rows: list[tuple[VectorSet, int]]) -> str:
         lines.append(
             f"| {vs.name} | {vs.purpose} | {vs.consumers} | {vs.spec_versions} | {count} |"
         )
-    # Second table: per-vector clause traceability for the MUST-reject corpus.
-    # Paste-ready for the "Enforces" table on the conformance page.
-    lines.append("")
-    lines.append("| Vector | Layer | Enforces |")
-    lines.append("| --- | --- | --- |")
+    return "\n".join(lines)
+
+
+def _render_enforces(_rows: list[tuple[VectorSet, int]]) -> str:
+    """Markdown "Enforces" table: per-vector clause traceability for the
+    MUST-reject corpus. Paste-ready for the clause-traceability table on the
+    conformance page; the reconciliation test pins that table to this data."""
+    lines = [
+        "| Vector | Layer | Enforces |",
+        "| --- | --- | --- |",
+    ]
     for case in malformed_corpus():
-        lines.append(f"| {case['name']} | {case['kind']} | {case['clause']} |")
+        enforces = f"[{case['clause']}]({case['anchor']})"
+        lines.append(f"| {case['name']} | {case['kind']} | {enforces} |")
     return "\n".join(lines)
 
 
@@ -283,15 +337,18 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
         "--format",
-        choices=("table", "md", "json"),
+        choices=("table", "md", "enforces", "json"),
         default="table",
         help="output format (default: table)",
     )
     args = parser.parse_args(argv)
 
-    renderer = {"table": _render_table, "md": _render_md, "json": _render_json}[
-        args.format
-    ]
+    renderer = {
+        "table": _render_table,
+        "md": _render_md,
+        "enforces": _render_enforces,
+        "json": _render_json,
+    }[args.format]
     try:
         rows = collect()
         # Render inside the try so a vector missing its `clause` (raised by

--- a/scripts/conformance_matrix/count.py
+++ b/scripts/conformance_matrix/count.py
@@ -195,9 +195,38 @@ def collect() -> list[tuple[VectorSet, int]]:
     return [(vs, vs.count()) for vs in VECTOR_SETS]
 
 
+def _malformed_set() -> VectorSet:
+    """The MUST-reject corpus set, located by path so its file is a single source."""
+    for vs in VECTOR_SETS:
+        if vs.path.endswith("malformed_vectors.json"):
+            return vs
+    raise KeyError("malformed vector set not found in VECTOR_SETS")
+
+
+def malformed_corpus() -> list[dict[str, str]]:
+    """Clause traceability for every vector in the MUST-reject corpus.
+
+    Reads the same file the ``malformed (MUST-reject)`` set counts and returns
+    one ``{name, kind, clause}`` entry per vector — receipt-level cases from
+    ``receipts[]`` and chain-level cases from ``chains[]``. The ``clause`` names
+    the normative spec section the vector enforces; it feeds the "Enforces"
+    column on the conformance page. A vector missing its ``clause`` raises
+    ``KeyError`` here, so an unannotated vector fails the count rather than
+    silently shipping a blank cell.
+    """
+    doc = json.loads((_REPO_ROOT / _malformed_set().path).read_text(encoding="utf-8"))
+    out: list[dict[str, str]] = []
+    for kind, key in (("receipt", "receipts"), ("chain", "chains")):
+        for case in doc[key]:
+            out.append({"name": case["name"], "kind": kind, "clause": case["clause"]})
+    return out
+
+
 def _render_table(rows: list[tuple[VectorSet, int]]) -> str:
     header = ("Vector set", "Purpose", "Consumers", "Spec", "Count")
-    lines = [f"{header[0]:<24} {header[1]:<48} {header[2]:<44} {header[3]:<16} {header[4]}"]
+    lines = [
+        f"{header[0]:<24} {header[1]:<48} {header[2]:<44} {header[3]:<16} {header[4]}"
+    ]
     for vs, count in rows:
         lines.append(
             f"{vs.name:<24} {vs.purpose:<48} {vs.consumers:<44} {vs.spec_versions:<16} {count}"
@@ -220,6 +249,13 @@ def _render_md(rows: list[tuple[VectorSet, int]]) -> str:
         lines.append(
             f"| {vs.name} | {vs.purpose} | {vs.consumers} | {vs.spec_versions} | {count} |"
         )
+    # Second table: per-vector clause traceability for the MUST-reject corpus.
+    # Paste-ready for the "Enforces" table on the conformance page.
+    lines.append("")
+    lines.append("| Vector | Layer | Enforces |")
+    lines.append("| --- | --- | --- |")
+    for case in malformed_corpus():
+        lines.append(f"| {case['name']} | {case['kind']} | {case['clause']} |")
     return "\n".join(lines)
 
 
@@ -238,6 +274,7 @@ def _render_json(rows: list[tuple[VectorSet, int]]) -> str:
             for vs, count in rows
         ],
         "total": sum(count for _, count in rows),
+        "malformedCorpus": malformed_corpus(),
     }
     return json.dumps(payload, indent=2)
 
@@ -252,14 +289,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    renderer = {"table": _render_table, "md": _render_md, "json": _render_json}[
+        args.format
+    ]
     try:
         rows = collect()
+        # Render inside the try so a vector missing its `clause` (raised by
+        # malformed_corpus during md/json rendering) is reported as a count
+        # error, not an uncaught traceback.
+        output = renderer(rows)
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError) as err:
         print(f"error: could not count vectors: {err}", file=sys.stderr)
         return 1
 
-    renderer = {"table": _render_table, "md": _render_md, "json": _render_json}[args.format]
-    print(renderer(rows))
+    print(output)
     return 0
 
 

--- a/scripts/conformance_matrix/test_count.py
+++ b/scripts/conformance_matrix/test_count.py
@@ -51,6 +51,22 @@ class TestCollect(unittest.TestCase):
         # Go/Py/TS columns, so this is a reference table, not a drop-in paste.
         self.assertEqual(len(lines), 2 + len(on_page))
 
+    def test_enforces_output_has_one_row_per_malformed_vector(self) -> None:
+        enforces = count._render_enforces(count.collect())
+        lines = enforces.splitlines()
+        corpus = count.malformed_corpus()
+        # header + separator + one row per MUST-reject vector.
+        self.assertEqual(len(lines), 2 + len(corpus))
+        for case in corpus:
+            self.assertIn(case["name"], enforces)
+            self.assertIn(case["clause"], enforces)
+
+    def test_every_malformed_vector_has_a_clause(self) -> None:
+        # A vector missing its `clause` must fail the count, not ship a blank
+        # "Enforces" cell — malformed_corpus raises KeyError in that case.
+        for case in count.malformed_corpus():
+            self.assertTrue(case["clause"], f"{case['name']} has an empty clause")
+
     def test_md_output_excludes_off_page_sets(self) -> None:
         # Off-page reference fixtures (currently did:key) are counted but must
         # not appear in the markdown output, matching the published page.

--- a/site/src/content/docs/conformance.mdx
+++ b/site/src/content/docs/conformance.mdx
@@ -29,7 +29,7 @@ Each row is a frozen vector set. The **Go / Py / TS** columns mark which impleme
 | --- | --- | :-: | :-: | :-: | --- | ---: |
 | [canonicalization](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/canonicalization_vectors.json) | RFC 8785 canonical JSON + receipt-hash agreement | ✓ | ✓ | ✓ | version-independent | 44 |
 | [emit-failure](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/emit_failure_vectors.json) | emit-failure outcome contract (ADR-0025) | ✓ | ✓ | ✓ | version-independent | 2 |
-| [malformed (MUST-reject)](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/malformed_vectors.json) | negative corpus every verifier MUST reject | ✓ | ✓ | ✓ | version-independent | 7 |
+| [malformed (MUST-reject)](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/malformed_vectors.json) | negative corpus every verifier MUST reject | ✓ | ✓ | ✓ | version-independent | 11 |
 | [v0.2.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v020_vectors.json) | frozen v0.2.0 receipts + chains | ✓ | ✓ | ✓ | 0.2.0 | 3 |
 | [v0.3.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v030_vectors.json) | frozen v0.3.0 receipts + chains | ✓ | ✓ | ✓ | 0.3.0 | 3 |
 | [v0.4.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v040_vectors.json) | frozen v0.4.0 receipts + chains | ✓ | ✓ | ✓ | 0.4.0 | 2 |
@@ -40,9 +40,33 @@ Each row is a frozen vector set. The **Go / Py / TS** columns mark which impleme
 
 Each linked vector set above is pinned to an immutable commit, so a citation stays valid as the corpus grows.
 
+The **rotation event** row is pinned at spec v0.2.1 rather than 0.2.0 because, per its [vector README](https://github.com/agent-receipts/obsigna/blob/main/spec/test-vectors/rotation-event/README.md), every field is exactly what a 0.2.1 receipt already requires with ADR-0015's `keyRotation` field layered on and nothing else changed — so its wire shape tracks the 0.2.1 schema baseline it extends.
+
 <Aside type="caution" title="Honest coverage — these are seed-level counts">
-The counts are the real sizes of the frozen corpora today, not a coverage claim. They are seed-level and growing: 44 canonicalization/receipt-hash vectors, a 7-case MUST-reject corpus, and the per-version receipt/chain counts shown in the matrix above. They are **not** exhaustive — they pin the shapes that mattered enough to freeze, and the corpus is extended as the specification evolves.
+The counts are the real sizes of the frozen corpora today, not a coverage claim. They are seed-level and growing: 44 canonicalization/receipt-hash vectors, an 11-case MUST-reject corpus, and the per-version receipt/chain counts shown in the matrix above. They are **not** exhaustive — they pin the shapes that mattered enough to freeze, and the corpus is extended as the specification evolves.
 </Aside>
+
+<Aside type="note" title="What a green run does and does not prove">
+A green run proves the three implementations agree on canonical form (RFC 8785), receipt hashing, signature verification, and chain linkage. It does not prove a receipt describes an action that occurred — a correctly signed receipt for a fabricated action is MUST-accept here by construction. Provenance (out-of-process signing, external anchoring) is a separate layer; see the [Trust Model](/specification/trust-model/).
+</Aside>
+
+## Clause traceability
+
+Every vector in the MUST-reject corpus names the normative spec clause it enforces, so a reviewer can trace each negative case to the requirement it guards. The **Enforces** column is generated from each vector's `clause` field by [`count.py`](https://github.com/agent-receipts/obsigna/blob/main/scripts/conformance_matrix/count.py) — the same generator that emits the counts — and pinned to this page by the [reconciliation test](https://github.com/agent-receipts/obsigna/blob/main/cross-sdk-tests/conformance_page_test.go); it is never hand-typed. Section references point into the [receipt-chain-verification](/specification/receipt-chain-verification/) and [agent-receipt-schema](/specification/agent-receipt-schema/) spec pages.
+
+| Vector | Layer | Enforces |
+| --- | --- | --- |
+| wrong_proof_type | receipt | §4.3.3 proof — type MUST be Ed25519Signature2020 |
+| mutated_action_type | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
+| mutated_principal_id | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
+| truncated_proof_value | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
+| wrong_multibase_prefix | receipt | §4.3.3 proof — proofValue is u-prefixed base64url |
+| flipped_proof_byte | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
+| schema_missing_required_field | receipt | §4.3.2 credentialSubject — chain.chain_id is required |
+| missing_previous_receipt_hash_mid_chain | chain | §7.3 Chain integrity verification — hash linkage (previous_receipt_hash) |
+| chain_wrong_previous_receipt_hash | chain | §7.3 Chain integrity verification — hash linkage (previous_receipt_hash) |
+| chain_duplicate_sequence | chain | §7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1 |
+| chain_sequence_gap | chain | §7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1 |
 
 ## CI enforcement
 

--- a/site/src/content/docs/conformance.mdx
+++ b/site/src/content/docs/conformance.mdx
@@ -52,21 +52,21 @@ A green run proves the three implementations agree on canonical form (RFC 8785),
 
 ## Clause traceability
 
-Every vector in the MUST-reject corpus names the normative spec clause it enforces, so a reviewer can trace each negative case to the requirement it guards. The **Enforces** column is generated from each vector's `clause` field by [`count.py`](https://github.com/agent-receipts/obsigna/blob/main/scripts/conformance_matrix/count.py) — the same generator that emits the counts — and pinned to this page by the [reconciliation test](https://github.com/agent-receipts/obsigna/blob/main/cross-sdk-tests/conformance_page_test.go); it is never hand-typed. Section references point into the [receipt-chain-verification](/specification/receipt-chain-verification/) and [agent-receipt-schema](/specification/agent-receipt-schema/) spec pages.
+Every vector in the MUST-reject corpus names the normative spec clause it enforces, so a reviewer can trace each negative case to the requirement it guards. The **Enforces** column is generated from each vector's `clause` field by [`count.py`](https://github.com/agent-receipts/obsigna/blob/main/scripts/conformance_matrix/count.py) — the same generator that emits the counts — and pinned to this page by the [reconciliation test](https://github.com/agent-receipts/obsigna/blob/main/cross-sdk-tests/conformance_page_test.go); it is never hand-typed. Each entry links to the published spec section it enforces. (The source spec's `§7.3.5` and `§7.8` fold into the published [chain-integrity-verification](/specification/receipt-chain-verification/#chain-integrity-verification) section, which has no finer on-page anchor.)
 
 | Vector | Layer | Enforces |
 | --- | --- | --- |
-| wrong_proof_type | receipt | §4.3.3 proof — type MUST be Ed25519Signature2020 |
-| mutated_action_type | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
-| mutated_principal_id | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
-| truncated_proof_value | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
-| wrong_multibase_prefix | receipt | §4.3.3 proof — proofValue is u-prefixed base64url |
-| flipped_proof_byte | receipt | §7.8 End-to-end receipt verification — signature over canonical bytes |
-| schema_missing_required_field | receipt | §4.3.2 credentialSubject — chain.chain_id is required |
-| missing_previous_receipt_hash_mid_chain | chain | §7.3 Chain integrity verification — hash linkage (previous_receipt_hash) |
-| chain_wrong_previous_receipt_hash | chain | §7.3 Chain integrity verification — hash linkage (previous_receipt_hash) |
-| chain_duplicate_sequence | chain | §7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1 |
-| chain_sequence_gap | chain | §7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1 |
+| wrong_proof_type | receipt | [§4.3.3 proof — type MUST be Ed25519Signature2020](/specification/agent-receipt-schema/#proof) |
+| mutated_action_type | receipt | [§7.8 End-to-end receipt verification — signature over canonical bytes](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| mutated_principal_id | receipt | [§7.8 End-to-end receipt verification — signature over canonical bytes](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| truncated_proof_value | receipt | [§7.8 End-to-end receipt verification — signature over canonical bytes](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| wrong_multibase_prefix | receipt | [§4.3.3 proof — proofValue is u-prefixed base64url](/specification/agent-receipt-schema/#proof) |
+| flipped_proof_byte | receipt | [§7.8 End-to-end receipt verification — signature over canonical bytes](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| schema_missing_required_field | receipt | [§4.3.2 credentialSubject — chain.chain_id is required](/specification/agent-receipt-schema/#chain) |
+| missing_previous_receipt_hash_mid_chain | chain | [§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| chain_wrong_previous_receipt_hash | chain | [§7.3 Chain integrity verification — hash linkage (previous_receipt_hash)](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| chain_duplicate_sequence | chain | [§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1](/specification/receipt-chain-verification/#chain-integrity-verification) |
+| chain_sequence_gap | chain | [§7.3.5 Sequence number contiguity and store trust — sequence MUST equal predecessor + 1](/specification/receipt-chain-verification/#chain-integrity-verification) |
 
 ## CI enforcement
 
@@ -103,6 +103,9 @@ The frozen vectors and the suites that consume them live in the repository. Run 
 
 # Regenerate the vector counts in the matrix above
 python3 scripts/conformance_matrix/count.py --format md
+
+# Regenerate the "Enforces" clause-traceability table
+python3 scripts/conformance_matrix/count.py --format enforces
 ```
 
 See [`cross-sdk-tests/README.md`](https://github.com/agent-receipts/obsigna/blob/main/cross-sdk-tests/README.md) for how the shared vectors are generated and consumed.

--- a/site/src/content/docs/conformance.mdx
+++ b/site/src/content/docs/conformance.mdx
@@ -29,7 +29,7 @@ Each row is a frozen vector set. The **Go / Py / TS** columns mark which impleme
 | --- | --- | :-: | :-: | :-: | --- | ---: |
 | [canonicalization](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/canonicalization_vectors.json) | RFC 8785 canonical JSON + receipt-hash agreement | ✓ | ✓ | ✓ | version-independent | 44 |
 | [emit-failure](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/emit_failure_vectors.json) | emit-failure outcome contract (ADR-0025) | ✓ | ✓ | ✓ | version-independent | 2 |
-| [malformed (MUST-reject)](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/malformed_vectors.json) | negative corpus every verifier MUST reject | ✓ | ✓ | ✓ | version-independent | 11 |
+| [malformed (MUST-reject)](https://github.com/agent-receipts/obsigna/blob/98bcea3b99942ca3eb4400a3c0f7f0fbfb81d7bd/cross-sdk-tests/malformed_vectors.json) | negative corpus every verifier MUST reject | ✓ | ✓ | ✓ | version-independent | 11 |
 | [v0.2.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v020_vectors.json) | frozen v0.2.0 receipts + chains | ✓ | ✓ | ✓ | 0.2.0 | 3 |
 | [v0.3.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v030_vectors.json) | frozen v0.3.0 receipts + chains | ✓ | ✓ | ✓ | 0.3.0 | 3 |
 | [v0.4.0](https://github.com/agent-receipts/obsigna/blob/cbbfa6b9ce55b4d0dbc9ef7cc7f3a025a2edd877/cross-sdk-tests/v040_vectors.json) | frozen v0.4.0 receipts + chains | ✓ | ✓ | ✓ | 0.4.0 | 2 |


### PR DESCRIPTION
## What

Adds normative spec section references (`clause` field) to all 11 vectors in the MUST-reject corpus (`malformed_vectors.json`), enabling traceability from each negative test case to the specific requirement it enforces. Updates the conformance tooling to parse and render these clauses in a new "Enforces" column on the conformance page.

## Why

The MUST-reject corpus is the primary mechanism for ensuring verifiers correctly reject malformed receipts. Each vector should be traceable to the normative spec section it guards, so reviewers and implementers can verify coverage of all MUST-reject requirements. This change:

- Adds explicit `clause` annotations to all 7 receipt-level and 4 chain-level test cases
- Implements `count.py --format enforces` to generate a clause-traceability table for the conformance page
- Adds a reconciliation test (`TestConformancePageReconciles/enforces`) to pin the page's "Enforces" column to the committed vector clauses, preventing drift
- Expands the malformed corpus from 7 to 11 vectors with three new chain-integrity test cases:
  - `chain_wrong_previous_receipt_hash`: points at a valid hash of the wrong predecessor
  - `chain_duplicate_sequence`: fork/equivocation with duplicate sequence numbers
  - `chain_sequence_gap`: non-contiguous sequences (1, 2, 4) with a gap at 3

The new chain cases isolate specific verification checks by keeping hash linkage valid while breaking the targeted constraint, ensuring only that check fails (not the signature).

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (malformed vector format unchanged; new vectors follow existing schema)
- [x] AGENTS.md not needed (no project structure changes)

## Security

- [ ] This PR does not touch crypto, auth, or secrets handling