### PR TITLE
chore(sdk-go): prepare v0.24.0 release

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -11,13 +11,21 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-17
+
 ### Added
 
 - **Forensic response disclosure** ([#819](https://github.com/agent-receipts/obsigna/issues/819)) — `EncryptResponse` / `DecryptResponse` and the `Outcome.ResponseDisclosure` field, mirroring `EncryptDisclosure` / `Action.ParametersDisclosure` for the tool output side (ADR-0012). Same HPKE v1 envelope, forensic keypair, and JCS canonicalization; `Outcome.ResponseHash` remains the authoritative commitment. Catches the Go SDK up to the TS/Python SDKs, which shipped response disclosure in 0.6.0 (PR #913).
+- **`did:key` v0.7 resolution** ([#958](https://github.com/agent-receipts/obsigna/pull/958)) — new `did` package (base58btc encode/decode, `FromPublicKey`, `Resolve`) conforming to the shared cross-SDK test vectors (ADR-0007), with no new dependencies. `Resolve` caps input length to bound the base58btc decode's cost.
+- **`checkpoint` package** ([#932](https://github.com/agent-receipts/obsigna/pull/932)) — the checkpoint wire types and sign/verify crypto used to live only inside the daemon's internal package; they're now public at `obsigna.dev/sdk/go/checkpoint` so the daemon emitter, the verify CLI, and the browser verifier can share one implementation. Behaviour-preserving move plus a focused crypto unit test (sign/verify round-trip, tampered body, wrong key, malformed signature, bad PEM) that previously only had daemon-level integration coverage.
 
 ### Changed
 
 - **Protocol version bumped to `0.6.0` and JSON-LD context to v3** to match the TS and Python SDKs. New receipts stamp `version: "0.6.0"` and reference `https://agentreceipts.ai/context/v3`, restoring the cross-SDK live-emit version invariant (the Go SDK was intentionally held at `0.5.0`/context v2 pending the vanity module-path migration).
+
+### Security
+
+- Bumped `golang.org/x/crypto` to v0.52.0 (39 open Dependabot alerts across the Go modules, several critical).
 
 ## [0.23.0] - 2026-06-23
 


### PR DESCRIPTION
## What

Cut `sdk/go`'s `[Unreleased]` CHANGELOG section into `[0.24.0]`, covering everything merged to `main` since `v0.23.0`: forensic response disclosure (#819), `did:key` v0.7 resolution (#958), the `checkpoint` package extraction (#932), the protocol version bump to 0.6.0, and the `golang.org/x/crypto` security bump.

## Why

Part of unblocking #978. No published `sdk/go` version contains the `checkpoint` package yet (it landed in #932, after `sdk/go`'s last tag). `daemon`'s GoReleaser release build already runs with `GOWORK=off`, and with the workspace disabled, `daemon`'s own production code (`internal/checkpoint/checkpoint.go`) fails to compile — it imports `obsigna.dev/sdk/go/checkpoint`, which the pinned `v0.22.0` (and even the latest tag, `v0.23.0`) don't have. Cutting `sdk/go/v0.24.0` and then bumping `daemon`'s pin (follow-up PR) fixes that.

Once merged, I'll push the `sdk/go/v0.24.0` tag to trigger the release pipeline.

## Checklist

- [x] Tests pass for all changed components (`go vet`, `go build`, `go test ./...` in `sdk/go`)
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — no format change, CHANGELOG only
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling (if no, skip remaining items) — CHANGELOG-only change, no code touched