### PR TITLE
Resolve relative filesystem resources to absolute paths

### DIFF
--- a/hook/AGENTS.md
+++ b/hook/AGENTS.md
@@ -17,10 +17,13 @@ cmd/obsigna-hook/          # primary binary (ADR-0036)
   main.go                  # stdin read, format detection, emitter dispatch
   claude_code.go           # Claude Code PostToolUse frame parser
   claude_transcript.go     # transcript-derived model/token-usage lookup
+  shell_target.go          # Bash-command → filesystem target classifier
+  resource.go              # resolve action.target.resource to an absolute path
   main_test.go             # unit tests for readClaudeCode and detect
   integration_test.go      # end-to-end tests against a real AF_UNIX listener (linux/darwin)
   import_guard_test.go     # Gate A — fail-closed lean-import allowlist
   entrypoint_guard_test.go # obsigna-hook is primary; agent-receipts-hook only as shim
+  gate_absolute_resource_test.go # CI gate — every emitted filesystem resource is absolute
 cmd/agent-receipts-hook/   # deprecation shim — syscall.Execs into obsigna-hook
   main.go
   main_test.go

--- a/hook/cmd/obsigna-hook/claude_code.go
+++ b/hook/cmd/obsigna-hook/claude_code.go
@@ -55,6 +55,13 @@ type claudeCodeFrame struct {
 	AgentType      string          `json:"agent_type"`
 	TranscriptPath string          `json:"transcript_path"`
 
+	// Cwd is the working directory the tool ran in, sent by Claude Code on every
+	// hook frame. Relative filesystem resources (a Write of "out.go", a Bash
+	// "rm build") are resolved against it so the emitted action.target.resource is
+	// always absolute. Absent (older runtimes), resolution falls back to the hook
+	// process's own working directory.
+	Cwd string `json:"cwd"`
+
 	// Error and IsInterrupt are carried only on PostToolUseFailure frames.
 	// Error is the human-readable failure message. Claude Code sends a JSON
 	// string, but it is kept as RawMessage and decoded leniently (see
@@ -142,12 +149,12 @@ func readClaudeCode(stdin []byte, env func(string) string) (emitter.Event, strin
 			// like a harmless command. Unparseable commands fall through with
 			// no target, preserving current behaviour.
 			if sys, res, at := extractBashTarget(f.ToolInput); res != "" {
-				ev.Target = emitter.Target{System: sys, Resource: res}
+				ev.Target = emitter.Target{System: sys, Resource: absoluteResource(res, f.Cwd)}
 				ev.ActionType = at
 			}
 		default:
 			if sys, res, warn := extractFileTarget(f.ToolName, f.ToolInput); res != "" {
-				ev.Target = emitter.Target{System: sys, Resource: res}
+				ev.Target = emitter.Target{System: sys, Resource: absoluteResource(res, f.Cwd)}
 				// Set the taxonomic action type only for native tools whose verb we
 				// can name honestly (Read → read, Write/Edit/MultiEdit → modify).
 				// Opportunistically-captured tools yield a path but no known verb, so

--- a/hook/cmd/obsigna-hook/gate_absolute_resource_test.go
+++ b/hook/cmd/obsigna-hook/gate_absolute_resource_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"obsigna.dev/sdk/go/emitter"
+)
+
+// filesystemResourceIsAbsolute is the gate predicate and the single source of
+// truth the CI gate enforces: an emitted filesystem target must carry an
+// absolute resource path. A relative filesystem resource makes it return false,
+// which fails the gate below and, in CI, the build.
+//
+// Carve-out (ambiguity clause): the gate covers filesystem resources only.
+// "Absolute" is undefined for a non-filesystem resource identifier (e.g. an MCP
+// resource URI or an empty target), so any target whose System is not
+// "filesystem" — or that carries no resource at all — is exempt. The hook does
+// not emit non-filesystem targets today (MCP tools are skipped, both extractors
+// return System "filesystem"), so this carve-out is forward-looking; a
+// follow-up is filed to define absoluteness for non-fs resources at the spec
+// level rather than guessing here.
+func filesystemResourceIsAbsolute(ev emitter.Event) bool {
+	if ev.Target.System != "filesystem" || ev.Target.Resource == "" {
+		return true
+	}
+	return filepath.IsAbs(ev.Target.Resource)
+}
+
+// TestGate_EmittedFilesystemResourceIsAbsolute is the CI gate (frozen decision).
+// Every filesystem target readClaudeCode emits must have an absolute resource,
+// regardless of whether the runtime supplied a relative or an absolute path in
+// the tool input. The fixtures deliberately mix relative inputs (out.go, build,
+// out.txt, nested/pkg/file.go) with absolute ones (/etc/hosts) so the gate would
+// catch a regression that let a relative path reach the receipt.
+func TestGate_EmittedFilesystemResourceIsAbsolute(t *testing.T) {
+	const cwd = "/work/project"
+	noEnv := func(string) string { return "" }
+
+	// Each fixture is a tool_input paired with the tool name; cwd is injected
+	// uniformly so the emitted resource is deterministic.
+	fixtures := []struct {
+		tool  string
+		input map[string]any
+	}{
+		// Native file tools with relative paths — the common case Claude Code
+		// sends when the user works inside the project directory.
+		{"Write", map[string]any{"file_path": "out.go", "content": "package main"}},
+		{"Edit", map[string]any{"file_path": "x.go", "old_string": "a", "new_string": "b"}},
+		{"MultiEdit", map[string]any{"file_path": "nested/pkg/file.go", "edits": []any{}}},
+		{"Read", map[string]any{"file_path": "docs/readme.md"}},
+		// Already-absolute path — must pass through unchanged (and still absolute).
+		{"Read", map[string]any{"file_path": "/etc/hosts"}},
+		// Opportunistically-captured unknown tool carrying a relative file_path.
+		{"Move", map[string]any{"file_path": "old.go", "destination": "new.go"}},
+		// Bash filesystem mutations with relative operands.
+		{"Bash", map[string]any{"command": "rm -rf build"}},
+		{"Bash", map[string]any{"command": "mv a.txt b.txt"}},
+		{"Bash", map[string]any{"command": "cp src.txt dst.txt"}},
+		{"Bash", map[string]any{"command": "echo hi > out.txt"}},
+	}
+
+	for _, fx := range fixtures {
+		input, err := json.Marshal(fx.input)
+		if err != nil {
+			t.Fatalf("marshal input: %v", err)
+		}
+		stdin, err := json.Marshal(map[string]any{
+			"hook_event_name": "PostToolUse",
+			"session_id":      "gate",
+			"cwd":             cwd,
+			"tool_name":       fx.tool,
+			"tool_input":      json.RawMessage(input),
+		})
+		if err != nil {
+			t.Fatalf("marshal stdin: %v", err)
+		}
+		ev, _, err := readClaudeCode(stdin, noEnv)
+		if err != nil {
+			t.Fatalf("readClaudeCode(%s): %v", fx.tool, err)
+		}
+		// Only fixtures that resolve a filesystem target are in scope; a fixture
+		// that yields no target (none here) is simply skipped by the predicate.
+		if !filesystemResourceIsAbsolute(ev) {
+			t.Errorf("%s %v: emitted relative resource %q; every filesystem resource must be absolute",
+				fx.tool, fx.input, ev.Target.Resource)
+		}
+	}
+}
+
+// TestGate_PredicateHasTeeth is the negative control the frozen decision
+// requires: the gate must FAIL on a relative-path fixture, not merely pass on
+// absolute ones. A gate that can never fire is not a gate. It also pins the
+// carve-out: a non-filesystem resource is exempt.
+func TestGate_PredicateHasTeeth(t *testing.T) {
+	relative := emitter.Event{Target: emitter.Target{System: "filesystem", Resource: "relative/path.go"}}
+	if filesystemResourceIsAbsolute(relative) {
+		t.Error("gate passed a relative filesystem resource; it must fail so CI catches the regression")
+	}
+
+	dotRelative := emitter.Event{Target: emitter.Target{System: "filesystem", Resource: "./out.txt"}}
+	if filesystemResourceIsAbsolute(dotRelative) {
+		t.Error("gate passed a dot-relative filesystem resource; it must fail")
+	}
+
+	absolute := emitter.Event{Target: emitter.Target{System: "filesystem", Resource: "/abs/path.go"}}
+	if !filesystemResourceIsAbsolute(absolute) {
+		t.Error("gate failed an absolute filesystem resource; it must pass")
+	}
+
+	// Carve-out: a non-filesystem resource identifier and an empty target are
+	// exempt — "absolute" is undefined for them.
+	nonFS := emitter.Event{Target: emitter.Target{System: "mcp", Resource: "issue://123"}}
+	if !filesystemResourceIsAbsolute(nonFS) {
+		t.Error("gate must exempt non-filesystem resources (carve-out)")
+	}
+	empty := emitter.Event{Target: emitter.Target{}}
+	if !filesystemResourceIsAbsolute(empty) {
+		t.Error("gate must exempt an empty target")
+	}
+}

--- a/hook/cmd/obsigna-hook/integration_test.go
+++ b/hook/cmd/obsigna-hook/integration_test.go
@@ -129,11 +129,13 @@ type wireFrame struct {
 		Server string `json:"server,omitempty"`
 		Name   string `json:"name"`
 	} `json:"tool"`
-	Input    json.RawMessage `json:"input,omitempty"`
-	Output   json.RawMessage `json:"output,omitempty"`
-	Error    string          `json:"error,omitempty"`
-	Decision string          `json:"decision"`
-	TsEmit   string          `json:"ts_emit"`
+	Input          json.RawMessage `json:"input,omitempty"`
+	Output         json.RawMessage `json:"output,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	Decision       string          `json:"decision"`
+	TargetSystem   string          `json:"target_system,omitempty"`
+	TargetResource string          `json:"target_resource,omitempty"`
+	TsEmit         string          `json:"ts_emit"`
 }
 
 // TestIntegration_ClaudeCodeFrame exercises the full path from stdin parsing
@@ -203,6 +205,63 @@ func TestIntegration_ClaudeCodeFrame(t *testing.T) {
 	}
 	if !json.Valid(got.Output) {
 		t.Errorf("output not valid JSON: %s", got.Output)
+	}
+}
+
+// TestIntegration_ResourceIsAbsoluteOnTheWire exercises the full path from
+// stdin parsing through the emitter to a real AF_UNIX listener and asserts the
+// end-to-end guarantee: a relative file_path in the tool input is emitted as an
+// absolute target_resource on the wire. This is the integration-level backstop
+// for the absolute-resource property — the frame the daemon would sign carries
+// an unambiguous path, resolved against the frame's cwd.
+func TestIntegration_ResourceIsAbsoluteOnTheWire(t *testing.T) {
+	dir := shortSocketDir(t)
+	rl := newRecordingListener(t, dir)
+
+	const sessionID = "integ-abs-2026"
+	// A relative file_path (out.go) with an explicit cwd: the emitted resource
+	// must be the absolute join, never the bare relative token.
+	stdin := `{
+		"hook_event_name": "PostToolUse",
+		"session_id": "` + sessionID + `",
+		"cwd": "/work/project",
+		"tool_name": "Write",
+		"tool_input": {"file_path":"out.go","content":"package main"}
+	}`
+
+	ev, sid, err := readClaudeCode([]byte(stdin), func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("readClaudeCode: %v", err)
+	}
+
+	em, err := emitter.NewDaemon(
+		emitter.WithSocketPath(rl.path),
+		emitter.WithSessionID(sid),
+		emitter.WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	)
+	if err != nil {
+		t.Fatalf("emitter.NewDaemon: %v", err)
+	}
+	defer em.Close()
+
+	if err := em.Emit(context.Background(), ev); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	frames := rl.waitForFrames(t, 1, 2*time.Second)
+
+	var got wireFrame
+	if err := json.Unmarshal(frames[0], &got); err != nil {
+		t.Fatalf("unmarshal frame: %v (raw: %s)", err, frames[0])
+	}
+	if got.TargetSystem != "filesystem" {
+		t.Errorf("target_system = %q; want filesystem", got.TargetSystem)
+	}
+	if !filepath.IsAbs(got.TargetResource) {
+		t.Errorf("target_resource = %q; want an absolute path on the wire", got.TargetResource)
+	}
+	if got.TargetResource != "/work/project/out.go" {
+		t.Errorf("target_resource = %q; want /work/project/out.go", got.TargetResource)
 	}
 }
 

--- a/hook/cmd/obsigna-hook/main_test.go
+++ b/hook/cmd/obsigna-hook/main_test.go
@@ -687,7 +687,8 @@ func TestExtractFileTarget_MalformedJSON(t *testing.T) {
 
 // TestReadClaudeCode_Target verifies that readClaudeCode populates ev.Target
 // for filesystem tools, auto-captures unknown tools with file_path, and leaves
-// target empty for skip-listed and MCP tools.
+// target empty for skip-listed and MCP tools. Every frame carries a cwd, so a
+// relative file_path is resolved to an absolute resource before emit.
 func TestReadClaudeCode_Target(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -696,48 +697,48 @@ func TestReadClaudeCode_Target(t *testing.T) {
 		wantRes string
 	}{
 		{
-			name: "Read populates target",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Read",` +
+			name: "Read with absolute path passes through",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Read",` +
 				`"tool_input":{"file_path":"/etc/hosts"},"tool_response":{"content":"127.0.0.1"}}`,
 			wantSys: "filesystem",
 			wantRes: "/etc/hosts",
 		},
 		{
-			name: "Write populates target",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Write",` +
+			name: "Write relative path resolves against cwd",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Write",` +
 				`"tool_input":{"file_path":"out.go","content":"package main"}}`,
 			wantSys: "filesystem",
-			wantRes: "out.go",
+			wantRes: "/work/out.go",
 		},
 		{
-			name: "Edit populates target",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Edit",` +
+			name: "Edit relative path resolves against cwd",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Edit",` +
 				`"tool_input":{"file_path":"x.go","old_string":"a","new_string":"b"}}`,
 			wantSys: "filesystem",
-			wantRes: "x.go",
+			wantRes: "/work/x.go",
 		},
 		{
-			name: "MultiEdit populates target",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"MultiEdit",` +
+			name: "MultiEdit relative path resolves against cwd",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"MultiEdit",` +
 				`"tool_input":{"file_path":"z.go","edits":[]}}`,
 			wantSys: "filesystem",
-			wantRes: "z.go",
+			wantRes: "/work/z.go",
 		},
 		{
-			name: "unknown tool with file_path is auto-captured",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Move",` +
+			name: "unknown tool with relative file_path is auto-captured and resolved",
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Move",` +
 				`"tool_input":{"file_path":"old.go","destination":"new.go"}}`,
 			wantSys: "filesystem",
-			wantRes: "old.go",
+			wantRes: "/work/old.go",
 		},
 		{
 			name: "Bash leaves target empty",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Bash",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Bash",` +
 				`"tool_input":{"command":"echo hi"},"tool_response":{"output":"hi"}}`,
 		},
 		{
 			name: "MCP tool leaves target empty",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work",` +
 				`"tool_name":"mcp__github-audited__list_issues","tool_input":{"owner":"foo"}}`,
 		},
 	}
@@ -774,21 +775,21 @@ func TestReadClaudeCode_BashTarget(t *testing.T) {
 			name:       "rm -rf gets filesystem target and delete action",
 			command:    "rm -rf build",
 			wantSys:    "filesystem",
-			wantRes:    "build",
+			wantRes:    "/work/build",
 			wantAction: "filesystem.file.delete",
 		},
 		{
 			name:       "mv gets move action with dest target",
 			command:    "mv a.txt b.txt",
 			wantSys:    "filesystem",
-			wantRes:    "b.txt",
+			wantRes:    "/work/b.txt",
 			wantAction: "filesystem.file.move",
 		},
 		{
 			name:       "redirect gets create action",
 			command:    "echo hi > out.txt",
 			wantSys:    "filesystem",
-			wantRes:    "out.txt",
+			wantRes:    "/work/out.txt",
 			wantAction: "filesystem.file.create",
 		},
 		{
@@ -810,6 +811,7 @@ func TestReadClaudeCode_BashTarget(t *testing.T) {
 			stdin, err := json.Marshal(map[string]any{
 				"hook_event_name": "PostToolUse",
 				"session_id":      "s",
+				"cwd":             "/work",
 				"tool_name":       "Bash",
 				"tool_input":      json.RawMessage(input),
 			})
@@ -876,42 +878,42 @@ func TestReadClaudeCode_NativeActionType(t *testing.T) {
 	}{
 		{
 			name: "Read carries read action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Read",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Read",` +
 				`"tool_input":{"file_path":"/etc/hosts"},"tool_response":{"content":"127.0.0.1"}}`,
 			wantRes:    "/etc/hosts",
 			wantAction: "filesystem.file.read",
 		},
 		{
 			name: "Write carries modify action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Write",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Write",` +
 				`"tool_input":{"file_path":"out.go","content":"package main"}}`,
-			wantRes:    "out.go",
+			wantRes:    "/work/out.go",
 			wantAction: "filesystem.file.modify",
 		},
 		{
 			name: "Edit carries modify action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Edit",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Edit",` +
 				`"tool_input":{"file_path":"x.go","old_string":"a","new_string":"b"}}`,
-			wantRes:    "x.go",
+			wantRes:    "/work/x.go",
 			wantAction: "filesystem.file.modify",
 		},
 		{
 			name: "MultiEdit carries modify action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"MultiEdit",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"MultiEdit",` +
 				`"tool_input":{"file_path":"z.go","edits":[]}}`,
-			wantRes:    "z.go",
+			wantRes:    "/work/z.go",
 			wantAction: "filesystem.file.modify",
 		},
 		{
 			name: "opportunistic non-file tool with file_path carries empty action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Move",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work","tool_name":"Move",` +
 				`"tool_input":{"file_path":"old.go","destination":"new.go"}}`,
-			wantRes:    "old.go",
+			wantRes:    "/work/old.go",
 			wantAction: "",
 		},
 		{
 			name: "MCP tool carries empty action",
-			stdin: `{"hook_event_name":"PostToolUse","session_id":"s",` +
+			stdin: `{"hook_event_name":"PostToolUse","session_id":"s","cwd":"/work",` +
 				`"tool_name":"mcp__github-audited__list_issues","tool_input":{"owner":"foo"}}`,
 			wantRes:    "",
 			wantAction: "",

--- a/hook/cmd/obsigna-hook/resource.go
+++ b/hook/cmd/obsigna-hook/resource.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// absoluteResource resolves a filesystem resource path to an absolute, lexically
+// cleaned path so every emitted action.target.resource is unambiguous, whatever
+// relative path the runtime happened to pass (a native Write of "out.go", a Bash
+// "rm build"). A resource recorded as a bare relative path is meaningless in a
+// forensic trail — it cannot be located without also knowing the working
+// directory the tool ran in, which the receipt does not carry.
+//
+// A relative resource is resolved against base — the working directory the tool
+// ran in, taken from the Claude Code frame's cwd — falling back to the hook
+// process's own working directory when the frame omits cwd (the hook is a child
+// of the runtime and inherits that directory). An already-absolute resource is
+// returned lexically cleaned.
+//
+// Resolution is purely lexical: no symlink evaluation or other canonicalisation,
+// which is spec-level content/inode identity and out of scope here. When no
+// absolute base can be determined, the cleaned (still-relative) path is returned
+// rather than fabricating one — the CI gate (gate_absolute_resource_test.go)
+// guards against that path silently becoming the norm.
+func absoluteResource(resource, base string) string {
+	if resource == "" {
+		return ""
+	}
+	if filepath.IsAbs(resource) {
+		return filepath.Clean(resource)
+	}
+	if !filepath.IsAbs(base) {
+		if wd, err := os.Getwd(); err == nil {
+			base = wd
+		}
+	}
+	if filepath.IsAbs(base) {
+		return filepath.Join(base, resource)
+	}
+	return filepath.Clean(resource)
+}

--- a/hook/cmd/obsigna-hook/resource_test.go
+++ b/hook/cmd/obsigna-hook/resource_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAbsoluteResource covers the resolution rules: absolute paths pass through
+// (cleaned), relative paths resolve against the supplied base, and an empty
+// resource stays empty.
+func TestAbsoluteResource(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource string
+		base     string
+		want     string
+	}{
+		{"empty resource stays empty", "", "/work", ""},
+		{"absolute passes through", "/etc/hosts", "/work", "/etc/hosts"},
+		{"absolute is lexically cleaned", "/a/b/../c", "/work", "/a/c"},
+		{"relative resolves against base", "out.go", "/work/project", "/work/project/out.go"},
+		{"nested relative resolves against base", "pkg/x.go", "/work", "/work/pkg/x.go"},
+		{"dot-relative resolves and cleans", "./out.txt", "/work", "/work/out.txt"},
+		{"parent-relative resolves and cleans", "../sibling.go", "/work/project", "/work/sibling.go"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := absoluteResource(tc.resource, tc.base); got != tc.want {
+				t.Errorf("absoluteResource(%q, %q) = %q; want %q", tc.resource, tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAbsoluteResource_FallsBackToGetwd verifies that when the frame carries no
+// (absolute) base, a relative resource is resolved against the hook process's
+// own working directory — the directory Claude Code launched the hook in. The
+// result must always be absolute.
+func TestAbsoluteResource_FallsBackToGetwd(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	got := absoluteResource("out.go", "")
+	if !filepath.IsAbs(got) {
+		t.Fatalf("absoluteResource(out.go, \"\") = %q; want an absolute path", got)
+	}
+	if want := filepath.Join(wd, "out.go"); got != want {
+		t.Errorf("absoluteResource(out.go, \"\") = %q; want %q", got, want)
+	}
+}
+
+// TestAbsoluteResource_RelativeBaseFallsBack ensures a non-absolute base (which
+// cannot anchor a resolution) is ignored in favour of the process working
+// directory rather than producing a still-relative result.
+func TestAbsoluteResource_RelativeBaseFallsBack(t *testing.T) {
+	got := absoluteResource("out.go", "relative/base")
+	if !filepath.IsAbs(got) {
+		t.Errorf("absoluteResource(out.go, relative/base) = %q; want an absolute path", got)
+	}
+}


### PR DESCRIPTION
## What

Add absolute path resolution for filesystem resources emitted by the hook. Relative file paths in tool inputs (e.g., `Write` with `"out.go"`, `Bash` with `"rm build"`) are now resolved against the frame's `cwd` before emission, ensuring every emitted `action.target.resource` is an absolute, unambiguous path.

## Why

Relative paths in forensic audit trails are meaningless without the working directory context. The hook now receives `cwd` from Claude Code on every frame, enabling deterministic resolution. This ensures:

1. **Unambiguous audit records**: Every emitted resource can be located without additional context
2. **CI enforcement**: A new gate (`TestGate_EmittedFilesystemResourceIsAbsolute`) freezes this guarantee and will catch regressions
3. **Forward compatibility**: Non-filesystem resources (MCP URIs, etc.) are exempt via a carve-out clause; the gate is future-proof for when those are defined at the spec level

## Implementation

- **`resource.go`**: New `absoluteResource()` function that resolves relative paths against a base directory (the frame's `cwd`), falling back to the hook process's working directory if needed. Already-absolute paths are lexically cleaned.
- **`gate_absolute_resource_test.go`**: New test file with two test functions:
  - `TestGate_EmittedFilesystemResourceIsAbsolute`: Positive control verifying all fixtures emit absolute resources
  - `TestGate_PredicateHasTeeth`: Negative control ensuring the gate actually fails on relative paths and exempts non-filesystem resources
- **`resource_test.go`**: Unit tests for `absoluteResource()` covering resolution rules, fallback behavior, and edge cases
- **`claude_code.go`**: Updated to parse `cwd` from frames and call `absoluteResource()` when populating targets
- **`integration_test.go`**: New `TestIntegration_ResourceIsAbsoluteOnTheWire` verifying end-to-end that relative input paths become absolute on the wire
- **`main_test.go`**: Updated existing tests to include `cwd` in fixtures and expect absolute paths in results
- **`AGENTS.md`**: Updated to document new files

## Checklist

- [x] Tests pass for all changed components (unit, integration, and gate tests added)
- [x] Linter passes
- [x] No real keys or secrets in the diff
- [x] AGENTS.md updated
- [x] No crypto, auth, or secrets handling involved