### PR TITLE
chore(sdk-py): prepare v0.15.0 release

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,13 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-17
+
+### Added
+
+- **`target_system` / `target_resource` on `DaemonEmitter.emit()`** ([#946](https://github.com/agent-receipts/obsigna/pull/946)) — keyword-only params forwarding file-identity metadata the daemon maps onto `action.target.{system,resource}`. Validation mirrors the Go and TS emitters and the daemon's XOR rule: both fields must be set together or both empty, `target_system` capped at 256 UTF-8 bytes and `target_resource` at 4096, measured in bytes not code points. Additive and backwards-compatible; completes cross-SDK emitter target parity.
+- **`did:key` v0.7 resolution** ([#958](https://github.com/agent-receipts/obsigna/pull/958)) — new standalone `did` module (base58btc encode/decode, `did_from_public_key`, `resolve_did`) conforming to the shared cross-SDK test vectors (ADR-0007), with no new dependencies. `resolve_did` caps input length at 64 characters to bound the base58btc decode's cost.
+
 ## [0.14.0] - 2026-06-23
 
 Graduates `0.14.0a1` after the alpha pass. Ships the grounded-principal conformance tier (ADR-0038, spec §7.9): `GrantResolver` abstract base class and `verify_grounded_principal_tier`.

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsigna"
-version = "0.14.0"
+version = "0.15.0"
 description = "Python SDK for the Agent Receipts protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "obsigna"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Cut `sdk/py`'s `[Unreleased]` CHANGELOG section into `[0.15.0]`, and bump `pyproject.toml` (+ `uv.lock`) to match: `target_system`/`target_resource` on `DaemonEmitter.emit()` (#946) and `did:key` v0.7 resolution (#958).

## Why

Both features landed cross-SDK. `target` on the emitter already shipped in Go and TS; `did:key` v0.7 shipped in Go (v0.24.0, #979) and TS (v0.17.0, #983). This closes the gap for Python.

## Checklist

- [x] Tests pass for all changed components (`ruff check`, `ruff format --check`, `pyright src`, `pytest` — 524 passed, 7 skipped)
- [x] Linter passes
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass — no receipt format change, CHANGELOG/version only
- [ ] AGENTS.md updated — N/A
- [ ] Spec changes reviewed — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — CHANGELOG/version bump only, no code touched