### PR TITLE
build(deps): bump dompurify 3.4.11 -> 3.4.12 in site lockfiles

### DIFF
--- a/site-obsigna/pnpm-lock.yaml
+++ b/site-obsigna/pnpm-lock.yaml
@@ -1443,8 +1443,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3945,7 +3945,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4645,7 +4645,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.47.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -1447,8 +1447,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3957,7 +3957,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4655,7 +4655,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0


### PR DESCRIPTION
## What

Bump `dompurify` from 3.4.11 to 3.4.12 in `site/pnpm-lock.yaml` and `site-obsigna/pnpm-lock.yaml`.

## Why

Clears Dependabot alerts #111 and #112 (low severity): [GHSA-c2j3-45gr-mqc4](https://github.com/agent-receipts/obsigna/security/dependabot/111) — `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements, a hook-policy inconsistency that can become a second-order XSS gadget in specific configurations.

`dompurify` is transitive via mermaid/rehype-mermaid, so Dependabot couldn't open an automatic security-update PR for it (same as the last dompurify advisory, #921) — 3.4.12 satisfies the existing ranges (`^3.4.10` override in `site`, unpinned range in `site-obsigna`), so this is a lockfile-only change, no `package.json` edit needed.

## Checklist

- [x] Tests pass for all changed components (`pnpm build` succeeds for both `site` and `site-obsigna`)
- [ ] Linter passes (`go vet`, `ruff check`, `biome` as applicable) — N/A, no source changed
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, skipping remaining items