### PR TITLE
mcp-proxy: validate policy glob patterns at engine construction

### DIFF
--- a/mcp-proxy/internal/policy/engine.go
+++ b/mcp-proxy/internal/policy/engine.go
@@ -57,18 +57,43 @@ type Engine struct {
 }
 
 // NewEngine creates a policy engine with the given rules.
-// It validates that all rule actions are known; unknown actions are logged and
-// the rule is disabled to prevent silent misconfiguration.
+// It validates that all rule actions are known and that tool/server patterns
+// are well-formed globs; invalid rules are logged and disabled to prevent
+// silent misconfiguration.
 func NewEngine(rules []Rule) *Engine {
 	validated := make([]Rule, len(rules))
 	copy(validated, rules)
 	for i := range validated {
-		if _, ok := actionSeverity[validated[i].Action]; !ok && validated[i].Enabled {
+		if !validated[i].Enabled {
+			continue
+		}
+		if _, ok := actionSeverity[validated[i].Action]; !ok {
 			log.Printf("mcp-proxy: policy rule %q has unknown action %q — disabling", validated[i].Name, validated[i].Action)
+			validated[i].Enabled = false
+			continue
+		}
+		if pattern, ok := badPattern(validated[i]); ok {
+			log.Printf("mcp-proxy: policy rule %q has malformed glob pattern %q — disabling", validated[i].Name, pattern)
 			validated[i].Enabled = false
 		}
 	}
 	return &Engine{rules: validated}
+}
+
+// badPattern reports whether rule's tool or server pattern is not a valid
+// glob, returning the offending pattern.
+func badPattern(rule Rule) (string, bool) {
+	if rule.ToolPattern != "" {
+		if _, err := filepath.Match(rule.ToolPattern, ""); err != nil {
+			return rule.ToolPattern, true
+		}
+	}
+	if rule.ServerPattern != "" {
+		if _, err := filepath.Match(rule.ServerPattern, ""); err != nil {
+			return rule.ServerPattern, true
+		}
+	}
+	return "", false
 }
 
 // LoadRules loads policy rules from a YAML file.
@@ -184,7 +209,10 @@ func matchesRule(rule Rule, ctx EvalContext) bool {
 	return true
 }
 
-// globMatch does simple glob matching (supports * only).
+// globMatch does case-insensitive glob matching via filepath.Match, which
+// supports *, ?, and [...] character classes. Patterns are validated at
+// engine construction time (see NewEngine/badPattern); a malformed pattern
+// here just falls through to a non-match.
 func globMatch(pattern, value string) bool {
 	pattern = strings.ToLower(pattern)
 	value = strings.ToLower(value)

--- a/mcp-proxy/internal/policy/engine_test.go
+++ b/mcp-proxy/internal/policy/engine_test.go
@@ -186,6 +186,52 @@ func TestDescribeDisabled(t *testing.T) {
 	}
 }
 
+func TestMalformedToolPatternDisablesRule(t *testing.T) {
+	rules := []Rule{
+		{Name: "bad_tool_pattern", Enabled: true, ToolPattern: "delete[*", Action: "block"},
+	}
+	engine := NewEngine(rules)
+	if engine.rules[0].Enabled {
+		t.Error("expected rule with malformed tool pattern to be disabled")
+	}
+	d := engine.Evaluate(EvalContext{ToolName: "delete_secrets"})
+	if d.Action != "pass" {
+		t.Errorf("expected pass (rule disabled), got %s", d.Action)
+	}
+}
+
+func TestMalformedServerPatternDisablesRule(t *testing.T) {
+	rules := []Rule{
+		{Name: "bad_server_pattern", Enabled: true, ServerPattern: "[a-", Action: "block"},
+	}
+	engine := NewEngine(rules)
+	if engine.rules[0].Enabled {
+		t.Error("expected rule with malformed server pattern to be disabled")
+	}
+}
+
+func TestWellFormedPatternsStayEnabled(t *testing.T) {
+	rules := []Rule{
+		{Name: "ok", Enabled: true, ToolPattern: "delete_*", ServerPattern: "vault?", Action: "block"},
+	}
+	engine := NewEngine(rules)
+	if !engine.rules[0].Enabled {
+		t.Error("expected rule with well-formed patterns to remain enabled")
+	}
+}
+
+func TestDisabledRuleWithBadPatternNotValidated(t *testing.T) {
+	// A rule that's already disabled shouldn't trigger the malformed-pattern
+	// log/disable path; it's simply skipped.
+	rules := []Rule{
+		{Name: "off_bad_pattern", Enabled: false, ToolPattern: "rm[[", Action: "block"},
+	}
+	engine := NewEngine(rules)
+	if engine.rules[0].Enabled {
+		t.Error("expected already-disabled rule to remain disabled")
+	}
+}
+
 func TestHasPauseRules(t *testing.T) {
 	// Default rules include pause_high_risk.
 	engine := NewEngine(DefaultRules())


### PR DESCRIPTION
## What

`NewEngine` now validates each enabled rule's `tool_pattern` and `server_pattern` against `filepath.Match`, and disables (with a log line) any rule whose pattern is malformed — the same treatment already given to rules with unknown `action` values. Also corrected the `globMatch` doc comment, which claimed `*` was the only supported metacharacter when `filepath.Match` also honours `?` and `[...]` character classes.

## Why

`globMatch` (`mcp-proxy/internal/policy/engine.go`) called `filepath.Match` and discarded the returned error. A rule with a typo'd pattern (e.g. `delete[*`, `[a-`) never matches anything at evaluation time, but nothing logs or disables it — the rule is silently inert. For a `block` rule, that means an operator believes a dangerous action is blocked when it never was, with no signal anything is wrong. Fixes #1009.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, no receipt format changes
- [ ] AGENTS.md updated (if project structure changed) — N/A, no structural changes
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A, no spec changes

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no; it hardens policy-rule loading against silently-inert misconfiguration, closer to a reliability fix than a crypto/auth change
