### PR TITLE
chore(sdk-ts): prepare v0.17.0 release

### DIFF
--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,12 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-17
+
+### Added
+
+- **`did:key` v0.7 resolution** ([#958](https://github.com/agent-receipts/obsigna/pull/958)) — new standalone `did` module (base58btc encode/decode, `didFromPublicKey`, `resolveDid`) conforming to the shared cross-SDK test vectors (ADR-0007), with no new dependencies. `resolveDid` caps input length at 64 characters to bound the base58btc decode's cost.
+
 ## [0.16.0] - 2026-06-24
 
 ### Added

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@obsigna/sdk-ts",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "TypeScript SDK for the Agent Receipts protocol",
 	"license": "Apache-2.0",
 	"author": "Otto Jongerius",


### PR DESCRIPTION
## What

Cut `sdk/ts`'s `[Unreleased]` CHANGELOG section into `[0.17.0]`, and bump `package.json` to match: `did:key` v0.7 resolution (#958).

## Why

This feature landed across Go, Python, and TS SDKs simultaneously (#958), but only Go has shipped it so far (v0.24.0, #979). Catching TS up.

## Checklist

- [x] Tests pass for all changed components (`pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test` — 495/495 passing)
- [x] Linter passes (2 pre-existing warnings, unrelated to this change)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — no receipt format change, CHANGELOG/version only
- [ ] AGENTS.md updated — N/A
- [ ] Spec changes reviewed — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — CHANGELOG/version bump only, no code touched