### PR TITLE
ci: close dependabot.yml coverage gaps for go and npm modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,24 @@ updates:
           - "*"
 
   - package-ecosystem: npm
+    directory: /sdk/ts-aws
+    schedule:
+      interval: weekly
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /integrations/opencode-plugin
+    schedule:
+      interval: weekly
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
     directory: /site
     schedule:
       interval: weekly
@@ -39,7 +57,16 @@ updates:
     # locally via go.work; Dependabot bumping their pins (often to alpha tags)
     # is noise. Third-party deps still update normally.
     ignore:
-      - dependency-name: "github.com/agent-receipts/ar/*"
+      - dependency-name: "obsigna.dev/*"
+
+  - package-ecosystem: gomod
+    directory: /sdk/go/aws
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
 
   - package-ecosystem: gomod
     directory: /mcp-proxy
@@ -50,7 +77,40 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "github.com/agent-receipts/ar/*"
+      - dependency-name: "obsigna.dev/*"
+
+  - package-ecosystem: gomod
+    directory: /hook
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "obsigna.dev/*"
+
+  - package-ecosystem: gomod
+    directory: /daemon
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "obsigna.dev/*"
+
+  - package-ecosystem: gomod
+    directory: /collector
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "obsigna.dev/*"
 
   - package-ecosystem: gomod
     directory: /cross-sdk-tests
@@ -61,7 +121,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "github.com/agent-receipts/ar/*"
+      - dependency-name: "obsigna.dev/*"
 
   - package-ecosystem: uv
     directory: /sdk/py


### PR DESCRIPTION
## Summary
- Add missing `dependabot.yml` entries for `/sdk/ts-aws` and `/integrations/opencode-plugin` (npm) — these have `pnpm-lock.yaml` files but no config entry, so Dependabot alerts fired (postcss, undici) but no update PRs were ever opened.
- Add missing entries for `/collector`, `/daemon`, `/hook`, and `/sdk/go/aws` (gomod) — same gap, found by auditing all `go.mod`/`pnpm-lock.yaml` directories against the config.
- Fix the internal-module `ignore` pattern (`sdk/go`, `mcp-proxy`, `cross-sdk-tests`), stale since the ADR-0037 module-path migration: it still matched `github.com/agent-receipts/ar/*`, so it silently stopped suppressing `obsigna.dev/*` internal-module bumps (visible in #986, which bumped `obsigna.dev/daemon` even though internal bumps are meant to be release-cascade-managed noise).
- Apply the same `ignore: obsigna.dev/*` to the newly-added `hook`, `daemon`, and `collector` entries, since they also depend on `obsigna.dev/sdk/go`. `sdk/go/aws` has no internal-module dependency, so no ignore is needed there.

## Test plan
- [x] `ruby -ryaml` parse confirms valid YAML, 14 update entries
- [ ] After merge, confirm Dependabot opens security-update PRs for the currently-open alerts in `sdk/ts-aws` and `integrations/opencode-plugin` (postcss, undici — GHSA-fxqj-rqcc-2cmp, GHSA-m8rv-5g2x-5cg5, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272)