### PR TITLE
build(deps): bump postcss 8.5.15 -> 8.5.18 in sdk/ts-aws and opencode-plugin lockfiles

### DIFF
--- a/integrations/opencode-plugin/pnpm-lock.yaml
+++ b/integrations/opencode-plugin/pnpm-lock.yaml
@@ -481,8 +481,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pure-rand@8.4.0:
@@ -1008,7 +1008,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -1079,7 +1079,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/sdk/ts-aws/pnpm-lock.yaml
+++ b/sdk/ts-aws/pnpm-lock.yaml
@@ -525,8 +525,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   rolldown@1.0.3:
@@ -1187,7 +1187,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -1250,7 +1250,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## What

Bump `postcss` from 8.5.15 to 8.5.18 in `sdk/ts-aws/pnpm-lock.yaml` and `integrations/opencode-plugin/pnpm-lock.yaml`.

## Why

Clears Dependabot alerts #113 and #114 (high severity): PostCSS path traversal in previous source-map auto-loading (`sourceMappingURL`) can lead to arbitrary `.map` file disclosure. Vulnerable range is `<= 8.5.17`, patched at `8.5.18`.

`postcss` is transitive via `vite` in both packages, so Dependabot couldn't open an automatic security-update PR for it (same pattern as #993 for dompurify). vite's own dependency range (`^8.5.15`) already permits 8.5.18+, so this is a lockfile-only change — no `package.json` edit needed.

## Checklist

- [x] Tests pass for all changed components (`pnpm build` + `pnpm test` succeed for both `sdk/ts-aws` and `integrations/opencode-plugin`)
- [ ] Linter passes (`go vet`, `ruff check`, `biome` as applicable) — N/A, no source changed
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, skipping remaining items