### PR TITLE
Prevent unbounded line buffering in proxy and hook

### DIFF
--- a/hook/cmd/obsigna-hook/claude_transcript.go
+++ b/hook/cmd/obsigna-hook/claude_transcript.go
@@ -8,7 +8,20 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"obsigna.dev/sdk/go/emitter"
 )
+
+// maxTranscriptLineLength caps a single transcript JSONL line, reusing the
+// daemon's frame-size cap (via the already-imported emitter package):
+// bufio.Reader.ReadBytes otherwise grows its returned slice without limit
+// while it searches for a newline, so a line with no delimiter could exhaust
+// the short-lived hook process's memory.
+const maxTranscriptLineLength = emitter.MaxFrameSize
+
+// errTranscriptLineTooLong is returned by readBoundedLine when a line
+// exceeds maxTranscriptLineLength before a newline is found.
+var errTranscriptLineTooLong = errors.New("transcript line too large")
 
 // transcriptEntry is the minimal projection of one Claude Code transcript JSONL
 // line we need to resolve a tool call's model and token usage. Only assistant
@@ -50,7 +63,9 @@ type transcriptBlock struct {
 //     non-fatal condition for a best-effort enrichment.
 //   - found == true, usage == nil when the turn is located but has no usage
 //     object (model is still returned).
-//   - a non-nil err only for I/O failures opening or reading the file.
+//   - a non-nil err for I/O failures opening or reading the file, and for a
+//     line exceeding maxTranscriptLineLength (errTranscriptLineTooLong) —
+//     the scan aborts rather than accumulating an unbounded line in memory.
 //
 // The file may be large, so it is streamed line by line rather than read whole.
 // Each line is cheaply pre-filtered with a substring check on toolUseID before
@@ -69,7 +84,10 @@ func lookupTranscriptUsage(path, toolUseID string) (model string, usage json.Raw
 	needle := []byte(toolUseID)
 	r := bufio.NewReader(f)
 	for {
-		line, readErr := r.ReadBytes('\n')
+		line, readErr := readBoundedLine(r, maxTranscriptLineLength)
+		if errors.Is(readErr, errTranscriptLineTooLong) {
+			return "", nil, false, readErr
+		}
 		if len(line) > 0 && bytes.Contains(line, needle) {
 			m, u, ok := matchToolUse(line, toolUseID)
 			if ok {
@@ -82,6 +100,29 @@ func lookupTranscriptUsage(path, toolUseID string) (model string, usage json.Raw
 			}
 			return "", nil, false, readErr
 		}
+	}
+}
+
+// readBoundedLine reads one '\n'-delimited line from r, mirroring
+// bufio.Reader.ReadBytes but capping the accumulated line at max bytes
+// instead of growing the returned slice without bound while it searches for
+// the delimiter. Returns errTranscriptLineTooLong once max is exceeded,
+// before the oversized line is fully accumulated.
+func readBoundedLine(r *bufio.Reader, max int) ([]byte, error) {
+	var line []byte
+	for {
+		chunk, err := r.ReadSlice('\n')
+		if len(line)+len(chunk) > max {
+			return line, errTranscriptLineTooLong
+		}
+		line = append(line, chunk...)
+		if err == nil {
+			return line, nil
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		return line, err
 	}
 }
 

--- a/hook/cmd/obsigna-hook/claude_transcript.go
+++ b/hook/cmd/obsigna-hook/claude_transcript.go
@@ -63,9 +63,13 @@ type transcriptBlock struct {
 //     non-fatal condition for a best-effort enrichment.
 //   - found == true, usage == nil when the turn is located but has no usage
 //     object (model is still returned).
-//   - a non-nil err for I/O failures opening or reading the file, and for a
-//     line exceeding maxTranscriptLineLength (errTranscriptLineTooLong) —
-//     the scan aborts rather than accumulating an unbounded line in memory.
+//   - a non-nil err only for I/O failures opening or reading the file. A line
+//     exceeding maxTranscriptLineLength is skipped like a malformed line
+//     (readBoundedLine still bounds the memory used to read it) rather than
+//     aborting the scan — real transcripts can legitimately contain large
+//     tool_use inputs unrelated to the id being looked up, so one oversized
+//     line must not cost every other tool call in the session its receipt
+//     enrichment.
 //
 // The file may be large, so it is streamed line by line rather than read whole.
 // Each line is cheaply pre-filtered with a substring check on toolUseID before
@@ -86,7 +90,10 @@ func lookupTranscriptUsage(path, toolUseID string) (model string, usage json.Raw
 	for {
 		line, readErr := readBoundedLine(r, maxTranscriptLineLength)
 		if errors.Is(readErr, errTranscriptLineTooLong) {
-			return "", nil, false, readErr
+			// Can't be the JSON we're matching against — it would already
+			// have blown the daemon's own frame-size cap — so skip it like a
+			// malformed line and keep scanning instead of aborting.
+			continue
 		}
 		if len(line) > 0 && bytes.Contains(line, needle) {
 			m, u, ok := matchToolUse(line, toolUseID)
@@ -106,13 +113,20 @@ func lookupTranscriptUsage(path, toolUseID string) (model string, usage json.Raw
 // readBoundedLine reads one '\n'-delimited line from r, mirroring
 // bufio.Reader.ReadBytes but capping the accumulated line at max bytes
 // instead of growing the returned slice without bound while it searches for
-// the delimiter. Returns errTranscriptLineTooLong once max is exceeded,
-// before the oversized line is fully accumulated.
+// the delimiter. Once max is exceeded it discards the remainder of the line
+// (still without accumulating it) so r is left positioned at the start of
+// the next line, then returns errTranscriptLineTooLong — the caller can
+// resume scanning from a subsequent readBoundedLine call.
 func readBoundedLine(r *bufio.Reader, max int) ([]byte, error) {
 	var line []byte
 	for {
 		chunk, err := r.ReadSlice('\n')
 		if len(line)+len(chunk) > max {
+			if err == bufio.ErrBufferFull {
+				if discardErr := discardRestOfLine(r); discardErr != nil {
+					return line, discardErr
+				}
+			}
 			return line, errTranscriptLineTooLong
 		}
 		line = append(line, chunk...)
@@ -123,6 +137,26 @@ func readBoundedLine(r *bufio.Reader, max int) ([]byte, error) {
 			continue
 		}
 		return line, err
+	}
+}
+
+// discardRestOfLine reads and discards bytes from r up to and including the
+// next '\n', without accumulating them, so readBoundedLine can resync to the
+// next line after abandoning an oversized one. Returns nil once the
+// delimiter is found, and also on io.EOF (the file's final line was itself
+// the oversized one, with no trailing newline — there is simply nothing left
+// to discard). A non-nil return is a genuine I/O error on the underlying
+// reader, distinct from EOF.
+func discardRestOfLine(r *bufio.Reader) error {
+	for {
+		_, err := r.ReadSlice('\n')
+		if err == nil || errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		return err
 	}
 }
 

--- a/hook/cmd/obsigna-hook/claude_transcript_test.go
+++ b/hook/cmd/obsigna-hook/claude_transcript_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -209,5 +214,60 @@ func TestReadClaudeCode_NoTranscriptLeavesFieldsUnset(t *testing.T) {
 	if ev.Model != "" || ev.Usage != nil || ev.CaptureMethod != "" {
 		t.Errorf("enrichment fields set without a transcript: model=%q usage=%s capture=%q",
 			ev.Model, ev.Usage, ev.CaptureMethod)
+	}
+}
+
+// TestLookupTranscriptUsage_LineTooLong asserts that a transcript line with no
+// newline within maxTranscriptLineLength aborts the scan with
+// errTranscriptLineTooLong rather than buffering it without bound (issue
+// #1010: an unbounded-length reader lets a malformed or hostile transcript
+// exhaust the short-lived hook process's memory).
+func TestLookupTranscriptUsage_LineTooLong(t *testing.T) {
+	// A single line, with no trailing newline, that exceeds the cap.
+	oversized := bytes.Repeat([]byte("a"), maxTranscriptLineLength+1)
+	path := writeTranscript(t, string(oversized))
+
+	_, _, found, err := lookupTranscriptUsage(path, "toolu_AAA")
+	if !errors.Is(err, errTranscriptLineTooLong) {
+		t.Fatalf("err = %v; want errTranscriptLineTooLong", err)
+	}
+	if found {
+		t.Error("found = true; want false when the scan aborts on an oversized line")
+	}
+}
+
+// TestReadBoundedLine_WithinMax confirms normal delimited and trailing
+// (EOF-terminated, no newline) lines are returned unchanged when under the
+// cap, matching bufio.Reader.ReadBytes's own behaviour.
+func TestReadBoundedLine_WithinMax(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("hello\nworld"))
+
+	line, err := readBoundedLine(r, 1024)
+	if err != nil {
+		t.Fatalf("first line: unexpected err %v", err)
+	}
+	if string(line) != "hello\n" {
+		t.Errorf("first line = %q; want %q", line, "hello\n")
+	}
+
+	line, err = readBoundedLine(r, 1024)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("second line: err = %v; want io.EOF", err)
+	}
+	if string(line) != "world" {
+		t.Errorf("second line = %q; want %q", line, "world")
+	}
+}
+
+// TestReadBoundedLine_ExceedsMax confirms the cap is enforced even when the
+// oversized line spans more than one internal buffer refill.
+func TestReadBoundedLine_ExceedsMax(t *testing.T) {
+	const max = 4096
+	data := bytes.Repeat([]byte("x"), max*3) // no delimiter anywhere
+	r := bufio.NewReader(bytes.NewReader(data))
+
+	_, err := readBoundedLine(r, max)
+	if !errors.Is(err, errTranscriptLineTooLong) {
+		t.Fatalf("err = %v; want errTranscriptLineTooLong", err)
 	}
 }

--- a/hook/cmd/obsigna-hook/claude_transcript_test.go
+++ b/hook/cmd/obsigna-hook/claude_transcript_test.go
@@ -217,22 +217,48 @@ func TestReadClaudeCode_NoTranscriptLeavesFieldsUnset(t *testing.T) {
 	}
 }
 
-// TestLookupTranscriptUsage_LineTooLong asserts that a transcript line with no
-// newline within maxTranscriptLineLength aborts the scan with
-// errTranscriptLineTooLong rather than buffering it without bound (issue
-// #1010: an unbounded-length reader lets a malformed or hostile transcript
-// exhaust the short-lived hook process's memory).
+// TestLookupTranscriptUsage_LineTooLong asserts that a transcript line
+// exceeding maxTranscriptLineLength (with no delimiter) is skipped like a
+// malformed line, bounding the memory used to read it, without aborting the
+// whole scan (issue #1010 follow-up: real transcripts can legitimately
+// contain a large tool_use input unrelated to the id being looked up, so an
+// oversized line elsewhere in the file must not cost every other tool call
+// in the session its receipt enrichment). The smaller, matching line that
+// follows the oversized one must still be found.
 func TestLookupTranscriptUsage_LineTooLong(t *testing.T) {
-	// A single line, with no trailing newline, that exceeds the cap.
+	oversized := bytes.Repeat([]byte("a"), maxTranscriptLineLength+1) // no newline
+	body := string(oversized) + "\n" + twoModelTranscript
+	path := writeTranscript(t, body)
+
+	model, usage, found, err := lookupTranscriptUsage(path, "toolu_AAA")
+	if err != nil {
+		t.Fatalf("lookupTranscriptUsage: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false; want true — the oversized line should be skipped, not abort the scan")
+	}
+	if model != "claude-opus-4-8" {
+		t.Errorf("model = %q; want claude-opus-4-8", model)
+	}
+	if _, ok := usageField(t, usage, "input_tokens"); !ok {
+		t.Error("expected usage.input_tokens to be present")
+	}
+}
+
+// TestLookupTranscriptUsage_OnlyOversizedLine confirms a transcript
+// consisting solely of one too-long, undelimited line degrades to the
+// ordinary "not found" outcome (found=false, err=nil) rather than an error,
+// matching the ordinary missing-id contract.
+func TestLookupTranscriptUsage_OnlyOversizedLine(t *testing.T) {
 	oversized := bytes.Repeat([]byte("a"), maxTranscriptLineLength+1)
-	path := writeTranscript(t, string(oversized))
+	path := writeTranscript(t, string(oversized)) // no trailing newline
 
 	_, _, found, err := lookupTranscriptUsage(path, "toolu_AAA")
-	if !errors.Is(err, errTranscriptLineTooLong) {
-		t.Fatalf("err = %v; want errTranscriptLineTooLong", err)
+	if err != nil {
+		t.Fatalf("lookupTranscriptUsage: %v", err)
 	}
 	if found {
-		t.Error("found = true; want false when the scan aborts on an oversized line")
+		t.Error("found = true; want false when the file has no valid lines")
 	}
 }
 
@@ -269,5 +295,31 @@ func TestReadBoundedLine_ExceedsMax(t *testing.T) {
 	_, err := readBoundedLine(r, max)
 	if !errors.Is(err, errTranscriptLineTooLong) {
 		t.Fatalf("err = %v; want errTranscriptLineTooLong", err)
+	}
+}
+
+// TestReadBoundedLine_ExceedsMax_ResyncsAtNextLine confirms that after an
+// oversized line is abandoned, the reader is left positioned at the start of
+// the following line rather than mid-line — the discard behind
+// errTranscriptLineTooLong must consume exactly the abandoned line, not more
+// or less. A tiny underlying buffer forces bufio.ErrBufferFull mid-line
+// (rather than the delimiter turning up in the very first read), exercising
+// the multi-refill discard path.
+func TestReadBoundedLine_ExceedsMax_ResyncsAtNextLine(t *testing.T) {
+	const max = 16
+	oversized := strings.Repeat("a", 64) // no delimiter, spans many buffer refills
+	data := oversized + "\nsecond\n"
+	r := bufio.NewReaderSize(strings.NewReader(data), 8)
+
+	if _, err := readBoundedLine(r, max); !errors.Is(err, errTranscriptLineTooLong) {
+		t.Fatalf("first call: err = %v; want errTranscriptLineTooLong", err)
+	}
+
+	line, err := readBoundedLine(r, max)
+	if err != nil {
+		t.Fatalf("second call: unexpected err %v", err)
+	}
+	if string(line) != "second\n" {
+		t.Errorf("second call: line = %q; want %q", line, "second\n")
 	}
 }

--- a/mcp-proxy/internal/proxy/proxy.go
+++ b/mcp-proxy/internal/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +15,17 @@ import (
 	"sync"
 	"time"
 )
+
+// maxLineLength bounds a single line (one JSON-RPC message) read from either
+// STDIO pipe. bufio.Reader.ReadBytes grows its returned slice without limit
+// while it searches for the delimiter, so a peer that streams an arbitrarily
+// large line with no newline would otherwise exhaust the proxy's memory.
+// readLine enforces this cap explicitly instead.
+const maxLineLength = 10 * 1024 * 1024 // 10MiB
+
+// errLineTooLong is returned by readLine when a line exceeds maxLineLength
+// before a newline is found.
+var errLineTooLong = errors.New("line too large")
 
 // HandlerResult tells the proxy what to do with a message.
 type HandlerResult struct {
@@ -147,10 +159,14 @@ func (p *Proxy) writeToClient(data []byte) error {
 }
 
 func (p *Proxy) pipe(src io.Reader, dst io.Writer, direction string) {
-	reader := bufio.NewReaderSize(src, 10*1024*1024) // 10MB buffer
+	reader := bufio.NewReaderSize(src, 64*1024)
 
 	for {
-		line, err := reader.ReadBytes('\n')
+		line, err := readLine(reader, maxLineLength)
+		if errors.Is(err, errLineTooLong) {
+			log.Printf("mcp-proxy: pipe %s line too large (max %d bytes), closing", direction, maxLineLength)
+			return
+		}
 		if len(line) > 0 {
 			// Trim trailing newline for processing.
 			raw := line
@@ -204,6 +220,29 @@ func (p *Proxy) pipe(src io.Reader, dst io.Writer, direction string) {
 			}
 			return
 		}
+	}
+}
+
+// readLine reads one '\n'-delimited line from r, mirroring
+// bufio.Reader.ReadBytes but capping the accumulated line at max bytes
+// instead of growing the returned slice without bound while it searches for
+// the delimiter. Returns errLineTooLong once max is exceeded, before the
+// oversized line is fully accumulated.
+func readLine(r *bufio.Reader, max int) ([]byte, error) {
+	var line []byte
+	for {
+		chunk, err := r.ReadSlice('\n')
+		if len(line)+len(chunk) > max {
+			return line, errLineTooLong
+		}
+		line = append(line, chunk...)
+		if err == nil {
+			return line, nil
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		return line, err
 	}
 }
 

--- a/mcp-proxy/internal/proxy/proxy_unit_test.go
+++ b/mcp-proxy/internal/proxy/proxy_unit_test.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -344,6 +346,71 @@ func TestPipe_HandlerBlockWithNilClientResponse(t *testing.T) {
 	// Nothing forwarded to dst.
 	if dst.Len() > 0 {
 		t.Errorf("expected nothing forwarded, got: %q", dst.String())
+	}
+}
+
+// TestPipe_LineTooLong asserts that a line with no newline exceeding
+// maxLineLength closes the pipe instead of buffering it without bound (issue
+// #1010: bufio.Reader.ReadBytes grows its returned slice without limit while
+// searching for the delimiter, so a peer streaming an arbitrarily large line
+// could otherwise exhaust the proxy's memory). Nothing should be forwarded
+// for the oversized, unterminated line.
+func TestPipe_LineTooLong(t *testing.T) {
+	var dst bytes.Buffer
+	p := &Proxy{handler: nil}
+
+	oversized := bytes.Repeat([]byte("a"), maxLineLength+1) // no trailing newline
+	p.pipe(bytes.NewReader(oversized), &dst, "client_to_server")
+
+	if dst.Len() > 0 {
+		t.Errorf("expected nothing forwarded for an oversized line, got %d bytes", dst.Len())
+	}
+}
+
+// TestPipe_LineAtMaxIsForwarded confirms the cap doesn't reject a line that
+// exactly matches maxLineLength.
+func TestPipe_LineAtMaxIsForwarded(t *testing.T) {
+	var dst bytes.Buffer
+	p := &Proxy{handler: nil}
+
+	payload := append(bytes.Repeat([]byte("a"), maxLineLength-1), '\n')
+	p.pipe(bytes.NewReader(payload), &dst, "client_to_server")
+
+	if !bytes.Contains(dst.Bytes(), bytes.Repeat([]byte("a"), maxLineLength-1)) {
+		t.Errorf("expected the max-length line to be forwarded")
+	}
+}
+
+// --- readLine ---
+
+func TestReadLine_WithinMax(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("hello\nworld"))
+
+	line, err := readLine(r, 1024)
+	if err != nil {
+		t.Fatalf("first line: unexpected err %v", err)
+	}
+	if string(line) != "hello\n" {
+		t.Errorf("first line = %q; want %q", line, "hello\n")
+	}
+
+	line, err = readLine(r, 1024)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("second line: err = %v; want io.EOF", err)
+	}
+	if string(line) != "world" {
+		t.Errorf("second line = %q; want %q", line, "world")
+	}
+}
+
+func TestReadLine_ExceedsMax(t *testing.T) {
+	const max = 4096
+	data := bytes.Repeat([]byte("x"), max*3) // no delimiter anywhere
+	r := bufio.NewReader(bytes.NewReader(data))
+
+	_, err := readLine(r, max)
+	if !errors.Is(err, errLineTooLong) {
+		t.Fatalf("err = %v; want errLineTooLong", err)
 	}
 }
 


### PR DESCRIPTION
## What

Add memory-safe line reading functions to the MCP proxy and Claude transcript hook that enforce maximum line length limits, preventing unbounded buffer growth when reading from untrusted peers.

## Why

The standard `bufio.Reader.ReadBytes` grows its internal buffer without limit while searching for a delimiter. A malicious or malformed peer could stream an arbitrarily large line with no newline, exhausting the process's memory (issue #1010).

This change introduces bounded line readers that:
- Cap accumulated line length at a configurable maximum
- Bound memory the moment the limit is exceeded, before fully buffering the oversized line
- Maintain compatibility with normal delimited and EOF-terminated lines

## Changes

**mcp-proxy/internal/proxy/proxy.go:**
- Add `maxLineLength` constant (10 MiB) and `errLineTooLong` error
- Implement `readLine()` function that enforces the cap while reading from `bufio.Reader`
- Update `pipe()` to use `readLine()` instead of `ReadBytes()`; an oversized line closes that pipe direction (same as any other read error) rather than forwarding a truncated JSON-RPC message
- Reduce initial buffer size from 10 MB to 64 KB (no longer needed for large lines)

**hook/cmd/obsigna-hook/claude_transcript.go:**
- Add `maxTranscriptLineLength` constant (reusing daemon's `emitter.MaxFrameSize`)
- Add `errTranscriptLineTooLong` error
- Implement `readBoundedLine()` with the same bound as the proxy's `readLine()`, plus `discardRestOfLine()` to drain (without accumulating) the remainder of an abandoned oversized line so the reader resyncs at the start of the next line
- Update `lookupTranscriptUsage()` to **skip** an oversized line and keep scanning, rather than aborting the whole lookup — real transcripts can legitimately contain a large `tool_use` input (e.g. a `Write` call embedding a big file) unrelated to the id being searched for, so one oversized line must not cost every other tool call in the session its receipt enrichment. This mirrors how a malformed (non-JSON) line is already treated as a non-match rather than a fatal error.

**Tests:**
- Add `TestPipe_LineTooLong` and `TestPipe_LineAtMaxIsForwarded` for proxy line handling
- Add `TestReadLine_WithinMax` and `TestReadLine_ExceedsMax` for proxy's `readLine()` function
- Add `TestLookupTranscriptUsage_LineTooLong` (oversized line skipped, later matching line still found) and `TestLookupTranscriptUsage_OnlyOversizedLine` (file with nothing but an oversized line degrades to the ordinary not-found outcome) for the hook's transcript scanning
- Add `TestReadBoundedLine_WithinMax`, `TestReadBoundedLine_ExceedsMax`, and `TestReadBoundedLine_ExceedsMax_ResyncsAtNextLine` (forces multi-buffer-refill discard via a tiny reader buffer) for the hook's `readBoundedLine()` function

## Checklist

- [x] Tests pass for all changed components
- [x] No real keys or secrets in the diff
- [x] Input validation at trust boundaries (peer-provided data)
- [x] Edge cases tested (oversized lines, exact-limit lines, EOF-terminated lines, oversized-line resync)