### PR TITLE
daemon: validate runtime.usage for canonicalisation-safety

### DIFF
--- a/daemon/CHANGELOG.md
+++ b/daemon/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Validate `runtime.usage` for canonicalisation-safety before embedding it in the signed receipt** ([#1008](https://github.com/agent-receipts/obsigna/issues/1008)) — `issuer.runtime.usage` is an ADR-0026 open container forwarded verbatim from an external artifact (e.g. the Claude Code transcript). It previously reached the signer unvalidated, so a syntactically-valid-but-uncanonicalisable payload (a number like `1e400`, which overflows `float64` on RFC 8785 re-parse) would fail the whole-receipt canonicalisation and drop the event, defeating the audit trail. The daemon now validates `usage` at the trust boundary; on a canonicalisation violation it drops the field, logs a warning, and still emits the receipt — mirroring the existing forensic-disclosure fallback (degrade, never drop the event).
+
 ## [0.31.0] - 2026-08-08
 
 ### Changed

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -888,7 +888,7 @@ func (p *Pipeline) buildAndSign(
 	}
 
 	return p.signAndHash(receipt.CreateInput{
-		Issuer:        issuerFromFrame(f, p.IssuerID),
+		Issuer:        p.issuerFromFrame(f),
 		Principal:     principalFromPeer(peer),
 		Action:        action,
 		Outcome:       outcome,
@@ -906,7 +906,7 @@ func (p *Pipeline) buildAndSign(
 // issuerFromFrame builds the receipt Issuer from the emitter frame and the
 // daemon's own DID. Name, Model, and Operator come from the proxy; they are
 // empty/nil when an old proxy that predates this field set emits the frame.
-func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
+func (p *Pipeline) issuerFromFrame(f *EmitterFrame) receipt.Issuer {
 	var op *receipt.Operator
 	if f.OperatorID != "" {
 		op = &receipt.Operator{ID: f.OperatorID, Name: f.OperatorName}
@@ -920,7 +920,7 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 	// has transcript-derived model/usage even though it has no agent_id.
 	// Forward usage verbatim, but only a real JSON payload — a literal null or
 	// empty must not be stored as the runtime's reported usage.
-	hasUsage := hasJSONPayload(f.Usage)
+	usage, hasUsage := p.validatedUsage(f.Usage)
 	var runtime *receipt.Runtime
 	if f.AgentID != "" || f.Model != "" || f.CaptureMethod != "" || hasUsage {
 		runtime = &receipt.Runtime{
@@ -930,11 +930,11 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 			CaptureMethod: f.CaptureMethod,
 		}
 		if hasUsage {
-			runtime.Usage = f.Usage
+			runtime.Usage = usage
 		}
 	}
 	return receipt.Issuer{
-		ID:        daemonID,
+		ID:        p.IssuerID,
 		Type:      "AgentReceiptsDaemon",
 		Name:      f.IssuerName,
 		Model:     f.IssuerModel,
@@ -942,6 +942,32 @@ func issuerFromFrame(f *EmitterFrame, daemonID string) receipt.Issuer {
 		SessionID: f.SessionID,
 		Runtime:   runtime,
 	}
+}
+
+// validatedUsage reports whether raw is a real, canonicalisation-safe JSON
+// payload, returning it (unchanged) alongside true when so.
+//
+// Usage is an ADR-0026 open container: the emitter forwards it verbatim from
+// an external artifact (the Claude Code transcript, for other runtimes
+// whatever they report), so the daemon cannot assume it is well-formed enough
+// to survive RFC 8785 canonicalisation — e.g. a number like 1e400 is
+// syntactically valid JSON but overflows float64 when Canonicalize re-parses
+// it (see canonicalSHA256). Unlike Input/Output, Usage is not required for
+// the receipt to be a valid audit record, so a violation here MUST NOT fail
+// the whole receipt build the way a bad Input/Output hash does. Instead it is
+// dropped with a logged warning — mirroring the disclosure-encryption
+// fallback (degrade, never drop the event) — so the receipt still gets
+// signed and stored via the normal path, and the failure surfaces later, once
+// only, when the whole receipt is canonicalised for hashing/signing.
+func (p *Pipeline) validatedUsage(raw json.RawMessage) (json.RawMessage, bool) {
+	if !hasJSONPayload(raw) {
+		return nil, false
+	}
+	if _, err := receipt.Canonicalize(raw); err != nil {
+		p.logError("dropping runtime.usage (not canonicalization-safe): %v", err)
+		return nil, false
+	}
+	return raw, true
 }
 
 // intentFromFrame builds the receipt Intent from the emitter frame, redacting

--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -954,11 +954,13 @@ func (p *Pipeline) issuerFromFrame(f *EmitterFrame) receipt.Issuer {
 // syntactically valid JSON but overflows float64 when Canonicalize re-parses
 // it (see canonicalSHA256). Unlike Input/Output, Usage is not required for
 // the receipt to be a valid audit record, so a violation here MUST NOT fail
-// the whole receipt build the way a bad Input/Output hash does. Instead it is
-// dropped with a logged warning — mirroring the disclosure-encryption
-// fallback (degrade, never drop the event) — so the receipt still gets
-// signed and stored via the normal path, and the failure surfaces later, once
-// only, when the whole receipt is canonicalised for hashing/signing.
+// the whole receipt build the way a bad Input/Output hash does. Instead the
+// check runs eagerly, right here, before the field is ever attached to the
+// Runtime the caller builds: on failure it is dropped with a logged warning
+// — mirroring the disclosure-encryption fallback (degrade, never drop the
+// event) — so the later whole-receipt canonicalisation in signAndHash never
+// sees an uncanonicalisable usage payload and the receipt still gets signed
+// and stored via the normal path.
 func (p *Pipeline) validatedUsage(raw json.RawMessage) (json.RawMessage, bool) {
 	if !hasJSONPayload(raw) {
 		return nil, false

--- a/daemon/internal/pipeline/build_test.go
+++ b/daemon/internal/pipeline/build_test.go
@@ -1870,6 +1870,73 @@ func TestProcess_RuntimeModelUsageOnRootReceipt(t *testing.T) {
 	}
 }
 
+// TestProcess_DropsUncanonicalizableUsage verifies the fix for issue #1008:
+// runtime.usage is an ADR-0026 open container forwarded verbatim from an
+// external artifact (the emitter's transcript reader), so the daemon cannot
+// assume it survives RFC 8785 canonicalisation. A payload that is
+// syntactically valid JSON but not canonicalisation-safe (1e400 overflows
+// float64 — see TestProcess_RejectsUnrepresentableNumbers) MUST NOT fail the
+// whole receipt build the way a bad Input/Output does; the daemon drops the
+// field, logs a warning, and still emits the receipt.
+func TestProcess_DropsUncanonicalizableUsage(t *testing.T) {
+	ks := newTestKeySource(t)
+	st := newTestStore(t)
+	state := chain.New("root")
+	p := New(state, ks, st, "did:agent-receipts-daemon:test")
+
+	var warnings []string
+	p.ErrorLog = func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	body, err := json.Marshal(EmitterFrame{
+		Version:       "1",
+		TsEmit:        "2026-05-03T00:00:00Z",
+		SessionID:     "sess-abc",
+		Channel:       "claude-code",
+		Tool:          EmitterTool{Name: "Bash"},
+		Decision:      "allowed",
+		Model:         "claude-opus-4-8",
+		Usage:         json.RawMessage(`{"input_tokens":1e400}`),
+		CaptureMethod: "transcript",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(socket.Frame{Payload: body}); err != nil {
+		t.Fatalf("Process: %v (usage must be dropped, not fail the receipt)", err)
+	}
+
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1 logged warning about the dropped usage field: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "usage") {
+		t.Errorf("warning = %q; want it to mention usage", warnings[0])
+	}
+
+	receipts, err := st.GetChain("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("got %d receipts, want 1", len(receipts))
+	}
+	rt := receipts[0].Issuer.Runtime
+	if rt == nil {
+		t.Fatal("issuer.runtime is nil; want it present for the surviving model/capture_method")
+	}
+	if rt.Usage != nil {
+		t.Errorf("runtime.usage = %s; want nil (dropped)", rt.Usage)
+	}
+	if rt.Model != "claude-opus-4-8" {
+		t.Errorf("runtime.model = %q; want claude-opus-4-8 (unaffected by the dropped usage)", rt.Model)
+	}
+
+	if _, err := receipt.HashReceipt(receipts[0]); err != nil {
+		t.Fatalf("HashReceipt on the surviving receipt: %v", err)
+	}
+}
+
 // TestProcess_AgentIDRoutesToSeparateChain verifies that frames with a non-empty
 // agent_id land on a per-agent chain distinct from the root chain.
 func TestProcess_AgentIDRoutesToSeparateChain(t *testing.T) {


### PR DESCRIPTION
## What

`issuer.runtime.usage` (`daemon/internal/pipeline/build.go`) is now validated for RFC 8785 canonicalisation-safety at the trust boundary before it is embedded in the signed receipt. On a violation, the field is dropped and a warning is logged via `Pipeline.ErrorLog` — the receipt is still built, signed, and stored.

`issuerFromFrame` became a `Pipeline` method (was a free function taking `daemonID string`) so it can reach `p.logError`. A new `validatedUsage` helper attempts `receipt.Canonicalize` on the raw `usage` payload and reports whether it's safe to embed.

## Why

`EmitterTool.Usage` is a `json.RawMessage` forwarded **verbatim** into `issuer.runtime.usage`, per the ADR-0026 open-container design — arbitrary JSON from an external artifact (the Claude Code transcript, for the in-tree hook) with no well-formedness validation.

Being *open* is deliberate. Being *unvalidated for canonicalisation-safety* was the gap: the field reached the signer unchecked, so a syntactically-valid-but-uncanonicalisable payload — e.g. a JSON number like `1e400`, which overflows `float64` when `receipt.Canonicalize` re-parses it — would fail canonicalisation of the *whole* receipt during signing, and `Process` would return an error and drop the entire event. That's exactly the audit-trail hole the pipeline's existing comments (`build.go`) argue against for `Input`/`Output` hashing failures.

The fix mirrors the existing disclosure fallback pattern already used for forensic encryption failures: degrade (drop the field, log a warning), never drop the event.

Closes #1008.

## Testing

- `go vet ./...` and `go test ./...` in `daemon/` — all pass.
- Added `TestProcess_DropsUncanonicalizableUsage`, mirroring the existing `TestProcess_RejectsUnrepresentableNumbers` fixture (`1e400`) but for `usage` instead of `input`/`output`: asserts `Process` succeeds, exactly one warning is logged, `runtime.usage` is absent from the stored receipt while `runtime.model`/`capture_method` survive, and the receipt still re-hashes cleanly.

## Checklist

- [x] Tests pass for all changed components (`daemon`)
- [x] Linter passes (`go vet`)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, no receipt schema or wire-format change
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A, no spec change

## Security

- [x] This PR touches crypto, auth, or secrets handling — it touches what gets embedded in a *signed* receipt (not crypto primitives themselves)
- [x] Primitives and parameters have been reviewed — no crypto primitives changed
- [x] All inputs are validated at trust boundaries — `runtime.usage` is now validated before being embedded in signed output
- [x] Edge cases are tested (nil, empty, corrupted, concurrent) — covered by the new test plus pre-existing `TestProcess_RuntimeModelUsageOnRootReceipt` (valid usage) and `TestProcess_RejectsUnrepresentableNumbers` (the analogous input/output case)
