### PR TITLE
daemon: fix principalFromPeer comment describing nonexistent emitter-supplied principal path

### DIFF
--- a/daemon/internal/pipeline/build.go
+++ b/daemon/internal/pipeline/build.go
@@ -1100,9 +1100,10 @@ func ptrUint32(v uint32) *uint32 { return &v }
 var lookupUID = user.LookupId
 
 // principalFromPeer derives the receipt Principal from kernel-attested peer
-// credentials. Absent an emitter-supplied principal, the OS user that ran the
-// emitting process is the best attested stand-in for "on whose authority": it is
-// the same LOCAL_PEERCRED/SO_PEERCRED identity the daemon already vouches for in
+// credentials. Emitters cannot supply their own principal — the frame format
+// has no such field — so the OS user that ran the emitting process is the
+// best attested stand-in for "on whose authority": it is the same
+// LOCAL_PEERCRED/SO_PEERCRED identity the daemon already vouches for in
 // action.peer_credential, so the principal inherits that field's tamper-evidence
 // instead of trusting an emitter self-report.
 //


### PR DESCRIPTION
## What

Reword the `principalFromPeer` comment (`daemon/internal/pipeline/build.go`) to stop implying emitters can supply their own principal.

## Why

Fixes #1007. Emitters have no principal field in the frame format (see the field set at `build.go:116-171`); every `Principal` assignment in the daemon comes from `principalFromPeer(peer)` (kernel-attested), a hardcoded `did:user:unknown` sentinel, or `cfg.IssuerID` from daemon config. The trust model is sound — only the comment was wrong, and misleadingly so inside the one function that implements that model, where a future contributor is most likely to be misled into adding the path it described.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes (`go vet`, `ruff check`, `biome` as applicable)
- [x] No real keys or secrets in the diff
- [ ] Cross-language tests pass (if receipt format, signing, or hashing changed) — N/A, comment-only change
- [ ] AGENTS.md updated (if project structure changed) — N/A
- [ ] Spec changes have been reviewed by a maintainer (if applicable) — N/A

## Security

- [ ] This PR touches crypto, auth, or secrets handling — no, comment-only change