### PR TITLE
feat(formal): guard the chain-invariants model against spec drift

### DIFF
--- a/.github/workflows/formal-spec-pins.yml
+++ b/.github/workflows/formal-spec-pins.yml
@@ -11,9 +11,10 @@ on:
   push:
     branches: [main]
     paths: &paths
-      - "spec/v0.5.0/spec.md"
+      - "spec/v*/spec.md"
       - "formal/chain-invariants/spec-pins.json"
       - "scripts/formal_spec_pins/**"
+      - ".github/workflows/formal-spec-pins.yml"
   pull_request:
     branches: [main]
     paths: *paths

--- a/.github/workflows/formal-spec-pins.yml
+++ b/.github/workflows/formal-spec-pins.yml
@@ -1,0 +1,32 @@
+name: "CI: formal spec pins"
+
+# Guards against the formal chain-invariants Alloy model silently drifting from
+# the spec clauses it claims to encode. The model does not parse spec.md, so a
+# spec edit under a modeled clause (§3.2, §4.3.2, §7.3.x, §7.5, ...) can land
+# without the model changing, and CI: formal would stay green re-proving the
+# same, now-stale claim. Logic and the pinned clause set live in
+# scripts/formal_spec_pins/check.py and formal/chain-invariants/spec-pins.json.
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - "spec/v0.5.0/spec.md"
+      - "formal/chain-invariants/spec-pins.json"
+      - "scripts/formal_spec_pins/**"
+  pull_request:
+    branches: [main]
+    paths: *paths
+
+permissions:
+  contents: read
+
+jobs:
+  check-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Self-test the guard
+        run: python3 scripts/formal_spec_pins/test_check.py
+      - name: Check formal-model spec pins
+        run: python3 scripts/formal_spec_pins/check.py

--- a/formal/chain-invariants/README.md
+++ b/formal/chain-invariants/README.md
@@ -15,6 +15,9 @@ sole residual being the *deliberately documented* tail-truncation floor
 - **Model:** [`chain-tamper-evidence.als`](./chain-tamper-evidence.als)
 - **Decision record:** [`docs/adr/0039-formal-verification-chain-invariants.md`](../../docs/adr/0039-formal-verification-chain-invariants.md)
 - **Tool:** Alloy 6.2.0, SAT4J (pure-Java) backend.
+- **Spec-drift guard:** [`spec-pins.json`](./spec-pins.json) pins the exact spec
+  text every clause above depends on; CI: formal spec pins fails a spec PR the
+  moment one drifts. See [`scripts/formal_spec_pins/AGENTS.md`](../../scripts/formal_spec_pins/AGENTS.md).
 
 Behavioral / concurrent properties (parallel emission, crash-recovery,
 at-least-once delivery) are **out of scope** for this model — they are

--- a/formal/chain-invariants/spec-pins.json
+++ b/formal/chain-invariants/spec-pins.json
@@ -1,0 +1,64 @@
+{
+  "$comment": "Pins the exact spec/v0.5.0/spec.md text each chain-tamper-evidence.als assumption depends on. Checked by scripts/formal_spec_pins/check.py, gated by .github/workflows/formal-spec-pins.yml on every spec/** PR. If this check fails: read the new clause text, decide whether the Alloy model still holds, update it if not, then run `python3 scripts/formal_spec_pins/check.py --write` to re-pin.",
+  "pins": [
+    {
+      "id": "chain-definition",
+      "anchor": "3.2",
+      "text": "### 3.2 Receipt Chain\n\nAn ordered sequence of Agent Receipts linked by hash references. Each receipt contains the hash of the previous receipt in the chain, creating a tamper-evident log. The first receipt in a chain has a `null` previous hash.\n\n> **Note:** In this version, receipt chains are strictly linear — each receipt has exactly one predecessor. Concurrent action streams (e.g., parallel tool calls, sub-agent fan-out) cannot be represented within a single chain. See §9.8 for discussion of this limitation."
+    },
+    {
+      "id": "chain-id-field",
+      "anchor": "4.3.2",
+      "row": "`chain.chain_id`",
+      "text": "| `chain.chain_id` | Yes | Opaque identifier grouping receipts into a logical chain (e.g. per session). All receipts within a single chain MUST share the same value; verifiers MUST reject input that mixes receipts from different chains. See §7.3.4. |"
+    },
+    {
+      "id": "chain-sequence-field",
+      "anchor": "4.3.2",
+      "row": "`chain.sequence`",
+      "text": "| `chain.sequence` | Yes | Monotonically increasing integer position within the chain. Starts at `1`. |"
+    },
+    {
+      "id": "chain-previous-receipt-hash-field",
+      "anchor": "4.3.2",
+      "row": "`chain.previous_receipt_hash`",
+      "text": "| `chain.previous_receipt_hash` | Yes | `sha256:` prefixed hash of the previous receipt's canonical form. MUST be `null` for the first receipt in a chain (`sequence: 1`). The field MUST always be present; `null` is not the same as omitting it. |"
+    },
+    {
+      "id": "chain-terminal-field",
+      "anchor": "4.3.2",
+      "row": "`chain.terminal`",
+      "text": "| `chain.terminal` | No | When present, MUST be `true`. Asserts that no further receipts will be appended to this chain. Explicit `false` is schema-invalid; absence is the only valid way to express \"no claim\". Verifiers that observe any receipt following a terminal receipt in the verified input sequence MUST fail with a \"receipt after terminal\" error regardless of caller parameters. See §7.3.2. |"
+    },
+    {
+      "id": "chain-integrity-verification-algorithm",
+      "anchor": "7.3",
+      "text": "### 7.3 Chain integrity verification\n\nTo verify a receipt chain:\n\n1. Retrieve all receipts for the chain, ordered by `chain.sequence`. Let _n_ be the number of receipts.\n2. For each receipt _R(i)_ (0-based index):\n   a. Verify the `proof` signature against the issuer's public key at `proof.verificationMethod`. (Note: resolving the public key from the `verificationMethod` DID URL requires a DID resolution mechanism, which is not specified by this version of the protocol. See §9.6.)\n   b. Compute the hex-encoded SHA-256 digest of the RFC 8785 canonical form of _R(i)_ with the `proof` field removed.\n   c. If _i < n - 1_, confirm _R(i+1)_'s `chain.previous_receipt_hash` equals `sha256:` concatenated with that hex digest.\n3. For each receipt _R(i)_ where _i > 0_, confirm `chain.sequence` equals _R(i-1)_'s `chain.sequence` + 1.\n4. Confirm _R(0)_'s `chain.previous_receipt_hash` is `null`."
+    },
+    {
+      "id": "chain-truncation-detection",
+      "anchor": "7.3.1",
+      "text": "#### 7.3.1 Chain truncation detection\n\nChain verification as defined in steps 1–4 does **not** detect tail truncation: dropping the last N receipts from a chain still produces `Valid: true`, because no in-chain field commits to the chain's total length or final state. This is a deliberate design floor — a receipt can only commit to values its issuer already knows at signing time.\n\nThree mitigations are available:\n\n1. **Out-of-band witness (`ExpectedLength` / `ExpectedFinalHash`).** Callers who maintain an external record of chain state (audit log, transparency log, signed checkpoint) MAY supply `ExpectedLength` and/or `ExpectedFinalHash` to `VerifyChain`. Verification fails when the observed chain does not match. When unsupplied, the verifier preserves current behaviour — `Valid: true` for a tail-truncated chain is intentional and documented.\n\n2. **In-band terminal marker (`chain.terminal` + `chain.status` + `RequireTerminal`).** When the final receipt in a chain bears `chain.terminal: true`, no receipt referencing it via `previous_receipt_hash` is permitted — this check runs unconditionally (§7.3.2). The terminal receipt MAY also carry `chain.status` (§7.3.3) to distinguish normal `\"complete\"` termination from best-effort `\"interrupted\"` termination on signal. Callers MAY additionally supply `RequireTerminal`; verification then fails if the final observed receipt is not explicitly terminal. If the terminal receipt itself was dropped, `RequireTerminal` fires, but `chain.terminal` alone cannot detect this case — the verifier classifies the chain's termination status as `\"unknown\"` (§7.3.3) regardless of `RequireTerminal`.\n\n3. **Floor.** Tail truncation of an open (non-terminal) chain without any external witness **cannot** be detected by any mechanism defined in this specification. Operators whose compliance requirements demand detection of such truncation MUST maintain an out-of-band chain record and supply `ExpectedFinalHash`."
+    },
+    {
+      "id": "receipt-after-terminal-check",
+      "anchor": "7.3.2",
+      "text": "#### 7.3.2 Receipt-after-terminal integrity check (automatic)\n\nIf any receipt R(i) in the verified input has `chain.terminal: true`, and a subsequent receipt R(i+1) exists at position i+1 in the input, verification MUST fail immediately with a clear \"receipt after terminal\" error. This check is unconditional — no caller parameter can suppress it. It does not depend on R(i+1)'s `previous_receipt_hash` field; the presence of any receipt after a terminal predecessor in the verified sequence is sufficient to trigger the failure. This is the verifier's enforcement mechanism against an issuer who marks a chain closed and then extends it, or an attacker who appends a receipt to a chain its issuer marked terminal.\n\nIf any step fails, the chain is broken at that point. Receipts before the break may still be individually valid; receipts after are suspect.\n\n> **Note:** This algorithm assumes a linear chain where each receipt has exactly one predecessor. It does not cover concurrent or branching topologies (e.g., fan-out tool calls producing multiple receipts with the same predecessor). See §9.8."
+    },
+    {
+      "id": "chain-identifier-binding",
+      "anchor": "7.3.4",
+      "text": "#### 7.3.4 Chain identifier binding (automatic)\n\nAll receipts within a chain MUST share the same `chain.chain_id` (per §7.5, a chain is the authoritative log of a single issuer; the `chain_id` is the opaque identifier that groups its receipts). Verifiers MUST reject input in which any receipt R(i) has a `chain.chain_id` different from that of R(0), failing immediately with a clear \"chain_id mismatch\" error that identifies the offending index and both `chain_id` values. This check is unconditional — no caller parameter can suppress it, and it runs independently of `previous_receipt_hash` linkage so that an attacker who splices in a forged hash link cannot mix receipts from two distinct chains under a single verification call. Verifiers MUST NOT attempt to \"stitch\" or partition cross-chain input; the only correct response is rejection.\n\nThis check parallels §7.3.2: both enforce single-chain integrity invariants that no caller parameter can disable. Verifying receipts from multiple chains requires multiple calls to the chain verifier, one per chain."
+    },
+    {
+      "id": "sequence-contiguity-and-store-trust",
+      "anchor": "7.3.5",
+      "text": "#### 7.3.5 Sequence number contiguity and store trust\n\nVerification step 3 (above) mandates strict contiguity: each receipt's `chain.sequence` MUST equal its predecessor's + 1. Any gap (e.g. receipts at sequence 1, 3, 5 missing sequence 2 and 4) is a hard verification failure, not a warning. Verifiers MUST mark the chain invalid and identify the offending index. This applies even when signatures and hash linkage on the surviving receipts are otherwise valid — a partial chain with gaps cannot be silently accepted.\n\n**Store trust model.** Chain verification proves the integrity of the receipts the verifier is *given*; it cannot, on its own, prove that the verifier was given every receipt the issuer wrote. If an attacker can both delete receipts from the store AND re-sign every downstream receipt with an updated `previous_receipt_hash` (which requires the agent's signing key), they can erase mid-chain history undetectably from chain verification alone. The receipt store is therefore a trusted component for completeness claims.\n\nOperators who require detection of store-level tampering SHOULD layer at least one of the following on top of chain verification:\n\n- **Append-only storage backend** — S3 Object Lock, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.\n- **External chain-state witnesses** — `ExpectedLength` and/or `ExpectedFinalHash` (per §7.3.1) supplied from an out-of-band record the attacker cannot also rewrite (separate audit log, transparency log, signed checkpoint).\n- **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.\n\nThese are operational controls outside the protocol; the verifier cannot synthesize them and the spec does not mandate any specific backend. They are listed here so that compliance reviewers can match the protocol's verification contract to their operational threat model."
+    },
+    {
+      "id": "chain-issuer-model",
+      "anchor": "7.5",
+      "text": "### 7.5 Chain issuer model\n\nA receipt chain MUST have a single issuer. All receipts within a chain MUST have the same `issuer.id`. Delegated agents MUST create a new chain and link it to the parent chain via the `delegation` field (see §4.3.2). This ensures that each chain is an authoritative log from a single agent, and cross-agent workflows are represented as linked chains rather than mixed-issuer sequences."
+    }
+  ]
+}

--- a/formal/chain-invariants/spec-pins.json
+++ b/formal/chain-invariants/spec-pins.json
@@ -1,10 +1,20 @@
 {
-  "$comment": "Pins the exact spec/v0.5.0/spec.md text each chain-tamper-evidence.als assumption depends on. Checked by scripts/formal_spec_pins/check.py, gated by .github/workflows/formal-spec-pins.yml on every spec/** PR. If this check fails: read the new clause text, decide whether the Alloy model still holds, update it if not, then run `python3 scripts/formal_spec_pins/check.py --write` to re-pin.",
+  "$comment": "Pins the exact spec text each chain-tamper-evidence.als assumption depends on, resolved against the latest spec/v<X.Y.Z>/spec.md on disk. Checked by scripts/formal_spec_pins/check.py, gated by .github/workflows/formal-spec-pins.yml. If this check fails: read the new clause text, decide whether the Alloy model still holds, update it if not, then run `python3 scripts/formal_spec_pins/check.py --write` to re-pin.",
   "pins": [
     {
       "id": "chain-definition",
       "anchor": "3.2",
       "text": "### 3.2 Receipt Chain\n\nAn ordered sequence of Agent Receipts linked by hash references. Each receipt contains the hash of the previous receipt in the chain, creating a tamper-evident log. The first receipt in a chain has a `null` previous hash.\n\n> **Note:** In this version, receipt chains are strictly linear — each receipt has exactly one predecessor. Concurrent action streams (e.g., parallel tool calls, sub-agent fan-out) cannot be represented within a single chain. See §9.8 for discussion of this limitation."
+    },
+    {
+      "id": "canonical-form",
+      "anchor": "7.1",
+      "text": "### 7.1 Canonical form\n\nFor hashing and signing, receipts MUST be serialized using the JSON Canonicalization Scheme (RFC 8785) with the `proof` field removed before hashing. This canonicalization step is aligned with the use of RFC 8785 in the W3C Verifiable Credentials Data Integrity specification; however, the overall signing procedure defined in this document (see §7.2 and §10) is intentionally simplified and is not a full implementation of the W3C Data Integrity algorithm."
+    },
+    {
+      "id": "signing",
+      "anchor": "7.2",
+      "text": "### 7.2 Signing\n\nThe issuer MUST sign the canonical receipt (proof field excluded) with its Ed25519 private key. The signature MUST be encoded as a multibase string (`u`-prefixed base64url, no padding) and placed in `proof.proofValue`."
     },
     {
       "id": "chain-id-field",
@@ -51,9 +61,10 @@
       "text": "#### 7.3.4 Chain identifier binding (automatic)\n\nAll receipts within a chain MUST share the same `chain.chain_id` (per §7.5, a chain is the authoritative log of a single issuer; the `chain_id` is the opaque identifier that groups its receipts). Verifiers MUST reject input in which any receipt R(i) has a `chain.chain_id` different from that of R(0), failing immediately with a clear \"chain_id mismatch\" error that identifies the offending index and both `chain_id` values. This check is unconditional — no caller parameter can suppress it, and it runs independently of `previous_receipt_hash` linkage so that an attacker who splices in a forged hash link cannot mix receipts from two distinct chains under a single verification call. Verifiers MUST NOT attempt to \"stitch\" or partition cross-chain input; the only correct response is rejection.\n\nThis check parallels §7.3.2: both enforce single-chain integrity invariants that no caller parameter can disable. Verifying receipts from multiple chains requires multiple calls to the chain verifier, one per chain."
     },
     {
-      "id": "sequence-contiguity-and-store-trust",
+      "id": "sequence-contiguity",
       "anchor": "7.3.5",
-      "text": "#### 7.3.5 Sequence number contiguity and store trust\n\nVerification step 3 (above) mandates strict contiguity: each receipt's `chain.sequence` MUST equal its predecessor's + 1. Any gap (e.g. receipts at sequence 1, 3, 5 missing sequence 2 and 4) is a hard verification failure, not a warning. Verifiers MUST mark the chain invalid and identify the offending index. This applies even when signatures and hash linkage on the surviving receipts are otherwise valid — a partial chain with gaps cannot be silently accepted.\n\n**Store trust model.** Chain verification proves the integrity of the receipts the verifier is *given*; it cannot, on its own, prove that the verifier was given every receipt the issuer wrote. If an attacker can both delete receipts from the store AND re-sign every downstream receipt with an updated `previous_receipt_hash` (which requires the agent's signing key), they can erase mid-chain history undetectably from chain verification alone. The receipt store is therefore a trusted component for completeness claims.\n\nOperators who require detection of store-level tampering SHOULD layer at least one of the following on top of chain verification:\n\n- **Append-only storage backend** — S3 Object Lock, immutable WORM volumes, or an equivalent that prevents in-place mutation and rejects deletes.\n- **External chain-state witnesses** — `ExpectedLength` and/or `ExpectedFinalHash` (per §7.3.1) supplied from an out-of-band record the attacker cannot also rewrite (separate audit log, transparency log, signed checkpoint).\n- **Periodic chain-head anchoring** — publish chain-head hashes to an append-only public log at regular intervals; gaps relative to the anchored state are evidence of store-level rewriting.\n\nThese are operational controls outside the protocol; the verifier cannot synthesize them and the spec does not mandate any specific backend. They are listed here so that compliance reviewers can match the protocol's verification contract to their operational threat model."
+      "stop_before": "**Store trust model.**",
+      "text": "#### 7.3.5 Sequence number contiguity and store trust\n\nVerification step 3 (above) mandates strict contiguity: each receipt's `chain.sequence` MUST equal its predecessor's + 1. Any gap (e.g. receipts at sequence 1, 3, 5 missing sequence 2 and 4) is a hard verification failure, not a warning. Verifiers MUST mark the chain invalid and identify the offending index. This applies even when signatures and hash linkage on the surviving receipts are otherwise valid — a partial chain with gaps cannot be silently accepted."
     },
     {
       "id": "chain-issuer-model",

--- a/scripts/formal_spec_pins/AGENTS.md
+++ b/scripts/formal_spec_pins/AGENTS.md
@@ -3,7 +3,7 @@
 Guards against `formal/chain-invariants/chain-tamper-evidence.als` silently
 drifting from the spec clauses it claims to encode.
 
-The Alloy model does not parse `spec/v0.5.0/spec.md` — it is a hand-written
+The Alloy model does not parse `spec/v<X.Y.Z>/spec.md` — it is a hand-written
 formalization with prose citations (§3.2, §4.3.2, §7.3, ...). Nothing forces it
 to change when those clauses do, so a spec edit under a modeled clause can
 land, merge, and leave the model quietly describing a spec that no longer
@@ -15,7 +15,7 @@ same (now possibly stale) claim and passes.
 
 | File | Role |
 |------|------|
-| `check.py` | Extracts the live text of each pinned clause from `spec/v0.5.0/spec.md` and compares it to the text pinned in `formal/chain-invariants/spec-pins.json`. |
+| `check.py` | Extracts the live text of each pinned clause from the current spec (the highest-versioned `spec/v<X.Y.Z>/spec.md` on disk) and compares it to the text pinned in `formal/chain-invariants/spec-pins.json`. |
 | `test_check.py` | Unit tests for the extraction/comparison core against a fake spec fragment, plus one test that runs the real manifest against the real spec.md. |
 
 ## Run locally
@@ -39,6 +39,13 @@ model depends on:
   single row by its first cell (e.g. `` "`chain.chain_id`" ``) instead of the
   whole table, so an edit to an unrelated field (`outcome.response_hash`, say)
   doesn't trip the gate.
+- `stop_before` (optional) — truncates the pinned text before a literal marker
+  string, for a section that mixes modeled and unmodeled prose. §7.3.5 pins
+  only the contiguity paragraph via `stop_before: "**Store trust model.**"`,
+  excluding the trailing operational-controls prose the model doesn't
+  formalize — an edit there shouldn't trip the gate. If the marker text itself
+  drifts, extraction fails loudly (same as a missing anchor) rather than
+  silently including everything.
 - `text` — the exact pinned text, maintained by `check.py --write`. Never hand-edit
   this field.
 
@@ -57,9 +64,14 @@ This gate only detects that the spec moved out from under a pin — it has no
 opinion on whether the model still needs a change. That judgment call is the
 point of making it a required, blocking step rather than a silent re-pin.
 
-## Known limitation
+`--write` re-pins every entry it can and reports (with a non-zero exit) any
+pin whose anchor or row no longer resolves — e.g. a clause was renumbered —
+rather than aborting before writing anything. Fix those pins' `anchor`/`row`
+by hand, then re-run `--write` to pick up the rest.
 
-`DEFAULT_SPEC` hardcodes `spec/v0.5.0/spec.md`. If a future spec revision
-supersedes v0.5.0 in a new directory, this script's target (and every pin) will
-need reconciling against the new file — a larger, one-time migration, not
-something this gate can automate away.
+## Spec version resolution
+
+`check.py` targets the highest-versioned `spec/v<X.Y.Z>/spec.md` under `spec/`
+— not a hardcoded version — so cutting a new spec version directory doesn't
+require editing this script. If a version bump also renumbers or restructures
+a pinned clause, the pin will (correctly) report drift against the new file.

--- a/scripts/formal_spec_pins/AGENTS.md
+++ b/scripts/formal_spec_pins/AGENTS.md
@@ -1,0 +1,65 @@
+# formal_spec_pins
+
+Guards against `formal/chain-invariants/chain-tamper-evidence.als` silently
+drifting from the spec clauses it claims to encode.
+
+The Alloy model does not parse `spec/v0.5.0/spec.md` — it is a hand-written
+formalization with prose citations (§3.2, §4.3.2, §7.3, ...). Nothing forces it
+to change when those clauses do, so a spec edit under a modeled clause can
+land, merge, and leave the model quietly describing a spec that no longer
+exists. Re-running `formal/chain-invariants/run.sh` after such an edit would
+not catch this either — the Alloy source is unchanged, so it re-proves the
+same (now possibly stale) claim and passes.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `check.py` | Extracts the live text of each pinned clause from `spec/v0.5.0/spec.md` and compares it to the text pinned in `formal/chain-invariants/spec-pins.json`. |
+| `test_check.py` | Unit tests for the extraction/comparison core against a fake spec fragment, plus one test that runs the real manifest against the real spec.md. |
+
+## Run locally
+
+```sh
+python3 scripts/formal_spec_pins/test_check.py     # unit tests
+python3 scripts/formal_spec_pins/check.py           # fail if any pin has drifted
+python3 scripts/formal_spec_pins/check.py --write   # re-pin everything to current spec text
+```
+
+## The manifest
+
+`formal/chain-invariants/spec-pins.json` lists one entry per spec clause the
+model depends on:
+
+- `anchor` — the clause's numeral (e.g. `"7.3.5"`), matched against the leading
+  number in a markdown heading. The pinned text runs from that heading to the
+  next heading of *any* level, so a parent clause's own body doesn't swallow
+  its subsections.
+- `row` (optional) — for the `credentialSubject` schema table (§4.3.2), pins a
+  single row by its first cell (e.g. `` "`chain.chain_id`" ``) instead of the
+  whole table, so an edit to an unrelated field (`outcome.response_hash`, say)
+  doesn't trip the gate.
+- `text` — the exact pinned text, maintained by `check.py --write`. Never hand-edit
+  this field.
+
+## On a CI failure
+
+The gate (`.github/workflows/formal-spec-pins.yml`) fails a spec PR the moment
+a pinned clause's text changes. To fix it:
+
+1. Read the new clause text and decide whether
+   `formal/chain-invariants/chain-tamper-evidence.als` still holds.
+2. If it doesn't, update the model and re-run `formal/chain-invariants/run.sh`.
+3. Run `check.py --write` to re-pin the manifest, and commit it alongside
+   whatever else changed.
+
+This gate only detects that the spec moved out from under a pin — it has no
+opinion on whether the model still needs a change. That judgment call is the
+point of making it a required, blocking step rather than a silent re-pin.
+
+## Known limitation
+
+`DEFAULT_SPEC` hardcodes `spec/v0.5.0/spec.md`. If a future spec revision
+supersedes v0.5.0 in a new directory, this script's target (and every pin) will
+need reconciling against the new file — a larger, one-time migration, not
+something this gate can automate away.

--- a/scripts/formal_spec_pins/check.py
+++ b/scripts/formal_spec_pins/check.py
@@ -30,15 +30,23 @@ heading to the next heading of any level. A pin may instead target one
 markdown table row within a section via ``"row"`` (the row's first cell,
 e.g. ``"`chain.chain_id`"``) — used for the handful of `credentialSubject`
 schema fields the model depends on, so an edit to an unrelated field in the
-same table doesn't trip the gate.
+same table doesn't trip the gate. A pin may also set ``"stop_before"`` (a
+literal substring) to cut off the section short of a subsequent paragraph the
+model doesn't depend on, e.g. §7.3.5's contiguity rule versus its trailing
+"Store trust model" prose.
+
+The spec file itself is resolved dynamically as the highest-versioned
+``spec/v<X.Y.Z>/spec.md`` on disk, not a hardcoded version, so a new spec
+version directory is picked up without editing this script.
 
 Usage:
     check.py              # fail if any pin has drifted from the live spec
     check.py --write       # re-pin every entry to the current spec text
 
 Exit codes:
-    0  every pin matches the live spec (or --write completed)
-    1  at least one pin has drifted, or a pin's anchor/row no longer exists
+    0  every pin matches the live spec (or --write re-pinned everything)
+    1  at least one pin has drifted or is malformed, or --write couldn't
+       resolve at least one pin's anchor/row (others are still re-pinned)
 """
 
 from __future__ import annotations
@@ -49,18 +57,52 @@ import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_SPEC = _REPO_ROOT / "spec" / "v0.5.0" / "spec.md"
 DEFAULT_PINS = _REPO_ROOT / "formal" / "chain-invariants" / "spec-pins.json"
 
 # Matches an ATX heading's leading clause numeral: "## 3. Core Concepts" -> "3",
 # "### 3.2 Receipt Chain" -> "3.2", "#### 7.3.1 Chain truncation..." -> "7.3.1".
 _HEADING_RE = re.compile(r"^#{1,6}\s+(?P<num>\d+(?:\.\d+)*)\.?\s")
+_SPEC_DIR_RE = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
+
+
+def _latest_spec_in(spec_dir: Path) -> Path:
+    """Return the highest-versioned ``<spec_dir>/v<X.Y.Z>/spec.md``.
+
+    Spec versions accumulate as sibling directories (``v0.4.0``, ``v0.5.0``,
+    ...) rather than mutating in place forever, so hardcoding one version
+    would silently stop protecting anything the day a newer directory becomes
+    the one receiving edits. Resolving the latest version by directory name
+    keeps this guard pointed at whatever is currently live without a code
+    change.
+    """
+    candidates = []
+    for d in spec_dir.glob("v*"):
+        m = _SPEC_DIR_RE.fullmatch(d.name)
+        spec_file = d / "spec.md"
+        if m and spec_file.is_file():
+            candidates.append((tuple(int(x) for x in m.groups()), spec_file))
+    if not candidates:
+        raise FileNotFoundError(f"no v<X.Y.Z>/spec.md found under {spec_dir}")
+    return max(candidates)[1]
+
+
+DEFAULT_SPEC = _latest_spec_in(_REPO_ROOT / "spec")
 
 
 def _iter_headings(lines: list[str]) -> list[tuple[int, str]]:
-    """Return [(line_index, clause_numeral), ...] for every numbered heading."""
+    """Return [(line_index, clause_numeral), ...] for every numbered heading.
+
+    Lines inside fenced (```) code blocks are skipped, so an embedded example
+    containing a ``#``-prefixed comment line isn't mistaken for a real heading.
+    """
     headings = []
+    in_fence = False
     for i, line in enumerate(lines):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         m = _HEADING_RE.match(line)
         if m:
             headings.append((i, m.group("num")))
@@ -77,12 +119,15 @@ def extract_section(spec_text: str, anchor: str) -> str:
     """
     lines = spec_text.splitlines()
     headings = _iter_headings(lines)
-    for idx, (line_no, num) in enumerate(headings):
-        if num != anchor:
-            continue
-        end = headings[idx + 1][0] if idx + 1 < len(headings) else len(lines)
-        return "\n".join(lines[line_no:end]).strip()
-    raise ValueError(f"no heading numbered {anchor!r} found in spec")
+    matches = [idx for idx, (_, num) in enumerate(headings) if num == anchor]
+    if not matches:
+        raise ValueError(f"no heading numbered {anchor!r} found in spec")
+    if len(matches) > 1:
+        raise ValueError(f"heading numbered {anchor!r} is ambiguous: {len(matches)} headings match")
+    idx = matches[0]
+    line_no = headings[idx][0]
+    end = headings[idx + 1][0] if idx + 1 < len(headings) else len(lines)
+    return "\n".join(lines[line_no:end]).strip()
 
 
 def extract_row(section_text: str, row: str) -> str:
@@ -100,25 +145,34 @@ def extract_row(section_text: str, row: str) -> str:
 def current_text(spec_text: str, pin: dict) -> str:
     section = extract_section(spec_text, pin["anchor"])
     row = pin.get("row")
-    return extract_row(section, row) if row else section
+    text = extract_row(section, row) if row else section
+    stop_before = pin.get("stop_before")
+    if stop_before:
+        idx = text.index(stop_before)  # raises ValueError if the marker itself drifted
+        text = text[:idx].strip()
+    return text
+
+
+def _pin_label(pin: dict) -> str:
+    suffix = f", row {pin['row']}" if pin.get("row") else ""
+    return f"{pin['id']} (§{pin['anchor']}{suffix})"
 
 
 def check_pins(spec_text: str, pins: list[dict]) -> list[str]:
     """Return a human-readable mismatch message per drifted or broken pin."""
     problems = []
     for pin in pins:
-        label = f"{pin['id']} (§{pin['anchor']}" + (f", row {pin['row']}" if pin.get("row") else "") + ")"
         try:
+            label = _pin_label(pin)
             live = current_text(spec_text, pin)
-        except ValueError as exc:
-            problems.append(f"{label}: {exc}")
-            continue
-        if live != pin["text"]:
-            problems.append(
-                f"{label}: spec text has changed since this pin was last reviewed\n"
-                f"    pinned: {pin['text']!r}\n"
-                f"    live:   {live!r}"
-            )
+            if live != pin["text"]:
+                problems.append(
+                    f"{label}: spec text has changed since this pin was last reviewed\n"
+                    f"    pinned: {pin['text']!r}\n"
+                    f"    live:   {live!r}"
+                )
+        except (KeyError, ValueError) as exc:
+            problems.append(f"{pin.get('id', pin)}: {exc}")
     return problems
 
 
@@ -127,12 +181,23 @@ def _load_manifest(path: Path) -> dict:
         return json.load(fh)
 
 
-def _write_manifest(path: Path, manifest: dict, spec_text: str) -> None:
+def _write_manifest(path: Path, manifest: dict, spec_text: str) -> list[str]:
+    """Re-pin every entry to the current spec text. Returns ids that failed.
+
+    A pin whose anchor/row no longer resolves is skipped (and reported) rather
+    than aborting the whole run, so one stale pin doesn't block re-pinning the
+    rest — the point of ``--write`` is to make exactly that recovery possible.
+    """
+    failed = []
     for pin in manifest["pins"]:
-        pin["text"] = current_text(spec_text, pin)
+        try:
+            pin["text"] = current_text(spec_text, pin)
+        except (KeyError, ValueError) as exc:
+            failed.append(f"{pin.get('id', pin)}: {exc}")
     with path.open("w", encoding="utf-8") as fh:
         json.dump(manifest, fh, indent=2, ensure_ascii=False)
         fh.write("\n")
+    return failed
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -146,8 +211,14 @@ def main(argv: list[str] | None = None) -> int:
     manifest = _load_manifest(args.pins)
 
     if args.write:
-        _write_manifest(args.pins, manifest, spec_text)
-        print(f"formal_spec_pins: re-pinned {len(manifest['pins'])} clause(s) in {args.pins}")
+        failed = _write_manifest(args.pins, manifest, spec_text)
+        ok = len(manifest["pins"]) - len(failed)
+        print(f"formal_spec_pins: re-pinned {ok}/{len(manifest['pins'])} clause(s) in {args.pins}")
+        if failed:
+            print("\nThe following pins could not be re-pinned (anchor/row no longer resolves):")
+            for f in failed:
+                print(f"  - {f}")
+            return 1
         return 0
 
     problems = check_pins(spec_text, manifest["pins"])

--- a/scripts/formal_spec_pins/check.py
+++ b/scripts/formal_spec_pins/check.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Guard against a spec edit silently outrunning the formal chain-invariants model.
+
+``formal/chain-invariants/chain-tamper-evidence.als`` formalizes a specific set
+of normative clauses from ``spec/v0.5.0/spec.md`` (see its header comment).
+Nothing forces the Alloy model to change when those clauses do — the model does
+not parse the spec, so a wording or requirement change under, say, §7.3.5 can
+land, merge, and leave the model quietly describing a spec that no longer
+exists.
+
+This script pins the exact text of every clause the model depends on in
+``formal/chain-invariants/spec-pins.json`` and fails if the live spec text at
+that clause no longer matches. It is deliberately narrow: it does not
+understand Alloy or re-run the model (that's ``formal/chain-invariants/run.sh``,
+gated separately and expensively by CI: formal); it only detects that the spec
+moved out from under a pin.
+
+On a legitimate spec change to a pinned clause:
+
+    1. Read the new clause text and decide whether
+       chain-tamper-evidence.als still holds.
+    2. If it doesn't, update the model (and re-run run.sh).
+    3. Run ``check.py --write`` to re-pin the manifest to the new text, and
+       commit the updated formal/chain-invariants/spec-pins.json alongside
+       whatever else changed.
+
+Anchors are the clause's numeral (e.g. ``"7.3.5"``), matched against the
+leading number in a markdown heading; a pin's extracted text runs from that
+heading to the next heading of any level. A pin may instead target one
+markdown table row within a section via ``"row"`` (the row's first cell,
+e.g. ``"`chain.chain_id`"``) — used for the handful of `credentialSubject`
+schema fields the model depends on, so an edit to an unrelated field in the
+same table doesn't trip the gate.
+
+Usage:
+    check.py              # fail if any pin has drifted from the live spec
+    check.py --write       # re-pin every entry to the current spec text
+
+Exit codes:
+    0  every pin matches the live spec (or --write completed)
+    1  at least one pin has drifted, or a pin's anchor/row no longer exists
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SPEC = _REPO_ROOT / "spec" / "v0.5.0" / "spec.md"
+DEFAULT_PINS = _REPO_ROOT / "formal" / "chain-invariants" / "spec-pins.json"
+
+# Matches an ATX heading's leading clause numeral: "## 3. Core Concepts" -> "3",
+# "### 3.2 Receipt Chain" -> "3.2", "#### 7.3.1 Chain truncation..." -> "7.3.1".
+_HEADING_RE = re.compile(r"^#{1,6}\s+(?P<num>\d+(?:\.\d+)*)\.?\s")
+
+
+def _iter_headings(lines: list[str]) -> list[tuple[int, str]]:
+    """Return [(line_index, clause_numeral), ...] for every numbered heading."""
+    headings = []
+    for i, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m:
+            headings.append((i, m.group("num")))
+    return headings
+
+
+def extract_section(spec_text: str, anchor: str) -> str:
+    """Return the text of the clause numbered *anchor*, heading to next heading.
+
+    The slice runs from the matching heading line up to (not including) the
+    next heading of ANY level, so a parent clause's own body (e.g. §7.3's
+    steps 1-4) does not swallow its subsections (§7.3.1, §7.3.2, ...) — those
+    are pinned separately when needed.
+    """
+    lines = spec_text.splitlines()
+    headings = _iter_headings(lines)
+    for idx, (line_no, num) in enumerate(headings):
+        if num != anchor:
+            continue
+        end = headings[idx + 1][0] if idx + 1 < len(headings) else len(lines)
+        return "\n".join(lines[line_no:end]).strip()
+    raise ValueError(f"no heading numbered {anchor!r} found in spec")
+
+
+def extract_row(section_text: str, row: str) -> str:
+    """Return the single markdown table row in *section_text* whose first cell
+    (trimmed) equals *row*, e.g. ``"`chain.chain_id`"``."""
+    for line in section_text.splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        first_cell = line.strip().strip("|").split("|", 1)[0].strip()
+        if first_cell == row:
+            return line.strip()
+    raise ValueError(f"no table row {row!r} found in section")
+
+
+def current_text(spec_text: str, pin: dict) -> str:
+    section = extract_section(spec_text, pin["anchor"])
+    row = pin.get("row")
+    return extract_row(section, row) if row else section
+
+
+def check_pins(spec_text: str, pins: list[dict]) -> list[str]:
+    """Return a human-readable mismatch message per drifted or broken pin."""
+    problems = []
+    for pin in pins:
+        label = f"{pin['id']} (§{pin['anchor']}" + (f", row {pin['row']}" if pin.get("row") else "") + ")"
+        try:
+            live = current_text(spec_text, pin)
+        except ValueError as exc:
+            problems.append(f"{label}: {exc}")
+            continue
+        if live != pin["text"]:
+            problems.append(
+                f"{label}: spec text has changed since this pin was last reviewed\n"
+                f"    pinned: {pin['text']!r}\n"
+                f"    live:   {live!r}"
+            )
+    return problems
+
+
+def _load_manifest(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _write_manifest(path: Path, manifest: dict, spec_text: str) -> None:
+    for pin in manifest["pins"]:
+        pin["text"] = current_text(spec_text, pin)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC, help=f"Spec file to check against (default: {DEFAULT_SPEC})")
+    parser.add_argument("--pins", type=Path, default=DEFAULT_PINS, help=f"Pin manifest (default: {DEFAULT_PINS})")
+    parser.add_argument("--write", action="store_true", help="Re-pin every entry to the current spec text instead of checking")
+    args = parser.parse_args(argv)
+
+    spec_text = args.spec.read_text(encoding="utf-8")
+    manifest = _load_manifest(args.pins)
+
+    if args.write:
+        _write_manifest(args.pins, manifest, spec_text)
+        print(f"formal_spec_pins: re-pinned {len(manifest['pins'])} clause(s) in {args.pins}")
+        return 0
+
+    problems = check_pins(spec_text, manifest["pins"])
+    if problems:
+        print(f"formal_spec_pins: {len(problems)} pin(s) out of sync with {args.spec}:\n")
+        for p in problems:
+            print(f"  - {p}\n")
+        print(
+            "The formal chain-invariants model (formal/chain-invariants/*.als) claims to "
+            "encode these clauses. Read the new text, decide whether the model still "
+            "holds, update it if not, then run `check.py --write` to re-pin."
+        )
+        return 1
+
+    print(f"formal_spec_pins: clean — {len(manifest['pins'])} pin(s) match {args.spec}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/formal_spec_pins/check.py
+++ b/scripts/formal_spec_pins/check.py
@@ -2,7 +2,8 @@
 """Guard against a spec edit silently outrunning the formal chain-invariants model.
 
 ``formal/chain-invariants/chain-tamper-evidence.als`` formalizes a specific set
-of normative clauses from ``spec/v0.5.0/spec.md`` (see its header comment).
+of normative clauses from the spec (see its header comment; as of this writing
+``spec/v0.5.0/spec.md``, but see below for how the path is resolved).
 Nothing forces the Alloy model to change when those clauses do — the model does
 not parse the spec, so a wording or requirement change under, say, §7.3.5 can
 land, merge, and leave the model quietly describing a spec that no longer

--- a/scripts/formal_spec_pins/test_check.py
+++ b/scripts/formal_spec_pins/test_check.py
@@ -10,7 +10,10 @@ only by the dedicated CI: formal spec pins workflow.
 
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
 import check
 
@@ -49,6 +52,39 @@ Step 1. Step 2.
 #### 7.3.1 Chain truncation detection
 
 Truncation is a floor.
+
+### 7.5 Chain issuer model
+
+A receipt chain MUST have a single issuer.
+
+Some prose.
+
+**Store trust model.** Unrelated operational content that follows.
+
+More unrelated prose.
+"""
+
+FAKE_SPEC_DUPLICATE_ANCHOR = """\
+### 7.3.5 First section
+
+First.
+
+### 7.3.5 Second section (renumbering slip)
+
+Second.
+"""
+
+FAKE_SPEC_WITH_CODE_FENCE = """\
+### 3.2 Receipt Chain
+
+Real prose.
+
+```bash
+# 3.2 this looks like a heading but is inside a fence
+echo hi
+```
+
+More real prose.
 """
 
 
@@ -73,6 +109,15 @@ class TestExtractSection(unittest.TestCase):
     def test_unknown_anchor_raises(self) -> None:
         with self.assertRaises(ValueError):
             check.extract_section(FAKE_SPEC, "99.9")
+
+    def test_duplicate_anchor_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            check.extract_section(FAKE_SPEC_DUPLICATE_ANCHOR, "7.3.5")
+
+    def test_heading_inside_fenced_code_block_is_ignored(self) -> None:
+        section = check.extract_section(FAKE_SPEC_WITH_CODE_FENCE, "3.2")
+        self.assertIn("More real prose.", section)
+        self.assertIn("echo hi", section)  # fence content is still part of 3.2's body
 
 
 class TestExtractRow(unittest.TestCase):
@@ -110,6 +155,77 @@ class TestCheckPins(unittest.TestCase):
         problems = check.check_pins(FAKE_SPEC, [pin])
         self.assertEqual(len(problems), 1)
         self.assertIn("no heading numbered", problems[0])
+
+    def test_pin_missing_text_key_is_reported_not_raised(self) -> None:
+        # A hand-added pin with only id/anchor (before running --write) must
+        # not crash the whole check with an uncaught KeyError.
+        pin = {"id": "incomplete-pin", "anchor": "3.2"}
+        problems = check.check_pins(FAKE_SPEC, [pin])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("incomplete-pin", problems[0])
+
+    def test_stop_before_truncates_before_marker(self) -> None:
+        pin = {"id": "x", "anchor": "7.5", "stop_before": "**Store trust model.**"}
+        pin["text"] = check.current_text(FAKE_SPEC, pin)
+        self.assertIn("Some prose.", pin["text"])
+        self.assertNotIn("Store trust model", pin["text"])
+        self.assertNotIn("More unrelated prose.", pin["text"])
+        self.assertEqual(check.check_pins(FAKE_SPEC, [pin]), [])
+
+    def test_stop_before_marker_missing_is_reported_not_raised(self) -> None:
+        pin = {"id": "x", "anchor": "7.5", "stop_before": "**Nonexistent Marker**", "text": "anything"}
+        problems = check.check_pins(FAKE_SPEC, [pin])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("x", problems[0])
+
+
+class TestWriteManifest(unittest.TestCase):
+    def test_one_broken_pin_does_not_block_repinning_the_rest(self) -> None:
+        manifest = {
+            "pins": [
+                {"id": "good", "anchor": "3.2", "text": "stale"},
+                {"id": "broken", "anchor": "99.9", "text": "stale"},
+            ]
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "pins.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            failed = check._write_manifest(path, manifest, FAKE_SPEC)
+            self.assertEqual(len(failed), 1)
+            self.assertIn("broken", failed[0])
+            written = json.loads(path.read_text(encoding="utf-8"))
+        good = next(p for p in written["pins"] if p["id"] == "good")
+        broken = next(p for p in written["pins"] if p["id"] == "broken")
+        self.assertIn("An ordered sequence of things.", good["text"])
+        self.assertEqual(broken["text"], "stale")  # left untouched, not crashed-and-lost
+
+
+class TestLatestSpecIn(unittest.TestCase):
+    def test_picks_the_highest_semver_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            spec_dir = Path(td)
+            for v in ["v0.4.0", "v0.10.0", "v0.5.0"]:
+                d = spec_dir / v
+                d.mkdir()
+                (d / "spec.md").write_text(v, encoding="utf-8")
+            result = check._latest_spec_in(spec_dir)
+            self.assertEqual(result.read_text(encoding="utf-8"), "v0.10.0")
+
+    def test_ignores_non_semver_and_directories_without_spec_md(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            spec_dir = Path(td)
+            (spec_dir / "v0.4.0").mkdir()
+            (spec_dir / "v0.4.0" / "spec.md").write_text("v0.4.0", encoding="utf-8")
+            (spec_dir / "vNext").mkdir()  # not a semver directory
+            (spec_dir / "vNext" / "spec.md").write_text("vNext", encoding="utf-8")
+            (spec_dir / "v9.9.9").mkdir()  # semver, but no spec.md inside
+            result = check._latest_spec_in(spec_dir)
+            self.assertEqual(result.read_text(encoding="utf-8"), "v0.4.0")
+
+    def test_raises_when_nothing_found(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(FileNotFoundError):
+                check._latest_spec_in(Path(td))
 
 
 class TestRealManifestMatchesRealSpec(unittest.TestCase):

--- a/scripts/formal_spec_pins/test_check.py
+++ b/scripts/formal_spec_pins/test_check.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Unit tests for the formal-model spec-pin guard.
+
+Most tests exercise the extraction/comparison core against a small fake spec
+fragment (no dependency on the real, 600+ line spec.md). One test runs against
+the real, committed manifest and the real spec.md — so a drift between the
+formal model's pinned assumptions and the live spec is caught here too, not
+only by the dedicated CI: formal spec pins workflow.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import check
+
+FAKE_SPEC = """\
+# Fake Spec
+
+## 3. Core Concepts
+
+### 3.2 Receipt Chain
+
+An ordered sequence of things.
+
+### 3.3 Action Taxonomy
+
+Unrelated section.
+
+## 4. Schema
+
+#### 4.3.2 `credentialSubject`
+
+| Field | Required | Description |
+|---|---|---|
+| `chain.chain_id` | Yes | Groups receipts. |
+| `chain.sequence` | Yes | Starts at 1. |
+
+#### 4.3.2.1 Intent field guidance (non-normative)
+
+Not part of 4.3.2.
+
+## 7. Receipt Chain Verification
+
+### 7.3 Chain integrity verification
+
+Step 1. Step 2.
+
+#### 7.3.1 Chain truncation detection
+
+Truncation is a floor.
+"""
+
+
+class TestExtractSection(unittest.TestCase):
+    def test_extracts_up_to_next_heading_of_any_level(self) -> None:
+        section = check.extract_section(FAKE_SPEC, "7.3")
+        self.assertIn("### 7.3 Chain integrity verification", section)
+        self.assertIn("Step 1. Step 2.", section)
+        self.assertNotIn("7.3.1", section)  # subsection excluded, not swallowed
+
+    def test_same_level_sibling_does_not_leak_in(self) -> None:
+        section = check.extract_section(FAKE_SPEC, "3.2")
+        self.assertIn("An ordered sequence of things.", section)
+        self.assertNotIn("Unrelated section.", section)
+
+    def test_same_level_child_heading_terminates_parent(self) -> None:
+        # 4.3.2.1 is the same heading level (####) as 4.3.2 but a distinct
+        # clause; it must not be included in 4.3.2's extracted text.
+        section = check.extract_section(FAKE_SPEC, "4.3.2")
+        self.assertNotIn("Not part of 4.3.2.", section)
+
+    def test_unknown_anchor_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            check.extract_section(FAKE_SPEC, "99.9")
+
+
+class TestExtractRow(unittest.TestCase):
+    def test_finds_row_by_first_cell(self) -> None:
+        section = check.extract_section(FAKE_SPEC, "4.3.2")
+        row = check.extract_row(section, "`chain.sequence`")
+        self.assertIn("Starts at 1.", row)
+
+    def test_unknown_row_raises(self) -> None:
+        section = check.extract_section(FAKE_SPEC, "4.3.2")
+        with self.assertRaises(ValueError):
+            check.extract_row(section, "`chain.nonexistent`")
+
+
+class TestCheckPins(unittest.TestCase):
+    def test_matching_pin_reports_no_problems(self) -> None:
+        pin = {"id": "x", "anchor": "3.2", "text": check.extract_section(FAKE_SPEC, "3.2")}
+        self.assertEqual(check.check_pins(FAKE_SPEC, [pin]), [])
+
+    def test_drifted_pin_is_reported_with_both_texts(self) -> None:
+        pin = {"id": "x", "anchor": "3.2", "text": "stale pinned text"}
+        problems = check.check_pins(FAKE_SPEC, [pin])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("x (§3.2)", problems[0])
+        self.assertIn("stale pinned text", problems[0])
+        self.assertIn("An ordered sequence of things.", problems[0])
+
+    def test_row_pin_label_includes_row(self) -> None:
+        pin = {"id": "x", "anchor": "4.3.2", "row": "`chain.chain_id`", "text": "stale"}
+        problems = check.check_pins(FAKE_SPEC, [pin])
+        self.assertIn("row `chain.chain_id`", problems[0])
+
+    def test_broken_anchor_is_reported_not_raised(self) -> None:
+        pin = {"id": "x", "anchor": "99.9", "text": "anything"}
+        problems = check.check_pins(FAKE_SPEC, [pin])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no heading numbered", problems[0])
+
+
+class TestRealManifestMatchesRealSpec(unittest.TestCase):
+    """Guards the actual formal-model pins, not just the fake fragment above.
+
+    If this fails, the live spec has drifted from what
+    formal/chain-invariants/chain-tamper-evidence.als claims to encode — read
+    the new clause text, update the model if it no longer holds, then run
+    `check.py --write` to re-pin.
+    """
+
+    def test_no_drift(self) -> None:
+        spec_text = check.DEFAULT_SPEC.read_text(encoding="utf-8")
+        manifest = check._load_manifest(check.DEFAULT_PINS)
+        problems = check.check_pins(spec_text, manifest["pins"])
+        self.assertEqual(problems, [], "\n\n" + "\n".join(problems))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a pin manifest (`formal/chain-invariants/spec-pins.json`) and a check script (`scripts/formal_spec_pins/check.py`) that fail CI the moment the live spec text at a clause the Alloy chain-invariants model depends on drifts from what's pinned. A new `CI: formal spec pins` workflow runs it (plus its own unit tests) on every `spec/v0.5.0/spec.md` change.

13 pins cover exactly what `chain-tamper-evidence.als`'s header claims to formalize: §3.2 (chain definition), §7.1 (canonical form, RFC 8785), §7.2 (signing), four `credentialSubject.chain.*` schema rows (§4.3.2 — pinned per-row, not the whole table, so unrelated field edits don't trip the gate), §7.3 (verification algorithm steps 1-4), §7.3.1 (truncation floor), §7.3.2 (receipt-after-terminal), §7.3.4 (chain_id binding), §7.3.5 (sequence contiguity), and §7.5 (chain issuer model).

## Why

`chain-tamper-evidence.als` (#967) formalizes specific spec clauses but never parses `spec/v0.5.0/spec.md` — it's a hand-written model with prose citations. Nothing forces it to change when those clauses do, and re-running `formal/chain-invariants/run.sh` after a spec edit wouldn't catch drift either: the Alloy source is unchanged, so it re-proves the same, now-possibly-stale claim and passes. This gate fails loudly with the exact before/after text instead, forcing whoever touches a pinned clause to consciously decide whether the model still holds before merging — rather than a `spec/**`-triggered re-run of the (expensive, ~4 min) Alloy check that would pass trivially and prove nothing.

On a legitimate spec change: read the new clause text, update the model if it no longer holds, then run `check.py --write` to re-pin.

## Checklist

- [x] Tests pass for all changed components — `python3 scripts/formal_spec_pins/test_check.py` (11 tests, incl. one against the real manifest + real spec.md)
- [x] Linter passes — `ruff check scripts/` clean
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed) — n/a, no receipt format change
- [x] AGENTS.md updated (if project structure changed) — added `scripts/formal_spec_pins/AGENTS.md`; linked from `formal/chain-invariants/README.md`
- [x] Spec changes have been reviewed by a maintainer (if applicable) — n/a, `spec/` not modified (read-only guard)

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, skip remaining items
