### PR TITLE
ci(release): tag daemon/mcp-proxy/hook/collector submodules on obsigna release

### DIFF
--- a/.github/workflows/release-obsigna.yml
+++ b/.github/workflows/release-obsigna.yml
@@ -124,6 +124,42 @@ jobs:
       - name: Run unit tests for daemon-protocol gate
         run: python3 scripts/daemon_protocol/test_check.py
 
+  # Go module resolution (#978): daemon, mcp-proxy, hook, and collector are
+  # each their own Go module, and Go's monorepo convention resolves a
+  # submodule's version off a per-subdirectory tag (daemon/vX.Y.Z, ...), not
+  # off the packaging tag this workflow triggers on. Nothing has pushed those
+  # tags since ADR-0034 retired the standalone per-component release
+  # workflows, so obsigna.dev/daemon et al. were stuck resolving pre-ADR-0037
+  # versions whose go.mod still declared the old github.com/agent-receipts/ar/...
+  # path — breaking Dependabot remediation and any GOWORK=off build that needs
+  # a fresh cross-module import. Push a matching tag for each submodule at this
+  # release's commit and version (ADR-0034 decision 3: one shared version
+  # number across the whole toolset) once every other gate has passed.
+  tag-go-submodules:
+    needs: [release, daemon-protocol, reproducible-attest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Tag each Go submodule at this release's commit
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#obsigna/}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for mod in daemon mcp-proxy hook collector; do
+            tag="${mod}/${VERSION}"
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "already exists, skipping: ${tag}"
+              continue
+            fi
+            git tag -a "${tag}" -m "obsigna ${VERSION}" "${GITHUB_REF_NAME}"
+            git push origin "refs/tags/${tag}"
+          done
+
   # Gate B (release side, ADR-0031/0033/0034/0035/0036): the attestation claim is
   # that auditors can independently rebuild each primary toolset binary and match
   # a published hash. With the trains folded into one (ADR-0034 PR 2), prove it


### PR DESCRIPTION
## What

Adds a `tag-go-submodules` job to `release-obsigna.yml` that runs after `release`, `daemon-protocol`, and `reproducible-attest` all succeed, and pushes a `daemon/vX.Y.Z`, `mcp-proxy/vX.Y.Z`, `hook/vX.Y.Z`, `collector/vX.Y.Z` tag at the same commit and version as the `obsigna/vX.Y.Z` release that triggered it. Skips any tag that already exists (idempotent on re-run).

## Why

Go's monorepo convention resolves a submodule's version off a per-subdirectory tag, not off whatever packaging tag scheme a repo uses. ADR-0034 consolidated the toolset's release packaging into one `obsigna/vX.Y.Z` train and retired the standalone `release-daemon.yml` / `release-mcp-proxy.yml` / `release-hook.yml` workflows — but nothing replaced the per-module tags those workflows used to push. Since 2026-06-12, `obsigna.dev/daemon`, `obsigna.dev/mcp-proxy`, and `obsigna.dev/hook` have been frozen at their last individually-tagged version, all of which predate the ADR-0037 vanity-path migration (#922) — so their `go.mod` still declares the old `github.com/agent-receipts/ar/...` path.

Concretely, this breaks:
- **Dependabot remediation** — it can't resolve `mcp-proxy`'s test-only `obsigna.dev/daemon` import against the module proxy, because the only published version's `go.mod` declares a different module path than requested (see #978, alert #94).
- **The actual release build** — `daemon`'s GoReleaser config already runs with `GOWORK=off`; any future cross-module import that needs a fresh submodule version would hit the identical resolution failure outside this monorepo's workspace.

Filed as #978. This is the durable fix — the follow-up PRs bumping `daemon`/`hook`/`mcp-proxy`'s `sdk/go` pin and cutting one catch-up round of tags close the immediate gap; this stops it from recurring on every future release.

## Checklist

- [x] Tests pass for all changed components — N/A, workflow-only change; validated YAML structure and job dependency graph by hand (no local GitHub Actions runner in this repo)
- [ ] Linter passes — N/A, no `actionlint` available locally; please have CI/a maintainer double check the job syntax before merging
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — N/A
- [ ] AGENTS.md updated — N/A, no structural change
- [ ] Spec changes reviewed — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, it only pushes lightweight git tags with `contents: write` permission the job already has via the existing `release` job

Per repo convention, CI/CD workflow changes need explicit human review — opening as a PR for you to review and merge rather than merging it myself.