### PR TITLE
Fix ADR-0009 normalisation in signing and hashing

### DIFF
--- a/sdk/py/CHANGELOG.md
+++ b/sdk/py/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`hash_receipt` no longer fabricates a `chain` object on chainless dict input** ([#1005](https://github.com/agent-receipts/obsigna/issues/1005)) — a plain-dict receipt missing `credentialSubject.chain` entirely (schema-invalid, but reachable via hand-built dicts) previously had `chain: {previous_receipt_hash: null}` injected via `setdefault`, inventing structure that was never on the wire and diverging from the TS SDK's `pluckChain` (which only restores the field when a chain object already exists). `previous_receipt_hash` is now restored only when the input already has a `chain` object.
+
 ## [0.15.0] - 2026-07-17
 
 ### Added

--- a/sdk/py/src/obsigna/receipt/hash.py
+++ b/sdk/py/src/obsigna/receipt/hash.py
@@ -175,7 +175,9 @@ def hash_receipt(receipt: AgentReceipt | dict[str, Any]) -> str:
     Applies ADR-0009 Rule 2 before canonicalising:
     - Optional fields with null values are normalised to absent.
     - ``previous_receipt_hash`` (required-nullable) is always emitted as
-      ``null`` when absent/None.
+      ``null`` when absent/None, but only if the input already has a
+      ``chain`` object — a dict input missing ``chain`` entirely is
+      schema-invalid, and this function does not fabricate one.
     """
     from obsigna.receipt.types import AgentReceipt
 
@@ -189,13 +191,20 @@ def hash_receipt(receipt: AgentReceipt | dict[str, Any]) -> str:
 
     d.pop("proof", None)
 
-    # Ensure previous_receipt_hash is preserved as null when None.
-    # Use setdefault so an injected nested dict actually attaches to `d` —
-    # `.get(key, {})` returns a temporary that mutations would discard.
-    cs: dict[str, Any] = d.setdefault("credentialSubject", {})
-    chain: dict[str, Any] = cs.setdefault("chain", {})
-    if "previous_receipt_hash" not in chain:
-        chain["previous_receipt_hash"] = None
+    # Restore previous_receipt_hash (required-nullable) only when a chain
+    # object is already present in the input — mirrors the TS SDK's
+    # pluckChain, which restores the field without fabricating a chain that
+    # wasn't there. A receipt missing `chain` entirely is schema-invalid
+    # regardless of this step; the point is just not to invent structure
+    # that was never on the wire (see issue #1005).
+    cs = d.get("credentialSubject")
+    if isinstance(cs, dict):
+        cs = cast("dict[str, Any]", cs)
+        chain = cs.get("chain")
+        if isinstance(chain, dict):
+            chain = cast("dict[str, Any]", chain)
+            if "previous_receipt_hash" not in chain:
+                chain["previous_receipt_hash"] = None
 
     canonical = canonicalize(d)
     return sha256(canonical)

--- a/sdk/py/tests/receipt/test_hash.py
+++ b/sdk/py/tests/receipt/test_hash.py
@@ -107,3 +107,49 @@ class TestHashReceipt:
         # Modify proof — hash should be identical
         r2.proof.proofValue = "udifferent"
         assert hash_receipt(r1) == hash_receipt(r2)
+
+    def test_dict_input_without_chain_does_not_fabricate_chain(self) -> None:
+        """Regression test for issue #1005.
+
+        A dict receipt missing `credentialSubject.chain` entirely is
+        schema-invalid, but hash_receipt must not fabricate
+        `chain: {previous_receipt_hash: null}` out of nothing — that
+        invents structure that was never on the wire and diverges from the
+        TS SDK's pluckChain, which only restores the field when a chain
+        object already exists. If nothing was fabricated, the hash equals
+        hashing the input completely unchanged (there are no nulls to strip
+        and no proof to pop here).
+        """
+        receipt: dict[str, object] = {
+            "credentialSubject": {
+                "principal": {"id": "did:user:test"},
+            },
+        }
+
+        assert hash_receipt(receipt) == sha256(canonicalize(receipt))
+
+    def test_dict_input_with_chain_still_preserves_null_previous_hash(self) -> None:
+        """The fabrication fix must not regress the required-nullable rule
+        when a chain object is genuinely present.
+        """
+        receipt: dict[str, object] = {
+            "credentialSubject": {
+                "chain": {"sequence": 1, "chain_id": "chain_test"},
+            },
+        }
+
+        expected = sha256(
+            canonicalize(
+                {
+                    "credentialSubject": {
+                        "chain": {
+                            "sequence": 1,
+                            "chain_id": "chain_test",
+                            "previous_receipt_hash": None,
+                        },
+                    },
+                }
+            )
+        )
+
+        assert hash_receipt(receipt) == expected

--- a/sdk/ts/CHANGELOG.md
+++ b/sdk/ts/CHANGELOG.md
@@ -12,6 +12,10 @@ tracked in [#253](https://github.com/agent-receipts/obsigna/issues/253).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`signReceipt`/`verifyReceipt` now normalise optional-null fields before canonicalising** ([#1005](https://github.com/agent-receipts/obsigna/issues/1005)) — `canonicalizeReceipt` previously canonicalised the caller's object verbatim, so an explicit `null` on an optional field (reachable via an `as UnsignedAgentReceipt` cast or untyped JSON) was signed/verified as `"field":null`, while `hashReceipt` on the same object normalised it to absent per ADR-0009 Rule 2 — producing a different byte form for the signature than for the chain hash. Both now share `normalizeForCanonicalization()`, so a receipt's signature and its chain hash always commit to identical canonical bytes.
+
 ## [0.17.0] - 2026-07-17
 
 ### Added

--- a/sdk/ts/src/receipt/hash.ts
+++ b/sdk/ts/src/receipt/hash.ts
@@ -77,16 +77,30 @@ function canonicalizeNumber(n: number): string {
  */
 export function hashReceipt(receipt: AgentReceipt): string {
 	const { proof: _proof, ...unsigned } = receipt;
-	const stripped = stripOptionalNulls(unsigned);
+	return sha256(canonicalize(normalizeForCanonicalization(unsigned)));
+}
+
+/**
+ * Apply ADR-0009 Rule 2 to an unsigned receipt (or any receipt-shaped value)
+ * ahead of canonicalisation: optional fields whose value is null are
+ * normalised to absent, while the sole required-nullable field,
+ * chain.previous_receipt_hash, is preserved (including as JSON null).
+ *
+ * Shared by hashReceipt and signing.ts's canonicalizeReceipt so that a
+ * receipt's signature and its chain hash always commit to the same
+ * normalised byte form of the document.
+ */
+export function normalizeForCanonicalization(value: unknown): unknown {
+	const stripped = stripOptionalNulls(value);
 	// stripOptionalNulls drops null-valued keys, including
 	// previous_receipt_hash when it is null. previous_receipt_hash is the sole
 	// required-nullable field per ADR-0009; restore it so it is always emitted.
 	const chain = pluckChain(stripped);
 	if (chain) {
 		chain.previous_receipt_hash =
-			receipt.credentialSubject?.chain?.previous_receipt_hash ?? null;
+			pluckChain(value)?.previous_receipt_hash ?? null;
 	}
-	return sha256(canonicalize(stripped));
+	return stripped;
 }
 
 function pluckChain(stripped: unknown): Record<string, unknown> | null {

--- a/sdk/ts/src/receipt/signing.test.ts
+++ b/sdk/ts/src/receipt/signing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { hashReceipt } from "./hash.js";
 import { generateKeyPair, signReceipt, verifyReceipt } from "./signing.js";
-import type { UnsignedAgentReceipt } from "./types.js";
+import type { AgentReceipt, UnsignedAgentReceipt } from "./types.js";
 import { CONTEXT, CREDENTIAL_TYPE, VERSION } from "./types.js";
 
 function makeUnsignedReceipt(): UnsignedAgentReceipt {
@@ -143,5 +144,65 @@ describe("verifyReceipt", () => {
 		expect(() =>
 			signReceipt(unsigned, privateKey, "did:agent:test#key-1"),
 		).toThrow(/terminal/);
+	});
+});
+
+describe("ADR-0009 optional-null normalisation (issue #1005)", () => {
+	// Ed25519 signing is deterministic (RFC 8032): the same key and message
+	// always produce the same signature. That makes proofValue equality a
+	// precise probe for "these two calls signed identical canonical bytes".
+	it("signs identical bytes whether an optional field is null or absent", () => {
+		const { privateKey } = generateKeyPair();
+
+		const withNull = makeUnsignedReceipt();
+		// Bypass the type system the way an `as UnsignedAgentReceipt` cast or
+		// untyped JSON consumer would.
+		(withNull.credentialSubject.outcome as { error: unknown }).error = null;
+		const withAbsent = makeUnsignedReceipt();
+
+		const signedWithNull = signReceipt(
+			withNull,
+			privateKey,
+			"did:agent:test#key-1",
+		);
+		const signedWithAbsent = signReceipt(
+			withAbsent,
+			privateKey,
+			"did:agent:test#key-1",
+		);
+
+		expect(signedWithNull.proof.proofValue).toBe(
+			signedWithAbsent.proof.proofValue,
+		);
+	});
+
+	it("verifies a receipt carrying an explicit null on an optional field", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const unsigned = makeUnsignedReceipt();
+		(unsigned.credentialSubject.outcome as { error: unknown }).error = null;
+
+		const signed = signReceipt(unsigned, privateKey, "did:agent:test#key-1");
+
+		expect(verifyReceipt(signed, publicKey)).toBe(true);
+	});
+
+	it("signs over the same canonical bytes hashReceipt commits to", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = makeUnsignedReceipt();
+		(unsigned.credentialSubject.outcome as { error: unknown }).error = null;
+
+		const signed = signReceipt(unsigned, privateKey, "did:agent:test#key-1");
+		const signedWithoutNull: AgentReceipt = {
+			...signed,
+			credentialSubject: {
+				...signed.credentialSubject,
+				outcome: { status: "success" },
+			},
+		};
+
+		// The proof differs (created timestamp), but the hash — which also
+		// excludes proof — must be identical, since both signReceipt and
+		// hashReceipt normalise `error: null` to absent before committing.
+		expect(hashReceipt(signed)).toBe(hashReceipt(signedWithoutNull));
 	});
 });

--- a/sdk/ts/src/receipt/signing.ts
+++ b/sdk/ts/src/receipt/signing.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSync, sign, verify } from "node:crypto";
-import { canonicalize } from "./hash.js";
+import { canonicalize, normalizeForCanonicalization } from "./hash.js";
 import type { AgentReceipt, Proof, UnsignedAgentReceipt } from "./types.js";
 
 export interface KeyPair {
@@ -33,9 +33,16 @@ export function generateKeyPair(): KeyPair {
 
 /**
  * Serialize an unsigned receipt to bytes using RFC 8785 canonicalization.
+ *
+ * Applies ADR-0009 Rule 2 (optional-null normalisation) via the same
+ * normalizeForCanonicalization() helper hashReceipt() uses, so a receipt's
+ * signature and its chain hash always commit to identical canonical bytes.
  */
 function canonicalizeReceipt(receipt: UnsignedAgentReceipt): Buffer {
-	return Buffer.from(canonicalize(receipt), "utf-8");
+	return Buffer.from(
+		canonicalize(normalizeForCanonicalization(receipt)),
+		"utf-8",
+	);
 }
 
 /**


### PR DESCRIPTION
## What

Align receipt signing and hashing to apply ADR-0009 Rule 2 (optional-null normalisation) consistently before canonicalisation. Extract the normalisation logic into a shared `normalizeForCanonicalization()` function used by both `hashReceipt()` and `signReceipt()`. Fix `hash_receipt()` in the Python SDK to not fabricate a `chain` object on chainless dict input.

## Why

**TypeScript SDK:** `signReceipt()` was canonicalising receipts verbatim without normalising optional-null fields, while `hashReceipt()` applied ADR-0009 Rule 2 normalisation. This meant a receipt with an explicit `null` on an optional field (reachable via `as UnsignedAgentReceipt` casts or untyped JSON) would be signed over different canonical bytes than its chain hash, breaking the invariant that a receipt's signature and chain hash commit to identical byte forms.

**Python SDK:** `hash_receipt()` used `setdefault()` to unconditionally inject `chain: {previous_receipt_hash: null}` into dict inputs missing a `chain` object entirely. This fabricated structure that was never on the wire and diverged from the TS SDK's `pluckChain()`, which only restores the field when a chain object already exists. Schema-invalid inputs (missing `chain`) should not have structure invented.

## Checklist

- [x] Tests pass for all changed components
- [x] Linter passes
- [x] No real keys or secrets in the diff
- [x] Cross-language tests pass (receipt format, signing, and hashing changed)
- [x] AGENTS.md not applicable (no project structure changes)
- [x] Spec changes not applicable

## Security

- [x] This PR touches crypto and signing (Ed25519)
- [x] Primitives and parameters reviewed — RFC 8032 deterministic signing used as a probe for canonical byte equality
- [x] Inputs validated — normalisation applied before canonicalisation at trust boundaries
- [x] Edge cases tested — explicit nulls on optional fields, missing chain objects, and null-valued required-nullable fields all covered by new test cases