### PR TITLE
daemon: apply Redactor to intent.prompt_preview

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Apply the Redactor to `intent.prompt_preview`** ([#1012](https://github.com/agent-receipts/obsigna/issues/1012)) — the daemon redacted `outcome.error` but wrote `prompt_preview` into signed receipts verbatim after truncation only, leaving a documented wire-protocol field free to carry pasted secrets unredacted. `intentFromFrame` now redacts before truncating, matching the ordering already used for `outcome.error`. No in-tree emitter populates `prompt_preview` today, so this closes a latent gap rather than a live leak.
+
 ## [0.30.0] - 2026-07-17
 
 ### Added

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -855,10 +855,7 @@ func (p *Pipeline) buildAndSign(
 	// placeholder), so capping first could still leave an over-cap value. The
 	// error is plaintext written inline (issue #478); truncating keeps a hostile
 	// or runaway message from inflating the receipt and slowing canonicalisation.
-	errText := f.Error
-	if p.Redactor != nil {
-		errText = p.Redactor.Redact(errText)
-	}
+	errText := p.Redactor.RedactIfSet(f.Error)
 	errText = truncateError(errText, p.MaxErrorLen)
 
 	outcome := receipt.Outcome{
@@ -962,10 +959,7 @@ func intentFromFrame(f *EmitterFrame, redactor *Redactor, maxPreviewLen int) *re
 	if f.PromptPreview == "" {
 		return nil
 	}
-	preview := f.PromptPreview
-	if redactor != nil {
-		preview = redactor.Redact(preview)
-	}
+	preview := redactor.RedactIfSet(f.PromptPreview)
 	// A non-positive cap disables truncation, matching truncateError and the
 	// flag/env/TOML contract ("negative disables"). The shared
 	// TruncatePromptPreview helper instead treats maxLen <= 0 as "drop the

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -212,10 +212,11 @@ type Pipeline struct {
 	ResponseDisclosurePolicy DisclosurePolicy
 
 	// Redactor is applied to text fields before they are persisted in the
-	// receipt body. Today that means outcome.error only; input and output are
-	// never stored as raw text — only their SHA-256 hashes go into
-	// parameters_hash / response_hash, so those hashes are always over the
-	// original emitter payload. Nil = no redaction.
+	// receipt body: outcome.error and intent.prompt_preview, the two inline
+	// plaintext fields the daemon writes (see MaxErrorLen/MaxPromptPreviewLen
+	// below). Input and output are never stored as raw text — only their
+	// SHA-256 hashes go into parameters_hash / response_hash, so those hashes
+	// are always over the original emitter payload. Nil = no redaction.
 	Redactor *Redactor
 
 	// MaxErrorLen and MaxPromptPreviewLen bound, in runes, the two plaintext
@@ -894,7 +895,7 @@ func (p *Pipeline) buildAndSign(
 		Principal:     principalFromPeer(peer),
 		Action:        action,
 		Outcome:       outcome,
-		Intent:        intentFromFrame(f, p.MaxPromptPreviewLen),
+		Intent:        intentFromFrame(f, p.Redactor, p.MaxPromptPreviewLen),
 		CorrelationID: f.CorrelationID,
 		Delegation:    delegation,
 		Chain: receipt.Chain{
@@ -946,24 +947,33 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 	}
 }
 
-// intentFromFrame builds the receipt Intent from the emitter frame, truncating
-// the plaintext prompt_preview to maxPreviewLen runes (issue #478). It returns
-// nil when the emitter sent no preview, so the receipt omits the intent block
-// entirely rather than emitting an empty object. The conversation/reasoning
-// hashes are not carried on the daemon emit path today — only the one inline
-// plaintext intent field is, which is why it is the only one bounded here.
-func intentFromFrame(f *EmitterFrame, maxPreviewLen int) *receipt.Intent {
+// intentFromFrame builds the receipt Intent from the emitter frame, redacting
+// then truncating the plaintext prompt_preview (issue #478, issue #1012). It
+// returns nil when the emitter sent no preview, so the receipt omits the
+// intent block entirely rather than emitting an empty object. The
+// conversation/reasoning hashes are not carried on the daemon emit path today
+// — only the one inline plaintext intent field is, which is why it is the
+// only one bounded here.
+//
+// Redaction runs before the cap, mirroring errText's ordering (build.go:852-
+// 856): redaction can lengthen the string, so capping first could leave an
+// over-cap value.
+func intentFromFrame(f *EmitterFrame, redactor *Redactor, maxPreviewLen int) *receipt.Intent {
 	if f.PromptPreview == "" {
 		return nil
+	}
+	preview := f.PromptPreview
+	if redactor != nil {
+		preview = redactor.Redact(preview)
 	}
 	// A non-positive cap disables truncation, matching truncateError and the
 	// flag/env/TOML contract ("negative disables"). The shared
 	// TruncatePromptPreview helper instead treats maxLen <= 0 as "drop the
 	// whole preview", so guard it here rather than route a disable through it.
 	if maxPreviewLen <= 0 {
-		return &receipt.Intent{PromptPreview: f.PromptPreview}
+		return &receipt.Intent{PromptPreview: preview}
 	}
-	preview, truncated := receipt.TruncatePromptPreview(f.PromptPreview, maxPreviewLen)
+	preview, truncated := receipt.TruncatePromptPreview(preview, maxPreviewLen)
 	intent := &receipt.Intent{PromptPreview: preview}
 	if truncated {
 		intent.PromptPreviewTruncated = &truncated

--- a/daemon/internal/pipeline/redact.go
+++ b/daemon/internal/pipeline/redact.go
@@ -162,6 +162,16 @@ func (r *Redactor) Redact(raw string) string {
 	return raw
 }
 
+// RedactIfSet applies Redact when r is non-nil, and returns raw unchanged
+// when it is nil — the "no Redactor configured" case every call site would
+// otherwise have to guard against individually.
+func (r *Redactor) RedactIfSet(raw string) string {
+	if r == nil {
+		return raw
+	}
+	return r.Redact(raw)
+}
+
 func redactJSONValue(v any) any {
 	switch val := v.(type) {
 	case map[string]any:

--- a/daemon/internal/pipeline/redact_test.go
+++ b/daemon/internal/pipeline/redact_test.go
@@ -395,6 +395,97 @@ func TestPipeline_RedactionAppliedToError(t *testing.T) {
 	}
 }
 
+// TestPipeline_PromptPreviewIsRedactedInReceipt verifies intent.prompt_preview
+// — the second inline plaintext field alongside outcome.error (issue #1012) —
+// is redacted before persistence when it contains a recognisable secret shape.
+func TestPipeline_PromptPreviewIsRedactedInReceipt(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-preview-redact")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+	p.Redactor = NewRedactor(nil)
+
+	secret := "ghp_" + strings.Repeat("x", 36)
+	body, err := json.Marshal(EmitterFrame{
+		Version:       "1",
+		TsEmit:        "2026-05-03T00:00:00Z",
+		SessionID:     "s",
+		Channel:       "sdk",
+		Tool:          EmitterTool{Name: "t"},
+		PromptPreview: "use token " + secret + " to authenticate",
+		Decision:      "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("chain-preview-redact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	intent := receipts[0].CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil; daemon must populate intent.prompt_preview")
+	}
+	if strings.Contains(intent.PromptPreview, secret) {
+		t.Errorf("prompt_preview contains raw secret — redaction did not run: %q", intent.PromptPreview)
+	}
+	if !strings.Contains(intent.PromptPreview, "[REDACTED]") {
+		t.Errorf("prompt_preview does not contain [REDACTED]: %q", intent.PromptPreview)
+	}
+}
+
+// TestPipeline_PromptPreviewRedactedBeforeTruncation verifies redaction runs
+// before the rune cap, matching the ordering already used for outcome.error
+// (build.go:852-856): redaction can lengthen a string (a short secret replaced
+// by the longer "[REDACTED]" placeholder), so capping first could leave an
+// over-cap value, and redacting after truncation could leave a secret's tail
+// exposed if the cap split it mid-match.
+func TestPipeline_PromptPreviewRedactedBeforeTruncation(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("chain-preview-redact-trunc")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+	p.Redactor = NewRedactor(nil)
+	p.MaxPromptPreviewLen = 4096
+
+	secret := "ghp_" + strings.Repeat("x", 36)
+	preview := "leading text " + secret + " trailing text"
+	body, err := json.Marshal(EmitterFrame{
+		Version:       "1",
+		TsEmit:        "2026-05-03T00:00:00Z",
+		SessionID:     "s",
+		Channel:       "sdk",
+		Tool:          EmitterTool{Name: "t"},
+		PromptPreview: preview,
+		Decision:      "allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	receipts, err := st.GetChain("chain-preview-redact-trunc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	intent := receipts[0].CredentialSubject.Intent
+	if intent == nil {
+		t.Fatal("intent nil")
+	}
+	if intent.PromptPreview != "leading text [REDACTED] trailing text" {
+		t.Errorf("prompt_preview = %q, want redacted", intent.PromptPreview)
+	}
+	if intent.PromptPreviewTruncated != nil {
+		t.Error("prompt_preview_truncated must be absent; well within cap after redaction")
+	}
+}
+
 // TestPipeline_NoRedactorIsNoop verifies that when no Redactor is set (nil),
 // the pipeline behaves exactly as before — hashes and error field are
 // unmodified. Nil Redactor must not panic.

--- a/daemon/internal/pipeline/redact_test.go
+++ b/daemon/internal/pipeline/redact_test.go
@@ -440,17 +440,23 @@ func TestPipeline_PromptPreviewIsRedactedInReceipt(t *testing.T) {
 
 // TestPipeline_PromptPreviewRedactedBeforeTruncation verifies redaction runs
 // before the rune cap, matching the ordering already used for outcome.error
-// (build.go:852-856): redaction can lengthen a string (a short secret replaced
-// by the longer "[REDACTED]" placeholder), so capping first could leave an
-// over-cap value, and redacting after truncation could leave a secret's tail
-// exposed if the cap split it mid-match.
+// (build.go:852-856). The cap (30) is chosen to land strictly between the
+// redacted length (37 runes: "leading text [REDACTED] trailing text") and the
+// point in the raw preview where truncation would still leave the full 36+
+// character run the ghp_ pattern requires (raw truncation at 30 runes cuts
+// the token down to "ghp_" + 13 x's, short of the {36,} minimum). So:
+//   - redact-then-truncate (correct): the placeholder is already in place
+//     before the cut, so "[REDACTED]" survives and no raw "ghp_" remains.
+//   - truncate-then-redact (wrong): the cut token no longer matches the
+//     pattern, so the raw secret prefix "ghp_xxx..." would leak untouched.
 func TestPipeline_PromptPreviewRedactedBeforeTruncation(t *testing.T) {
 	ks := newTestKeySource(t)
 	st := newTestStore(t)
 	state := chain.New("chain-preview-redact-trunc")
 	p := New(state, ks, st, "did:agent-receipts-daemon:test")
 	p.Redactor = NewRedactor(nil)
-	p.MaxPromptPreviewLen = 4096
+	const cap = 30
+	p.MaxPromptPreviewLen = cap
 
 	secret := "ghp_" + strings.Repeat("x", 36)
 	preview := "leading text " + secret + " trailing text"
@@ -478,11 +484,14 @@ func TestPipeline_PromptPreviewRedactedBeforeTruncation(t *testing.T) {
 	if intent == nil {
 		t.Fatal("intent nil")
 	}
-	if intent.PromptPreview != "leading text [REDACTED] trailing text" {
-		t.Errorf("prompt_preview = %q, want redacted", intent.PromptPreview)
+	if want := "leading text [REDACTED] traili"; intent.PromptPreview != want {
+		t.Errorf("prompt_preview = %q, want %q", intent.PromptPreview, want)
 	}
-	if intent.PromptPreviewTruncated != nil {
-		t.Error("prompt_preview_truncated must be absent; well within cap after redaction")
+	if strings.Contains(intent.PromptPreview, "ghp_") {
+		t.Errorf("prompt_preview contains raw secret prefix — truncation ran before redaction: %q", intent.PromptPreview)
+	}
+	if intent.PromptPreviewTruncated == nil || !*intent.PromptPreviewTruncated {
+		t.Error("prompt_preview_truncated must be true; the redacted string (37 runes) exceeds the 30-rune cap")
 	}
 }
 


### PR DESCRIPTION
## What

`intentFromFrame` (`daemon/internal/pipeline/build.go`) now runs `f.PromptPreview` through `p.Redactor` before truncating it, matching the redact-then-truncate ordering already used for `outcome.error` in `buildAndSign`. Also updates the stale `Redactor` doc comment on `Pipeline`, which claimed `outcome.error` was the only field it covered.

## Why

`intentFromFrame` truncated `prompt_preview` but never redacted it, even though the daemon's `Redactor` (30 sensitive-key rules, 13 secret-detection patterns) was already wired up and applied to `outcome.error` at the same call site. A prompt preview is one of the likeliest places for a pasted secret to appear, so this left a documented wire-protocol field free to write unredacted plaintext into signed, shareable receipts.

Redaction runs before truncation for the same reason it does for `errText`: redaction can lengthen a string (a short secret replaced by the longer `[REDACTED]` placeholder), so capping first could leave an over-cap value.

No in-tree emitter currently populates `prompt_preview`, so this closes a latent gap rather than a live leak.

Fixes #1012

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, no receipt format change
- [x] AGENTS.md updated (if project structure changed) — N/A, no structure change
- [x] Spec changes have been reviewed by a maintainer (if applicable) — N/A, no spec change

## Security

- [x] This PR touches crypto, auth, or secrets handling
- [x] Primitives and parameters have been reviewed — no crypto/primitive change, redaction logic reused as-is
- [x] All inputs are validated at trust boundaries — `Redactor.Redact` already handles empty/nil safely; `intentFromFrame` guards nil `redactor`
- [x] Edge cases are tested (nil, empty, corrupted, concurrent) — added tests cover redaction-then-truncation ordering and interaction with the existing prompt-preview truncation/cap tests